### PR TITLE
fix: consolidate coverage reports into single PR comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,25 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: test
-    strategy:
-      matrix:
-        package:
-          - { name: 'core', dir: './packages/core', label: 'Core Package Coverage' }
-          - { name: 'ui', dir: './packages/ui', label: 'UI Package Coverage' }
-          - { name: 'cli', dir: './packages/cli', label: 'CLI Package Coverage' }
-          - { name: 'auth', dir: './packages/auth', label: 'Auth Package Coverage' }
-          - { name: 'storage', dir: './packages/storage', label: 'Storage Package Coverage' }
-          - { name: 'rag', dir: './packages/rag', label: 'RAG Package Coverage' }
-          - {
-              name: 'storage-s3',
-              dir: './packages/storage-s3',
-              label: 'Storage S3 Package Coverage',
-            }
-          - {
-              name: 'storage-vercel',
-              dir: './packages/storage-vercel',
-              label: 'Storage Vercel Package Coverage',
-            }
 
     steps:
       - name: Checkout code
@@ -141,8 +122,50 @@ jobs:
           name: coverage-reports
           path: packages/
 
-      - name: Report coverage for ${{ matrix.package.name }}
+      - name: Report coverage for Core Package
         uses: davelosert/vitest-coverage-report-action@v2
         with:
-          working-directory: ${{ matrix.package.dir }}
-          name: ${{ matrix.package.label }}
+          working-directory: ./packages/core
+          name: 'Core Package Coverage'
+
+      - name: Report coverage for UI Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/ui
+          name: 'UI Package Coverage'
+
+      - name: Report coverage for CLI Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/cli
+          name: 'CLI Package Coverage'
+
+      - name: Report coverage for Auth Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/auth
+          name: 'Auth Package Coverage'
+
+      - name: Report coverage for Storage Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/storage
+          name: 'Storage Package Coverage'
+
+      - name: Report coverage for RAG Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/rag
+          name: 'RAG Package Coverage'
+
+      - name: Report coverage for Storage S3 Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/storage-s3
+          name: 'Storage S3 Package Coverage'
+
+      - name: Report coverage for Storage Vercel Package
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          working-directory: ./packages/storage-vercel
+          name: 'Storage Vercel Package Coverage'


### PR DESCRIPTION
## Summary

Consolidates all package coverage reports into a single PR comment instead of creating 8 separate comments.

## Changes

- Replaced matrix-based coverage job with sequential steps in the same job
- Each package coverage report now runs as a separate step with a unique `name` parameter
- The `davelosert/vitest-coverage-report-action@v2` automatically consolidates multiple invocations within the same job into a single PR comment

## Benefits

✅ Single consolidated PR comment with all 8 package coverage reports  
✅ Cleaner PR interface without comment clutter  
✅ Maintains all existing coverage reporting features  
✅ Each package has its own section within the consolidated comment  

## Test Plan

- [ ] Create a test PR to verify the new workflow produces a single consolidated comment
- [ ] Verify all 8 packages (core, ui, cli, auth, storage, rag, storage-s3, storage-vercel) appear in the comment
- [ ] Confirm comment updates on subsequent pushes instead of creating duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)