### PR TITLE
Create migration config generator for opensaas

### DIFF
--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -139,7 +139,14 @@ export class MigrationGenerator {
 
     // Generate each list
     const listDefinitions = modelsToGenerate.map((model) => {
-      return this.generateList(model, schema, ownerModels.has(model.name), answers, usedFieldTypes, warnings)
+      return this.generateList(
+        model,
+        schema,
+        ownerModels.has(model.name),
+        answers,
+        usedFieldTypes,
+        warnings,
+      )
     })
 
     return listDefinitions.join('\n')
@@ -382,10 +389,7 @@ const isOwner: AccessControl = ({ session, item }) => {
       case 'postgresql':
         return {
           provider: 'postgresql',
-          imports: [
-            "import { PrismaPg } from '@prisma/adapter-pg'",
-            "import pg from 'pg'",
-          ],
+          imports: ["import { PrismaPg } from '@prisma/adapter-pg'", "import pg from 'pg'"],
           configCode: `    db: {
       provider: 'postgresql',
       prismaClientConstructor: (PrismaClient) => {
@@ -399,9 +403,7 @@ const isOwner: AccessControl = ({ session, item }) => {
       case 'mysql':
         return {
           provider: 'mysql',
-          imports: [
-            "import { PrismaPlanetScale } from '@prisma/adapter-planetscale'",
-          ],
+          imports: ["import { PrismaPlanetScale } from '@prisma/adapter-planetscale'"],
           configCode: `    db: {
       provider: 'mysql',
       prismaClientConstructor: (PrismaClient) => {
@@ -417,9 +419,7 @@ const isOwner: AccessControl = ({ session, item }) => {
       default:
         return {
           provider: 'sqlite',
-          imports: [
-            "import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'",
-          ],
+          imports: ["import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'"],
           configCode: `    db: {
       provider: 'sqlite',
       prismaClientConstructor: (PrismaClient) => {
@@ -475,8 +475,7 @@ const isOwner: AccessControl = ({ session, item }) => {
     authMethods: string[]
     adminBasePath: string
   }): string {
-    const { imports, accessHelpers, dbConfig, lists, useAuth, authMethods, adminBasePath } =
-      options
+    const { imports, accessHelpers, dbConfig, lists, useAuth, authMethods, adminBasePath } = options
 
     // Generate auth plugin config
     let authPluginStr = ''

--- a/packages/cli/tests/migration-generator.test.ts
+++ b/packages/cli/tests/migration-generator.test.ts
@@ -202,9 +202,7 @@ describe('MigrationGenerator', () => {
 
       const output = await generator.generate(session)
 
-      const secretStep = output.steps.find((step) =>
-        step.includes('BETTER_AUTH_SECRET'),
-      )
+      const secretStep = output.steps.find((step) => step.includes('BETTER_AUTH_SECRET'))
       expect(secretStep).toBeDefined()
       expect(secretStep).toContain('openssl rand -base64 32')
     })
@@ -563,7 +561,9 @@ describe('MigrationGenerator', () => {
 
       const output = await generator.generate(session)
 
-      expect(output.configContent).toContain("import type { AccessControl } from '@opensaas/stack-core'")
+      expect(output.configContent).toContain(
+        "import type { AccessControl } from '@opensaas/stack-core'",
+      )
     })
 
     it('should not include AccessControl type when auth disabled', async () => {


### PR DESCRIPTION
Implements comprehensive migration config generator that produces complete opensaas.config.ts files from migration session data.

Features:
- Generates complete config with imports, DB setup, lists, and access control
- Supports all database providers (SQLite, PostgreSQL, MySQL) with Prisma 7 adapters
- Maps Prisma/Keystone types to OpenSaaS field types
- Handles relationships with proper refs
- Converts enums to select fields
- Generates access control based on wizard answers (public-read-auth-write, authenticated-only, owner-only, admin-only)
- Integrates auth plugin when enabled
- Generates .env.example with appropriate variables
- Provides clear next steps for users
- Comprehensive test suite with 21 passing tests

This completes Phase 5 of the migration wizard implementation.