### PR TITLE
Add Prisma format to CLI package

### DIFF
--- a/.changeset/smooth-trees-format.md
+++ b/.changeset/smooth-trees-format.md
@@ -1,0 +1,11 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Add automatic Prisma schema formatting after generation
+
+The `opensaas generate` command now automatically runs `prisma format` after generating the schema file. This ensures consistent formatting of the generated `prisma/schema.prisma` file.
+
+The formatting step is non-critical - if it fails (e.g., due to missing environment variables or network issues), generation will continue with a warning instead of failing.
+
+No action required - formatting happens automatically during `pnpm generate`.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -139,6 +139,25 @@ export async function generateCommand() {
           throw err
         }
       }
+
+      // Format Prisma schema
+      const formatSpinner = ora('Formatting Prisma schema...').start()
+      try {
+        execSync('npx prisma format', {
+          cwd,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        })
+        formatSpinner.succeed(chalk.green('Prisma schema formatted'))
+        console.log(chalk.green('✅ Prisma schema formatted'))
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (_err) {
+        // Formatting is optional - don't fail generation if it doesn't work
+        formatSpinner.warn(chalk.yellow('Prisma schema formatting skipped'))
+        console.log(
+          chalk.yellow('⚠️  Prisma format failed (this is non-critical, continuing generation)'),
+        )
+      }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       generatorSpinner.fail(chalk.red('Failed to generate'))


### PR DESCRIPTION
- Run 'prisma format' after generating schema.prisma
- Format step is non-fatal - shows warning if it fails
- Ensures consistent formatting of generated schemas