### PR TITLE
Add original item to afterOperation hook

### DIFF
--- a/.changeset/brave-hooks-compare.md
+++ b/.changeset/brave-hooks-compare.md
@@ -1,0 +1,50 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Add `originalItem` parameter to `afterOperation` hooks for comparing previous and new values
+
+Both field-level and list-level `afterOperation` hooks now receive an `originalItem` parameter containing the item's state before the operation. This enables use cases like detecting field changes, cleaning up old files, tracking state transitions, and sending conditional notifications.
+
+Usage in list-level hooks:
+
+```typescript
+Post: list({
+  hooks: {
+    afterOperation: async ({ operation, item, originalItem, context }) => {
+      if (operation === 'update' && originalItem) {
+        // Compare previous and new values
+        if (originalItem.status !== item.status) {
+          await notifyStatusChange(originalItem.status, item.status)
+        }
+      }
+    },
+  },
+})
+```
+
+Usage in field-level hooks:
+
+```typescript
+fields: {
+  thumbnail: text({
+    hooks: {
+      afterOperation: async ({ operation, value, item, originalItem }) => {
+        if (operation === 'update' && originalItem) {
+          const oldValue = originalItem.thumbnail
+          if (oldValue !== value && oldValue) {
+            // Clean up old file when thumbnail changes
+            await deleteFromCDN(oldValue)
+          }
+        }
+      },
+    },
+  })
+}
+```
+
+The `originalItem` parameter is:
+
+- `undefined` for `create` and `query` operations (no previous state)
+- The item before the update for `update` operations
+- The item before deletion for `delete` operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,29 +151,29 @@ The hooks system provides data transformation and side effects during database o
 6. Field-level `beforeOperation` - Side effects for individual fields
 7. List-level `beforeOperation` - Side effects at list level
 8. **Database operation**
-9. List-level `afterOperation` - Side effects at list level
-10. Field-level `afterOperation` - Side effects for individual fields
+9. List-level `afterOperation` - Side effects at list level (receives `item` and `originalItem`)
+10. Field-level `afterOperation` - Side effects for individual fields (receives `value`, `item`, and `originalItem`)
 
 **Hook execution order (read operations - query):**
 
 1. **Database operation**
 2. Field-level access control - Filter readable fields
 3. Field-level `resolveOutput` - Transform individual field values (e.g., wrap passwords)
-4. Field-level `afterOperation` - Side effects for individual fields
+4. Field-level `afterOperation` - Side effects for individual fields (receives `value` and `item`, no `originalItem` for queries)
 
 **List-level hook use cases:**
 
 - `resolveInput`: Auto-set publishedAt when status changes to "published"
 - `validateInput`: Business logic validation (e.g., "title cannot contain spam")
 - `beforeOperation`: Logging, sending notifications
-- `afterOperation`: Cache invalidation, webhooks
+- `afterOperation`: Cache invalidation, webhooks, comparing previous and new values using `originalItem`
 
 **Field-level hook use cases:**
 
 - `resolveInput`: Hash passwords, normalize phone numbers, resize images
 - `resolveOutput`: Wrap passwords with HashedPassword class, format dates
 - `beforeOperation`: Log field changes, validate external constraints
-- `afterOperation`: Update search indexes, invalidate CDN caches
+- `afterOperation`: Update search indexes, invalidate CDN caches, cleanup old files by comparing `originalItem` field values
 
 ### Config System
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -92,7 +92,11 @@ export type FieldHooks<
    *
    * @example
    * ```typescript
-   * afterOperation: async ({ operation, value, item }) => {
+   * afterOperation: async ({ operation, value, item, originalItem }) => {
+   *   // For update operations, compare previous and new values
+   *   if (operation === 'update' && originalItem) {
+   *     console.log('Changed from:', originalItem[fieldName], 'to:', value)
+   *   }
    *   await invalidateCache({ listKey, itemId: item.id })
    *   await sendWebhook({ operation, item })
    * }
@@ -102,6 +106,13 @@ export type FieldHooks<
     operation: 'create' | 'update' | 'delete' | 'query'
     value: GetFieldValueType<TTypeInfo['fields'], TFieldKey> | undefined
     item: TTypeInfo['item']
+    /**
+     * The original item before the operation (for update/delete operations)
+     * - For 'create' and 'query' operations: undefined
+     * - For 'update' operations: the item before the update
+     * - For 'delete' operations: the item before deletion (same as item)
+     */
+    originalItem?: TTypeInfo['item']
     listKey: string
     fieldName: TFieldKey
     context: import('../access/types.js').AccessContext
@@ -626,6 +637,13 @@ export type HookArgs<
   operation: 'create' | 'update' | 'delete'
   resolvedData?: TCreateInput | TUpdateInput
   item?: TOutput
+  /**
+   * The original item before the operation (for update/delete operations)
+   * - For 'create' operations: undefined
+   * - For 'update' operations: the item before the update
+   * - For 'delete' operations: the item before deletion (same as item)
+   */
+  originalItem?: TOutput
   context: import('../access/types.js').AccessContext
 }
 

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -107,6 +107,8 @@ async function executeFieldAfterOperationHooks(
   operation: 'create' | 'update' | 'delete' | 'query',
   context: AccessContext,
   listKey: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  originalItem?: any,
 ): Promise<void> {
   for (const [fieldName, fieldConfig] of Object.entries(fields)) {
     // Skip if no hooks defined
@@ -122,6 +124,7 @@ async function executeFieldAfterOperationHooks(
       fieldName,
       listKey,
       item,
+      originalItem,
       context,
     })
   }
@@ -483,6 +486,7 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       'query',
       context,
       listName,
+      undefined, // originalItem is undefined for query operations
     )
 
     return filtered
@@ -579,6 +583,7 @@ function createFindMany<TPrisma extends PrismaClientLike>(
           'query',
           context,
           listName,
+          undefined, // originalItem is undefined for query operations
         ),
       ),
     )
@@ -677,6 +682,7 @@ function createCreate<TPrisma extends PrismaClientLike>(
     await executeAfterOperation(listConfig.hooks, {
       operation: 'create',
       item,
+      originalItem: undefined,
       context,
     })
 
@@ -688,6 +694,7 @@ function createCreate<TPrisma extends PrismaClientLike>(
       'create',
       context,
       listName,
+      undefined, // originalItem is undefined for create operations
     )
 
     // 11. Filter readable fields and apply resolveOutput hooks (including nested relationships)
@@ -832,6 +839,7 @@ function createUpdate<TPrisma extends PrismaClientLike>(
     await executeAfterOperation(listConfig.hooks, {
       operation: 'update',
       item: updated,
+      originalItem: item, // item is the original item before the update
       context,
     })
 
@@ -843,6 +851,7 @@ function createUpdate<TPrisma extends PrismaClientLike>(
       'update',
       context,
       listName,
+      item, // item is the original item before the update
     )
 
     // 12. Filter readable fields and apply resolveOutput hooks (including nested relationships)
@@ -930,6 +939,7 @@ function createDelete<TPrisma extends PrismaClientLike>(
     await executeAfterOperation(listConfig.hooks, {
       operation: 'delete',
       item: deleted,
+      originalItem: item, // item is the original item before deletion
       context,
     })
 
@@ -941,6 +951,7 @@ function createDelete<TPrisma extends PrismaClientLike>(
       'delete',
       context,
       listName,
+      item, // item is the original item before deletion
     )
 
     return deleted

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -143,6 +143,7 @@ export async function executeAfterOperation<
     operation: 'create' | 'update' | 'delete'
     resolvedData?: TCreateInput | TUpdateInput
     item: TOutput
+    originalItem?: TOutput
     context: AccessContext
   },
 ): Promise<void> {

--- a/packages/core/tests/hooks.test.ts
+++ b/packages/core/tests/hooks.test.ts
@@ -252,6 +252,70 @@ describe('Hooks', () => {
         context: mockContext,
       })
     })
+
+    it('should pass originalItem to afterOperation hook for update operation', async () => {
+      const originalItem = { id: '1', name: 'John' }
+      const updatedItem = { id: '1', name: 'Jane' }
+      const hooks: Hooks = {
+        afterOperation: vi.fn(async () => {}),
+      }
+
+      await executeAfterOperation(hooks, {
+        operation: 'update',
+        item: updatedItem,
+        originalItem,
+        context: mockContext,
+      })
+
+      expect(hooks.afterOperation).toHaveBeenCalledWith({
+        operation: 'update',
+        item: updatedItem,
+        originalItem,
+        context: mockContext,
+      })
+    })
+
+    it('should pass originalItem to afterOperation hook for delete operation', async () => {
+      const item = { id: '1', name: 'John' }
+      const hooks: Hooks = {
+        afterOperation: vi.fn(async () => {}),
+      }
+
+      await executeAfterOperation(hooks, {
+        operation: 'delete',
+        item,
+        originalItem: item,
+        context: mockContext,
+      })
+
+      expect(hooks.afterOperation).toHaveBeenCalledWith({
+        operation: 'delete',
+        item,
+        originalItem: item,
+        context: mockContext,
+      })
+    })
+
+    it('should pass undefined originalItem for create operation', async () => {
+      const item = { id: '1', name: 'John' }
+      const hooks: Hooks = {
+        afterOperation: vi.fn(async () => {}),
+      }
+
+      await executeAfterOperation(hooks, {
+        operation: 'create',
+        item,
+        originalItem: undefined,
+        context: mockContext,
+      })
+
+      expect(hooks.afterOperation).toHaveBeenCalledWith({
+        operation: 'create',
+        item,
+        originalItem: undefined,
+        context: mockContext,
+      })
+    })
   })
 
   describe('validateFieldRules', () => {


### PR DESCRIPTION
…ew values

This enhancement allows users to compare the previous state (originalItem) with the new state (item) in afterOperation hooks, enabling use cases like:
- Detecting field value changes
- Cleaning up old files when values change
- Tracking state transitions
- Sending notifications on specific changes

Changes:
- Updated field-level afterOperation hook types to include originalItem parameter
- Updated list-level afterOperation hook types to include originalItem parameter
- Modified hook execution to pass originalItem for update and delete operations
- Added test coverage for originalItem parameter in all operation types
- Updated documentation in CLAUDE.md and docs/ to explain originalItem usage
- Added examples showing how to use originalItem for value comparison

For create and query operations, originalItem is undefined (no previous state). For update operations, originalItem contains the item before the update. For delete operations, originalItem contains the item before deletion.