### PR TITLE
Add native database type option to text field

### DIFF
--- a/.changeset/brave-fields-grow.md
+++ b/.changeset/brave-fields-grow.md
@@ -1,0 +1,28 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Add `db.nativeType` and `db.isNullable` options to text field
+
+You can now specify Prisma native database type attributes and control nullability independently:
+
+```typescript
+// Use PostgreSQL Text type instead of default String
+fields: {
+  description: text({
+    validation: { isRequired: true },
+    db: {
+      nativeType: 'Text',
+      isNullable: false,
+    },
+  }),
+}
+```
+
+This generates:
+
+```prisma
+description String @db.Text
+```
+
+The `db.nativeType` option allows you to override the default Prisma type for your database provider (e.g., `Text`, `VarChar(255)`, `MediumText`), while `db.isNullable` lets you control nullability independently from the `isRequired` validation.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -324,6 +324,37 @@ export type TextField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<T
     }
   }
   isIndexed?: boolean | 'unique'
+  db?: {
+    map?: string
+    /**
+     * Prisma native database type attribute
+     * Allows overriding the default String type for the database provider
+     * @example
+     * ```typescript
+     * // PostgreSQL/MySQL
+     * fields: {
+     *   description: text({ db: { nativeType: 'Text' } })
+     *   // Generates: description String @db.Text
+     * }
+     * ```
+     */
+    nativeType?: string
+    /**
+     * Controls nullability in the database schema
+     * When specified, overrides the default behavior (isRequired determines nullability)
+     * @example
+     * ```typescript
+     * fields: {
+     *   description: text({
+     *     validation: { isRequired: true },
+     *     db: { isNullable: false }
+     *   })
+     *   // Generates: description String (non-nullable)
+     * }
+     * ```
+     */
+    isNullable?: boolean
+  }
   ui?: {
     displayMode?: 'input' | 'textarea'
   }

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -67,12 +67,19 @@ export function text<
     },
     getPrismaType: (_fieldName: string) => {
       const validation = options?.validation
+      const db = options?.db
       const isRequired = validation?.isRequired
+      const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
       // Optional modifier
-      if (!isRequired) {
+      if (isNullable) {
         modifiers += '?'
+      }
+
+      // Native type modifier (e.g., @db.Text)
+      if (db?.nativeType) {
+        modifiers += ` @db.${db.nativeType}`
       }
 
       // Unique/index modifiers
@@ -83,8 +90,8 @@ export function text<
       }
 
       // Map modifier
-      if (options?.db?.map) {
-        modifiers += ` @map("${options.db.map}")`
+      if (db?.map) {
+        modifiers += ` @map("${db.map}")`
       }
 
       return {


### PR DESCRIPTION
This change adds two new database configuration options to the text field type:

- db.nativeType: Allows specifying Prisma native database type attributes (e.g., @db.Text, @db.VarChar(255))
- db.isNullable: Controls nullability in the database schema independently from validation rules

These options give developers more fine-grained control over the generated Prisma schema, enabling them to use database-specific types while maintaining type safety.