### PR TITLE
Fix image field typing in database queries

### DIFF
--- a/.changeset/quick-rivers-flow.md
+++ b/.changeset/quick-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage': patch
+---
+
+Fix image and file field typing in context.db operations

--- a/packages/storage/src/fields/index.ts
+++ b/packages/storage/src/fields/index.ts
@@ -101,6 +101,11 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
     type: 'file',
     ...restOptions,
 
+    // Override Prisma's Json type with FileMetadata | null in context.db types
+    resultExtension: {
+      outputType: "import('@opensaas/stack-storage').FileMetadata | null",
+    },
+
     hooks: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
       resolveInput: async ({ inputValue, context, item, fieldName }: any) => {
@@ -245,6 +250,11 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
   const fieldConfig: ImageFieldConfig<TTypeInfo> = {
     type: 'image',
     ...restOptions,
+
+    // Override Prisma's Json type with ImageMetadata | null in context.db types
+    resultExtension: {
+      outputType: "import('@opensaas/stack-storage').ImageMetadata | null",
+    },
 
     hooks: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime


### PR DESCRIPTION
Added resultExtension to image() and file() field builders to ensure they are correctly typed as ImageMetadata | null and FileMetadata | null in context.db operations instead of Json | null.

Previously, these fields were stored as JSON in the database but were not included in the TransformedFields type, which meant context.db operations would see them as Prisma's raw Json type instead of the proper metadata types.