### PR TITLE
Fix async resolveOutput hooks not being awaited

### DIFF
--- a/.changeset/async-resolve-output-hooks.md
+++ b/.changeset/async-resolve-output-hooks.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix async resolveOutput hooks not being awaited in filterReadableFields
+
+The `resolveOutput` hooks for fields (especially virtual fields) were being called but not awaited, causing Promise objects to appear in output instead of resolved values. This fix properly awaits async `resolveOutput` hooks using `Promise.resolve()` wrapper for backwards compatibility with sync hooks.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -283,19 +283,32 @@ export type FieldHooks<
    * Called when returning results from query operations
    * This is where you should transform output data (e.g., wrap passwords, format values)
    *
+   * Supports both sync and async implementations. When async, the hook will be
+   * properly awaited before returning results.
+   *
    * @example
    * ```typescript
+   * // Sync example
    * resolveOutput: ({ value }) => {
    *   if (typeof value === 'string' && value.length > 0) {
    *     return new HashedPassword(value)
    *   }
    *   return value
    * }
+   *
+   * // Async example (e.g., for virtual fields that query the database)
+   * resolveOutput: async ({ item, context }) => {
+   *   const related = await context.db.otherList.findUnique({ where: { id: item.relatedId } })
+   *   return related?.name
+   * }
    * ```
    */
   resolveOutput?: (
     args: FieldResolveOutputHookArgs<TTypeInfo, TFieldKey>,
-  ) => GetFieldValueType<TTypeInfo['fields'], TFieldKey> | undefined
+  ) =>
+    | GetFieldValueType<TTypeInfo['fields'], TFieldKey>
+    | undefined
+    | Promise<GetFieldValueType<TTypeInfo['fields'], TFieldKey> | undefined>
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes async `resolveOutput` hooks not being awaited in `filterReadableFields()`
- Promise objects were appearing in output instead of resolved values
- Uses `Promise.resolve()` wrapper for backwards compatibility with sync hooks

## Changes

- Updated `resolveOutput` type in `config/types.ts` to support Promise return values
- Updated `ResolveOutputHookRuntime` type in `access/engine.ts` to include Promise
- Added `await Promise.resolve()` wrapper at both hook call sites (lines 351 and 394)
- Added 4 new tests for async resolveOutput hooks

## Test plan

- [x] All 418 existing tests pass
- [x] New tests verify async resolveOutput for regular fields
- [x] New tests verify async resolveOutput for virtual fields
- [x] New tests verify backwards compatibility with sync hooks
- [x] New tests verify context is passed to async hooks

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)