### PR TITLE
Fix updatedAt field to include @default(now()) in generated Prisma schema

### DIFF
--- a/.changeset/silent-bears-run.md
+++ b/.changeset/silent-bears-run.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix updatedAt field to include @default(now()) in generated Prisma schema to prevent migration failures on databases with existing data

--- a/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
@@ -135,7 +135,7 @@ model User {
   name         String
   email        String
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -380,7 +380,7 @@ model User {
   id        String   @id @default(cuid())
   name         String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -488,7 +488,7 @@ model Post {
   id        String   @id @default(cuid())
   title        String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -507,7 +507,7 @@ model User {
   id        String   @id @default(cuid())
   name         String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;

--- a/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
@@ -27,7 +27,7 @@ model User {
   name         String?
   from_Post_author Post[]  @relation("Post_author")
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Post {
@@ -36,7 +36,7 @@ model Post {
   authorId     String? @map("author")
   author       User?  @relation("Post_author", fields: [authorId], references: [id])
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
   @@index([authorId])
 }
 "
@@ -58,7 +58,7 @@ model User {
   email        String
   age          Int?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -78,7 +78,7 @@ model Post {
   title        String?
   isPublished  Boolean @default(false)
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -98,7 +98,7 @@ model Post {
   title        String?
   publishedAt  DateTime?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -117,21 +117,21 @@ model User {
   id        String   @id @default(cuid())
   name         String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Post {
   id        String   @id @default(cuid())
   title        String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Comment {
   id        String   @id @default(cuid())
   content      String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;
@@ -151,14 +151,14 @@ model User {
   name         String?
   posts        Post[]
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Post {
   id        String   @id @default(cuid())
   title        String?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 "
 `;

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -190,7 +190,7 @@ describe('Prisma Schema Generator', () => {
 
       expect(schema).toContain('id        String   @id @default(cuid())')
       expect(schema).toContain('createdAt DateTime @default(now())')
-      expect(schema).toContain('updatedAt DateTime @updatedAt')
+      expect(schema).toContain('updatedAt DateTime @default(now()) @updatedAt')
     })
 
     it('should handle empty lists config', () => {

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -562,7 +562,7 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
 
     // Always add timestamps
     lines.push('  createdAt DateTime @default(now())')
-    lines.push('  updatedAt DateTime @updatedAt')
+    lines.push('  updatedAt DateTime @default(now()) @updatedAt')
 
     // Add indexes for foreign key fields
     for (const { foreignKeyField, indexType } of foreignKeyIndexes) {


### PR DESCRIPTION
Without @default(now()), Prisma generates migrations that add the NOT NULL
updatedAt column without a default value, causing migration failures on tables
with existing data. This fixes issue #301.

https://claude.ai/code/session_01SSGGyEN9wbrYN57wnqXS8o