### PR TITLE
docs: add access control terminology and two-phase read ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# OpenSaas Stack
+
+Config-first stack for admin-heavy Next.js applications, whose defining feature is an access-control engine that automatically secures every database operation.
+
+## Language
+
+### Access control
+
+**Operation-level access**:
+A check that gates whether a session may perform an action (query/create/update/delete) on a list, returning either a boolean or a Prisma filter that scopes which rows are visible.
+_Avoid_: list access, row access
+
+**Field-level access**:
+A check that gates whether a session may read or write a single field, returning a boolean only. Cannot scope rows — a denied field is removed, not used to exclude records.
+_Avoid_: column access, property access
+
+**Access Filter** (pre-query phase):
+The first pass of a read, run before the database is hit. Uses operation-level access to build the access-scoped `include`/`where` so the database only returns rows and relations the session is allowed to see.
+_Avoid_: query builder, include builder
+
+**Field Visibility** (post-query phase):
+The second pass of a read, run on the returned rows. Removes fields the session cannot read, runs `resolveOutput` hooks, and computes virtual fields.
+_Avoid_: result filter, output filter, field stripper
+
+**Silent failure**:
+The convention that an access-denied operation returns `null` (single) or `[]` (many) rather than throwing, so callers cannot distinguish "denied" from "does not exist".
+_Avoid_: access error, permission error

--- a/docs/adr/0001-access-control-is-a-two-phase-read.md
+++ b/docs/adr/0001-access-control-is-a-two-phase-read.md
@@ -1,0 +1,7 @@
+# Access control reads run in two phases that cannot be merged
+
+Reads are secured in two passes: **Access Filter** (pre-query) builds an access-scoped `include`/`where` from operation-level access so the database returns only permitted rows and relations, and **Field Visibility** (post-query) strips unreadable fields, runs `resolveOutput` hooks, and computes virtual fields on the returned rows.
+
+The split is not incidental and the phases cannot be collapsed into one. Field-level access functions receive the fetched `item`, so field visibility can depend on row contents that do not exist until after the query runs; virtual fields are likewise only computable post-query. A future reader is therefore likely to see field access being re-evaluated post-query as redundant and try to fold it into the pre-query pass — this is impossible for item-dependent access, and is recorded here so that optimization is not re-attempted.
+
+The two phases also evaluate different things with different return contracts: operation-level access returns `boolean | PrismaFilter` (a filter scopes rows), while field-level access returns `boolean` only (a denied field is removed, never used to exclude rows). They share no evaluator across phases. Field-level access is, however, evaluated by a single shared function (`checkFieldAccess`) across both the read and write paths — there is deliberately one field-access evaluator, not a per-phase copy.


### PR DESCRIPTION
## Summary

Adds foundational documentation for the access control system, establishing consistent terminology and explaining the architectural decision to split reads into two phases.

## Changes

- **CONTEXT.md** (new): Defines the canonical terminology for access control concepts used throughout the codebase:
  - Operation-level vs field-level access
  - Access Filter (pre-query phase)
  - Field Visibility (post-query phase)
  - Silent failure convention
  - Includes "avoid" terms to prevent alternative naming

- **docs/adr/0001-access-control-is-a-two-phase-read.md** (new): Architecture Decision Record explaining why reads cannot be collapsed into a single access control phase:
  - Field-level access functions depend on fetched row contents
  - Virtual fields are only computable post-query
  - Documents the different return contracts between phases (boolean|filter vs boolean-only)
  - Notes that field-level access is evaluated by a single shared function across both read and write paths

## Purpose

These documents serve as reference material for developers working with the access control system and prevent future optimization attempts that would be impossible to implement due to architectural constraints.

https://claude.ai/code/session_011UAbJCYBJiM31UUYbXiLzP