### PR TITLE
ci: cache Playwright browsers, turbo builds, and Next.js build

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -1,0 +1,29 @@
+name: 'Install Playwright'
+description: 'Install Playwright chromium with browser binary caching keyed on the resolved Playwright version'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve Playwright version
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+    # Cache miss: download chromium and install its system dependencies.
+    - name: Install Playwright chromium (with deps)
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm exec playwright install --with-deps chromium
+
+    # Cache hit: browser binaries are restored, only ensure system libs are present.
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: pnpm exec playwright install-deps chromium

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}
 
     # Cache miss: download chromium and install its system dependencies.
     - name: Install Playwright chromium (with deps)

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,3 +32,9 @@ runs:
     - name: Install Turbo
       shell: bash
       run: pnpm add -g turbo
+
+    # Back Turbo's remote cache with the GitHub Actions cache (no secrets required).
+    # Sets TURBO_API/TURBO_TOKEN/TURBO_TEAM env for subsequent turbo commands so
+    # build outputs are restored across runs and shared between the test and e2e jobs.
+    - name: Setup Turbo remote cache
+      uses: rharkor/caching-for-turbo@v2.4.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,14 +72,25 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build packages
-        run: |
-          pnpm --filter @opensaas/stack-core build
-          pnpm --filter @opensaas/stack-auth build
-          pnpm --filter @opensaas/stack-ui build
-          pnpm --filter @opensaas/stack-cli build
+        run: >
+          turbo run build
+          --filter=@opensaas/stack-core
+          --filter=@opensaas/stack-auth
+          --filter=@opensaas/stack-ui
+          --filter=@opensaas/stack-cli
 
       - name: Install Playwright browsers
         uses: ./.github/actions/playwright
+
+      # Cache the starter-auth Next.js build that Playwright's webServer compiles,
+      # so the production build is incremental instead of a full ~3 min build each run.
+      - name: Cache Next.js build
+        uses: actions/cache@v5
+        with:
+          path: examples/starter-auth/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('examples/starter-auth/**/*.{js,jsx,ts,tsx}') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel any in-progress run for the same PR/branch when a new push arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,7 @@ jobs:
           DATABASE_URL: 'file:./dev.db'
 
       - name: Install Playwright browsers
-        working-directory: ./packages/ui
-        run: pnpm exec playwright install --with-deps chromium
+        uses: ./.github/actions/playwright
 
       - name: Run browser tests with coverage
         working-directory: ./packages/ui
@@ -80,7 +79,7 @@ jobs:
           pnpm --filter @opensaas/stack-cli build
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        uses: ./.github/actions/playwright
 
       - name: Run E2E tests
         run: pnpm test:e2e


### PR DESCRIPTION
## Summary

Speeds up the `Test` workflow by caching the expensive, repeated work in the `test` and `e2e` jobs. The jobs stay separate and parallel (fast feedback); the duplication is removed via caching rather than serialization.

### Playwright browsers (fixes #398)
Both jobs re-downloaded chromium (~167 MiB) every run. Added a reusable composite action `.github/actions/playwright`:
- Resolves the installed Playwright version (`pnpm exec playwright --version`).
- Caches `~/.cache/ms-playwright` keyed on `runner.os` + `runner.arch` + Playwright version (invalidates on upgrade).
- Downloads chromium `--with-deps` only on a cache miss; on a hit, runs only `playwright install-deps chromium` to ensure system libs.

### Turbo build cache
Package builds were recompiled every run, and the `e2e` job built with raw `pnpm --filter … build` (couldn't share anything):
- Added `rharkor/caching-for-turbo` to the shared setup action — backs Turbo's remote cache with the GitHub Actions cache (no secrets), shared across runs and between jobs.
- Switched the `e2e` build to `turbo run build --filter=…` so it actually hits that cache.

### Next.js build cache
Playwright's `webServer` does a full ~3 min production build of `examples/starter-auth` on every e2e run:
- Cache `examples/starter-auth/.next/cache` keyed on lockfile + app sources so the Next build is incremental.

## Notes
- CI-infrastructure-only change (Actions YAML / composite actions); no package code changed, so no changeset and no unit tests to add.
- Job layout deliberately kept parallel (not merged) — see discussion; the chromium/turbo/Next caches remove the duplicated work without giving up wall-clock time.

## Test plan
- [x] YAML validated, `prettier` clean
- [ ] CI green: chromium restored from cache on cache hit (no re-download)
- [ ] Turbo build cache hits on subsequent runs (no full package rebuild)
- [ ] Next.js build is incremental in e2e
- [ ] Browser tests (`test:browser:coverage`) and E2E tests (`test:e2e`) still pass

Closes #398