### PR TITLE
Fix docs: use canonical authPlugin()/ragPlugin() pattern

### DIFF
--- a/.changeset/lazy-pandas-greet.md
+++ b/.changeset/lazy-pandas-greet.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-auth': patch
+'@opensaas/stack-rag': patch
+'@opensaas/stack-cli': patch
+---
+
+Fix docs to use the canonical `authPlugin()`/`ragPlugin()` config pattern instead of the non-existent `withAuth()`/`authConfig()`/`withRAG()`/`ragConfig()` wrappers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,7 +532,7 @@ The stack provides optional Better-auth integration through `@opensaas/stack-aut
 
 **Key files:**
 
-- `packages/auth/src/config/index.ts` - Config wrapper `withAuth()` and `authConfig()`
+- `packages/auth/src/config/plugin.ts` - `authPlugin()`, the auth configuration entry point
 - `packages/auth/src/lists/index.ts` - Auto-generated auth lists (User, Session, Account, Verification)
 - `packages/auth/src/server/index.ts` - Better-auth server setup
 - `packages/auth/src/client/index.ts` - Client-side auth hooks
@@ -540,12 +540,11 @@ The stack provides optional Better-auth integration through `@opensaas/stack-aut
 
 **How it works:**
 
-1. `withAuth()` wraps your config and merges in auth lists (User, Session, Account, Verification)
-2. `authConfig()` configures Better-auth plugins and session fields
-3. Generator creates Prisma schema with auth tables
-4. Better-auth handles OAuth flow and session management
-5. Context automatically includes session in all access control functions
-6. Session fields are configurable (e.g., `['userId', 'email', 'name', 'role']`)
+1. `authPlugin()` is added to the config's `plugins` array and merges in auth lists (User, Session, Account, Verification) and configures Better-auth plugins and session fields
+2. Generator creates Prisma schema with auth tables
+3. Better-auth handles OAuth flow and session management
+4. Context automatically includes session in all access control functions
+5. Session fields are configurable (e.g., `['userId', 'email', 'name', 'role']`)
 
 **See:** `packages/auth/CLAUDE.md` for detailed patterns and `examples/auth-demo` for usage.
 

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -13,10 +13,9 @@ Adds complete authentication to OpenSaas Stack apps with minimal configuration. 
 
 ## Key Files & Exports
 
-### Config (`src/config/index.ts`)
+### Config (`src/config/plugin.ts`)
 
-- `withAuth(config, authConfig)` - Wraps OpenSaas config, merges auth lists
-- `authConfig({ ... })` - Configures Better-auth plugins and session
+- `authPlugin({ ... })` - Plugin added to a config's `plugins` array; merges auth lists, configures Better-auth plugins and session. This is the only configuration entry point.
 
 ### Lists (`src/lists/index.ts`)
 
@@ -53,13 +52,13 @@ Pre-built forms (client components):
 
 ### Config Merging
 
-`withAuth()` merges auth lists into your config:
+`authPlugin()` merges auth lists into your config:
 
 ```typescript
-withAuth(
-  config({ lists: { Post: list({...}) } }),
-  authConfig({ emailAndPassword: { enabled: true } })
-)
+config({
+  lists: { Post: list({...}) },
+  plugins: [authPlugin({ emailAndPassword: { enabled: true } })],
+})
 // Result: { lists: { User, Session, Account, Verification, Post } }
 ```
 
@@ -78,7 +77,7 @@ const context = createContext(config, prisma, session)
 Control which User fields appear in session:
 
 ```typescript
-authConfig({ sessionFields: ['userId', 'email', 'name', 'role'] })
+authPlugin({ sessionFields: ['userId', 'email', 'name', 'role'] })
 // Access in access control:
 access: {
   operation: {
@@ -110,7 +109,7 @@ declare module '@opensaas/stack-core' {
 **Step 2: Ensure fields match your sessionFields configuration**
 
 ```typescript
-authConfig({
+authPlugin({
   sessionFields: ['userId', 'email', 'name', 'role'],
   extendUserList: {
     fields: {
@@ -153,7 +152,7 @@ if (context.session?.email) {
 Add custom fields to User:
 
 ```typescript
-authConfig({
+authPlugin({
   extendUserList: {
     fields: {
       role: select({ options: [{ label: 'User', value: 'user' }] }),
@@ -196,10 +195,11 @@ export const auth = createAuth(config, rawOpensaasContext)
 
 ```typescript
 // 1. Config
-export default withAuth(
-  config({ db: {...}, lists: {...} }),
-  authConfig({ emailAndPassword: { enabled: true } })
-)
+export default config({
+  db: {...},
+  lists: {...},
+  plugins: [authPlugin({ emailAndPassword: { enabled: true } })],
+})
 
 // 2. Server (lib/auth.ts)
 export const auth = createAuth(config)
@@ -235,7 +235,7 @@ Post: list({
 ### OAuth Providers
 
 ```typescript
-authConfig({
+authPlugin({
   socialProviders: {
     github: {
       clientId: process.env.GITHUB_CLIENT_ID!,
@@ -253,7 +253,7 @@ authConfig({
 Session type is inferred from `sessionFields`:
 
 ```typescript
-authConfig({ sessionFields: ['userId', 'email', 'role'] })
+authPlugin({ sessionFields: ['userId', 'email', 'role'] })
 // session: { userId: string, email: string, role: string } | null
 ```
 

--- a/packages/auth/INTEGRATION_SUMMARY.md
+++ b/packages/auth/INTEGRATION_SUMMARY.md
@@ -11,8 +11,7 @@ This document summarizes the complete better-auth integration for the OpenSaas S
 **Exports:**
 
 - **Main** (`@opensaas/stack-auth`):
-  - `withAuth()` - Config wrapper that adds auth lists
-  - `authConfig()` - Auth configuration builder
+  - `authPlugin()` - Plugin added to `config({ plugins: [...] })` that adds auth lists and configures Better-auth
   - `getAuthLists()` - Get all auth list definitions
 
 - **Server** (`@opensaas/stack-auth/server`):
@@ -112,20 +111,21 @@ A complete working example showing:
 
 ```typescript
 // opensaas.config.ts
-import { withAuth, authConfig } from '@opensaas/stack-auth'
+import { config } from '@opensaas/stack-core'
+import { authPlugin } from '@opensaas/stack-auth'
 
-export default withAuth(
-  config({
-    db: { provider: 'sqlite', url: 'file:./dev.db' },
-    lists: {
-      /* your custom lists */
-    },
-  }),
-  authConfig({
-    emailAndPassword: { enabled: true },
-    sessionFields: ['userId', 'email', 'name'],
-  }),
-)
+export default config({
+  db: { provider: 'sqlite', url: 'file:./dev.db' },
+  lists: {
+    /* your custom lists */
+  },
+  plugins: [
+    authPlugin({
+      emailAndPassword: { enabled: true },
+      sessionFields: ['userId', 'email', 'name'],
+    }),
+  ],
+})
 ```
 
 ### Step 2: Generate
@@ -194,7 +194,7 @@ No manual User model, no manual session handling, no manual auth routes. Everyth
 ### 2. Type-Safe Sessions
 
 ```typescript
-authConfig({
+authPlugin({
   sessionFields: ['userId', 'email', 'name', 'role'],
 })
 
@@ -205,7 +205,7 @@ authConfig({
 ### 3. Extensible User Model
 
 ```typescript
-authConfig({
+authPlugin({
   extendUserList: {
     fields: {
       role: select({ options: [...] }),
@@ -236,7 +236,7 @@ All forms accept custom props and callbacks:
 Configure what you need:
 
 ```typescript
-authConfig({
+authPlugin({
   emailAndPassword: { enabled: true },
   emailVerification: { enabled: true },
   passwordReset: { enabled: true },
@@ -325,7 +325,8 @@ Potential additions:
 packages/auth/
 ├── src/
 │   ├── config/
-│   │   ├── index.ts        # withAuth(), authConfig()
+│   │   ├── index.ts        # normalizeAuthConfig()
+│   │   ├── plugin.ts       # authPlugin()
 │   │   └── types.ts        # Auth config types
 │   ├── lists/
 │   │   └── index.ts        # User, Session, Account, Verification
@@ -366,7 +367,7 @@ Better-auth supports cookie caching to reduce database queries:
 
 ```typescript
 // Future enhancement
-authConfig({
+authPlugin({
   session: {
     cookieCaching: true, // Validate at cookie level
   },

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -23,30 +23,30 @@ pnpm add @opensaas/stack-auth better-auth
 
 ### 1. Update Your Config
 
-Wrap your OpenSaas config with `withAuth()`:
+Add `authPlugin()` to your config's `plugins` array:
 
 ```typescript
 // opensaas.config.ts
 import { config } from '@opensaas/stack-core'
-import { withAuth, authConfig } from '@opensaas/stack-auth'
+import { authPlugin } from '@opensaas/stack-auth'
 
-export default withAuth(
-  config({
-    db: {
-      provider: 'sqlite',
-      url: process.env.DATABASE_URL || 'file:./dev.db',
-    },
-    lists: {
-      // Your custom lists here
-    },
-  }),
-  authConfig({
-    emailAndPassword: { enabled: true },
-    emailVerification: { enabled: true },
-    passwordReset: { enabled: true },
-    sessionFields: ['userId', 'email', 'name'],
-  }),
-)
+export default config({
+  db: {
+    provider: 'sqlite',
+    url: process.env.DATABASE_URL || 'file:./dev.db',
+  },
+  lists: {
+    // Your custom lists here
+  },
+  plugins: [
+    authPlugin({
+      emailAndPassword: { enabled: true },
+      emailVerification: { enabled: true },
+      passwordReset: { enabled: true },
+      sessionFields: ['userId', 'email', 'name'],
+    }),
+  ],
+})
 ```
 
 ### 2. Generate Schema and Push to Database
@@ -112,32 +112,33 @@ Sessions are now automatically available in your access control functions:
 
 ```typescript
 // opensaas.config.ts
-import { withAuth, authConfig } from '@opensaas/stack-auth'
+import { config } from '@opensaas/stack-core'
+import { authPlugin } from '@opensaas/stack-auth'
 
-export default withAuth(
-  config({
-    lists: {
-      Post: list({
-        fields: { title: text(), content: text() },
-        access: {
-          operation: {
-            // Session is automatically populated from better-auth
-            create: ({ session }) => !!session,
-            update: ({ session, item }) => {
-              if (!session) return false
-              return { authorId: { equals: session.userId } }
-            },
+export default config({
+  lists: {
+    Post: list({
+      fields: { title: text(), content: text() },
+      access: {
+        operation: {
+          // Session is automatically populated from better-auth
+          create: ({ session }) => !!session,
+          update: ({ session, item }) => {
+            if (!session) return false
+            return { authorId: { equals: session.userId } }
           },
         },
-      }),
-    },
-  }),
-  authConfig({
-    emailAndPassword: { enabled: true },
-    // Session will contain: { userId, email, name }
-    sessionFields: ['userId', 'email', 'name'],
-  }),
-)
+      },
+    }),
+  },
+  plugins: [
+    authPlugin({
+      emailAndPassword: { enabled: true },
+      // Session will contain: { userId, email, name }
+      sessionFields: ['userId', 'email', 'name'],
+    }),
+  ],
+})
 ```
 
 ## Configuration
@@ -145,7 +146,7 @@ export default withAuth(
 ### Auth Config Options
 
 ```typescript
-authConfig({
+authPlugin({
   // Email/password authentication
   emailAndPassword: {
     enabled: true,
@@ -248,7 +249,7 @@ import { authClient } from '@/lib/auth-client'
 
 ## Auto-Generated Lists
 
-The following lists are automatically created when you use `withAuth()`:
+The following lists are automatically created when you use `authPlugin()`:
 
 ### User
 
@@ -322,7 +323,7 @@ The following lists are automatically created when you use `withAuth()`:
 Add custom fields to the User model:
 
 ```typescript
-authConfig({
+authPlugin({
   extendUserList: {
     fields: {
       role: select({
@@ -353,7 +354,7 @@ authConfig({
 Control which user fields are included in the session object:
 
 ```typescript
-authConfig({
+authPlugin({
   sessionFields: ['userId', 'email', 'name', 'role'],
 })
 
@@ -434,7 +435,7 @@ See `examples/auth-demo` for a complete working example.
 
 ## How It Works
 
-1. **withAuth()** merges auth lists (User, Session, Account, Verification) with your config
+1. **authPlugin()** merges auth lists (User, Session, Account, Verification) with your config
 2. **Generator** creates Prisma schema with all auth tables
 3. **Session Provider** uses better-auth to get current session
 4. **Context** includes session automatically in all access control functions

--- a/packages/auth/src/lists/index.ts
+++ b/packages/auth/src/lists/index.ts
@@ -240,7 +240,7 @@ export function createVerificationList(): ListConfig<any> {
 
 /**
  * Get all auth lists required by better-auth
- * This is the main export used by withAuth()
+ * This is the main export used by authPlugin()
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function getAuthLists(userConfig?: ExtendUserListConfig): Record<string, ListConfig<any>> {

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -283,7 +283,7 @@ export function convertTableToList(
 
 /**
  * Convert all Better Auth tables to OpenSaaS list configs
- * This is called by withAuth() to generate lists from Better Auth + plugins
+ * This is called by authPlugin() to generate lists from Better Auth + plugins
  */
 export function convertBetterAuthSchema(
   tables: Record<string, BetterAuthTableSchema>,

--- a/packages/cli/src/mcp/lib/documentation-provider.ts
+++ b/packages/cli/src/mcp/lib/documentation-provider.ts
@@ -295,48 +295,46 @@ For ${query}, you can also check:
         description: 'A blog application with user authentication and post management',
         code: `import { config, list } from '@opensaas/stack-core'
 import { text, relationship, timestamp, select } from '@opensaas/stack-core/fields'
-import { withAuth, authConfig } from '@opensaas/stack-auth'
+import { authPlugin } from '@opensaas/stack-auth'
 
 const isAuthor = ({ session, item }) =>
   session?.userId === item?.authorId
 
-export default withAuth(
-  config({
-    db: {
-      provider: 'sqlite',
-      url: 'file:./dev.db',
-      prismaClientConstructor: (PrismaClient) => {
-        // ... adapter setup
+export default config({
+  db: {
+    provider: 'sqlite',
+    url: 'file:./dev.db',
+    prismaClientConstructor: (PrismaClient) => {
+      // ... adapter setup
+    },
+  },
+  lists: {
+    Post: list({
+      fields: {
+        title: text({ validation: { isRequired: true } }),
+        content: text({ ui: { displayMode: 'textarea' } }),
+        status: select({
+          options: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' },
+          ],
+          defaultValue: 'draft',
+        }),
+        author: relationship({ ref: 'User.posts' }),
+        publishedAt: timestamp(),
       },
-    },
-    lists: {
-      Post: list({
-        fields: {
-          title: text({ validation: { isRequired: true } }),
-          content: text({ ui: { displayMode: 'textarea' } }),
-          status: select({
-            options: [
-              { label: 'Draft', value: 'draft' },
-              { label: 'Published', value: 'published' },
-            ],
-            defaultValue: 'draft',
-          }),
-          author: relationship({ ref: 'User.posts' }),
-          publishedAt: timestamp(),
+      access: {
+        operation: {
+          query: () => true,
+          create: ({ session }) => !!session,
+          update: isAuthor,
+          delete: isAuthor,
         },
-        access: {
-          operation: {
-            query: () => true,
-            create: ({ session }) => !!session,
-            update: isAuthor,
-            delete: isAuthor,
-          },
-        },
-      }),
-    },
-  }),
-  authConfig({ emailAndPassword: { enabled: true } })
-)`,
+      },
+    }),
+  },
+  plugins: [authPlugin({ emailAndPassword: { enabled: true } })],
+})`,
         notes:
           'This example uses the auth plugin for user management. The `isAuthor` helper restricts updates to the post creator.',
         sourcePath: 'examples/auth-demo/opensaas.config.ts',

--- a/packages/rag/CLAUDE.md
+++ b/packages/rag/CLAUDE.md
@@ -20,7 +20,7 @@ Adds vector embeddings and semantic search to OpenSaas Stack apps with minimal c
 ```
 packages/rag/
 ├── src/
-│   ├── config/         # withRAG(), ragConfig()
+│   ├── config/         # ragPlugin(), provider & storage helpers
 │   ├── fields/         # embedding() field type
 │   ├── providers/      # OpenAI, Ollama embedding providers
 │   ├── storage/        # pgvector, sqlite-vss, JSON backends
@@ -32,8 +32,7 @@ packages/rag/
 
 ### Main exports (`@opensaas/stack-rag`)
 
-- `withRAG(config, ragConfig)` - Wrap OpenSaas config with RAG integration
-- `ragConfig({ ... })` - RAG configuration builder
+- `ragPlugin({ ... })` - Plugin added to `config({ plugins: [...] })` that wires RAG into your config
 - `openaiEmbeddings({ ... })` - OpenAI provider config helper
 - `ollamaEmbeddings({ ... })` - Ollama provider config helper
 - `pgvectorStorage({ ... })` - pgvector backend config helper
@@ -78,76 +77,79 @@ packages/rag/
 // opensaas.config.ts
 import { config, list } from '@opensaas/stack-core'
 import { text } from '@opensaas/stack-core/fields'
-import { withRAG, ragConfig, openaiEmbeddings, pgvectorStorage } from '@opensaas/stack-rag'
+import { ragPlugin, openaiEmbeddings, pgvectorStorage } from '@opensaas/stack-rag'
 import { embedding } from '@opensaas/stack-rag/fields'
 
-export default withRAG(
-  config({
-    db: {
-      provider: 'postgresql',
-      url: process.env.DATABASE_URL!,
-    },
-    lists: {
-      Article: list({
-        fields: {
-          title: text({ validation: { isRequired: true } }),
-          content: text({ validation: { isRequired: true } }),
-          contentEmbedding: embedding({
-            sourceField: 'content',
-            provider: 'openai',
-            dimensions: 1536,
-            autoGenerate: true,
-          }),
-        },
-      }),
-    },
-  }),
-  ragConfig({
-    provider: openaiEmbeddings({
-      apiKey: process.env.OPENAI_API_KEY!,
-      model: 'text-embedding-3-small',
+export default config({
+  db: {
+    provider: 'postgresql',
+    url: process.env.DATABASE_URL!,
+  },
+  lists: {
+    Article: list({
+      fields: {
+        title: text({ validation: { isRequired: true } }),
+        content: text({ validation: { isRequired: true } }),
+        contentEmbedding: embedding({
+          sourceField: 'content',
+          provider: 'openai',
+          dimensions: 1536,
+          autoGenerate: true,
+        }),
+      },
     }),
-    storage: pgvectorStorage({ distanceFunction: 'cosine' }),
-  }),
-)
+  },
+  plugins: [
+    ragPlugin({
+      provider: openaiEmbeddings({
+        apiKey: process.env.OPENAI_API_KEY!,
+        model: 'text-embedding-3-small',
+      }),
+      storage: pgvectorStorage({ distanceFunction: 'cosine' }),
+    }),
+  ],
+})
 ```
 
 ### Local Development with Ollama
 
 ```typescript
 // opensaas.config.ts
-import { withRAG, ragConfig, ollamaEmbeddings, jsonStorage } from '@opensaas/stack-rag'
+import { config, list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { ragPlugin, ollamaEmbeddings, jsonStorage } from '@opensaas/stack-rag'
+import { embedding } from '@opensaas/stack-rag/fields'
 
-export default withRAG(
-  config({
-    db: { provider: 'sqlite', url: 'file:./dev.db' },
-    lists: {
-      Document: list({
-        fields: {
-          text: text(),
-          embedding: embedding({
-            sourceField: 'text',
-            provider: 'ollama',
-            autoGenerate: true,
-          }),
-        },
-      }),
-    },
-  }),
-  ragConfig({
-    provider: ollamaEmbeddings({
-      baseURL: 'http://localhost:11434',
-      model: 'nomic-embed-text',
+export default config({
+  db: { provider: 'sqlite', url: 'file:./dev.db' },
+  lists: {
+    Document: list({
+      fields: {
+        text: text(),
+        embedding: embedding({
+          sourceField: 'text',
+          provider: 'ollama',
+          autoGenerate: true,
+        }),
+      },
     }),
-    storage: jsonStorage(), // Good for development, no DB extensions needed
-  }),
-)
+  },
+  plugins: [
+    ragPlugin({
+      provider: ollamaEmbeddings({
+        baseURL: 'http://localhost:11434',
+        model: 'nomic-embed-text',
+      }),
+      storage: jsonStorage(), // Good for development, no DB extensions needed
+    }),
+  ],
+})
 ```
 
 ### Multiple Providers
 
 ```typescript
-ragConfig({
+ragPlugin({
   providers: {
     openai: openaiEmbeddings({
       apiKey: process.env.OPENAI_API_KEY!,
@@ -245,33 +247,34 @@ When RAG is enabled with MCP, semantic search tools are automatically generated:
 
 ```typescript
 // opensaas.config.ts
-import { withAuth, authConfig } from '@opensaas/stack-auth'
-import { withRAG, ragConfig } from '@opensaas/stack-rag'
+import { config, list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { authPlugin } from '@opensaas/stack-auth'
+import { ragPlugin, openaiEmbeddings } from '@opensaas/stack-rag'
+import { embedding } from '@opensaas/stack-rag/fields'
 
-export default withRAG(
-  withAuth(
-    config({
-      db: { provider: 'postgresql', url: process.env.DATABASE_URL! },
-      mcp: {
-        enabled: true,
-        auth: { type: 'better-auth', loginPage: '/sign-in' },
-      },
-      lists: {
-        Article: list({
-          fields: {
-            content: text(),
-            contentEmbedding: embedding({ sourceField: 'content' }),
-          },
-        }),
+export default config({
+  db: { provider: 'postgresql', url: process.env.DATABASE_URL! },
+  mcp: {
+    enabled: true,
+    auth: { type: 'better-auth', loginPage: '/sign-in' },
+  },
+  lists: {
+    Article: list({
+      fields: {
+        content: text(),
+        contentEmbedding: embedding({ sourceField: 'content' }),
       },
     }),
-    authConfig({ emailAndPassword: { enabled: true } }),
-  ),
-  ragConfig({
-    provider: openaiEmbeddings({ apiKey: process.env.OPENAI_API_KEY! }),
-    enableMcpTools: true, // Auto-generates semantic_search_article tool
-  }),
-)
+  },
+  plugins: [
+    authPlugin({ emailAndPassword: { enabled: true } }),
+    ragPlugin({
+      provider: openaiEmbeddings({ apiKey: process.env.OPENAI_API_KEY! }),
+      enableMcpTools: true, // Auto-generates semantic_search_article tool
+    }),
+  ],
+})
 ```
 
 AI assistants can then use:
@@ -290,7 +293,7 @@ AI assistants can then use:
 
 ### Automatic Embedding Generation
 
-The `withRAG()` wrapper injects hooks into fields with `sourceField` set:
+The `ragPlugin()` injects hooks into fields with `sourceField` set:
 
 ```typescript
 // User config
@@ -299,7 +302,7 @@ contentEmbedding: embedding({
   autoGenerate: true
 })
 
-// withRAG() automatically adds:
+// ragPlugin() automatically adds:
 contentEmbedding: embedding({
   hooks: {
     afterOperation: async ({ operation, value, item, context }) => {
@@ -525,7 +528,7 @@ describe('OpenAIEmbeddingProvider', () => {
 
 1. Install package: `pnpm add @opensaas/stack-rag`
 2. Install provider: `pnpm add openai` (for OpenAI)
-3. Wrap config with `withRAG()`
+3. Add `ragPlugin()` to your config's `plugins` array
 4. Add `embedding()` fields to lists
 5. Run `pnpm generate` and `pnpm db:push`
 6. Embeddings will be generated automatically on create/update

--- a/specs/rag-integration.md
+++ b/specs/rag-integration.md
@@ -319,7 +319,7 @@ const results = await storage.search('Article', 'contentEmbedding', queryVector,
 ### Local Development with Ollama
 
 ```typescript
-ragConfig({
+ragPlugin({
   provider: ollamaEmbeddings({
     baseURL: 'http://localhost:11434',
     model: 'nomic-embed-text',
@@ -416,7 +416,7 @@ No setup needed. Embeddings stored as JSON, similarity computed in JavaScript. G
 ### For Existing Apps
 
 1. Install package: `pnpm add @opensaas/stack-rag openai`
-2. Wrap config with `withRAG()`
+2. Add `ragPlugin()` to your config's `plugins` array
 3. Add `embedding()` fields
 4. Run `pnpm generate && pnpm db:push`
 5. Embeddings auto-generated on create/update


### PR DESCRIPTION
## Summary

Updates documentation and examples across the auth and RAG packages to use the canonical `authPlugin()` and `ragPlugin()` configuration pattern instead of the non-existent `withAuth()`/`authConfig()` and `withRAG()`/`ragConfig()` wrapper functions.

## Key Changes

- **Auth Package Documentation**: Updated all examples in `packages/auth/README.md`, `packages/auth/INTEGRATION_SUMMARY.md`, and `packages/auth/CLAUDE.md` to show `authPlugin()` added to the `plugins` array instead of `withAuth()` wrapper
- **RAG Package Documentation**: Updated all examples in `packages/rag/CLAUDE.md` to show `ragPlugin()` added to the `plugins` array instead of `withRAG()` wrapper
- **CLI Documentation Provider**: Fixed code examples in `packages/cli/src/mcp/lib/documentation-provider.ts` to use the plugin pattern
- **Specs**: Updated `specs/rag-integration.md` to use `ragPlugin()` instead of `ragConfig()`
- **Root Documentation**: Updated `CLAUDE.md` to reference the correct plugin entry point
- **Code Comments**: Updated internal comments in `packages/auth/src/lists/index.ts` and `packages/auth/src/server/schema-converter.ts` to reference `authPlugin()` instead of `withAuth()`
- **Changeset**: Added changeset documenting the documentation fixes

## Implementation Details

The changes reflect the actual implementation where:
- `authPlugin()` is the single configuration entry point (not separate `withAuth()` and `authConfig()`)
- `ragPlugin()` is the single configuration entry point (not separate `withRAG()` and `ragConfig()`)
- Both plugins are added to the `config({ plugins: [...] })` array
- This provides a cleaner, more consistent API aligned with how the stack's plugin system actually works

https://claude.ai/code/session_01PtBStujECNt5SjQpX87Zsx