### PR TITLE
refactor(core): move field-config types to the /fields entry point

### DIFF
--- a/.changeset/curvy-melons-rule.md
+++ b/.changeset/curvy-melons-rule.md
@@ -1,0 +1,24 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Move field-config types to `@opensaas/stack-core/fields`, beside their builders
+
+The concrete field-config types (`TextField`, `IntegerField`, `CheckboxField`,
+`TimestampField`, `PasswordField`, `SelectField`, `RelationshipField`,
+`JsonField`, `VirtualField`, plus `DecimalField`, `CalendarDayField`, and
+`PrismaRelationResult`) now live on the `/fields` entry point alongside the
+builders that produce them, instead of the root barrel. One concept, one import
+path:
+
+```typescript
+import { text, decimal } from '@opensaas/stack-core/fields'
+import type { TextField, DecimalField } from '@opensaas/stack-core/fields'
+```
+
+`DecimalField` and `CalendarDayField` were previously defined but exported from
+nowhere — they are now public, and the CLI's lists generator maps `decimal`/
+`calendarDay` fields to their precise types instead of the generic
+`BaseFieldConfig` fallback. The umbrella `FieldConfig` stays on the root entry
+point and `BaseFieldConfig` stays on `/extend`.

--- a/packages/cli/src/generator/lists.test.ts
+++ b/packages/cli/src/generator/lists.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import { generateListsNamespace } from './lists.js'
 import type { OpenSaasConfig } from '@opensaas/stack-core'
-import { text, integer, relationship, checkbox } from '@opensaas/stack-core/fields'
+import {
+  text,
+  integer,
+  relationship,
+  checkbox,
+  decimal,
+  calendarDay,
+  select,
+  json,
+} from '@opensaas/stack-core/fields'
 
 describe('Lists Namespace Generator', () => {
   describe('generateListsNamespace', () => {
@@ -329,6 +338,65 @@ describe('Lists Namespace Generator', () => {
       // Verify the List type uses ListConfig with TypeInfo
       expect(lists).toContain(
         "export type Post = import('@opensaas/stack-core').ListConfig<Lists.Post.TypeInfo>",
+      )
+    })
+
+    it('emits built-in field-config types from the /fields entry point', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Thing: {
+            fields: {
+              name: text(),
+              count: integer(),
+              price: decimal(),
+              active: checkbox(),
+              date: calendarDay(),
+              status: select({ options: [{ label: 'A', value: 'a' }] }),
+              meta: json(),
+              owner: relationship({ ref: 'User' }),
+            },
+          },
+        },
+      }
+
+      const lists = generateListsNamespace(config)
+
+      // Each built-in field type resolves from /fields (not the root barrel),
+      // including decimal/calendarDay which were previously missing from the map.
+      expect(lists).toContain(
+        "name: import('@opensaas/stack-core/fields').TextField<Lists.Thing.TypeInfo>",
+      )
+      expect(lists).toContain(
+        "price: import('@opensaas/stack-core/fields').DecimalField<Lists.Thing.TypeInfo>",
+      )
+      expect(lists).toContain(
+        "date: import('@opensaas/stack-core/fields').CalendarDayField<Lists.Thing.TypeInfo>",
+      )
+      expect(lists).toContain(
+        "owner: import('@opensaas/stack-core/fields').RelationshipField<Lists.Thing.TypeInfo>",
+      )
+      // No built-in field should fall back to the generic BaseFieldConfig.
+      expect(lists).not.toContain('BaseFieldConfig')
+    })
+
+    it('falls back to BaseFieldConfig from /extend for unknown (plugin) field types', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Doc: {
+            fields: {
+              // A field type the generator does not map (e.g. a plugin field).
+              embedding: { type: 'embedding' } as OpenSaasConfig['lists'][string]['fields'][string],
+            },
+          },
+        },
+      }
+
+      const lists = generateListsNamespace(config)
+
+      expect(lists).toContain(
+        "embedding: import('@opensaas/stack-core/extend').BaseFieldConfig<Lists.Doc.TypeInfo>",
       )
     })
   })

--- a/packages/cli/src/generator/lists.ts
+++ b/packages/cli/src/generator/lists.ts
@@ -6,16 +6,18 @@ import * as path from 'path'
  * Map a field type string to the TypeScript field-config type and the
  * `@opensaas/stack-core` entry point it is exported from.
  *
- * Built-in field types live on the root entry point. Unknown field types
- * (e.g. those contributed by plugins) fall back to the generic
- * `BaseFieldConfig`, which is exported from the `/extend` authoring surface.
+ * Built-in field types and their config types live on the `/fields` entry
+ * point. Unknown field types (e.g. those contributed by plugins) fall back to
+ * the generic `BaseFieldConfig`, exported from the `/extend` authoring surface.
  */
 function getFieldTypeImport(fieldType: string): { module: string; typeName: string } {
   const typeMap: Record<string, string> = {
     text: 'TextField',
     integer: 'IntegerField',
+    decimal: 'DecimalField',
     checkbox: 'CheckboxField',
     timestamp: 'TimestampField',
+    calendarDay: 'CalendarDayField',
     password: 'PasswordField',
     select: 'SelectField',
     relationship: 'RelationshipField',
@@ -25,7 +27,7 @@ function getFieldTypeImport(fieldType: string): { module: string; typeName: stri
 
   const typeName = typeMap[fieldType]
   if (typeName) {
-    return { module: '@opensaas/stack-core', typeName }
+    return { module: '@opensaas/stack-core/fields', typeName }
   }
 
   return { module: '@opensaas/stack-core/extend', typeName: 'BaseFieldConfig' }

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -1,9 +1,5 @@
-import type {
-  OpenSaasConfig,
-  FieldConfig,
-  RelationshipField,
-  PrismaRelationResult,
-} from '@opensaas/stack-core'
+import type { OpenSaasConfig, FieldConfig } from '@opensaas/stack-core'
+import type { RelationshipField, PrismaRelationResult } from '@opensaas/stack-core/fields'
 import * as fs from 'fs'
 import * as path from 'path'
 

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -1,4 +1,5 @@
-import type { OpenSaasConfig, FieldConfig, RelationshipField } from '@opensaas/stack-core'
+import type { OpenSaasConfig, FieldConfig } from '@opensaas/stack-core'
+import type { RelationshipField } from '@opensaas/stack-core/fields'
 import * as fs from 'fs'
 import * as path from 'path'
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -10,8 +10,8 @@ The foundation of OpenSaas Stack. Defines the config DSL, executes access contro
 
 The package exposes a curated surface across several import paths. Use the narrowest one that fits:
 
-- **`@opensaas/stack-core`** (root) — the everyday consumer surface: `config`, `list`, `getContext`, the naming helpers (`getDbKey`, `getUrlKey`, `getListKeyFromUrl`), `ValidationError`, and the config/access types you annotate with (`OpenSaasConfig`, `ListConfig`, `FieldConfig`, `AccessControl`, `FieldAccess`, `Session`, `AccessContext`, `PrismaFilter`, `OperationAccess`, plus the field-config types).
-- **`@opensaas/stack-core/fields`** — field builder functions (`text()`, `integer()`, …).
+- **`@opensaas/stack-core`** (root) — the everyday consumer surface: `config`, `list`, `getContext`, the naming helpers (`getDbKey`, `getUrlKey`, `getListKeyFromUrl`), `ValidationError`, and the config/access types you annotate with (`OpenSaasConfig`, `ListConfig`, `FieldConfig`, `AccessControl`, `FieldAccess`, `Session`, `AccessContext`, `PrismaFilter`, `OperationAccess`).
+- **`@opensaas/stack-core/fields`** — field builder functions (`text()`, `integer()`, …) and their config types (`TextField`, `IntegerField`, `DecimalField`, `CalendarDayField`, …, plus `PrismaRelationResult`). The builders and the types they produce live together here.
 - **`@opensaas/stack-core/extend`** — authoring contracts: implement these to build a plugin (`Plugin`, `PluginContext`, `GeneratedFiles`) or a third-party field package (`BaseFieldConfig`, `TypeInfo`, `TypeDescriptor`).
 - **`@opensaas/stack-core/mcp`** — MCP runtime handlers.
 - **`@opensaas/stack-core/internal`** — `@internal` plumbing shared between the `@opensaas/*` packages and generated `.opensaas/` code. **No semver guarantees**; application code should never import from here.

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -17,6 +17,24 @@ import type {
 } from '../config/types.js'
 import { hashPassword, isHashedPassword, HashedPassword } from '../utils/password.js'
 
+// Field-config types live here, alongside the builders that produce them.
+// (The umbrella `FieldConfig` and authoring `BaseFieldConfig` stay on the root
+// and `/extend` entry points respectively.)
+export type {
+  TextField,
+  IntegerField,
+  DecimalField,
+  CheckboxField,
+  TimestampField,
+  CalendarDayField,
+  PasswordField,
+  SelectField,
+  RelationshipField,
+  JsonField,
+  VirtualField,
+  PrismaRelationResult,
+} from '../config/types.js'
+
 /**
  * Format field name for display in error messages
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,24 +11,10 @@
 // Config builders
 export { config, list } from './config/index.js'
 
-// Config + field types a consumer annotates with
-export type {
-  OpenSaasConfig,
-  ListConfig,
-  FieldConfig,
-  // Field config types (relocating to /fields in a later change)
-  TextField,
-  IntegerField,
-  CheckboxField,
-  TimestampField,
-  PasswordField,
-  SelectField,
-  RelationshipField,
-  JsonField,
-  VirtualField,
-  PrismaRelationResult,
-  OperationAccess,
-} from './config/index.js'
+// Config types a consumer annotates with.
+// Concrete field-config types (TextField, …) live on '@opensaas/stack-core/fields'
+// alongside their builders.
+export type { OpenSaasConfig, ListConfig, FieldConfig, OperationAccess } from './config/index.js'
 
 // Access control — the types a consumer writes against
 export type {


### PR DESCRIPTION
## Summary

Candidate 3 of the public-interface review: consolidate everything field-related onto one import path.

The field **builders** live on `@opensaas/stack-core/fields`, but their **config types** (`TextField`, `IntegerField`, …) were exported from the root barrel — the same concept reachable from two paths, with no way for a consumer to tell why. This moves the concrete field-config types to `/fields` so a builder and the type it produces sit together.

Follow-up to #414 and #415.

## Changes

- **core**: the concrete field-config types (`TextField`, `IntegerField`, `CheckboxField`, `TimestampField`, `PasswordField`, `SelectField`, `RelationshipField`, `JsonField`, `VirtualField`, plus `DecimalField`, `CalendarDayField`, and `PrismaRelationResult`) are re-exported from `src/fields` and removed from the root barrel. The umbrella `FieldConfig` stays at root; `BaseFieldConfig` stays on `/extend`.
- **Closes a latent gap**: `DecimalField` and `CalendarDayField` were defined in `config/types.ts` but exported from nowhere. They are now public on `/fields`, and the lists generator maps `decimal`/`calendarDay` to their precise types instead of the generic `BaseFieldConfig` fallback.
- **cli**: generator imports (`prisma.ts`, `types.ts`) and the `getFieldTypeImport` map repointed to `/fields`; `decimal`/`calendarDay` added to the map.
- **tests**: added lists-generator assertions that lock the `/fields` emission for built-in fields and the `/extend` `BaseFieldConfig` fallback for unknown plugin fields. This emission was previously **untested** — the exact blind spot that broke #415's first CI run.
- **docs**: `packages/core/CLAUDE.md` entry-point section updated.

## Consumer impact

```typescript
// before
import { text } from '@opensaas/stack-core/fields'
import type { TextField } from '@opensaas/stack-core'
// after — one path
import { text, type TextField } from '@opensaas/stack-core/fields'
```

## Versioning

`minor` on core + cli (package in active development; no compat shims).

## Verification

All package builds pass (0 TS errors). All suites green: core, cli (192, +2 new), auth, rag, storage, ui, storage-s3, storage-vercel. `manypkg`, `lint`, `format:check` clean. Blog + rag examples regenerate and typecheck clean (`calendarDay` now emits `CalendarDayField` from `/fields`).

https://claude.ai/code/session_01PtBStujECNt5SjQpX87Zsx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtBStujECNt5SjQpX87Zsx)_