### PR TITLE
fix(create-opensaas-app): scaffold a runnable .env so the first run works

### DIFF
--- a/.changeset/swift-pandas-greet.md
+++ b/.changeset/swift-pandas-greet.md
@@ -1,0 +1,9 @@
+---
+'create-opensaas-app': minor
+---
+
+Scaffolded projects now start with a runnable environment file, so `pnpm generate` and `pnpm db:push` work immediately with no manual `.env` setup.
+
+Previously the basic template shipped an empty `.env` and a PostgreSQL-defaulted `.env.example` even though its config uses SQLite, so the very first documented command failed with `PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL`. Now the basic (SQLite) template writes a canonical `.env` (`DATABASE_URL="file:./dev.db"`) plus a matching `.env.example`, and the `--with-auth` template seeds `.env` from its own `.env.example` so the Better-auth variables are preserved.
+
+The scaffolder's project-name validation, `package.json` version rewriting, and env generation are now pure, unit-tested helpers in `src/lib/`. The unimplemented `--template` flag has been removed so advertised flags match real behaviour.

--- a/examples/starter/.env.example
+++ b/examples/starter/.env.example
@@ -1,4 +1,5 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_blog?schema=public"
+# SQLite (default) — zero setup, great for local development
+DATABASE_URL="file:./dev.db"
 
-# For SQLite (easier for testing):
-# DATABASE_URL="file:./dev.db"
+# For PostgreSQL, set provider: 'postgresql' in opensaas.config.ts and use:
+# DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_starter?schema=public"

--- a/packages/create-opensaas-app/CLAUDE.md
+++ b/packages/create-opensaas-app/CLAUDE.md
@@ -144,13 +144,21 @@ npm create opensaas-app@latest my-app --with-auth   # Auth template
 
 After copying the template, the CLI customizes:
 
-1. **package.json**: Updates `name` field to project name
-2. **README.md**: Replaces first h1 with project name
+1. **package.json**: Updates `name` field to project name (`applyProjectName`)
+2. **README.md**: Replaces first h1 with project name (`rewriteReadmeHeading`)
+3. **`.env`**: Writes a **runnable** environment file so `pnpm generate` /
+   `pnpm db:push` work with no manual setup. The basic (SQLite) template gets a
+   canonical `.env` + `.env.example` from `generateEnvFiles` (default
+   `DATABASE_URL="file:./dev.db"`); the with-auth template seeds `.env` from its
+   own `.env.example` so the Better-auth variables are preserved.
+
+These transforms live in `src/lib/` (`project-name.ts`, `env.ts`,
+`package-json.ts`) as pure, unit-tested functions; `src/index.ts` is a thin
+orchestrator over them.
 
 **Files NOT customized** (kept as-is from template):
 
 - `opensaas.config.ts` - User will customize themselves
-- `.env` / `.env.example` - Template values are appropriate
 - All other files
 
 ## Excluded Files

--- a/packages/create-opensaas-app/package.json
+++ b/packages/create-opensaas-app/package.json
@@ -13,6 +13,8 @@
   "scripts": {
     "build": "tsc && pnpm copy-templates",
     "copy-templates": "node dist/copy-templates.js",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist templates"
   },
   "dependencies": {
@@ -25,7 +27,9 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.9.1",
     "@types/prompts": "^2.4.9",
-    "typescript": "^5.9.3"
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/create-opensaas-app/src/copy-templates.ts
+++ b/packages/create-opensaas-app/src/copy-templates.ts
@@ -2,6 +2,7 @@
 import fs from 'fs-extra'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { replaceWorkspaceVersions } from './lib/package-json.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageDir = path.join(__dirname, '..')
@@ -31,26 +32,8 @@ async function updatePackageJsonVersions(
   stackVersion: string,
 ): Promise<void> {
   const packageJson = await fs.readJSON(packageJsonPath)
-
-  // Update all @opensaas/* dependencies from "workspace" to actual version
-  if (packageJson.dependencies) {
-    for (const [name, version] of Object.entries(packageJson.dependencies)) {
-      if (name.startsWith('@opensaas/') && version === 'workspace:*') {
-        packageJson.dependencies[name] = `^${stackVersion}`
-      }
-    }
-  }
-
-  // Update devDependencies too
-  if (packageJson.devDependencies) {
-    for (const [name, version] of Object.entries(packageJson.devDependencies)) {
-      if (name.startsWith('@opensaas/') && version === 'workspace:*') {
-        packageJson.devDependencies[name] = `^${stackVersion}`
-      }
-    }
-  }
-
-  await fs.writeJSON(packageJsonPath, packageJson, { spaces: 2 })
+  const updated = replaceWorkspaceVersions(packageJson, stackVersion)
+  await fs.writeJSON(packageJsonPath, updated, { spaces: 2 })
 }
 
 async function copyTemplate(

--- a/packages/create-opensaas-app/src/index.ts
+++ b/packages/create-opensaas-app/src/index.ts
@@ -6,6 +6,9 @@ import { spawn } from 'child_process'
 import prompts from 'prompts'
 import chalk from 'chalk'
 import ora from 'ora'
+import { validateProjectName } from './lib/project-name.js'
+import { generateEnvFiles, type DbProvider } from './lib/env.js'
+import { applyProjectName, rewriteReadmeHeading } from './lib/package-json.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -23,7 +26,6 @@ async function main() {
   let projectName = args.find((arg) => !arg.startsWith('--'))
   const hasAuthFlag = args.includes('--with-auth')
   const hasAiFlag = args.includes('--with-ai')
-  const hasTemplateFlag = args.some((arg) => arg.startsWith('--template'))
 
   // Prompt for project name if not provided
   if (!projectName) {
@@ -33,11 +35,8 @@ async function main() {
       message: 'Project name:',
       initial: 'my-app',
       validate: (value) => {
-        if (!value) return 'Project name is required'
-        if (!/^[a-z0-9-]+$/.test(value)) {
-          return 'Project name must only contain lowercase letters, numbers, and hyphens'
-        }
-        return true
+        const result = validateProjectName(value)
+        return result.ok ? true : result.message
       },
     })
 
@@ -50,16 +49,19 @@ async function main() {
   }
 
   // Validate project name
-  if (!projectName || !/^[a-z0-9-]+$/.test(projectName)) {
-    console.error(
-      chalk.red('\n❌ Project name must only contain lowercase letters, numbers, and hyphens'),
-    )
+  const validation = validateProjectName(projectName)
+  if (!validation.ok) {
+    console.error(chalk.red(`\n❌ ${validation.message}`))
+    process.exit(1)
+  }
+  if (!projectName) {
+    // Unreachable: validateProjectName rejects empty names. Narrows the type.
     process.exit(1)
   }
 
-  // Prompt for auth if not specified via flags
+  // Prompt for auth if not specified via flag
   let withAuth = hasAuthFlag
-  if (!hasAuthFlag && !hasTemplateFlag) {
+  if (!hasAuthFlag) {
     const response = await prompts({
       type: 'confirm',
       name: 'withAuth',
@@ -130,17 +132,18 @@ async function createProject(options: TemplateOptions) {
     // Customize package.json
     const pkgPath = path.join(targetDir, 'package.json')
     const pkg = await fs.readJSON(pkgPath)
-    pkg.name = projectName
-    await fs.writeJSON(pkgPath, pkg, { spaces: 2 })
+    await fs.writeJSON(pkgPath, applyProjectName(pkg, projectName), { spaces: 2 })
 
     // Customize README
     const readmePath = path.join(targetDir, 'README.md')
     if (await fs.pathExists(readmePath)) {
-      let readme = await fs.readFile(readmePath, 'utf-8')
-      // Replace first h1 with project name
-      readme = readme.replace(/^# .+$/m, `# ${projectName}`)
-      await fs.writeFile(readmePath, readme)
+      const readme = await fs.readFile(readmePath, 'utf-8')
+      await fs.writeFile(readmePath, rewriteReadmeHeading(readme, projectName))
     }
+
+    // Write a runnable .env so `pnpm generate` / `pnpm db:push` work with no
+    // manual setup. Both starter templates use SQLite by default.
+    await writeEnvFile(targetDir, projectName, 'sqlite', withAuth)
 
     spinner.succeed(chalk.green('Project created!'))
 
@@ -174,6 +177,33 @@ async function createProject(options: TemplateOptions) {
     console.error(error)
     process.exit(1)
   }
+}
+
+/**
+ * Write a runnable `.env` into the scaffolded project.
+ *
+ * The basic template gets canonical, provider-aware env files. The auth
+ * template ships a complete `.env.example` (database + Better-auth variables),
+ * so we seed its `.env` from that example to preserve those extra variables
+ * while still guaranteeing a working `DATABASE_URL`.
+ */
+async function writeEnvFile(
+  targetDir: string,
+  projectName: string,
+  provider: DbProvider,
+  withAuth: boolean,
+): Promise<void> {
+  const envPath = path.join(targetDir, '.env')
+  const envExamplePath = path.join(targetDir, '.env.example')
+
+  if (withAuth && (await fs.pathExists(envExamplePath))) {
+    await fs.copy(envExamplePath, envPath, { overwrite: true })
+    return
+  }
+
+  const { env, envExample } = generateEnvFiles({ provider, projectName })
+  await fs.writeFile(envPath, env)
+  await fs.writeFile(envExamplePath, envExample)
 }
 
 async function installMCPServer(): Promise<boolean> {

--- a/packages/create-opensaas-app/src/lib/env.ts
+++ b/packages/create-opensaas-app/src/lib/env.ts
@@ -1,0 +1,52 @@
+/**
+ * Environment-file generation for scaffolded apps.
+ *
+ * The defining onboarding bug this module fixes: a freshly scaffolded SQLite
+ * project must ship a runnable `.env` so that `pnpm generate` / `pnpm db:push`
+ * succeed on the first try. Given a database provider it returns the canonical
+ * `.env` (written into the project) and `.env.example` (committed for
+ * reference). Pure and provider-parametrised so it is trivially testable, and
+ * so a SQLite project can never be handed a PostgreSQL connection string.
+ */
+
+export type DbProvider = 'sqlite' | 'postgresql'
+
+export interface EnvFiles {
+  /** Runnable env written to `.env` in the scaffolded project. */
+  env: string
+  /** Reference env committed to `.env.example`. */
+  envExample: string
+}
+
+/** SQLite needs no setup: a file the CLI/`db:push` creates locally. */
+const SQLITE_URL = 'file:./dev.db'
+
+/** Derive a safe Postgres database name from the project name. */
+function postgresUrl(projectName: string): string {
+  const dbName = projectName.replace(/-/g, '_')
+  return `postgresql://user:password@localhost:5432/${dbName}?schema=public`
+}
+
+export function generateEnvFiles(options: { provider: DbProvider; projectName: string }): EnvFiles {
+  const { provider, projectName } = options
+
+  if (provider === 'sqlite') {
+    const env = `# SQLite database — zero setup, created locally by \`pnpm db:push\`\nDATABASE_URL="${SQLITE_URL}"\n`
+    const envExample =
+      `# SQLite (default) — zero setup, great for local development\n` +
+      `DATABASE_URL="${SQLITE_URL}"\n` +
+      `\n` +
+      `# For PostgreSQL, set provider: 'postgresql' in opensaas.config.ts and use:\n` +
+      `# DATABASE_URL="${postgresUrl(projectName)}"\n`
+    return { env, envExample }
+  }
+
+  const url = postgresUrl(projectName)
+  const env = `DATABASE_URL="${url}"\n`
+  const envExample =
+    `DATABASE_URL="${url}"\n` +
+    `\n` +
+    `# For SQLite (zero setup, great for local development):\n` +
+    `# DATABASE_URL="${SQLITE_URL}"\n`
+  return { env, envExample }
+}

--- a/packages/create-opensaas-app/src/lib/package-json.ts
+++ b/packages/create-opensaas-app/src/lib/package-json.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure transforms applied to a scaffolded project's files.
+ *
+ * Extracted from the CLI orchestrator so each transform — naming the package,
+ * resolving workspace versions, retitling the README — can be unit-tested
+ * without touching the filesystem.
+ */
+
+export interface PackageJsonLike {
+  name?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  // Other fields are preserved untouched.
+  [key: string]: unknown
+}
+
+/** Set the project's package name without disturbing any other field. */
+export function applyProjectName(pkg: PackageJsonLike, projectName: string): PackageJsonLike {
+  return { ...pkg, name: projectName }
+}
+
+/**
+ * Replace `@opensaas/*` `workspace:*` ranges with a concrete published range.
+ * Runs at build time when templates are copied out of the monorepo, so the
+ * published templates never carry an unresolvable `workspace:*` specifier.
+ */
+export function replaceWorkspaceVersions(
+  pkg: PackageJsonLike,
+  stackVersion: string,
+): PackageJsonLike {
+  const result: PackageJsonLike = { ...pkg }
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const deps = result[field]
+    if (!deps) continue
+    const updated: Record<string, string> = { ...deps }
+    for (const [name, version] of Object.entries(updated)) {
+      if (name.startsWith('@opensaas/') && version === 'workspace:*') {
+        updated[name] = `^${stackVersion}`
+      }
+    }
+    result[field] = updated
+  }
+  return result
+}
+
+/** Replace the first Markdown H1 with the project name, leaving the rest. */
+export function rewriteReadmeHeading(readme: string, projectName: string): string {
+  return readme.replace(/^# .+$/m, `# ${projectName}`)
+}

--- a/packages/create-opensaas-app/src/lib/project-name.ts
+++ b/packages/create-opensaas-app/src/lib/project-name.ts
@@ -1,0 +1,25 @@
+/**
+ * Project-name validation for scaffolded apps.
+ *
+ * A deep module with a tiny interface: a name string in, a structured
+ * validity result out. Kept pure so it can be unit-tested in isolation and
+ * reused by both the interactive prompt and the non-interactive flag path.
+ */
+
+export type ProjectNameValidation = { ok: true } | { ok: false; message: string }
+
+/** Project names map directly to a directory and an npm package name. */
+const PROJECT_NAME_PATTERN = /^[a-z0-9-]+$/
+
+export function validateProjectName(name: string | undefined | null): ProjectNameValidation {
+  if (!name) {
+    return { ok: false, message: 'Project name is required' }
+  }
+  if (!PROJECT_NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      message: 'Project name must only contain lowercase letters, numbers, and hyphens',
+    }
+  }
+  return { ok: true }
+}

--- a/packages/create-opensaas-app/tests/env.test.ts
+++ b/packages/create-opensaas-app/tests/env.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { generateEnvFiles } from '../src/lib/env.js'
+
+describe('generateEnvFiles', () => {
+  describe('sqlite (the default, zero-setup path)', () => {
+    const { env, envExample } = generateEnvFiles({ provider: 'sqlite', projectName: 'my-app' })
+
+    it('writes a runnable SQLite DATABASE_URL', () => {
+      expect(env).toContain('DATABASE_URL="file:./dev.db"')
+    })
+
+    it('never hands a SQLite project a PostgreSQL connection string', () => {
+      // The reproduced onboarding blocker: a Postgres URL in a SQLite project
+      // makes `pnpm generate` fail with PrismaConfigEnvError. The active
+      // (uncommented) DATABASE_URL must be SQLite.
+      const activeLines = env.split('\n').filter((line) => !line.trimStart().startsWith('#'))
+      expect(activeLines.join('\n')).not.toContain('postgresql://')
+    })
+
+    it('keeps the PostgreSQL hint commented out in the example', () => {
+      expect(envExample).toContain('DATABASE_URL="file:./dev.db"')
+      expect(envExample).toContain('# DATABASE_URL="postgresql://')
+    })
+  })
+
+  describe('postgresql', () => {
+    const { env, envExample } = generateEnvFiles({ provider: 'postgresql', projectName: 'my-app' })
+
+    it('writes a PostgreSQL DATABASE_URL derived from the project name', () => {
+      expect(env).toContain('DATABASE_URL="postgresql://')
+      expect(env).toContain('localhost:5432/my_app?schema=public')
+    })
+
+    it('offers SQLite as a commented alternative in the example', () => {
+      expect(envExample).toContain('# DATABASE_URL="file:./dev.db"')
+    })
+  })
+
+  it('always ends files with a trailing newline', () => {
+    for (const provider of ['sqlite', 'postgresql'] as const) {
+      const { env, envExample } = generateEnvFiles({ provider, projectName: 'app' })
+      expect(env.endsWith('\n')).toBe(true)
+      expect(envExample.endsWith('\n')).toBe(true)
+    }
+  })
+})

--- a/packages/create-opensaas-app/tests/package-json.test.ts
+++ b/packages/create-opensaas-app/tests/package-json.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyProjectName,
+  replaceWorkspaceVersions,
+  rewriteReadmeHeading,
+} from '../src/lib/package-json.js'
+
+describe('applyProjectName', () => {
+  it('sets the name and preserves every other field', () => {
+    const pkg = { name: 'opensaas-starter-example', version: '0.1.0', scripts: { dev: 'next dev' } }
+    const result = applyProjectName(pkg, 'my-app')
+    expect(result.name).toBe('my-app')
+    expect(result.version).toBe('0.1.0')
+    expect(result.scripts).toEqual({ dev: 'next dev' })
+  })
+})
+
+describe('replaceWorkspaceVersions', () => {
+  it('rewrites @opensaas workspace ranges to the published version', () => {
+    const pkg = {
+      dependencies: {
+        '@opensaas/stack-core': 'workspace:*',
+        '@opensaas/stack-ui': 'workspace:*',
+        next: '^16.1.6',
+      },
+      devDependencies: { '@opensaas/stack-cli': 'workspace:*', typescript: '^5.9.3' },
+    }
+    const result = replaceWorkspaceVersions(pkg, '1.2.3')
+    expect(result.dependencies?.['@opensaas/stack-core']).toBe('^1.2.3')
+    expect(result.dependencies?.['@opensaas/stack-ui']).toBe('^1.2.3')
+    expect(result.devDependencies?.['@opensaas/stack-cli']).toBe('^1.2.3')
+  })
+
+  it('leaves non-opensaas dependencies untouched', () => {
+    const pkg = { dependencies: { next: '^16.1.6', react: '^19.2.4' } }
+    const result = replaceWorkspaceVersions(pkg, '1.2.3')
+    expect(result.dependencies).toEqual({ next: '^16.1.6', react: '^19.2.4' })
+  })
+
+  it('only rewrites the workspace:* specifier, not pinned @opensaas ranges', () => {
+    const pkg = { dependencies: { '@opensaas/stack-core': '^0.1.0' } }
+    const result = replaceWorkspaceVersions(pkg, '1.2.3')
+    expect(result.dependencies?.['@opensaas/stack-core']).toBe('^0.1.0')
+  })
+
+  it('leaves no remaining workspace:* for @opensaas dependencies', () => {
+    const pkg = {
+      dependencies: { '@opensaas/stack-core': 'workspace:*' },
+      devDependencies: { '@opensaas/stack-cli': 'workspace:*' },
+    }
+    const result = replaceWorkspaceVersions(pkg, '9.9.9')
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('workspace:*')
+  })
+})
+
+describe('rewriteReadmeHeading', () => {
+  it('replaces only the first H1', () => {
+    const readme = '# OpenSaas Stack Starter\n\nIntro\n\n# Not a title\n'
+    const result = rewriteReadmeHeading(readme, 'my-app')
+    expect(result).toContain('# my-app')
+    expect(result).toContain('# Not a title')
+    expect(result.indexOf('# my-app')).toBe(0)
+  })
+})

--- a/packages/create-opensaas-app/tests/project-name.test.ts
+++ b/packages/create-opensaas-app/tests/project-name.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { validateProjectName } from '../src/lib/project-name.js'
+
+describe('validateProjectName', () => {
+  it('accepts lowercase, numbers, and hyphens', () => {
+    expect(validateProjectName('my-app')).toEqual({ ok: true })
+    expect(validateProjectName('my-saas-2024')).toEqual({ ok: true })
+    expect(validateProjectName('app')).toEqual({ ok: true })
+  })
+
+  it('rejects an empty or missing name', () => {
+    expect(validateProjectName('')).toMatchObject({ ok: false })
+    expect(validateProjectName(undefined)).toMatchObject({ ok: false })
+    expect(validateProjectName(null)).toMatchObject({ ok: false })
+  })
+
+  it('rejects uppercase, underscores, spaces, and other punctuation', () => {
+    for (const invalid of ['My-App', 'my_app', 'my app', 'my.app', 'café']) {
+      const result = validateProjectName(invalid)
+      expect(result.ok).toBe(false)
+    }
+  })
+
+  it('explains why a name is invalid', () => {
+    const result = validateProjectName('My App')
+    expect(result).toMatchObject({ ok: false })
+    if (!result.ok) {
+      expect(result.message).toMatch(/lowercase letters, numbers, and hyphens/)
+    }
+  })
+})

--- a/packages/create-opensaas-app/tsconfig.json
+++ b/packages/create-opensaas-app/tsconfig.json
@@ -16,5 +16,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "templates"]
+  "exclude": ["node_modules", "dist", "templates", "**/*.test.ts"]
 }

--- a/packages/create-opensaas-app/vitest.config.ts
+++ b/packages/create-opensaas-app/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'json-summary'],
+      exclude: ['node_modules/', 'tests/', 'dist/', 'templates/', '**/*.d.ts', '**/*.config.*'],
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -954,9 +954,15 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0))(vitest@4.1.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.0.18)(happy-dom@20.8.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/rag:
     dependencies:
@@ -10632,8 +10638,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -10659,7 +10665,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10670,22 +10676,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10696,7 +10702,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #419. Part of PRD #418.

## Problem

Following the documented setup of a freshly scaffolded basic project failed on the **very first command**. The basic template shipped an empty `.env` and a `.env.example` containing a **PostgreSQL** URL even though its config uses `provider: 'sqlite'`. Because `prisma.config.ts` resolves `env('DATABASE_URL')`, `pnpm generate` died with:

```
PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL
```

## Change

- **Scaffolder writes a runnable `.env`.** Basic (SQLite) projects now get a canonical `.env` (`DATABASE_URL="file:./dev.db"`) plus a matching `.env.example`; the `--with-auth` template seeds `.env` from its own `.env.example` so the Better-auth variables are preserved.
- **Fixed `examples/starter/.env.example`** to default to SQLite (it's the source of truth for the basic template).
- **Extracted pure, unit-tested deep modules** in `src/lib/`: `validateProjectName`, provider-aware `generateEnvFiles`, and the `package.json`/README transforms. `src/index.ts` is now a thin orchestrator; `copy-templates.ts` reuses the shared version-rewrite helper.
- **Removed the unimplemented `--template` flag** so advertised flags match real behaviour.
- Added a `minor` changeset and updated the package `CLAUDE.md`.

## Tests / verification

- **16 new unit tests pass** (`vitest run`) covering env generation (SQLite default yields `file:./dev.db`; a SQLite project never yields a Postgres URL), project-name validation, the `workspace:*`→version rewrite (none remain), and the README heading replacement.
- **End-to-end reproduction:** with the generated `.env`, `pnpm generate` and `pnpm db:push` both exit 0 and create `dev.db` + `.opensaas/context.ts` (previously the empty `.env` reproduced the failure above).
- `pnpm lint`, `pnpm manypkg check`, `pnpm format`, and `pnpm build` (tsc + copy-templates) all pass.

## Scope notes

This slice covers the SQLite first-run blocker and the testable scaffolder core. Auto-running install/generate/db:push (so the flow becomes **create → dev → build-with-Claude**) and the full scaffold smoke test are the next slice (#420). Auth-template port/styling fixes are #425.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_