### PR TITLE
fix(cli,core): reconcile SQLite adapter guidance to the installed API + regression guard

### DIFF
--- a/.changeset/honest-pumas-relate.md
+++ b/.changeset/honest-pumas-relate.md
@@ -1,0 +1,6 @@
+---
+'@opensaas/stack-cli': patch
+'@opensaas/stack-core': patch
+---
+
+Fix outdated SQLite adapter guidance to match the installed `@prisma/adapter-better-sqlite3` API (`PrismaBetterSqlite3` constructed with `{ url }`), so copied examples actually run. Updates the CLI "missing adapter" error message and the migration config it generates, plus the `prismaClientConstructor` JSDoc example.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "name": "opensaas-migration",
       "source": "./claude-plugins/opensaas-migration",
       "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "OpenSaaS Team",
         "url": "https://github.com/OpenSaasAU/stack"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,16 +630,14 @@ Prisma 7 requires database adapters. You must provide a `prismaClientConstructor
 
 ```typescript
 // opensaas.config.ts - SQLite example
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
-      const db = new Database(process.env.DATABASE_URL || './dev.db')
-      const adapter = new PrismaBetterSQLite3(db)
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
       return new PrismaClient({ adapter })
     },
   },

--- a/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
+++ b/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opensaas-migration",
   "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "OpenSaaS Team",
     "url": "https://github.com/OpenSaasAU/stack"

--- a/claude-plugins/opensaas-migration/agents/migration-assistant.md
+++ b/claude-plugins/opensaas-migration/agents/migration-assistant.md
@@ -62,16 +62,14 @@ export default config({
 ```typescript
 import { config, list } from '@opensaas/stack-core'
 import { text, relationship, timestamp } from '@opensaas/stack-core/fields'
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
-      const db = new Database(process.env.DATABASE_URL?.replace('file:', '') || './dev.db')
-      const adapter = new PrismaBetterSQLite3(db)
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
       return new PrismaClient({ adapter })
     },
   },
@@ -114,15 +112,13 @@ The only required addition is `prismaClientConstructor` (Prisma 7 uses driver ad
 **SQLite:**
 
 ```typescript
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 db: {
   provider: 'sqlite',
   url: process.env.DATABASE_URL || 'file:./dev.db',
   prismaClientConstructor: (PrismaClient) => {
-    const db = new Database(process.env.DATABASE_URL?.replace('file:', '') || './dev.db')
-    const adapter = new PrismaBetterSQLite3(db)
+    const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
     return new PrismaClient({ adapter })
   },
 },

--- a/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
@@ -160,16 +160,14 @@ operation: {
 **SQLite (Development):**
 
 ```typescript
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
-      const db = new Database(process.env.DATABASE_URL || './dev.db')
-      const adapter = new PrismaBetterSQLite3(db)
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
       return new PrismaClient({ adapter })
     },
   },

--- a/docs/content/core-concepts/generators.md
+++ b/docs/content/core-concepts/generators.md
@@ -13,7 +13,7 @@ The generator system reads your declarative config and creates:
 ## Running the Generator
 
 ```bash
-pnpm opensaas generate
+pnpm generate
 ```
 
 Or in a specific example:

--- a/docs/content/guides/migration.md
+++ b/docs/content/guides/migration.md
@@ -146,16 +146,14 @@ Convert it to OpenSaaS config:
 // opensaas.config.ts
 import { config, list } from '@opensaas/stack-core'
 import { text, checkbox, relationship } from '@opensaas/stack-core/fields'
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
-      const db = new Database(process.env.DATABASE_URL || './dev.db')
-      const adapter = new PrismaBetterSQLite3(db)
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
       return new PrismaClient({ adapter })
     },
   },

--- a/docs/content/quick-start.md
+++ b/docs/content/quick-start.md
@@ -115,7 +115,7 @@ export default config({
 ### 4. Generate Prisma Schema
 
 ```bash
-pnpm opensaas generate
+pnpm generate
 ```
 
 This creates:
@@ -227,7 +227,7 @@ OpenSaaS Stack includes a Claude Code plugin for feature-driven development. Ins
 
 ### "Cannot find module '@/.opensaas/context'"
 
-Make sure you've run `pnpm opensaas generate` to create the generated files.
+Make sure you've run `pnpm generate` to create the generated files.
 
 ### "PrismaClient is not configured"
 

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -228,16 +228,14 @@ pnpm next dev
 
 ```typescript
 // SQLite example
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
-      const db = new Database(process.env.DATABASE_URL || './dev.db')
-      const adapter = new PrismaBetterSQLite3(db)
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
       return new PrismaClient({ adapter })
     },
   },

--- a/packages/cli/src/generator/context.ts
+++ b/packages/cli/src/generator/context.ts
@@ -23,14 +23,12 @@ export function generateContext(config: OpenSaasConfig): string {
       throw new Error(
         'Prisma 7 requires a database adapter. Please add prismaClientConstructor to your opensaas.config.ts db configuration.\\n\\n' +
         'Example for SQLite:\\n' +
-        'import { PrismaBetterSQLite3 } from \\'@prisma/adapter-better-sqlite3\\'\\n' +
-        'import Database from \\'better-sqlite3\\'\\n\\n' +
+        'import { PrismaBetterSqlite3 } from \\'@prisma/adapter-better-sqlite3\\'\\n\\n' +
         'db: {\\n' +
         '  provider: \\'sqlite\\',\\n' +
         '  url: process.env.DATABASE_URL || \\'file:./dev.db\\',\\n' +
         '  prismaClientConstructor: (PrismaClient) => {\\n' +
-        '    const db = new Database(process.env.DATABASE_URL || \\'./dev.db\\')\\n' +
-        '    const adapter = new PrismaBetterSQLite3(db)\\n' +
+        '    const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || \\'file:./dev.db\\' })\\n' +
         '    return new PrismaClient({ adapter })\\n' +
         '  }\\n' +
         '}\\n\\n' +

--- a/packages/cli/src/mcp/lib/documentation-provider.ts
+++ b/packages/cli/src/mcp/lib/documentation-provider.ts
@@ -613,8 +613,7 @@ db: {
   provider: 'sqlite',
   url: 'file:./dev.db',
   prismaClientConstructor: (PrismaClient) => {
-    const db = new Database('./dev.db')
-    const adapter = new PrismaBetterSQLite3(db)
+    const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
     return new PrismaClient({ adapter })
   },
 }

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -245,15 +245,13 @@ db: {
       case 'sqlite':
       default:
         return `\`\`\`typescript
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import Database from 'better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 db: {
   provider: 'sqlite',
   url: process.env.DATABASE_URL || 'file:./dev.db',
   prismaClientConstructor: (PrismaClient) => {
-    const db = new Database(process.env.DATABASE_URL?.replace('file:', '') || './dev.db')
-    const adapter = new PrismaBetterSQLite3(db)
+    const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
     return new PrismaClient({ adapter })
   },
 },

--- a/packages/cli/tests/adapter-guidance.test.ts
+++ b/packages/cli/tests/adapter-guidance.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Regression guard for the database-adapter guidance.
+ *
+ * The installed `@prisma/adapter-better-sqlite3` exports `PrismaBetterSqlite3`
+ * and is constructed with `{ url }`. An earlier, outdated form
+ * (`PrismaBetterSQLite3` imported alongside `better-sqlite3` and constructed
+ * with a `new Database(...)` instance) does not match the installed package, so
+ * any code an LLM copied from it would not run. This test scans the guidance
+ * surfaces (docs, specs, CLAUDE.md files, the migration plugin, and the
+ * generator/migration source that emits example code) and fails if the
+ * outdated pattern reappears.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(here, '../../..')
+
+// Curated guidance surfaces — the places a user or LLM reads to learn the API.
+const SCAN_ROOTS = [
+  'CLAUDE.md',
+  'docs/content',
+  'specs',
+  'claude-plugins',
+  'packages/cli/src',
+  'packages/cli/CLAUDE.md',
+  'packages/core/src',
+  'packages/core/CLAUDE.md',
+]
+
+const SCAN_EXTENSIONS = new Set(['.md', '.ts'])
+const ADAPTER_PACKAGE = '@prisma/adapter-better-sqlite3'
+// Built by concatenation so this test file does not match its own scan.
+const WRONG_CLASS_NAME = 'PrismaBetter' + 'SQLite3'
+const MANUAL_DB_INSTANCE = 'new ' + 'Database('
+
+function collectFiles(absRoot: string): string[] {
+  if (!fs.existsSync(absRoot)) return []
+  const stat = fs.statSync(absRoot)
+  if (stat.isFile()) return SCAN_EXTENSIONS.has(path.extname(absRoot)) ? [absRoot] : []
+  const out: string[] = []
+  for (const entry of fs.readdirSync(absRoot, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue
+    const full = path.join(absRoot, entry.name)
+    if (entry.isDirectory()) out.push(...collectFiles(full))
+    else if (SCAN_EXTENSIONS.has(path.extname(entry.name))) out.push(full)
+  }
+  return out
+}
+
+const files = SCAN_ROOTS.flatMap((root) => collectFiles(path.join(repoRoot, root)))
+  // Exclude this guard so its needles don't flag itself.
+  .filter((file) => file !== fileURLToPath(import.meta.url))
+
+describe('database-adapter guidance stays current', () => {
+  it('scans a non-trivial set of guidance files', () => {
+    expect(files.length).toBeGreaterThan(20)
+  })
+
+  it('never uses the wrong adapter class name', () => {
+    const offenders = files.filter((file) =>
+      fs.readFileSync(file, 'utf-8').includes(WRONG_CLASS_NAME),
+    )
+    expect(offenders.map((f) => path.relative(repoRoot, f))).toEqual([])
+  })
+
+  it('never constructs the SQLite adapter from a manual Database instance', () => {
+    const offenders = files.filter((file) => {
+      const content = fs.readFileSync(file, 'utf-8')
+      return content.includes(ADAPTER_PACKAGE) && content.includes(MANUAL_DB_INSTANCE)
+    })
+    expect(offenders.map((f) => path.relative(repoRoot, f))).toEqual([])
+  })
+})

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1270,12 +1270,10 @@ export type DatabaseConfig = {
    *
    * @example SQLite with better-sqlite3
    * ```typescript
-   * import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-   * import Database from 'better-sqlite3'
+   * import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
    *
    * prismaClientConstructor: (PrismaClient) => {
-   *   const db = new Database(process.env.DATABASE_URL || './dev.db')
-   *   const adapter = new PrismaBetterSQLite3(db)
+   *   const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
    *   return new PrismaClient({ adapter })
    * }
    * ```

--- a/specs/keystone-migration.md
+++ b/specs/keystone-migration.md
@@ -67,10 +67,10 @@ export default config({
     url: process.env.DATABASE_URL ?? 'file:./dev.db',
     prismaClientConstructor: (PrismaClient) => {
       // Prisma 7 requires a driver adapter
-      const { PrismaBetterSQLite3 } = require('@prisma/adapter-better-sqlite3')
-      const Database = require('better-sqlite3')
-      const db = new Database(process.env.DATABASE_URL ?? './dev.db')
-      return new PrismaClient({ adapter: new PrismaBetterSQLite3(db) })
+      const { PrismaBetterSqlite3 } = require('@prisma/adapter-better-sqlite3')
+      return new PrismaClient({
+        adapter: new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' }),
+      })
     },
   },
   lists: {


### PR DESCRIPTION
Closes #422. Part of PRD #418.

## Problem

The database-adapter guidance an LLM relies on was outdated and internally inconsistent. The root `CLAUDE.md`, the CLI's "missing adapter" error message, the migration config generator, the `prismaClientConstructor` JSDoc, the migration plugin (agent + skill), and the migration docs/specs all instructed:

```ts
import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
import Database from 'better-sqlite3'
const db = new Database(process.env.DATABASE_URL || './dev.db')
const adapter = new PrismaBetterSQLite3(db)
```

The installed `@prisma/adapter-better-sqlite3` exports **`PrismaBetterSqlite3`** and is constructed with **`{ url }`** (as every working example already does). Code copied from the old guidance does not run.

## Change

- **Canonical adapter API everywhere:**
  ```ts
  import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
  const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
  return new PrismaClient({ adapter })
  ```
  Updated across the root `CLAUDE.md`, `packages/cli` (error message + migration generator + MCP docs provider + CLAUDE.md), `packages/core` (JSDoc + CLAUDE.md), `docs/`, `specs/`, and the **opensaas-migration** plugin.
- **Command-set consistency:** normalised the scaffold-flow generate command to `pnpm generate` (migration-context docs keep `pnpm opensaas generate`, which is correct where no project script exists yet).
- **Regression guard:** new `packages/cli/tests/adapter-guidance.test.ts` scans the guidance surfaces and fails if the outdated `PrismaBetterSQLite3` class name or the `new Database(...)` adapter pattern reappears.
- **Plugin version:** opensaas-migration bumped `0.2.2 → 0.2.3`; changeset added for `@opensaas/stack-cli` + `@opensaas/stack-core` (patch).

## Verification

- **All 195 CLI tests pass**, including the new 3-assertion regression guard (scans >20 guidance files; no wrong class name; no manual `Database` instance).
- `pnpm build` (core + cli typecheck), `pnpm manypkg check`, `pnpm lint` (0 errors), and `pnpm format` all pass.
- Repo-wide grep confirms zero remaining `PrismaBetterSQLite3` / `new Database(` adapter references outside dependency lists.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_