### PR TITLE
docs: user-first README & Getting Started (de-stale, lead with the Claude flow)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to OpenSaas Stack
+
+Thanks for working on OpenSaas Stack itself. This guide covers the **monorepo** workflow. If you just want to _build an app_ with the stack, start with the [README Quick Start](./README.md#quick-start-3-steps) instead.
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm (`npm install -g pnpm`)
+
+## Setup
+
+```bash
+pnpm install      # install all workspace dependencies
+pnpm build        # build all packages (turbo)
+pnpm dev          # watch-build packages
+```
+
+## Repository layout
+
+- `packages/*` — published packages (core, cli, ui, auth, tiptap, rag, storage\*, create-opensaas-app)
+- `examples/*` — runnable examples; each is named `opensaas-<name>-example`
+- `docs/` — the documentation site (Next.js), published at https://stack.opensaas.au/
+- `claude-plugins/*` — Claude Code plugins (`opensaas-stack`, `opensaas-migration`)
+- `specs/` — design documents and specifications
+
+## Trying an example
+
+```bash
+cd examples/blog
+cp .env.example .env     # SQLite by default
+pnpm generate            # generate Prisma schema + types from opensaas.config.ts
+pnpm db:push             # create the database
+pnpm dev
+```
+
+The `starter` and `starter-auth` examples are the **source of truth** for the
+`create-opensaas-app` templates — they are copied into the published package at
+build time, so changes to them flow to scaffolded projects.
+
+## Testing
+
+Tests use Vitest. Run them per package, e.g.:
+
+```bash
+cd packages/core && pnpm test
+cd packages/cli && pnpm test
+```
+
+End-to-end tests use Playwright (`pnpm test:e2e` from the repo root).
+
+## Before you commit
+
+Always run:
+
+```bash
+pnpm lint
+pnpm manypkg fix
+pnpm format
+```
+
+Match versions of any shared dependency across packages and examples (manypkg
+enforces this). Keep all types strongly typed — avoid `any` and type casting;
+`unknown` is for internal use only.
+
+## Versioning
+
+This monorepo uses two independent mechanisms:
+
+- **Changesets** for npm packages under `packages/*`. Every change to a package
+  needs a changeset in `.changeset/` (`patch` for fixes, `minor` for features,
+  `major` only when explicitly intended). Releases are automated by the
+  changesets GitHub Action.
+- **Plugin versions** for `claude-plugins/*`, bumped directly in each plugin's
+  `plugin.json` and the matching entry in `.claude-plugin/marketplace.json`.
+
+When working with Claude Code in this repo, the `pr-changeset` and
+`plugin-version` skills handle these for you.
+
+## Architecture notes
+
+See [`CLAUDE.md`](./CLAUDE.md) for the in-depth architectural guide (access
+control engine, hooks, config system, generators, field types) and the
+per-package `CLAUDE.md` files for package-specific patterns.
+
+## Reporting issues
+
+Issues live in [GitHub Issues](https://github.com/OpenSaasAU/stack/issues).

--- a/README.md
+++ b/README.md
@@ -1,312 +1,87 @@
 # OpenSaas Stack
 
-> **⚠️ Work in Progress - Alpha Stage**
->
-> This project is currently in active development and is in an alpha state. APIs may change in patches, and some features are still being implemented. Use in production at your own risk.
+> **Beta.** The onboarding path and core APIs are stable enough to build on; some advanced features are still evolving. Pin versions for production.
 
-A modern stack for building admin-heavy applications with Next.js App Router, designed to be AI-agent-friendly with built-in security guardrails.
+A config-first stack for building admin-heavy applications with Next.js App Router — designed so you can **describe features to an AI coding agent (Claude Code) and let the framework handle the technical complexity**, with access control enforced on every database operation by default.
 
-## Features
+- 🔒 **Access control first** — every `context.db` operation is automatically secured; denied reads return `null`/`[]` (no information leakage).
+- 🤖 **Built for Claude Code** — clear, predictable patterns plus a shipped project `CLAUDE.md` and MCP tooling, so you build by describing features.
+- ⚡ **Config-first** — define lists, fields, and access rules once; generate the Prisma schema, TypeScript types, and a typed context.
+- 🧩 **Composable & extensible** — shadcn/ui primitives → field components → standalone CRUD → full admin UI; add custom field types without forking core.
 
-- 🔒 **Access Control First**: Database operations automatically enforce access control patterns
-- 🤖 **AI-Safe Architecture**: Built to be easy for AI coding agents to work with safely
-- ⚡ **Modern Next.js Integration**: Works seamlessly with App Router and Server Components
-- 🎯 **Type-Safe**: Full TypeScript support with generated types from schema
-- 🔄 **Prisma-Powered**: Built on Prisma for reliable database operations
-- 🧩 **Fully Extensible**: Custom field types without modifying core code
-- 🎨 **Fully Composable UI**: Use primitives, fields, standalone components, or complete admin UI
-- ♿ **Accessible**: Built with Radix UI and shadcn/ui for production-ready components
-- 🔐 **Authentication Ready**: Optional Better-auth integration with OAuth support
-- 🤖 **AI Assistant Integration**: MCP server for seamless AI assistant access
-- 📁 **File Storage**: Abstract storage interface with S3 and Vercel Blob adapters
-- 📝 **Rich Text Editing**: Tiptap integration for advanced content editing
-- 🔍 **Semantic Search**: RAG integration with vector embeddings for AI-powered search
+## Quick Start (3 steps)
 
-## Project Structure
-
-This is a monorepo containing:
-
-### Packages
-
-- **`packages/core`**: The core OpenSaas stack (config, fields, access control, generators)
-- **`packages/cli`**: CLI tools for code generation and development
-- **`packages/ui`**: Composable React UI components (primitives, fields, standalone components, full admin UI)
-- **`packages/auth`**: Better-auth integration for authentication and sessions
-- **`packages/mcp`**: Model Context Protocol server for AI assistant integration
-- **`packages/tiptap`**: Rich text editor integration (third-party field example)
-- **`packages/storage`**: Abstract storage interface for file uploads
-- **`packages/storage-s3`**: S3-compatible storage adapter (AWS S3, R2, MinIO, etc.)
-- **`packages/storage-vercel`**: Vercel Blob storage adapter
-- **`packages/rag`**: RAG (Retrieval-Augmented Generation) integration with vector embeddings and semantic search
-
-### Examples
-
-- **`examples/blog`**: Basic blog example demonstrating the stack
-- **`examples/custom-field`**: Custom field types demonstration
-- **`examples/composable-dashboard`**: Composable UI components examples
-- **`examples/auth-demo`**: Authentication integration with Better-auth
-- **`examples/mcp-demo`**: MCP server integration for AI assistants
-- **`examples/tiptap-demo`**: Tiptap rich text editor integration
-- **`examples/json-demo`**: JSON field type demonstration
-- **`examples/file-upload-demo`**: File upload and image handling with storage adapters
-- **`examples/rag-demo`**: RAG integration with semantic search and embeddings
-
-## Quick Start
-
-### New Project (Recommended)
-
-Get started with a new project in 5 minutes:
+You need Node.js 18+ and `pnpm` (`npm install -g pnpm`).
 
 ```bash
-# Create a new project
+# 1. Scaffold — installs deps, generates the schema, and creates a SQLite DB for you
 npm create opensaas-app@latest my-app
+
+# 2. Run
 cd my-app
-
-# Install dependencies
-pnpm install
-
-# Generate Prisma schema and types
-pnpm generate
-
-# Create database
-pnpm db:push
-
-# Start dev server
 pnpm dev
 ```
 
-**With authentication:**
+**3. Build with Claude Code.** Open the project in Claude Code and describe what you want — e.g. _"add a comments feature to posts"_ or _"add authentication"_. The scaffolded project ships a `CLAUDE.md` and MCP tooling so Claude builds within the framework's guardrails.
+
+Your app runs at [http://localhost:3000](http://localhost:3000); the auto-generated admin UI is at [`/admin`](http://localhost:3000/admin).
+
+**Want authentication from the start?**
 
 ```bash
 npm create opensaas-app@latest my-app --with-auth
 ```
 
-Your app is now running at [http://localhost:3000](http://localhost:3000)!
+> The scaffolder runs install → generate → db:push for you. To skip that and run the steps yourself, pass `--no-install`.
 
-Visit `/admin` to see your auto-generated admin UI.
+📚 **[Full documentation →](https://stack.opensaas.au/docs)** · **[Quick Start guide →](https://stack.opensaas.au/docs/quick-start)** · **[Building with Claude Code →](https://stack.opensaas.au/docs/guides/claude-code)**
 
-### Deploy to Production
+## How it works
 
-Ready to deploy? Follow our [Deployment Guide](https://stack.opensaas.au/docs/guides/deployment) to deploy to Vercel + Neon in ~15 minutes.
-
----
-
-### Monorepo Development
-
-Working on the OpenSaas Stack itself? Here's how to get started:
-
-#### 1. Install Dependencies
-
-```bash
-pnpm install
-```
-
-#### 2. Build All Packages
-
-```bash
-# Build all packages in the monorepo
-pnpm build
-```
-
-#### 3. Try an Example
-
-Choose one of the examples to get started:
-
-#### Blog Example (Basic)
-
-```bash
-cd examples/blog
-
-# Copy environment file
-cp .env.example .env
-
-# Generate Prisma schema and types from config
-pnpm generate
-
-# Push schema to database (creates SQLite file)
-pnpm db:push
-
-# Start development server
-pnpm dev
-```
-
-#### Auth Demo (with Better-auth)
-
-```bash
-cd examples/auth-demo
-
-# Copy environment file
-cp .env.example .env
-
-# Generate and setup database
-pnpm generate
-pnpm db:push
-
-# Start development server
-pnpm dev
-```
-
-#### File Upload Demo (with storage adapters)
-
-```bash
-cd examples/file-upload-demo
-
-# Copy environment file and configure storage
-cp .env.example .env
-
-# Generate and setup database
-pnpm generate
-pnpm db:push
-
-# Start development server
-pnpm dev
-```
-
-#### RAG Demo (with semantic search)
-
-```bash
-cd examples/rag-demo
-
-# Copy environment file and add OpenAI API key
-cp .env.example .env
-
-# Generate and setup database
-pnpm generate
-pnpm db:push
-
-# Start development server
-pnpm dev
-```
-
-### 4. Test the Example
-
-Create a test script to see access control in action:
-
-```bash
-# Create a test file
-cat > examples/blog/test.ts << 'EOF'
-import { prisma } from './lib/context'
-import { getContext, getContextWithUser } from './lib/context'
-
-async function test() {
-  console.log('🧪 Testing OpenSaas Stack\n')
-
-  // Create a user
-  console.log('1. Creating a user...')
-  const user = await prisma.user.create({
-    data: {
-      name: 'Alice',
-      email: 'alice@example.com',
-      password: 'hashed_password_here'
-    }
-  })
-  console.log('✅ User created:', user.id, user.name)
-
-  // Create a post as that user
-  console.log('\n2. Creating a post as Alice...')
-  const contextAlice = await getContextWithUser(user.id)
-  const post = await contextAlice.db.post.create({
-    data: {
-      title: 'My First Post',
-      slug: 'my-first-post',
-      content: 'Hello world!',
-      internalNotes: 'Remember to add images later',
-      author: { connect: { id: user.id } }
-    }
-  })
-  console.log('✅ Post created:', post?.id, post?.title)
-  console.log('   Internal notes visible to author:', post?.internalNotes)
-
-  // Try to read as anonymous user
-  console.log('\n3. Reading post as anonymous user...')
-  const contextAnon = await getContext()
-  const postAnon = await contextAnon.db.post.findUnique({
-    where: { id: post!.id }
-  })
-  console.log('❌ Post not visible (draft):', postAnon)
-
-  // Publish the post
-  console.log('\n4. Publishing the post as Alice...')
-  const publishedPost = await contextAlice.db.post.update({
-    where: { id: post!.id },
-    data: { status: 'published', publishedAt: new Date() }
-  })
-  console.log('✅ Post published:', publishedPost?.status)
-
-  // Try to read as anonymous user again
-  console.log('\n5. Reading published post as anonymous user...')
-  const postAnonPublished = await contextAnon.db.post.findUnique({
-    where: { id: post!.id }
-  })
-  console.log('✅ Post visible:', postAnonPublished?.title)
-  console.log('🔒 Internal notes hidden:', postAnonPublished?.internalNotes)
-
-  // Create another user
-  console.log('\n6. Creating another user (Bob)...')
-  const bob = await prisma.user.create({
-    data: {
-      name: 'Bob',
-      email: 'bob@example.com',
-      password: 'hashed_password_here'
-    }
-  })
-  console.log('✅ User created:', bob.id, bob.name)
-
-  // Try to update Alice's post as Bob
-  console.log('\n7. Trying to update Alice\'s post as Bob...')
-  const contextBob = await getContextWithUser(bob.id)
-  const updatedByBob = await contextBob.db.post.update({
-    where: { id: post!.id },
-    data: { title: 'Hacked!' }
-  })
-  console.log('❌ Access denied (silent failure):', updatedByBob)
-
-  // Try to update as Alice
-  console.log('\n8. Updating post as Alice (owner)...')
-  const updatedByAlice = await contextAlice.db.post.update({
-    where: { id: post!.id },
-    data: { title: 'My Updated Post' }
-  })
-  console.log('✅ Update successful:', updatedByAlice?.title)
-
-  console.log('\n🎉 All tests passed!')
-
-  // Cleanup
-  await prisma.post.deleteMany()
-  await prisma.user.deleteMany()
-}
-
-test()
-  .catch(console.error)
-  .finally(() => prisma.$disconnect())
-EOF
-
-# Run the test
-npx tsx test.ts
-```
-
-## How It Works
-
-### 1. Define Your Schema
-
-Create `opensaas.config.ts`:
+### 1. Define your schema in `opensaas.config.ts`
 
 ```typescript
 import { config, list } from '@opensaas/stack-core'
-import { text, relationship, select } from '@opensaas/stack-core/fields'
+import { text, select, relationship } from '@opensaas/stack-core/fields'
 import type { AccessControl } from '@opensaas/stack-core'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
-const isAuthor: AccessControl = ({ session }) => {
-  if (!session) return false
-  return { authorId: { equals: session.userId } }
-}
+// Access control returns a boolean, or a Prisma filter that scopes the rows.
+const isAuthor: AccessControl = ({ session }) =>
+  session ? { authorId: { equals: session.userId } } : false
 
 export default config({
   db: {
     provider: 'sqlite',
-    url: 'file:./dev.db',
+    url: process.env.DATABASE_URL || 'file:./dev.db',
+    prismaClientConstructor: (PrismaClient) => {
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
+      return new PrismaClient({ adapter })
+    },
   },
   lists: {
+    Post: list({
+      fields: {
+        title: text({ validation: { isRequired: true } }),
+        content: text(),
+        status: select({
+          options: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' },
+          ],
+          defaultValue: 'draft',
+        }),
+        author: relationship({ ref: 'User.posts' }),
+      },
+      access: {
+        operation: {
+          // Anonymous users only see published posts; authors see their own drafts too.
+          query: ({ session }) => (session ? true : { status: { equals: 'published' } }),
+          update: isAuthor,
+          delete: isAuthor,
+        },
+      },
+    }),
     User: list({
       fields: {
         name: text({ validation: { isRequired: true } }),
@@ -314,391 +89,76 @@ export default config({
         posts: relationship({ ref: 'Post.author', many: true }),
       },
     }),
-    Post: list({
-      fields: {
-        title: text(),
-        content: text(),
-        status: select({
-          options: [
-            { label: 'Draft', value: 'draft' },
-            { label: 'Published', value: 'published' },
-          ],
-        }),
-        author: relationship({ ref: 'User.posts' }),
-      },
-      access: {
-        operation: {
-          query: ({ session }) => {
-            // Non-authenticated users only see published posts
-            if (!session) return { status: { equals: 'published' } }
-            return true
-          },
-          update: isAuthor, // Only author can update
-        },
-      },
-    }),
   },
 })
 ```
 
-### 2. Generate Schema and Types
+### 2. Generate
 
 ```bash
-pnpm generate
+pnpm generate   # → prisma/schema.prisma, .opensaas/types.ts, .opensaas/context.ts
+pnpm db:push    # creates the database
 ```
 
-This generates:
-
-- `prisma/schema.prisma` - Prisma schema
-- `.opensaas/types.ts` - TypeScript types
-
-### 3. Use in Your App
+### 3. Use the access-controlled context in your app
 
 ```typescript
-import { getContext } from './lib/context'
+import { getContext } from '@/.opensaas/context'
 
-export async function updatePost(postId: string, data: any) {
-  const context = await getContext()
-
-  // Access control is automatically enforced
-  const post = await context.db.post.update({
-    where: { id: postId },
-    data,
-  })
-
-  if (!post) {
-    // Either doesn't exist or user doesn't have access
-    return { error: 'Access denied' }
-  }
-
-  return { post }
+export async function getPosts() {
+  const context = await getContext() // pass a session for authenticated access
+  // Access control is enforced automatically.
+  return context.db.post.findMany({ include: { author: true } })
 }
 ```
 
-## Access Control Features
-
-### Operation-Level Access
-
-Control who can query, create, update, or delete records:
+Denied operations return `null` (single) or `[]` (many) rather than throwing, so callers can't distinguish "denied" from "doesn't exist". Always null-check writes:
 
 ```typescript
-access: {
-  operation: {
-    query: true,  // Everyone can read
-    create: isSignedIn,  // Must be signed in to create
-    update: isAuthor,  // Only author can update
-    delete: isAuthor,  // Only author can delete
-  }
-}
+const post = await context.db.post.update({ where: { id }, data })
+if (!post) return { error: 'Not found or access denied' }
 ```
 
-### Filter-Based Access
+## What's in the box
 
-Return Prisma filters to scope access:
+**Packages**
 
-```typescript
-const isAuthor: AccessControl = ({ session }) => {
-  return { authorId: { equals: session.userId } }
-}
-```
+| Package                                        | Purpose                                                                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `@opensaas/stack-core`                         | Config system, fields, access-control engine, hooks, generators (MCP runtime via `@opensaas/stack-core/mcp`) |
+| `@opensaas/stack-cli`                          | `opensaas generate` / `dev` and the migration tooling                                                        |
+| `@opensaas/stack-ui`                           | Composable admin UI — primitives, field components, standalone CRUD, full admin                              |
+| `@opensaas/stack-auth`                         | Better-auth integration (sessions, OAuth, MCP adapter via `@opensaas/stack-auth/mcp`)                        |
+| `@opensaas/stack-tiptap`                       | Rich-text `richText()` field (third-party field example)                                                     |
+| `@opensaas/stack-rag`                          | Semantic search with vector embeddings                                                                       |
+| `@opensaas/stack-storage` (+ `-s3`, `-vercel`) | File/image uploads with pluggable storage adapters                                                           |
+| `create-opensaas-app`                          | `npm create opensaas-app` project scaffolder                                                                 |
 
-### Field-Level Access
+**Examples** live in [`examples/`](./examples): `starter`, `starter-auth`, `blog`, `auth-demo`, `composable-dashboard`, `custom-field`, `json-demo`, `file-upload-demo`, `mcp-demo`, `rag-ollama-demo`, `rag-openai-chatbot`, `tiptap-demo`.
 
-Control access to individual fields:
+## Composable UI
 
-```typescript
-internalNotes: text({
-  access: {
-    read: isAuthor, // Only author can see
-    update: isAuthor, // Only author can modify
-  },
-})
-```
-
-### Silent Failures
-
-When access is denied, operations return `null` or `[]` instead of throwing errors. This prevents information leakage.
-
-## Architecture
-
-### Core Components
-
-1. **Config System** (`src/config/`): Schema definition and validation
-2. **Field Types** (`src/fields/`): Field type definitions (text, relationship, etc.)
-3. **Access Control** (`src/access/`): Access control engine
-4. **Context** (`src/context/`): Database wrapper with access control
-5. **Generators** (`src/generator/`): Prisma schema and TypeScript type generation
-
-### Access Control Flow
-
-When you call `context.db.post.update()`:
-
-1. Check operation-level access (can this user update posts?)
-2. Apply access filter as Prisma where clause (which posts can they update?)
-3. Check field-level access (which fields can they modify?)
-4. Execute database operation
-5. Filter readable fields from result
-6. Return result (or null if no access)
-
-## Development
-
-### Building the Core Package
-
-```bash
-cd packages/core
-pnpm build
-```
-
-### Running the Example
-
-```bash
-cd examples/blog
-pnpm dev
-```
-
-## Extensibility
-
-### Custom Field Types
-
-OpenSaas is designed to be fully extensible without modifying core code. Field types are self-contained with their own validation, schema generation, and UI components.
-
-**Built-in field types:**
-
-- `text()` - String field with validation
-- `integer()` - Number field with validation
-- `checkbox()` - Boolean field
-- `timestamp()` - Date/time field with auto-now support
-- `password()` - String field (excluded from reads)
-- `select()` - Enum field with predefined options
-- `relationship()` - Foreign key relationship
-- `json()` - JSON data storage
-- `image()` - Image upload with storage adapters
-- `file()` - File upload with storage adapters
-
-**Third-party field packages:**
-
-- `richText()` from `@opensaas/stack-tiptap` - Rich text editor with Tiptap
-- `embedding()` from `@opensaas/stack-rag` - Vector embeddings for semantic search
-
-**Create your own:**
-
-See `examples/custom-field` for a complete working example with:
-
-- **ColorPickerField**: Custom color picker component (global registration)
-- **SlugField**: Auto-generating slug field (per-field override)
-
-Learn more in [CLAUDE.md](./CLAUDE.md#customizing-ui-components).
-
-## Composability
-
-OpenSaas UI offers four levels of abstraction - choose what fits your needs:
-
-### Level 1: Primitives
+Choose your level of abstraction:
 
 ```tsx
-import { Button, Input, Card, Table } from '@opensaas/stack-ui/primitives'
-;<Card>
-  <Input placeholder="Search..." />
-  <Button>Submit</Button>
-</Card>
+import { Button, Card } from '@opensaas/stack-ui/primitives' // 1. shadcn/ui primitives
+import { TextField, SelectField } from '@opensaas/stack-ui/fields' // 2. field components
+import { ItemCreateForm, ListTable } from '@opensaas/stack-ui/standalone' // 3. standalone CRUD
+import { AdminUI } from '@opensaas/stack-ui' // 4. full admin UI
 ```
 
-### Level 2: Field Components
+See [`examples/composable-dashboard`](./examples/composable-dashboard) and the [UI docs](https://stack.opensaas.au/docs/packages/ui).
 
-```tsx
-import { TextField, SelectField } from '@opensaas/stack-ui/fields'
-;<form>
-  <TextField name="email" label="Email" value={email} onChange={setEmail} />
-  <SelectField name="role" label="Role" options={roles} />
-</form>
-```
+## Learn more
 
-### Level 3: Standalone Components
+- **[Quick Start](https://stack.opensaas.au/docs/quick-start)** — build a working app
+- **[Building with Claude Code](https://stack.opensaas.au/docs/guides/claude-code)** — the AI-assisted workflow
+- **[Access Control](https://stack.opensaas.au/docs/core-concepts/access-control)** · **[Field Types](https://stack.opensaas.au/docs/core-concepts/field-types)** · **[Hooks](https://stack.opensaas.au/docs/core-concepts/hooks)**
+- **[Authentication](https://stack.opensaas.au/docs/guides/authentication)** · **[Storage](https://stack.opensaas.au/docs/guides/storage-setup)** · **[RAG](https://stack.opensaas.au/docs/packages/rag)**
 
-```tsx
-import { ItemCreateForm, ListTable, SearchBar } from '@opensaas/stack-ui/standalone'
-;<ItemCreateForm
-  fields={config.lists.Post.fields}
-  onSubmit={async (data) => {
-    const post = await createPost(data)
-    return { success: !!post }
-  }}
-/>
-```
+## Contributing & monorepo development
 
-### Level 4: Full Admin UI
-
-```tsx
-import { AdminUI } from '@opensaas/stack-ui'
-;<AdminUI context={context} serverAction={handleAction} />
-```
-
-See [docs/COMPOSABILITY.md](./docs/COMPOSABILITY.md) for complete guide.
-
-## File Storage
-
-OpenSaas provides abstract file storage through the `@opensaas/stack-storage` package with multiple adapters:
-
-### Storage Adapters
-
-- **S3-Compatible** (`@opensaas/stack-storage-s3`): Works with AWS S3, Cloudflare R2, MinIO, and other S3-compatible services
-- **Vercel Blob** (`@opensaas/stack-storage-vercel`): Optimized for Vercel deployments
-
-### Usage
-
-```typescript
-import { config } from '@opensaas/stack-core'
-import { image, file } from '@opensaas/stack-core/fields'
-import { s3Storage } from '@opensaas/stack-storage-s3'
-
-export default config({
-  storage: s3Storage({
-    bucket: process.env.S3_BUCKET!,
-    region: process.env.S3_REGION!,
-    endpoint: process.env.S3_ENDPOINT, // Optional for R2/MinIO
-    credentials: {
-      accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-    },
-  }),
-  lists: {
-    Post: list({
-      fields: {
-        coverImage: image({
-          storage: { maxFileSize: 5 * 1024 * 1024 }, // 5MB
-        }),
-        attachment: file({
-          storage: { maxFileSize: 10 * 1024 * 1024 }, // 10MB
-        }),
-      },
-    }),
-  },
-})
-```
-
-See `examples/file-upload-demo` for complete working example.
-
-## Semantic Search & RAG
-
-OpenSaas provides RAG (Retrieval-Augmented Generation) capabilities through the `@opensaas/stack-rag` package, enabling semantic search with vector embeddings.
-
-### Features
-
-- **Multiple Embedding Providers**: OpenAI, Ollama, and custom providers
-- **Flexible Storage**: pgvector, SQLite VSS, and JSON storage
-- **Automatic Embeddings**: Auto-generate embeddings on create/update via plugin hooks
-- **Text Chunking**: Built-in chunking strategies for long documents
-- **MCP Integration**: Automatic semantic search tools for AI assistants
-- **Access Control**: All searches respect existing access control rules
-
-### Quick Start
-
-```typescript
-import { config, list } from '@opensaas/stack-core'
-import { text } from '@opensaas/stack-core/fields'
-import { ragPlugin, openaiEmbeddings, pgvectorStorage } from '@opensaas/stack-rag'
-import { embedding } from '@opensaas/stack-rag/fields'
-
-export default config({
-  plugins: [
-    ragPlugin({
-      provider: openaiEmbeddings({ apiKey: process.env.OPENAI_API_KEY! }),
-      storage: pgvectorStorage(),
-    }),
-  ],
-  db: { provider: 'postgresql', url: process.env.DATABASE_URL! },
-  lists: {
-    Article: list({
-      fields: {
-        title: text(),
-        content: text(),
-        contentEmbedding: embedding({
-          sourceField: 'content',
-          provider: 'openai',
-          dimensions: 1536,
-          autoGenerate: true, // Auto-generate on create/update
-        }),
-      },
-    }),
-  },
-})
-```
-
-### Semantic Search
-
-```typescript
-import { semanticSearch } from '@opensaas/stack-rag/runtime'
-
-// Search for similar articles
-const results = await semanticSearch({
-  listKey: 'Article',
-  fieldName: 'contentEmbedding',
-  query: 'articles about artificial intelligence',
-  context,
-  limit: 10,
-  minScore: 0.7,
-})
-```
-
-### Local Development
-
-Use Ollama for local development without API costs:
-
-```typescript
-import { ollamaEmbeddings, jsonStorage } from '@opensaas/stack-rag'
-
-ragPlugin({
-  provider: ollamaEmbeddings({
-    baseURL: 'http://localhost:11434',
-    model: 'nomic-embed-text',
-  }),
-  storage: jsonStorage(), // No DB extensions needed
-})
-```
-
-### Supported Storage Backends
-
-- **pgvector**: Production-ready PostgreSQL extension (recommended)
-- **SQLite VSS**: For SQLite-based applications
-- **JSON**: JavaScript-based search (development/small datasets)
-
-See `examples/rag-demo` for complete working example and `specs/rag-integration.md` for detailed documentation.
-
-## Roadmap
-
-- [x] **Phase 1**: Core foundation (config, fields, generators)
-- [x] **Phase 2**: Access control engine
-- [x] **Phase 3**: Hooks system (resolveInput, validateInput, etc.)
-- [x] **Phase 4**: CLI tooling (generate, dev watch mode)
-- [x] **Phase 5**: Composable UI (shadcn/ui primitives, standalone components)
-- [x] **Phase 6**: Better-auth integration
-- [x] **Phase 7**: MCP server for AI assistant integration
-- [x] **Phase 8**: File storage abstraction and adapters
-- [x] **Phase 9**: Third-party field packages (Tiptap, JSON)
-- [x] **Phase 10**: RAG integration with semantic search and embeddings
-- [ ] **Phase 11**: Documentation and guides
-- [ ] **Phase 12**: Testing utilities and helpers
-- [ ] **Phase 13**: Beta release and stability improvements
-
-## Philosophy
-
-### AI-Safe by Design
-
-OpenSaas is designed to be safe for AI coding agents to work with:
-
-- **Clear patterns**: Simple, predictable APIs
-- **Access control first**: Security is automatic, not an afterthought
-- **Type safety**: Catch errors at compile time
-- **Silent failures**: No information leakage
-
-### Inspired by KeystoneJS
-
-OpenSaas takes inspiration from KeystoneJS but modernized for:
-
-- Next.js App Router (not a separate GraphQL server)
-- Server Components and Server Actions
-- Embedded admin UI (not a separate app)
-- AI-agent-friendly development
+Working on OpenSaas Stack itself (not building an app with it)? See **[CONTRIBUTING.md](./CONTRIBUTING.md)** for monorepo setup, building packages, running tests, and the changeset/plugin-version workflow.
 
 ## License
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,273 +1,111 @@
 # Getting Started
 
-This guide will walk you through building and testing the OpenSaaS Stack from the monorepo.
+This guide walks you through building your first app with OpenSaaS Stack — from an empty folder to a running admin UI you can extend with Claude Code. It takes about five minutes.
 
 ## Prerequisites
 
 - Node.js 18+
-- pnpm (install with `npm install -g pnpm`)
-- Basic knowledge of Next.js, TypeScript, and Prisma
+- pnpm (`npm install -g pnpm`)
+- Basic familiarity with Next.js and TypeScript
 
-## Step-by-Step Setup
-
-### 1. Install Dependencies
-
-From the repository root:
+## 1. Scaffold your project
 
 ```bash
-pnpm install
+npm create opensaas-app@latest my-app
 ```
 
-This will install dependencies for all packages in the monorepo.
-
-### 2. Build the Core Package
-
-The `@opensaas/stack-core` package needs to be compiled before it can be used:
-
-```bash
-cd packages/core
-pnpm build
-```
-
-You should see TypeScript compile the source files to the `dist/` directory.
-
-### 3. Set Up the Blog Example
-
-Navigate to the blog example:
-
-```bash
-cd ../../examples/blog
-```
-
-The `.env` file is already created with SQLite configuration.
+The scaffolder does the setup for you: it installs dependencies, runs the
+generator, and creates a local SQLite database. When it finishes you have a
+complete, runnable Next.js project.
 
 {% callout type="info" %}
-Prisma 7 requires database adapters. The examples are pre-configured with the `@prisma/adapter-better-sqlite3` adapter. See the [Config System](/docs/core-concepts/config) for adapter examples.
+Want authentication out of the box? Add `--with-auth`. To skip the automatic
+install/generate/db:push and run those steps yourself, add `--no-install`.
 {% /callout %}
 
-### 4. Generate Prisma Schema and Types
-
-This is the key step - it reads your `opensaas.config.ts` and generates both the Prisma schema and TypeScript types:
+## 2. Run the app
 
 ```bash
-pnpm generate
+cd my-app
+pnpm dev
 ```
 
-You should see:
+Visit:
 
-- `prisma/schema.prisma` created
-- `.opensaas/types.ts` created
-- `.opensaas/context.ts` created
+- **App**: [http://localhost:3000](http://localhost:3000)
+- **Admin UI**: [http://localhost:3000/admin](http://localhost:3000/admin) — auto-generated CRUD for every list
 
-Take a look at these generated files to see what OpenSaaS created from your config!
+## 3. Build features with Claude Code
 
-### 5. Create the Database
+Your project ships ready for [Claude Code](/docs/guides/claude-code): a project
+`CLAUDE.md` describing the framework's patterns, plus MCP tooling. Open the
+project in Claude Code and describe what you want to build:
 
-Push the schema to create the SQLite database:
+- _"Add a comments feature to posts."_
+- _"Add a `publishedAt` timestamp and only show published posts to anonymous users."_
+- _"Add authentication."_
 
-```bash
-pnpm db:push
-```
+Claude makes the change in `opensaas.config.ts`, regenerates, and wires up the
+UI — staying within the access-control guardrails.
 
-This creates `dev.db` with your tables.
+## What just got generated
 
-### 6. Generate Prisma Client
+Your schema lives in `opensaas.config.ts`. Running the generator (which the
+scaffolder did for you, and which you re-run with `pnpm generate`) produces:
 
-```bash
-npx prisma generate
-```
+- **`prisma/schema.prisma`** — the Prisma schema
+- **`.opensaas/types.ts`** — TypeScript types for your lists
+- **`.opensaas/context.ts`** — the access-controlled context factory
 
-This creates the Prisma Client you'll use to interact with the database.
-
-### 7. Run the Test Script
-
-Now for the moment of truth - let's test the access control:
-
-```bash
-npx tsx test-access-control.ts
-```
-
-You should see a comprehensive test output showing:
-
-- ✅ Users being created
-- ✅ Posts being created with internal notes
-- ✅ Anonymous users unable to see draft posts
-- ✅ Published posts visible to everyone
-- ✅ Internal notes hidden from non-authors
-- ✅ Users unable to update others' posts
-- ✅ Silent failures on access denial
-
-## Understanding What Just Happened
-
-### The Config File (`opensaas.config.ts`)
-
-You defined your schema declaratively:
-
-```typescript
-Post: list({
-  fields: {
-    title: text(),
-    internalNotes: text({
-      access: {
-        read: isAuthor, // Field-level access control
-      },
-    }),
-    // ... more fields
-  },
-  access: {
-    operation: {
-      query: ({ session }) => {
-        // Filter posts based on who's asking
-        if (!session) return { status: { equals: 'published' } }
-        return true
-      },
-      update: isAuthor, // Only author can update
-    },
-  },
-})
-```
-
-### The Generator
-
-`pnpm generate` read this config and created:
-
-1. **Prisma Schema** with proper relationships and field types
-2. **TypeScript Types** for type-safe database operations
-3. **Context Factory** for access-controlled database operations
-
-### The Context
-
-Your application code uses the context to interact with the database:
+You interact with the database through the generated context, which enforces
+access control automatically:
 
 ```typescript
 import { getContext } from '@/.opensaas/context'
 
-const context = await getContext()
+const context = await getContext() // pass a session for authenticated access
 const posts = await context.db.post.findMany()
 ```
 
-The context automatically:
-
-- Checks access control rules
-- Filters results based on session
-- Hides fields the user can't access
-- Returns `null` or `[]` on access denial (silent failure)
-
-## Next Steps
-
-### Experiment with the Config
-
-Try modifying `opensaas.config.ts`:
-
-1. Add a new field to Post
-2. Run `pnpm generate` again
-3. See the changes in `prisma/schema.prisma` and `.opensaas/types.ts`
-4. Update the test script to use the new field
-
-### Try Different Access Control Patterns
-
-Modify the access control rules:
+Access-denied operations return `null` or `[]` instead of throwing, so always
+null-check writes:
 
 ```typescript
-// Make all posts public
-query: true
-
-// Require admin role
-update: ({ session }) => session?.role === 'admin'
-
-// Complex filter
-query: ({ session }) => ({
-  OR: [{ status: { equals: 'published' } }, { authorId: { equals: session?.userId } }],
-})
+const post = await context.db.post.update({ where: { id }, data })
+if (!post) {
+  // Either it doesn't exist, or the current session can't access it.
+  return { error: 'Not found or access denied' }
+}
 ```
 
-### Add More Models
+## The development loop
 
-Add a new list to the config:
-
-```typescript
-Comment: list({
-  fields: {
-    text: text({ validation: { isRequired: true } }),
-    post: relationship({ ref: 'Post.comments' }),
-    author: relationship({ ref: 'User.comments' }),
-  },
-  access: {
-    operation: {
-      query: true,
-      create: isSignedIn,
-      update: isAuthor,
-      delete: isAuthor,
-    },
-  },
-})
-```
-
-Then regenerate and test!
-
-## Viewing Your Data
-
-You can use Prisma Studio to view and edit data:
+When you change `opensaas.config.ts` by hand:
 
 ```bash
-pnpm db:studio
+pnpm generate   # regenerate schema, types, and context
+pnpm db:push    # apply schema changes to the database
 ```
 
-This opens a browser-based GUI for your database.
+Use `pnpm db:studio` to browse and edit data in Prisma Studio.
 
-## Troubleshooting
+## Switching to PostgreSQL
 
-### "Module not found" errors
+The starter uses SQLite for zero-setup local development. To move to Postgres,
+set `DATABASE_URL` in `.env`, change `provider` to `'postgresql'` in
+`opensaas.config.ts`, swap the adapter to `@prisma/adapter-pg`, then re-run
+`pnpm generate && pnpm db:push`. See the [Config System](/docs/core-concepts/config)
+for adapter examples.
 
-Make sure you've built the core package:
+## Next steps
 
-```bash
-cd packages/core && pnpm build
-```
+- **[Quick Start](/docs/quick-start)** — the condensed version, plus manual setup for an existing Next.js app
+- **[Building with Claude Code](/docs/guides/claude-code)** — the AI-assisted workflow in depth
+- **[Access Control](/docs/core-concepts/access-control)** — how the engine secures every operation
+- **[Field Types](/docs/core-concepts/field-types)** — all available fields
+- **[Hooks](/docs/core-concepts/hooks)** — data transformation and side effects
 
-### "Cannot find opensaas.config.ts"
-
-Make sure you're in the `examples/blog` directory when running `pnpm generate`.
-
-### TypeScript errors in generated types
-
-This usually means the Prisma client hasn't been generated. Run:
-
-```bash
-npx prisma generate
-```
-
-### Database errors
-
-Reset your database:
-
-```bash
-rm dev.db
-pnpm db:push
-npx prisma generate
-```
-
-## Architecture Overview
-
-```
-Your opensaas.config.ts
-         ↓
-    [Generator]
-         ↓
-    ├─→ prisma/schema.prisma → [Prisma] → @prisma/client
-    ├─→ .opensaas/types.ts → TypeScript types
-    └─→ .opensaas/context.ts → Context factory
-                                    ↓
-                              [getContext]
-                                    ↓
-                           Context with access control
-                                    ↓
-                              Your application
-```
-
-## Learn More
-
-- **[Quick Start](/docs/quick-start)** - 5-minute tutorial
-- **[Access Control](/docs/core-concepts/access-control)** - Deep dive into access control
-- **[Field Types](/docs/core-concepts/field-types)** - All available field types
-- **[Hooks](/docs/core-concepts/hooks)** - Data transformation and side effects
+{% callout type="info" %}
+Contributing to OpenSaaS Stack itself? The monorepo setup (building packages,
+running tests, changesets) lives in `CONTRIBUTING.md` in the repository.
+{% /callout %}


### PR DESCRIPTION
Closes #423. Part of PRD #418.

Rewrites the entry-point docs to be **user-first** (not framework-contributor-first) and accurate to the shipped 3-step onboarding (now on `main` via #426/#429/#428).

## README
- Leads with the 3-step Quick Start: `npm create opensaas-app` → `pnpm dev` → **build with Claude Code** (describe a feature, it builds it).
- A real, correct `opensaas.config.ts` example using the canonical adapter API (`PrismaBetterSqlite3` + `{ url }`) and `@/.opensaas/context`.
- Removed stale content: `examples/rag-demo` (→ `rag-ollama-demo` / `rag-openai-chatbot`), `./lib/context` import path, the deprecated `packages/mcp` listing, and the "Alpha" framing (now "Beta").
- Monorepo/contributor instructions moved to a new **`CONTRIBUTING.md`**.

## Docs "Getting Started"
- Replaced the monorepo build walkthrough (which referenced `test-access-control.ts`) with an app-builder path: scaffold → run → build-with-Claude, including how the generated `.opensaas/context.ts` enforces access control and the silent-failure null-check pattern.

## Notes
- No `packages/*` source changed → no changeset.
- Stale-reference grep is clean; Prettier-formatted.
- Targets `main` (which already has the auto-run flow from #429), so the described 3-step flow matches the shipped code.
- This was completed directly by the EM after the assigned worktree agent stalled; the branch is `claude/onboarding-e2-423`.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_