### PR TITLE
fix(create-opensaas-app): repair with-auth starter — ports + legible auth pages

### DIFF
--- a/.changeset/lucky-zebras-auth.md
+++ b/.changeset/lucky-zebras-auth.md
@@ -1,0 +1,5 @@
+---
+'create-opensaas-app': patch
+---
+
+Fix the with-auth starter template: align all auth URLs to port 3000 (`.env.example` and the `auth-client` default no longer point at 3003), and make the sign-in / sign-up / forgot-password pages legible in light and dark mode by replacing the dark `bg-gray-500/600` card backgrounds with semantic theme tokens (`bg-card`, `text-card-foreground`, `text-muted-foreground`, `text-primary`).

--- a/examples/starter-auth/.env.example
+++ b/examples/starter-auth/.env.example
@@ -3,8 +3,8 @@ DATABASE_URL=file:./dev.db
 
 # Better-auth
 BETTER_AUTH_SECRET=your_secret_key_here  # Generate with: openssl rand -base64 32
-BETTER_AUTH_URL=http://localhost:3003
-NEXT_PUBLIC_APP_URL=http://localhost:3003
+BETTER_AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Rate Limiting
 # Set to true to disable rate limiting (useful for local development and E2E tests)

--- a/examples/starter-auth/app/forgot-password/page.tsx
+++ b/examples/starter-auth/app/forgot-password/page.tsx
@@ -4,18 +4,18 @@ import Link from 'next/link'
 
 export default function ForgotPasswordPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold">Reset Password</h1>
-          <p className="text-gray-600 mt-2">Enter your email to receive a reset link</p>
+          <h1 className="text-3xl font-bold text-foreground">Reset Password</h1>
+          <p className="text-muted-foreground mt-2">Enter your email to receive a reset link</p>
         </div>
 
-        <div className="bg-white rounded-lg shadow-md p-8">
+        <div className="bg-card text-card-foreground border border-border rounded-lg shadow-md p-8">
           <ForgotPasswordForm authClient={authClient} />
 
           <div className="mt-6 text-center text-sm">
-            <Link href="/sign-in" className="text-blue-600 hover:underline">
+            <Link href="/sign-in" className="text-primary hover:underline">
               Back to sign in
             </Link>
           </div>

--- a/examples/starter-auth/app/sign-in/page.tsx
+++ b/examples/starter-auth/app/sign-in/page.tsx
@@ -4,25 +4,25 @@ import Link from 'next/link'
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold">Welcome Back</h1>
-          <p className="text-gray-600 mt-2">Sign in to your account</p>
+          <h1 className="text-3xl font-bold text-foreground">Welcome Back</h1>
+          <p className="text-muted-foreground mt-2">Sign in to your account</p>
         </div>
 
-        <div className="bg-gray-500 rounded-lg shadow-md p-8">
+        <div className="bg-card text-card-foreground border border-border rounded-lg shadow-md p-8">
           <SignInForm authClient={authClient} redirectTo="/admin" showSocialProviders={false} />
 
           <div className="mt-6 text-center text-sm">
-            <Link href="/forgot-password" className="text-blue-600 hover:underline">
+            <Link href="/forgot-password" className="text-primary hover:underline">
               Forgot your password?
             </Link>
           </div>
 
-          <div className="mt-4 text-center text-sm text-gray-600">
-            Don&apost have an account?{' '}
-            <Link href="/sign-up" className="text-blue-600 hover:underline font-medium">
+          <div className="mt-4 text-center text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link href="/sign-up" className="text-primary hover:underline font-medium">
               Sign up
             </Link>
           </div>

--- a/examples/starter-auth/app/sign-up/page.tsx
+++ b/examples/starter-auth/app/sign-up/page.tsx
@@ -4,14 +4,14 @@ import Link from 'next/link'
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold">Create Account</h1>
-          <p className="text-gray-600 mt-2">Get started with OpenSaas Auth Demo</p>
+          <h1 className="text-3xl font-bold text-foreground">Create Account</h1>
+          <p className="text-muted-foreground mt-2">Get started with OpenSaas Auth Demo</p>
         </div>
 
-        <div className="bg-gray-600 rounded-lg shadow-md p-8">
+        <div className="bg-card text-card-foreground border border-border rounded-lg shadow-md p-8">
           <SignUpForm
             authClient={authClient}
             redirectTo="/admin"
@@ -19,9 +19,9 @@ export default function SignUpPage() {
             requirePasswordConfirmation={true}
           />
 
-          <div className="mt-6 text-center text-sm text-gray-600">
+          <div className="mt-6 text-center text-sm text-muted-foreground">
             Already have an account?{' '}
-            <Link href="/sign-in" className="text-blue-600 hover:underline font-medium">
+            <Link href="/sign-in" className="text-primary hover:underline font-medium">
               Sign in
             </Link>
           </div>

--- a/examples/starter-auth/lib/auth-client.ts
+++ b/examples/starter-auth/lib/auth-client.ts
@@ -17,5 +17,5 @@ import { createClient } from '@opensaas/stack-auth/client'
  * ```
  */
 export const authClient = createClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3003',
+  baseURL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
 })


### PR DESCRIPTION
Closes #425. Part of PRD #418.

Repairs the with-auth starter (`examples/starter-auth`, the source of the `create-opensaas-app` with-auth template).

## Port alignment
`BETTER_AUTH_URL` / `NEXT_PUBLIC_APP_URL` in `.env.example` and the `auth-client` default were pointed at port **3003** while the app/README use **3000**. All now use **3000**, so a user who copies `.env.example` can complete sign-up/sign-in without editing ports. (Verified: no `3003` remains anywhere under `examples/starter-auth`.)

## Legibility
The sign-in / sign-up / forgot-password pages rendered form text on dark `bg-gray-500`/`bg-gray-600` cards. They now use semantic theme tokens — `bg-card` / `text-card-foreground` / `text-muted-foreground` / `text-primary` / `border-border` — which are defined in `@opensaas/stack-ui/styles` with `light-dark()` values, so the forms are legible in **both light and dark mode**. Also fixed a `Don&apos;t` apostrophe typo.

## Notes
- Changeset added (`create-opensaas-app: patch`) since this template ships via the scaffolder.
- Lint + Prettier clean; confirmed the theme tokens exist in the UI globals.
- Adopted from the assigned worktree agent's work after reviewing it for correctness (the agent stalled before committing); branch is `claude/onboarding-g2-425`.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_