### PR TITLE
feat(docs): landing page redesign — lead with npm create + the build-with-Claude flow

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,5 +1,62 @@
 import Link from 'next/link'
-import { ArrowRight, BookOpen, Code2, Zap } from 'lucide-react'
+import { ArrowRight, Code2, MessageSquareCode, Rocket, ShieldCheck, Terminal } from 'lucide-react'
+import { CodeBlockServer } from '@/components/CodeBlockServer'
+
+const INSTALL_COMMAND = 'npm create opensaas-app@latest my-app'
+
+const CONFIG_SNIPPET = `import { config, list } from '@opensaas/stack-core'
+import { text, select, relationship } from '@opensaas/stack-core/fields'
+
+export default config({
+  db: { provider: 'sqlite', url: 'file:./dev.db' },
+  lists: {
+    Post: list({
+      fields: {
+        title: text({ validation: { isRequired: true } }),
+        status: select({
+          options: ['draft', 'published'],
+          defaultValue: 'draft',
+        }),
+        author: relationship({ ref: 'User.posts' }),
+      },
+      access: {
+        // Anyone can read; only signed-in authors can edit their own posts.
+        operation: {
+          query: () => true,
+          update: ({ session }) => Boolean(session?.userId),
+        },
+        filter: {
+          update: ({ session }) => ({ authorId: { equals: session?.userId } }),
+        },
+      },
+    }),
+  },
+})
+`
+
+const STEPS = [
+  {
+    icon: Terminal,
+    label: 'Step 1',
+    title: 'Scaffold your app',
+    code: 'npm create opensaas-app',
+    description: 'One command sets up a fully configured OpenSaaS Stack project.',
+  },
+  {
+    icon: Rocket,
+    label: 'Step 2',
+    title: 'Start the dev server',
+    code: 'pnpm dev',
+    description: 'Your admin UI, database, and access control are wired up out of the box.',
+  },
+  {
+    icon: MessageSquareCode,
+    label: 'Step 3',
+    title: 'Describe a feature',
+    code: 'Ask Claude Code',
+    description: 'Tell Claude Code what you want. It builds it on OpenSaaS Stack for you.',
+  },
+]
 
 export default function HomePage() {
   return (
@@ -21,113 +78,151 @@ export default function HomePage() {
       </header>
 
       {/* Hero Section */}
-      <section className="container mx-auto px-4 py-20 text-center">
-        <h1 className="text-5xl font-bold mb-6">
-          Build Admin-Heavy Apps
-          <br />
-          <span className="text-primary">With Built-In Security</span>
-        </h1>
-        <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          A Next.js-based stack for building applications with automatic access control,
-          config-first development, and AI-agent-friendly architecture.
-        </p>
-        <div className="flex gap-4 justify-center">
-          <Link
-            href="/docs/quick-start"
-            className="flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
-          >
-            Quick Start <ArrowRight className="h-4 w-4" />
-          </Link>
-          <Link
-            href="/docs/getting-started"
-            className="flex items-center gap-2 px-6 py-3 border rounded-lg hover:bg-muted transition-colors"
-          >
-            <BookOpen className="h-4 w-4" /> Documentation
-          </Link>
+      <section className="container mx-auto px-4 pt-16 pb-12 md:pt-24 md:pb-20">
+        <div className="max-w-3xl mx-auto text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 mb-6 rounded-full border bg-muted text-sm text-muted-foreground">
+            <ShieldCheck className="h-4 w-4 text-primary" />
+            Access control handled for you
+          </div>
+
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight mb-6">
+            Describe a feature.
+            <br />
+            <span className="text-primary">Claude Code builds it.</span>
+          </h1>
+
+          <p className="text-lg sm:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
+            OpenSaaS Stack is a config-first Next.js stack built for AI-assisted development. Tell
+            Claude Code what you want and it ships real features &mdash; with security and
+            access&#8209;control baked in.
+          </p>
+
+          {/* Prominent install command */}
+          <div className="max-w-xl mx-auto mb-8">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2 font-mono">
+              Start in seconds
+            </p>
+            <div className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-muted/60 shadow-sm text-left">
+              <span className="text-primary font-mono select-none">$</span>
+              <code className="flex-1 font-mono text-sm sm:text-base text-foreground overflow-x-auto whitespace-nowrap">
+                {INSTALL_COMMAND}
+              </code>
+            </div>
+          </div>
+
+          {/* CTAs */}
+          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
+            <Link
+              href="/docs/quick-start"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors font-medium"
+            >
+              Quick Start <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/docs/guides/claude-code"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 border rounded-lg hover:bg-muted transition-colors font-medium"
+            >
+              <MessageSquareCode className="h-4 w-4" /> Build with Claude Code
+            </Link>
+          </div>
         </div>
       </section>
 
-      {/* Features Grid */}
-      <section className="container mx-auto px-4 py-20">
-        <div className="grid md:grid-cols-3 gap-8">
-          <div className="p-6 border rounded-lg">
-            <div className="h-12 w-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-              <Zap className="h-6 w-6 text-primary" />
+      {/* Config snippet */}
+      <section className="container mx-auto px-4 pb-16 md:pb-24">
+        <div className="max-w-3xl mx-auto">
+          <div className="text-center mb-6">
+            <h2 className="text-2xl sm:text-3xl font-bold mb-2">One config, fully secured</h2>
+            <p className="text-muted-foreground max-w-xl mx-auto">
+              Define your data and access rules in{' '}
+              <code className="font-mono">opensaas.config.ts</code>. The engine secures every
+              database operation automatically.
+            </p>
+          </div>
+          <div className="rounded-xl border overflow-hidden shadow-sm">
+            <div className="flex items-center gap-2 px-4 py-2 bg-muted border-b">
+              <span className="h-3 w-3 rounded-full bg-red-400/70" />
+              <span className="h-3 w-3 rounded-full bg-yellow-400/70" />
+              <span className="h-3 w-3 rounded-full bg-green-400/70" />
+              <span className="ml-2 text-xs font-mono text-muted-foreground">
+                opensaas.config.ts
+              </span>
             </div>
-            <h3 className="text-xl font-semibold mb-2">Automatic Access Control</h3>
+            <CodeBlockServer language="typescript" content={CONFIG_SNIPPET} />
+          </div>
+        </div>
+      </section>
+
+      {/* Three-step flow */}
+      <section className="container mx-auto px-4 py-16 md:py-20 border-t">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl font-bold mb-3">From zero to feature in three steps</h2>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            No boilerplate, no manual wiring. Scaffold, run, and let Claude Code do the building.
+          </p>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+          {STEPS.map((step, index) => {
+            const Icon = step.icon
+            return (
+              <div key={step.title} className="relative p-6 border rounded-xl bg-muted/30">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="h-12 w-12 bg-primary/10 rounded-lg flex items-center justify-center">
+                    <Icon className="h-6 w-6 text-primary" />
+                  </div>
+                  <span className="text-4xl font-bold text-primary/15 select-none">
+                    {index + 1}
+                  </span>
+                </div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground font-mono mb-1">
+                  {step.label}
+                </p>
+                <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
+                <code className="inline-block px-2 py-1 mb-3 text-sm font-mono rounded bg-muted text-foreground border">
+                  {step.code}
+                </code>
+                <p className="text-muted-foreground text-sm">{step.description}</p>
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Why it matters */}
+      <section className="container mx-auto px-4 py-16 md:py-20 border-t">
+        <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+          <div className="p-6 border rounded-xl">
+            <div className="h-12 w-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
+              <ShieldCheck className="h-6 w-6 text-primary" />
+            </div>
+            <h3 className="text-xl font-semibold mb-2">Security by default</h3>
             <p className="text-muted-foreground">
-              Define access rules in your config. The engine automatically secures all database
-              operations with zero boilerplate.
+              Access control wraps every database operation. Denied requests fail silently &mdash;
+              no data leaks, no boilerplate.
             </p>
           </div>
 
-          <div className="p-6 border rounded-lg">
+          <div className="p-6 border rounded-xl">
             <div className="h-12 w-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
               <Code2 className="h-6 w-6 text-primary" />
             </div>
-            <h3 className="text-xl font-semibold mb-2">Config-First Development</h3>
+            <h3 className="text-xl font-semibold mb-2">Config-first development</h3>
             <p className="text-muted-foreground">
-              Define your schema, fields, and access rules in one place. Generate Prisma schemas and
-              TypeScript types automatically.
+              Define schema, fields, and rules in one place. Prisma schema and TypeScript types are
+              generated for you.
             </p>
           </div>
 
-          <div className="p-6 border rounded-lg">
+          <div className="p-6 border rounded-xl">
             <div className="h-12 w-12 bg-primary/10 rounded-lg flex items-center justify-center mb-4">
-              <BookOpen className="h-6 w-6 text-primary" />
+              <MessageSquareCode className="h-6 w-6 text-primary" />
             </div>
-            <h3 className="text-xl font-semibold mb-2">AI-Agent Friendly</h3>
+            <h3 className="text-xl font-semibold mb-2">Built for Claude Code</h3>
             <p className="text-muted-foreground">
-              Designed to be understandable by AI coding assistants with clear patterns and
-              comprehensive documentation.
+              Clear, predictable patterns mean AI assistants can map your requirements to real,
+              working features.
             </p>
           </div>
-        </div>
-      </section>
-
-      {/* Quick Links */}
-      <section className="container mx-auto px-4 py-20 border-t">
-        <h2 className="text-3xl font-bold text-center mb-12">Explore the Docs</h2>
-        <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-          <Link
-            href="/docs/quick-start"
-            className="p-6 border rounded-lg hover:border-primary transition-colors"
-          >
-            <h3 className="text-xl font-semibold mb-2">Quick Start</h3>
-            <p className="text-muted-foreground">
-              Get up and running in 5 minutes with a working application.
-            </p>
-          </Link>
-
-          <Link
-            href="/docs/core-concepts/access-control"
-            className="p-6 border rounded-lg hover:border-primary transition-colors"
-          >
-            <h3 className="text-xl font-semibold mb-2">Access Control</h3>
-            <p className="text-muted-foreground">
-              Learn how the automatic access control engine works.
-            </p>
-          </Link>
-
-          <Link
-            href="/docs/guides/custom-fields"
-            className="p-6 border rounded-lg hover:border-primary transition-colors"
-          >
-            <h3 className="text-xl font-semibold mb-2">Custom Fields</h3>
-            <p className="text-muted-foreground">
-              Create custom field types with validation and UI components.
-            </p>
-          </Link>
-
-          <Link
-            href="/docs/api-reference/config"
-            className="p-6 border rounded-lg hover:border-primary transition-colors"
-          >
-            <h3 className="text-xl font-semibold mb-2">API Reference</h3>
-            <p className="text-muted-foreground">
-              Complete API documentation for all config options and field types.
-            </p>
-          </Link>
         </div>
       </section>
 

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -14,19 +14,21 @@ export default config({
       fields: {
         title: text({ validation: { isRequired: true } }),
         status: select({
-          options: ['draft', 'published'],
+          options: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' },
+          ],
           defaultValue: 'draft',
         }),
         author: relationship({ ref: 'User.posts' }),
       },
       access: {
-        // Anyone can read; only signed-in authors can edit their own posts.
         operation: {
-          query: () => true,
-          update: ({ session }) => Boolean(session?.userId),
-        },
-        filter: {
-          update: ({ session }) => ({ authorId: { equals: session?.userId } }),
+          // Anonymous visitors only see published posts; an access rule can
+          // return a boolean or a Prisma filter that scopes the rows.
+          query: ({ session }) => (session ? true : { status: { equals: 'published' } }),
+          // Only the author can edit their own post.
+          update: ({ session }) => (session ? { authorId: { equals: session.userId } } : false),
         },
       },
     }),


### PR DESCRIPTION
Closes #424. Part of PRD #418.

Redesigns the docs-site homepage (`docs/app/page.tsx`) so a prospective user understands the value and the entry point in seconds. Previously it was a generic "Build Admin-Heavy Apps" page with three feature cards — no install command, no code sample, no Claude story.

## New landing page
- **Hero** leads with the one command to start — `npm create opensaas-app@latest my-app` — and the differentiated value prop: describe a feature → Claude Code builds it on OpenSaaS Stack, with access control handled for you.
- A **real, syntax-highlighted `opensaas.config.ts` snippet** (via the existing `CodeBlockServer` component) so visitors can judge the ergonomics.
- The **three-step flow** (scaffold → `pnpm dev` → build with Claude Code) presented visually.
- Clear CTAs to **Quick Start** and the **Claude Code guide** (`/docs/guides/claude-code`).
- Consistent with the existing Tailwind theme; responsive and dark-mode friendly.

## Verification
- `pnpm --filter opensaas-stack-docs build` compiles successfully and the homepage prerenders as static (`○ /`). The only build step needing an env var is the pre-existing `/api/search` route (`OPENAI_API_KEY`), unrelated to this change.
- No `packages/*` change → no changeset.
- Adopted from the assigned worktree agent's work after review (the agent stalled before committing); branch is `claude/onboarding-f2-424`.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_