### PR TITLE
feat(create-opensaas-app): ship a Claude Code AI bundle into scaffolded apps

### DIFF
--- a/.changeset/eager-otters-guide.md
+++ b/.changeset/eager-otters-guide.md
@@ -1,0 +1,7 @@
+---
+'create-opensaas-app': minor
+---
+
+Scaffolded projects are now Claude-Code-ready out of the box. Every template ships an AI bundle — a concise, project-oriented `CLAUDE.md` (the framework's hard rules plus example "ask Claude to build X" prompts) and a `.claude/settings.json` that registers the OpenSaaS MCP server for the project — so your third step is simply to describe a feature to Claude Code.
+
+The bundle is included when AI tooling is enabled (the default / `--with-ai`). Opting out (declining the prompt) removes the bundle from the generated project via `removeAiTooling`.

--- a/examples/starter-auth/.claude/settings.json
+++ b/examples/starter-auth/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "opensaas-stack": {
+      "command": "npx",
+      "args": ["-y", "@opensaas/stack-cli@latest", "mcp", "start"]
+    }
+  }
+}

--- a/examples/starter-auth/CLAUDE.md
+++ b/examples/starter-auth/CLAUDE.md
@@ -1,0 +1,53 @@
+# Building this app with Claude Code
+
+This project is built on **OpenSaaS Stack** with **authentication** (`@opensaas/stack-auth` / Better-auth) already wired in. You describe the feature you want; Claude implements it against the framework's guardrails. This file tells Claude (and you) the rules that keep changes correct and secure.
+
+## The model
+
+Your whole schema lives in **`opensaas.config.ts`** — lists, fields, access control, and hooks, plus the `authPlugin()` that adds the `User`/`Session`/`Account`/`Verification` lists. `pnpm generate` produces the Prisma schema, TypeScript types, and an access-controlled context in `.opensaas/`. The admin UI is generated from the same config; sign-in/up pages live under `app/`.
+
+## How to ask Claude to build features
+
+Describe the outcome, not the plumbing. For example:
+
+- _"Add a `Comment` list owned by the signed-in user; anyone can read, only the author can edit or delete."_
+- _"Add a `role` field to users and let only admins delete posts."_
+- _"Add GitHub OAuth sign-in."_
+
+Claude edits `opensaas.config.ts` (and auth config where needed), runs `pnpm generate`, and updates UI/server code.
+
+## Rules Claude must follow
+
+1. **Always go through the context, never Prisma directly.** Use `import { getContext } from '@/.opensaas/context'` and `context.db.<list>...`. Direct Prisma access bypasses access control.
+2. **Use the session in access control.** Access checks receive `{ session }`; gate with it and scope rows with Prisma filters, e.g. an owner check returns `{ authorId: { equals: session.userId } }`. Anonymous = `session` is null.
+3. **Every list needs access control** (`access.operation`: query/create/update/delete). A check returns a boolean or a Prisma filter.
+4. **Access denial is silent.** Denied operations return `null` (single) or `[]` (many) — never an error. Always null-check writes:
+   ```ts
+   const post = await context.db.post.update({ where: { id }, data })
+   if (!post) return { error: 'Not found or access denied' }
+   ```
+5. **No `any`, no type casts.** Rely on the generated types.
+6. **List names are PascalCase** in config (`Post`); the context uses camelCase (`context.db.post`).
+7. **The database adapter** is `PrismaBetterSqlite3` from `@prisma/adapter-better-sqlite3`, constructed with `{ url }`. Don't use the old `new Database()` form.
+8. **Env**: set `BETTER_AUTH_SECRET` in `.env` (`openssl rand -base64 32`); auth URLs default to `http://localhost:3000`.
+
+## The loop
+
+After changing `opensaas.config.ts`:
+
+```bash
+pnpm generate   # regenerate schema, types, context
+pnpm db:push    # apply to the database
+pnpm dev        # run the app + admin UI
+```
+
+## Get more help from the plugin
+
+For guided, wizard-style feature building, install the OpenSaaS Stack Claude Code plugin once:
+
+```
+/plugin marketplace add OpenSaasAU/stack
+/plugin install opensaas-stack@opensaas-stack-marketplace
+```
+
+This project already registers the OpenSaaS MCP server in `.claude/settings.json`, so the `opensaas_*` tools are available here. Learn more: https://stack.opensaas.au/docs/guides/claude-code

--- a/examples/starter/.claude/settings.json
+++ b/examples/starter/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "opensaas-stack": {
+      "command": "npx",
+      "args": ["-y", "@opensaas/stack-cli@latest", "mcp", "start"]
+    }
+  }
+}

--- a/examples/starter/CLAUDE.md
+++ b/examples/starter/CLAUDE.md
@@ -1,0 +1,52 @@
+# Building this app with Claude Code
+
+This project is built on **OpenSaaS Stack**. You describe the feature you want; Claude implements it against the framework's guardrails. This file tells Claude (and you) the rules that keep changes correct and secure.
+
+## The model
+
+Your whole schema lives in **`opensaas.config.ts`** — lists, fields, access control, and hooks. From it, `pnpm generate` produces the Prisma schema, TypeScript types, and an access-controlled database context in `.opensaas/`. The admin UI at `/admin` is generated from the same config.
+
+## How to ask Claude to build features
+
+Describe the outcome, not the plumbing. For example:
+
+- _"Add a `Comment` list: text body, a relationship to `Post`, and an author relationship to `User`. Anyone can read; only signed-in users can create; only the author can edit or delete."_
+- _"Add a `publishedAt` timestamp to `Post` and only show published posts to anonymous visitors."_
+- _"Add a `coverImage` image field to `Post`."_
+- _"Add authentication."_ (installs and wires `@opensaas/stack-auth`)
+
+Claude edits `opensaas.config.ts`, runs `pnpm generate`, and updates any UI/server code.
+
+## Rules Claude must follow
+
+1. **Always go through the context, never Prisma directly.** Use `import { getContext } from '@/.opensaas/context'` and `context.db.<list>...`. Direct Prisma access bypasses access control.
+2. **Every list needs access control.** Define `access.operation` (query/create/update/delete) on each list. A check returns a boolean, or a Prisma filter that scopes which rows are visible.
+3. **Access denial is silent.** Denied operations return `null` (single) or `[]` (many) — never an error. Always null-check writes:
+   ```ts
+   const post = await context.db.post.update({ where: { id }, data })
+   if (!post) return { error: 'Not found or access denied' }
+   ```
+4. **No `any`, no type casts.** Rely on the generated types; keep everything strongly typed.
+5. **Field/list names are PascalCase** in the config (`Post`, `BlogPost`); the context uses camelCase (`context.db.post`).
+6. **The database adapter** is `PrismaBetterSqlite3` from `@prisma/adapter-better-sqlite3`, constructed with `{ url }` (see `opensaas.config.ts`). Don't introduce the old `new Database()` form.
+
+## The loop
+
+After changing `opensaas.config.ts`:
+
+```bash
+pnpm generate   # regenerate schema, types, context
+pnpm db:push    # apply to the database
+pnpm dev        # run the app + admin UI
+```
+
+## Get more help from the plugin
+
+For guided, wizard-style feature building, install the OpenSaaS Stack Claude Code plugin once:
+
+```
+/plugin marketplace add OpenSaasAU/stack
+/plugin install opensaas-stack@opensaas-stack-marketplace
+```
+
+This project already registers the OpenSaaS MCP server in `.claude/settings.json`, so the `opensaas_*` tools are available here. Learn more: https://stack.opensaas.au/docs/guides/claude-code

--- a/packages/create-opensaas-app/src/index.ts
+++ b/packages/create-opensaas-app/src/index.ts
@@ -10,6 +10,7 @@ import { validateProjectName } from './lib/project-name.js'
 import { generateEnvFiles, type DbProvider } from './lib/env.js'
 import { applyProjectName, rewriteReadmeHeading } from './lib/package-json.js'
 import { planSetupSteps, formatStepFailure, nextStepCommands, type SetupStep } from './lib/setup.js'
+import { removeAiTooling } from './lib/ai-tooling.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -148,6 +149,10 @@ async function createProject(options: TemplateOptions) {
     // Write a runnable .env so `pnpm generate` / `pnpm db:push` work with no
     // manual setup. Both starter templates use SQLite by default.
     await writeEnvFile(targetDir, projectName, 'sqlite', withAuth)
+
+    // Templates ship a Claude Code AI bundle (project CLAUDE.md + .claude/).
+    // Remove it when the user opted out of AI tooling.
+    await removeAiTooling(targetDir, enableMCP)
 
     spinner.succeed(chalk.green('Project created!'))
 

--- a/packages/create-opensaas-app/src/lib/ai-tooling.ts
+++ b/packages/create-opensaas-app/src/lib/ai-tooling.ts
@@ -1,0 +1,49 @@
+/**
+ * AI development-tooling bundle for scaffolded apps.
+ *
+ * Every template ships an "AI bundle" — a project-oriented `CLAUDE.md` plus a
+ * `.claude/` directory that registers the OpenSaaS MCP server — so a freshly
+ * scaffolded project is Claude-Code-ready out of the box. When the user opts
+ * out of AI tooling (`--with-ai` off / "Enable AI development tools?" declined)
+ * that bundle must NOT ship.
+ *
+ * This module keeps the opt-out logic small, pure, and testable:
+ *  - `aiBundlePaths` lists the bundle entries (relative paths) and is the single
+ *    source of truth for what "the AI bundle" is.
+ *  - `removeAiTooling` deletes those entries from a scaffolded project. It is a
+ *    no-op when AI tooling is enabled, so callers can call it unconditionally.
+ */
+
+import fs from 'fs-extra'
+import path from 'path'
+
+/**
+ * The relative paths, inside a scaffolded project, that make up the AI bundle.
+ * Removing exactly these (and nothing else) is what "opting out" means.
+ */
+export const aiBundlePaths: readonly string[] = ['.claude', 'CLAUDE.md']
+
+/**
+ * Remove the AI development-tooling bundle from a scaffolded project unless it
+ * is enabled. The decision is driven only by `enableMCP`; the sole side effect
+ * is deleting the bundle paths under `targetDir`. It is a no-op (and removes
+ * nothing) when AI tooling is enabled, so callers can invoke it unconditionally.
+ *
+ * @returns the relative paths that were removed (empty when AI tooling is kept).
+ */
+export async function removeAiTooling(
+  targetDir: string,
+  enableMCP: boolean,
+): Promise<readonly string[]> {
+  if (enableMCP) return []
+
+  const removed: string[] = []
+  for (const relativePath of aiBundlePaths) {
+    const fullPath = path.join(targetDir, relativePath)
+    if (await fs.pathExists(fullPath)) {
+      await fs.remove(fullPath)
+      removed.push(relativePath)
+    }
+  }
+  return removed
+}

--- a/packages/create-opensaas-app/tests/ai-tooling.test.ts
+++ b/packages/create-opensaas-app/tests/ai-tooling.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+import { aiBundlePaths, removeAiTooling } from '../src/lib/ai-tooling.js'
+
+/**
+ * Build a fake scaffolded project containing the full AI bundle (a project
+ * `CLAUDE.md` and a `.claude/` directory with settings) plus an unrelated file
+ * that must always survive.
+ */
+async function scaffoldProjectWithAiBundle(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'create-opensaas-app-'))
+  await fs.writeFile(path.join(dir, 'CLAUDE.md'), '# project rules\n')
+  await fs.ensureDir(path.join(dir, '.claude'))
+  await fs.writeJSON(path.join(dir, '.claude', 'settings.json'), { mcpServers: {} })
+  // An unrelated project file the opt-out must never touch.
+  await fs.writeFile(path.join(dir, 'opensaas.config.ts'), 'export default {}\n')
+  return dir
+}
+
+describe('removeAiTooling', () => {
+  let projectDir: string
+
+  beforeEach(async () => {
+    projectDir = await scaffoldProjectWithAiBundle()
+  })
+
+  afterEach(async () => {
+    await fs.remove(projectDir)
+  })
+
+  it('keeps the AI bundle when AI tooling is enabled (enableMCP = true)', async () => {
+    const removed = await removeAiTooling(projectDir, true)
+
+    expect(removed).toEqual([])
+    expect(await fs.pathExists(path.join(projectDir, 'CLAUDE.md'))).toBe(true)
+    expect(await fs.pathExists(path.join(projectDir, '.claude'))).toBe(true)
+    expect(await fs.pathExists(path.join(projectDir, '.claude', 'settings.json'))).toBe(true)
+  })
+
+  it('removes the AI bundle when AI tooling is disabled (enableMCP = false)', async () => {
+    const removed = await removeAiTooling(projectDir, false)
+
+    expect(removed).toEqual([...aiBundlePaths])
+    expect(await fs.pathExists(path.join(projectDir, 'CLAUDE.md'))).toBe(false)
+    expect(await fs.pathExists(path.join(projectDir, '.claude'))).toBe(false)
+  })
+
+  it('leaves unrelated project files untouched when opting out', async () => {
+    await removeAiTooling(projectDir, false)
+
+    expect(await fs.pathExists(path.join(projectDir, 'opensaas.config.ts'))).toBe(true)
+  })
+
+  it('only reports paths that actually existed', async () => {
+    // A project that somehow lacks `.claude` (e.g. a template without it) must
+    // not error and must only report what it actually removed.
+    await fs.remove(path.join(projectDir, '.claude'))
+
+    const removed = await removeAiTooling(projectDir, false)
+
+    expect(removed).toEqual(['CLAUDE.md'])
+    expect(await fs.pathExists(path.join(projectDir, 'CLAUDE.md'))).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #421. Part of PRD #418.

Delivers the core "hand it to an LLM" promise: a scaffolded project is **Claude-Code-ready out of the box**, so the user's third onboarding step is simply to describe a feature.

## What ships into scaffolded apps
Each starter template (`examples/starter`, `examples/starter-auth` — the template sources) now includes an **AI bundle**:
- A concise, **project-oriented `CLAUDE.md`** stating the framework's hard rules (use `context.db` not Prisma; access control required on every list; silent-failure null-checks; no `any`/casts; PascalCase lists; the canonical `PrismaBetterSqlite3 { url }` adapter) and concrete _"ask Claude to build X"_ prompts. The with-auth variant adds session/auth guidance.
- A **`.claude/settings.json`** registering the OpenSaaS MCP server so the `opensaas_*` tools are available in the project.

## Opt-out
`--with-ai` (the default) keeps the bundle. Declining AI tooling removes it via the new `removeAiTooling(targetDir, enableMCP)` helper — pure, single-source-of-truth (`aiBundlePaths = ['.claude', 'CLAUDE.md']`), and called unconditionally by the CLI.

## Verification
- `pnpm --filter create-opensaas-app build` confirms the bundle is copied into **both** `templates/basic` and `templates/with-auth`.
- **26 tests pass** (incl. 4 new `removeAiTooling` tests: keeps when enabled, removes when disabled, leaves unrelated files, reports only what existed) + the scaffold smoke test.
- Changeset added (`create-opensaas-app: minor`). Lint/format clean.
- Built on `main` (which already has A's scaffolder + B's auto-run). The opt-out helper + comprehensive tests came from the assigned worktree agent; the bundle content and CLI wiring were completed by the EM after the agent stalled. Branch: `claude/onboarding-c2-421`.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_