### PR TITLE
refactor(core): deepen the write path into a single Write Pipeline

### DIFF
--- a/.changeset/swift-otters-gather.md
+++ b/.changeset/swift-otters-gather.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Refactor the write path into a single Write Pipeline. The canonical secured write sequence (hooks, validation, access, writable-field filtering, nested operations, persistence, after-hooks, Field Visibility) now lives in one module; create/update/delete are thin adapters over it parameterised by a per-operation strategy. Internal refactor only — no public API or behaviour change.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,3 +25,7 @@ _Avoid_: result filter, output filter, field stripper
 **Silent failure**:
 The convention that an access-denied operation returns `null` (single) or `[]` (many) rather than throwing, so callers cannot distinguish "denied" from "does not exist".
 _Avoid_: access error, permission error
+
+**Write Pipeline**:
+The single module that runs the canonical, secured write sequence (hooks → validation → operation-level access → writable-field filtering → nested operations → persistence → after-hooks → Field Visibility) for one create/update/delete. Owns the phase order in one place; per-operation differences (target resolution, which input phases run, the database verb and returned row) are supplied by a per-operation strategy.
+_Avoid_: operation handler, mutation service

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -4,26 +4,18 @@ import {
   checkAccess,
   mergeFilters,
   filterReadableFields,
-  filterWritableFields,
   buildIncludeWithAccessControl,
 } from '../access/index.js'
-import {
-  executeResolveInput,
-  executeValidate,
-  executeBeforeOperation,
-  executeAfterOperation,
-  executeFieldResolveInputHooks,
-  executeFieldValidateHooks,
-  executeFieldBeforeOperationHooks,
-  executeFieldAfterOperationHooks,
-  validateFieldRules,
-  ValidationError,
-  DatabaseError,
-} from '../hooks/index.js'
-import { processNestedOperations } from './nested-operations.js'
+import { ValidationError, DatabaseError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { PrismaClientLike } from '../access/types.js'
 import { buildInclude, pickFields, isFragment } from '../query/index.js'
+import {
+  runWritePipeline,
+  createWriteStrategy,
+  updateWriteStrategy,
+  deleteWriteStrategy,
+} from './write-pipeline.js'
 
 export type ServerActionProps =
   | { listKey: string; action: 'create'; data: Record<string, unknown> }
@@ -222,7 +214,7 @@ export function getContext<
       findMany: findManyOp,
       create: createOp,
       update: updateOp,
-      delete: createDelete(listName, listConfig, prisma, context),
+      delete: createDelete(listName, listConfig, prisma, context, config),
       count: createCount(listName, listConfig, prisma, context),
       createMany: createCreateMany(listName, listConfig, prisma, context, config, createOp),
       updateMany: createUpdateMany(
@@ -577,163 +569,18 @@ function createCreate<TPrisma extends PrismaClientLike>(
   context: AccessContext<TPrisma>,
   config: OpenSaasConfig,
 ) {
+  // Thin adapter over the Write Pipeline: pick the create strategy, run the
+  // canonical secured write sequence, return its result.
   return async (args: { data: Record<string, unknown> }) => {
-    // 0. Check singleton constraint (enforce even in sudo mode)
-    if (isSingletonList(listConfig)) {
-      // Access Prisma model dynamically - required because model names are generated at runtime
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const model = (prisma as any)[getDbKey(listName)]
-      const existingCount = await model.count()
-
-      if (existingCount > 0) {
-        throw new ValidationError(
-          [`Cannot create: ${listName} is a singleton list with an existing record`],
-          {},
-        )
-      }
-    }
-
-    // 1. Check create access (skip if sudo mode)
-    if (!context._isSudo) {
-      const createAccess = listConfig.access?.operation?.create
-      const accessResult = await checkAccess(createAccess, {
-        session: context.session,
-        context,
-      })
-
-      if (accessResult === false) {
-        return null
-      }
-    }
-
-    // 2. Execute list-level resolveInput hook
-    let resolvedData = await executeResolveInput(listConfig.hooks, {
-      listKey: listName,
-      operation: 'create',
-      inputData: args.data,
-      resolvedData: args.data,
-      item: undefined,
-      context,
-    })
-
-    // 2.5. Execute field-level resolveInput hooks (e.g., hash passwords)
-    resolvedData = await executeFieldResolveInputHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'create',
-      context,
+    return runWritePipeline({
       listName,
-    )
-
-    // 3. Execute list-level validate hook
-    await executeValidate(listConfig.hooks, {
-      listKey: listName,
-      operation: 'create',
-      inputData: args.data,
-      resolvedData,
-      item: undefined,
+      listConfig,
+      prisma,
       context,
-    })
-
-    // 3.5. Execute field-level validate hooks
-    await executeFieldValidateHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'create',
-      context,
-      listName,
-    )
-
-    // 4. Field validation (isRequired, length, etc.)
-    const validation = validateFieldRules(resolvedData, listConfig.fields, 'create')
-    if (validation.errors.length > 0) {
-      throw new ValidationError(validation.errors, validation.fieldErrors)
-    }
-
-    // 5. Filter writable fields (field-level access control, skip if sudo mode)
-    const filteredData = await filterWritableFields(resolvedData, listConfig.fields, 'create', {
-      session: context.session,
-      context: { ...context, _isSudo: context._isSudo },
-      inputData: args.data,
-    })
-
-    // 5.5. Process nested relationship operations
-    const data = await processNestedOperations(
-      filteredData,
-      listConfig.fields,
       config,
-      { ...context, prisma },
-      'create',
-    )
-
-    // 6. Execute field-level beforeOperation hooks (side effects only)
-    await executeFieldBeforeOperationHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'create',
-      context,
-      listName,
-    )
-
-    // 7. Execute list-level beforeOperation hook
-    await executeBeforeOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'create',
       inputData: args.data,
-      resolvedData,
-      context,
+      strategy: createWriteStrategy(listName, listConfig, context),
     })
-
-    // 8. Execute database create
-    // Access Prisma model dynamically - required because model names are generated at runtime
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const model = (prisma as any)[getDbKey(listName)]
-    // Singleton lists use Int @id with value always 1 (matching Keystone 6 behaviour)
-    const createData = isSingletonList(listConfig) ? { id: 1, ...data } : data
-    const item = await model.create({
-      data: createData,
-    })
-
-    // 9. Execute list-level afterOperation hook
-    await executeAfterOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'create',
-      inputData: args.data,
-      item,
-      resolvedData,
-      context,
-    })
-
-    // 10. Execute field-level afterOperation hooks (side effects only)
-    await executeFieldAfterOperationHooks(
-      item,
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'create',
-      context,
-      listName,
-      undefined, // originalItem is undefined for create operations
-    )
-
-    // 11. Filter readable fields and apply resolveOutput hooks (including nested relationships)
-    // Pass sudo flag through context to skip field-level access checks
-    const filtered = await filterReadableFields(
-      item,
-      listConfig.fields,
-      {
-        session: context.session,
-        context: { ...context, _isSudo: context._isSudo },
-      },
-      config,
-      0,
-      listName,
-    )
-
-    return filtered
   }
 }
 
@@ -774,174 +621,18 @@ function createUpdate<TPrisma extends PrismaClientLike>(
   context: AccessContext<TPrisma>,
   config: OpenSaasConfig,
 ) {
+  // Thin adapter over the Write Pipeline: pick the update strategy, run the
+  // canonical secured write sequence, return its result.
   return async (args: { where: { id: string }; data: Record<string, unknown> }) => {
-    // 1. Fetch the item to pass to access control and hooks
-    // Access Prisma model dynamically - required because model names are generated at runtime
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const model = (prisma as any)[getDbKey(listName)]
-    const item = await model.findUnique({
-      where: args.where,
-    })
-
-    if (!item) {
-      return null
-    }
-
-    // 2. Check update access (skip if sudo mode)
-    if (!context._isSudo) {
-      const updateAccess = listConfig.access?.operation?.update
-      const accessResult = await checkAccess(updateAccess, {
-        session: context.session,
-        item,
-        context,
-      })
-
-      if (accessResult === false) {
-        return null
-      }
-
-      // If access returns a filter, check if item matches
-      if (typeof accessResult === 'object') {
-        const matchesFilter = await model.findFirst({
-          where: mergeFilters(args.where, accessResult),
-        })
-
-        if (!matchesFilter) {
-          return null
-        }
-      }
-    }
-
-    // 3. Execute list-level resolveInput hook
-    let resolvedData = await executeResolveInput(listConfig.hooks, {
-      listKey: listName,
-      operation: 'update',
-      inputData: args.data,
-      resolvedData: args.data,
-      item,
-      context,
-    })
-
-    // 3.5. Execute field-level resolveInput hooks (e.g., hash passwords)
-    resolvedData = await executeFieldResolveInputHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'update',
-      context,
+    return runWritePipeline({
       listName,
-      item,
-    )
-
-    // 4. Execute list-level validate hook
-    await executeValidate(listConfig.hooks, {
-      listKey: listName,
-      operation: 'update',
-      inputData: args.data,
-      resolvedData,
-      item,
+      listConfig,
+      prisma,
       context,
-    })
-
-    // 4.5. Execute field-level validate hooks
-    await executeFieldValidateHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'update',
-      context,
-      listName,
-      item,
-    )
-
-    // 5. Field validation (isRequired, length, etc.)
-    const validation = validateFieldRules(resolvedData, listConfig.fields, 'update')
-    if (validation.errors.length > 0) {
-      throw new ValidationError(validation.errors, validation.fieldErrors)
-    }
-
-    // 6. Filter writable fields (field-level access control, skip if sudo mode)
-    const filteredData = await filterWritableFields(resolvedData, listConfig.fields, 'update', {
-      session: context.session,
-      item,
-      context: { ...context, _isSudo: context._isSudo },
-      inputData: args.data,
-    })
-
-    // 6.5. Process nested relationship operations
-    const data = await processNestedOperations(
-      filteredData,
-      listConfig.fields,
       config,
-      { ...context, prisma },
-      'update',
-    )
-
-    // 7. Execute field-level beforeOperation hooks (side effects only)
-    await executeFieldBeforeOperationHooks(
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'update',
-      context,
-      listName,
-      item,
-    )
-
-    // 8. Execute list-level beforeOperation hook
-    await executeBeforeOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'update',
       inputData: args.data,
-      item,
-      resolvedData,
-      context,
+      strategy: updateWriteStrategy(listConfig, context, args.where),
     })
-
-    // 9. Execute database update
-    const updated = await model.update({
-      where: args.where,
-      data,
-    })
-
-    // 10. Execute list-level afterOperation hook
-    await executeAfterOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'update',
-      inputData: args.data,
-      originalItem: item, // item is the original item before the update
-      item: updated,
-      resolvedData,
-      context,
-    })
-
-    // 11. Execute field-level afterOperation hooks (side effects only)
-    await executeFieldAfterOperationHooks(
-      updated,
-      args.data,
-      resolvedData,
-      listConfig.fields,
-      'update',
-      context,
-      listName,
-      item, // item is the original item before the update
-    )
-
-    // 12. Filter readable fields and apply resolveOutput hooks (including nested relationships)
-    // Pass sudo flag through context to skip field-level access checks
-    const filtered = await filterReadableFields(
-      updated,
-      listConfig.fields,
-      {
-        session: context.session,
-        context: { ...context, _isSudo: context._isSudo },
-      },
-      config,
-      0,
-      listName,
-    )
-
-    return filtered
   }
 }
 
@@ -985,114 +676,20 @@ function createDelete<TPrisma extends PrismaClientLike>(
   listConfig: ListConfig<any>,
   prisma: TPrisma,
   context: AccessContext<TPrisma>,
+  config: OpenSaasConfig,
 ) {
+  // Thin adapter over the Write Pipeline: pick the delete strategy, run the
+  // canonical secured write sequence, return its result.
   return async (args: { where: { id: string } }) => {
-    // 0. Check singleton constraint (enforce even in sudo mode)
-    if (isSingletonList(listConfig)) {
-      throw new ValidationError([`Cannot delete: ${listName} is a singleton list`], {})
-    }
-
-    // 1. Fetch the item to pass to access control and hooks
-    // Access Prisma model dynamically - required because model names are generated at runtime
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const model = (prisma as any)[getDbKey(listName)]
-    const item = await model.findUnique({
-      where: args.where,
-    })
-
-    if (!item) {
-      return null
-    }
-
-    // 2. Check delete access (skip if sudo mode)
-    if (!context._isSudo) {
-      const deleteAccess = listConfig.access?.operation?.delete
-      const accessResult = await checkAccess(deleteAccess, {
-        session: context.session,
-        item,
-        context,
-      })
-
-      if (accessResult === false) {
-        return null
-      }
-
-      // If access returns a filter, check if item matches
-      if (typeof accessResult === 'object') {
-        const matchesFilter = await model.findFirst({
-          where: mergeFilters(args.where, accessResult),
-        })
-
-        if (!matchesFilter) {
-          return null
-        }
-      }
-    }
-
-    // 3. Execute list-level validate hook
-    await executeValidate(listConfig.hooks, {
-      listKey: listName,
-      operation: 'delete',
-      item,
-      context,
-    })
-
-    // 3.5. Execute field-level validate hooks
-    await executeFieldValidateHooks(
-      undefined,
-      undefined,
-      listConfig.fields,
-      'delete',
-      context,
+    return runWritePipeline({
       listName,
-      item,
-    )
-
-    // 4. Execute field-level beforeOperation hooks (side effects only)
-    await executeFieldBeforeOperationHooks(
-      {},
-      {},
-      listConfig.fields,
-      'delete',
+      listConfig,
+      prisma,
       context,
-      listName,
-      item,
-    )
-
-    // 5. Execute list-level beforeOperation hook
-    await executeBeforeOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'delete',
-      item,
-      context,
+      config,
+      inputData: undefined,
+      strategy: deleteWriteStrategy(listName, listConfig, context, args.where),
     })
-
-    // 6. Execute database delete
-    const deleted = await model.delete({
-      where: args.where,
-    })
-
-    // 7. Execute list-level afterOperation hook
-    await executeAfterOperation(listConfig.hooks, {
-      listKey: listName,
-      operation: 'delete',
-      originalItem: item, // item is the original item before deletion
-      context,
-    })
-
-    // 8. Execute field-level afterOperation hooks (side effects only)
-    await executeFieldAfterOperationHooks(
-      deleted,
-      undefined,
-      undefined,
-      listConfig.fields,
-      'delete',
-      context,
-      listName,
-      item, // item is the original item before deletion
-    )
-
-    return deleted
   }
 }
 

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -1,0 +1,605 @@
+import type { OpenSaasConfig, ListConfig } from '../config/types.js'
+import type { AccessContext, PrismaClientLike } from '../access/types.js'
+import {
+  checkAccess,
+  mergeFilters,
+  filterReadableFields,
+  filterWritableFields,
+} from '../access/index.js'
+import {
+  executeResolveInput,
+  executeValidate,
+  executeBeforeOperation,
+  executeAfterOperation,
+  executeFieldResolveInputHooks,
+  executeFieldValidateHooks,
+  executeFieldBeforeOperationHooks,
+  executeFieldAfterOperationHooks,
+  validateFieldRules,
+  ValidationError,
+} from '../hooks/index.js'
+import { processNestedOperations } from './nested-operations.js'
+import { getDbKey } from '../lib/case-utils.js'
+
+/**
+ * Write Pipeline — the single module that runs the canonical, secured write
+ * sequence for one create/update/delete. It owns the phase order in one place;
+ * the per-operation differences (target resolution + access, which input phases
+ * run, the DB verb and returned row) are supplied by a {@link WriteStrategy}.
+ *
+ * The phase order is the framework's single most important invariant. See the
+ * "Write Pipeline" glossary term in CONTEXT.md and the hooks ordering in
+ * CLAUDE.md. Reads (findUnique/findMany) and the two-phase read model
+ * (ADR-0001) are intentionally out of scope here.
+ */
+
+/**
+ * The write operations the pipeline can run.
+ */
+export type WriteOperation = 'create' | 'update' | 'delete'
+
+/**
+ * Result of resolving a write target (axis 1).
+ *
+ * - `{ status: 'ok', originalItem }` — proceed. `originalItem` is the existing
+ *   row for update/delete, or `undefined` for create.
+ * - `{ status: 'denied' }` — access denied, missing target, or filter
+ *   non-match. The pipeline short-circuits to `null` (silent failure) BEFORE
+ *   any input phases, before-hooks, or the DB call.
+ */
+export type TargetResolution =
+  | { status: 'ok'; originalItem: Record<string, unknown> | undefined }
+  | { status: 'denied' }
+
+/**
+ * Minimal dynamic Prisma model surface used by the write pipeline. Model names
+ * are generated at runtime, so the concrete client type is not known here.
+ */
+export interface PrismaModel {
+  findUnique: (args: { where: Record<string, unknown> }) => Promise<Record<string, unknown> | null>
+  findFirst: (args: { where: Record<string, unknown> }) => Promise<Record<string, unknown> | null>
+  count: () => Promise<number>
+  create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>
+  update: (args: {
+    where: Record<string, unknown>
+    data: Record<string, unknown>
+  }) => Promise<Record<string, unknown>>
+  delete: (args: { where: Record<string, unknown> }) => Promise<Record<string, unknown>>
+}
+
+/**
+ * Per-operation strategy. Supplies the three axes on which create/update/delete
+ * genuinely differ; the pipeline owns the shared phase order around them.
+ *
+ *   1. `resolveTarget` — fetch the target row (if any) + operation-level access.
+ *   2. `runInputPhases` — whether the resolveInput → validate-hooks → field
+ *      rules → filter-writable → nested-ops span runs (create & update: yes;
+ *      delete: no).
+ *   3. `persist` — the DB verb; returns the row passed through Field Visibility.
+ */
+export interface WriteStrategy {
+  operation: WriteOperation
+
+  /**
+   * Axis 1: resolve the target row and check operation-level access. Receives
+   * the dynamically-resolved Prisma model so it can fetch rows and perform
+   * filter re-checks. Implementations must honour `context._isSudo`.
+   */
+  resolveTarget(model: PrismaModel): Promise<TargetResolution>
+
+  /**
+   * Axis 2: whether to run the input-shaping phases (resolveInput → validate
+   * hooks → built-in field rules → filter-writable → nested ops). Delete runs
+   * only its `validate`/field-validate hooks and skips the rest.
+   */
+  runInputPhases: boolean
+
+  /**
+   * Axis 3: execute the database write and return the persisted/deleted row.
+   * `data` is the fully-resolved write payload (empty object for delete).
+   */
+  persist(model: PrismaModel, data: Record<string, unknown>): Promise<Record<string, unknown>>
+}
+
+/**
+ * Resolve the dynamic Prisma model for a list. Model names are generated at
+ * runtime from list keys, which is the one place a cast is unavoidable — it is
+ * kept localized here (mirroring the existing pattern in `context/index.ts`).
+ */
+function getModel<TPrisma extends PrismaClientLike>(
+  prisma: TPrisma,
+  listName: string,
+): PrismaModel {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- model names are generated at runtime
+  return (prisma as any)[getDbKey(listName)] as PrismaModel
+}
+
+/**
+ * Check if a list is configured as a singleton.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function isSingletonList(listConfig: ListConfig<any>): boolean {
+  return !!listConfig.isSingleton
+}
+
+/**
+ * Arguments shared by every write pipeline run.
+ */
+export interface WritePipelineArgs<TPrisma extends PrismaClientLike> {
+  listName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>
+  prisma: TPrisma
+  context: AccessContext<TPrisma>
+  config: OpenSaasConfig
+  /** The original input data for the write (create/update). `undefined` for delete. */
+  inputData: Record<string, unknown> | undefined
+  /** The per-operation strategy supplying the three variation axes. */
+  strategy: WriteStrategy
+}
+
+/**
+ * Run the canonical secured write sequence once.
+ *
+ * Phase order (owned here, in one place):
+ *   resolve target + operation-level access
+ *     → list/field `resolveInput`
+ *     → list/field `validate`
+ *     → built-in field rules (`validateFieldRules`)
+ *     → filter writable fields
+ *     → nested operations
+ *     → list/field `beforeOperation`
+ *     → DB
+ *     → list/field `afterOperation`
+ *     → `filterReadableFields` (Field Visibility)
+ *
+ * Contract preserved exactly:
+ *   - missing target / access denied / filter non-match → `null` (silent),
+ *     BEFORE the DB call and BEFORE `beforeOperation`.
+ *   - validation failure → THROW `ValidationError` (never silent).
+ *   - sudo mode skips access checks and writable-field filtering (the strategy
+ *     and `filterWritableFields` both honour `context._isSudo`).
+ *   - `afterOperation` receives `originalItem` for update/delete (undefined for
+ *     create).
+ *   - delete returns the deleted row as-is (no Field Visibility pass), matching
+ *     current behaviour.
+ */
+export async function runWritePipeline<TPrisma extends PrismaClientLike>(
+  args: WritePipelineArgs<TPrisma>,
+): Promise<Record<string, unknown> | null> {
+  const { listName, listConfig, prisma, context, config, inputData, strategy } = args
+  const { operation } = strategy
+  const model = getModel(prisma, listName)
+
+  // ── Phase 1: resolve target + operation-level access ──────────────────────
+  // Short-circuits to `null` (silent failure) for missing target, denied
+  // access, or filter non-match — before any hook side effects or the DB call.
+  const resolution = await strategy.resolveTarget(model)
+  if (resolution.status === 'denied') {
+    return null
+  }
+  const originalItem = resolution.originalItem
+
+  // ── Delete path: skip input phases, run only validate/field-validate ────────
+  // (matches current delete behaviour exactly).
+  if (!strategy.runInputPhases) {
+    return runDeletePath({ listName, listConfig, context, originalItem, model, strategy })
+  }
+
+  // Only create/update reach here (delete short-circuited above). Narrow the
+  // operation so the field-hook helpers receive a 'create' | 'update' value.
+  const writeOp: 'create' | 'update' = operation === 'create' ? 'create' : 'update'
+
+  // `inputData` is always present for create/update (the operations that run
+  // input phases). Default to {} only as a defensive measure.
+  const input = inputData ?? {}
+
+  // ── Phase 2: list-level resolveInput ──────────────────────────────────────
+  let resolvedData = await executeResolveInput(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData: input,
+          resolvedData: input,
+          item: undefined,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData: input,
+          resolvedData: input,
+          item: originalItem,
+          context,
+        },
+  )
+
+  // ── Phase 2.5: field-level resolveInput (e.g. hash passwords) ──────────────
+  resolvedData = await executeFieldResolveInputHooks(
+    input,
+    resolvedData,
+    listConfig.fields,
+    writeOp,
+    context,
+    listName,
+    originalItem,
+  )
+
+  // ── Phase 3: list-level validate ───────────────────────────────────────────
+  await executeValidate(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData: input,
+          resolvedData,
+          item: undefined,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData: input,
+          resolvedData,
+          item: originalItem,
+          context,
+        },
+  )
+
+  // ── Phase 3.5: field-level validate ─────────────────────────────────────────
+  await executeFieldValidateHooks(
+    input,
+    resolvedData,
+    listConfig.fields,
+    writeOp,
+    context,
+    listName,
+    originalItem,
+  )
+
+  // ── Phase 4: built-in field rules (isRequired, length, etc.) ────────────────
+  // Validation failures THROW (validation is not silent).
+  const validation = validateFieldRules(resolvedData, listConfig.fields, writeOp)
+  if (validation.errors.length > 0) {
+    throw new ValidationError(validation.errors, validation.fieldErrors)
+  }
+
+  // ── Phase 5: filter writable fields (field-level access, skip if sudo) ──────
+  const filteredData = await filterWritableFields(resolvedData, listConfig.fields, writeOp, {
+    session: context.session,
+    item: originalItem,
+    context: { ...context, _isSudo: context._isSudo },
+    inputData: input,
+  })
+
+  // ── Phase 5.5: process nested relationship operations ───────────────────────
+  const data = await processNestedOperations(
+    filteredData,
+    listConfig.fields,
+    config,
+    { ...context, prisma },
+    writeOp,
+  )
+
+  // ── Phase 6: field-level beforeOperation (side effects only) ────────────────
+  await executeFieldBeforeOperationHooks(
+    input,
+    resolvedData,
+    listConfig.fields,
+    writeOp,
+    context,
+    listName,
+    originalItem,
+  )
+
+  // ── Phase 7: list-level beforeOperation ─────────────────────────────────────
+  await executeBeforeOperation(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData: input,
+          resolvedData,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData: input,
+          item: originalItem,
+          resolvedData,
+          context,
+        },
+  )
+
+  // ── Phase 8: DB write ───────────────────────────────────────────────────────
+  const item = await strategy.persist(model, data)
+
+  // ── Phase 9: list-level afterOperation ──────────────────────────────────────
+  await executeAfterOperation(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData: input,
+          item,
+          resolvedData,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData: input,
+          // originalItem is the row before the update
+          originalItem: originalItem as Record<string, unknown>,
+          item,
+          resolvedData,
+          context,
+        },
+  )
+
+  // ── Phase 10: field-level afterOperation (side effects only) ────────────────
+  await executeFieldAfterOperationHooks(
+    item,
+    input,
+    resolvedData,
+    listConfig.fields,
+    writeOp,
+    context,
+    listName,
+    originalItem, // undefined for create, original row for update
+  )
+
+  // ── Phase 11: Field Visibility (filter readable fields + resolveOutput) ─────
+  return filterReadableFields(
+    item,
+    listConfig.fields,
+    {
+      session: context.session,
+      context: { ...context, _isSudo: context._isSudo },
+    },
+    config,
+    0,
+    listName,
+  )
+}
+
+/**
+ * The delete tail of the pipeline: skips the input-shaping phases and runs only
+ * validate/field-validate before the DB delete, then the after-hooks. Returns
+ * the deleted row as-is (no Field Visibility pass) — matching current delete
+ * behaviour exactly.
+ */
+async function runDeletePath(args: {
+  listName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>
+  context: AccessContext
+  originalItem: Record<string, unknown> | undefined
+  model: PrismaModel
+  strategy: WriteStrategy
+}): Promise<Record<string, unknown>> {
+  const { listName, listConfig, context, originalItem, model, strategy } = args
+  const item = originalItem as Record<string, unknown>
+
+  // ── Phase 3: list-level validate (delete) ──────────────────────────────────
+  await executeValidate(listConfig.hooks, {
+    listKey: listName,
+    operation: 'delete',
+    item,
+    context,
+  })
+
+  // ── Phase 3.5: field-level validate (delete) ────────────────────────────────
+  await executeFieldValidateHooks(
+    undefined,
+    undefined,
+    listConfig.fields,
+    'delete',
+    context,
+    listName,
+    item,
+  )
+
+  // ── Phase 6: field-level beforeOperation (delete) ───────────────────────────
+  await executeFieldBeforeOperationHooks(
+    {},
+    {},
+    listConfig.fields,
+    'delete',
+    context,
+    listName,
+    item,
+  )
+
+  // ── Phase 7: list-level beforeOperation (delete) ────────────────────────────
+  await executeBeforeOperation(listConfig.hooks, {
+    listKey: listName,
+    operation: 'delete',
+    item,
+    context,
+  })
+
+  // ── Phase 8: DB delete ──────────────────────────────────────────────────────
+  const deleted = await strategy.persist(model, {})
+
+  // ── Phase 9: list-level afterOperation (delete) ─────────────────────────────
+  await executeAfterOperation(listConfig.hooks, {
+    listKey: listName,
+    operation: 'delete',
+    originalItem: item,
+    context,
+  })
+
+  // ── Phase 10: field-level afterOperation (delete) ───────────────────────────
+  await executeFieldAfterOperationHooks(
+    deleted,
+    undefined,
+    undefined,
+    listConfig.fields,
+    'delete',
+    context,
+    listName,
+    item, // original row before deletion
+  )
+
+  return deleted
+}
+
+// ── Per-operation strategies ──────────────────────────────────────────────────
+
+/**
+ * Create strategy.
+ *
+ * Axis 1: checks `create` access with NO existing row. Enforces the
+ * singleton-create constraint even under sudo. On create, an access result of
+ * `true` OR a filter object both proceed — there is no filter re-check.
+ * Axis 2: runs all input phases.
+ * Axis 3: `model.create({ data })`, prepending `id: 1` for singleton lists.
+ */
+export function createWriteStrategy(
+  listName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  context: AccessContext,
+): WriteStrategy {
+  const singleton = isSingletonList(listConfig)
+  return {
+    operation: 'create',
+    runInputPhases: true,
+    async resolveTarget(model) {
+      // Singleton constraint is enforced even under sudo.
+      if (singleton) {
+        const existingCount = await model.count()
+        if (existingCount > 0) {
+          throw new ValidationError(
+            [`Cannot create: ${listName} is a singleton list with an existing record`],
+            {},
+          )
+        }
+      }
+
+      if (!context._isSudo) {
+        const accessResult = await checkAccess(listConfig.access?.operation?.create, {
+          session: context.session,
+          context,
+        })
+        if (accessResult === false) {
+          return { status: 'denied' }
+        }
+      }
+
+      return { status: 'ok', originalItem: undefined }
+    },
+    async persist(model, data) {
+      // Singleton lists use Int @id with value always 1 (matching Keystone 6).
+      const createData = singleton ? { id: 1, ...data } : data
+      return model.create({ data: createData })
+    },
+  }
+}
+
+/**
+ * Build the shared target resolution for update/delete: fetch the row (missing
+ * → denied), check operation-level access (false → denied), and if access
+ * returns a filter, re-check via `findFirst(mergeFilters(where, filter))`
+ * (no match → denied). An access result of `true` proceeds with no re-check.
+ */
+function resolveExistingTarget(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  context: AccessContext,
+  where: { id: string },
+  access: 'update' | 'delete',
+): (model: PrismaModel) => Promise<TargetResolution> {
+  return async (model) => {
+    const item = await model.findUnique({ where })
+    if (!item) {
+      return { status: 'denied' }
+    }
+
+    if (!context._isSudo) {
+      const accessResult = await checkAccess(listConfig.access?.operation?.[access], {
+        session: context.session,
+        item,
+        context,
+      })
+
+      if (accessResult === false) {
+        return { status: 'denied' }
+      }
+
+      // A filter result must additionally match the target row.
+      if (typeof accessResult === 'object') {
+        const matchesFilter = await model.findFirst({
+          where: mergeFilters(where, accessResult) ?? {},
+        })
+        if (!matchesFilter) {
+          return { status: 'denied' }
+        }
+      }
+    }
+
+    return { status: 'ok', originalItem: item }
+  }
+}
+
+/**
+ * Update strategy.
+ *
+ * Axis 1: fetch row, check `update` access, re-check filter results.
+ * Axis 2: runs all input phases.
+ * Axis 3: `model.update({ where, data })`; afterOperation gets `originalItem`.
+ */
+export function updateWriteStrategy(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  context: AccessContext,
+  where: { id: string },
+): WriteStrategy {
+  return {
+    operation: 'update',
+    runInputPhases: true,
+    resolveTarget: resolveExistingTarget(listConfig, context, where, 'update'),
+    async persist(model, data) {
+      return model.update({ where, data })
+    },
+  }
+}
+
+/**
+ * Delete strategy.
+ *
+ * Axis 1: enforce singleton constraint (even under sudo), fetch row, check
+ * `delete` access, re-check filter results.
+ * Axis 2: SKIPS input phases (runs only validate/field-validate).
+ * Axis 3: `model.delete({ where })`; afterOperation gets `originalItem`.
+ */
+export function deleteWriteStrategy(
+  listName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  context: AccessContext,
+  where: { id: string },
+): WriteStrategy {
+  const resolveTarget = resolveExistingTarget(listConfig, context, where, 'delete')
+  return {
+    operation: 'delete',
+    runInputPhases: false,
+    async resolveTarget(model) {
+      // Singleton lists may not be deleted (enforced even under sudo).
+      if (isSingletonList(listConfig)) {
+        throw new ValidationError([`Cannot delete: ${listName} is a singleton list`], {})
+      }
+      return resolveTarget(model)
+    },
+    async persist(model) {
+      return model.delete({ where })
+    },
+  }
+}

--- a/packages/core/tests/write-pipeline.test.ts
+++ b/packages/core/tests/write-pipeline.test.ts
@@ -1,0 +1,588 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  runWritePipeline,
+  createWriteStrategy,
+  updateWriteStrategy,
+  deleteWriteStrategy,
+} from '../src/context/write-pipeline.js'
+import { ValidationError } from '../src/hooks/index.js'
+import { text } from '../src/fields/index.js'
+import type { OpenSaasConfig, ListConfig } from '../src/config/types.js'
+import type { AccessContext, PrismaClientLike } from '../src/access/types.js'
+
+/**
+ * Unit tests for the Write Pipeline — the single module that owns the canonical
+ * secured write sequence. These drive the pipeline directly through its
+ * interface (fake Prisma model + spy hooks + a list config), which is the whole
+ * point of the deepening: the phase order becomes the test surface.
+ *
+ * Asserted once, across create/update/delete:
+ *   - phases run in the documented order;
+ *   - access denial / missing target / filter non-match short-circuit to `null`
+ *     BEFORE the DB call and BEFORE beforeOperation;
+ *   - validation failure throws ValidationError and never hits the DB;
+ *   - sudo bypasses access + writable filtering;
+ *   - afterOperation sees the persisted row and the correct originalItem.
+ */
+
+// Shared ordered log of phase events for order assertions.
+let events: string[]
+
+/**
+ * Build a fake Prisma model whose methods log their calls. The pipeline
+ * resolves the model dynamically via getDbKey('Post') -> 'post'.
+ */
+function makeFakePrisma(overrides?: {
+  existing?: Record<string, unknown> | null
+  filterMatch?: Record<string, unknown> | null
+  created?: Record<string, unknown>
+  updated?: Record<string, unknown>
+  deleted?: Record<string, unknown>
+  count?: number
+}) {
+  const created = overrides?.created ?? { id: '1', title: 'created' }
+  const updated = overrides?.updated ?? { id: '1', title: 'updated' }
+  const deleted = overrides?.deleted ?? { id: '1', title: 'deleted' }
+
+  const post = {
+    findUnique: vi.fn(async () => {
+      events.push('db:findUnique')
+      return overrides?.existing ?? null
+    }),
+    findFirst: vi.fn(async () => {
+      events.push('db:findFirst')
+      return overrides?.filterMatch ?? null
+    }),
+    count: vi.fn(async () => {
+      events.push('db:count')
+      return overrides?.count ?? 0
+    }),
+    create: vi.fn(async () => {
+      events.push('db:create')
+      return created
+    }),
+    update: vi.fn(async () => {
+      events.push('db:update')
+      return updated
+    }),
+    delete: vi.fn(async () => {
+      events.push('db:delete')
+      return deleted
+    }),
+  }
+
+  return { prisma: { post } as unknown as PrismaClientLike, post }
+}
+
+/**
+ * Build a minimal AccessContext for the pipeline.
+ */
+function makeContext(opts?: { isSudo?: boolean }): AccessContext {
+  return {
+    session: { userId: 'u1' },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prisma: {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db: {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    storage: {} as any,
+    plugins: {},
+    _isSudo: opts?.isSudo ?? false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+}
+
+/**
+ * A list config with a spy on every hook, recording its phase into `events`.
+ * `title` is a required field so we can exercise built-in field rules.
+ */
+function makeListConfig(opts?: {
+  operationAccess?: {
+    create?: () => boolean | Record<string, unknown>
+    update?: () => boolean | Record<string, unknown>
+    delete?: () => boolean | Record<string, unknown>
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}): ListConfig<any> {
+  return {
+    fields: {
+      // Use the real text() builder so built-in field rules (isRequired) and
+      // getZodSchema actually exist, while spying on each hook phase.
+      title: text({
+        validation: { isRequired: true },
+        hooks: {
+          resolveInput: async ({ resolvedData, fieldKey }) => {
+            events.push('field:resolveInput')
+            return resolvedData[fieldKey]
+          },
+          validate: async () => {
+            events.push('field:validate')
+          },
+          beforeOperation: async () => {
+            events.push('field:beforeOperation')
+          },
+          afterOperation: async () => {
+            events.push('field:afterOperation')
+          },
+        },
+      }),
+    },
+    access: {
+      operation: {
+        query: () => true,
+        create: opts?.operationAccess?.create ?? (() => true),
+        update: opts?.operationAccess?.update ?? (() => true),
+        delete: opts?.operationAccess?.delete ?? (() => true),
+      },
+    },
+    hooks: {
+      resolveInput: async ({ resolvedData }) => {
+        events.push('list:resolveInput')
+        return resolvedData
+      },
+      validate: async () => {
+        events.push('list:validate')
+      },
+      beforeOperation: async () => {
+        events.push('list:beforeOperation')
+      },
+      afterOperation: async () => {
+        events.push('list:afterOperation')
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as ListConfig<any>
+}
+
+function makeConfig(listConfig: ListConfig<unknown>): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite' },
+    lists: { Post: listConfig },
+  } as unknown as OpenSaasConfig
+}
+
+beforeEach(() => {
+  events = []
+})
+
+describe('Write Pipeline — phase order', () => {
+  it('runs create phases in the documented order (resolveInput → validate → beforeOp → DB → afterOp → Field Visibility)', async () => {
+    const { prisma, post } = makeFakePrisma({ created: { id: '1', title: 'hi' } })
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'hi' },
+      strategy: createWriteStrategy('Post', listConfig, context),
+    })
+
+    expect(result).toEqual({ id: '1', title: 'hi' })
+    // The DB call must come AFTER all input/validate/before hooks and BEFORE after hooks.
+    expect(events).toEqual([
+      'list:resolveInput',
+      'field:resolveInput',
+      'list:validate',
+      'field:validate',
+      'field:beforeOperation',
+      'list:beforeOperation',
+      'db:create',
+      'list:afterOperation',
+      'field:afterOperation',
+    ])
+    // resolveInput strictly precedes validate, which precedes the DB write.
+    expect(events.indexOf('list:resolveInput')).toBeLessThan(events.indexOf('list:validate'))
+    expect(events.indexOf('list:validate')).toBeLessThan(events.indexOf('db:create'))
+    expect(events.indexOf('db:create')).toBeLessThan(events.indexOf('list:afterOperation'))
+    expect(post.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs update phases in the documented order, fetching the target first', async () => {
+    const existing = { id: '1', title: 'old' }
+    const { prisma, post } = makeFakePrisma({ existing, updated: { id: '1', title: 'new' } })
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toEqual({ id: '1', title: 'new' })
+    expect(events).toEqual([
+      'db:findUnique',
+      'list:resolveInput',
+      'field:resolveInput',
+      'list:validate',
+      'field:validate',
+      'field:beforeOperation',
+      'list:beforeOperation',
+      'db:update',
+      'list:afterOperation',
+      'field:afterOperation',
+    ])
+    expect(post.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs delete phases in the documented order, SKIPPING the input-shaping phases', async () => {
+    const existing = { id: '1', title: 'doomed' }
+    const { prisma, post } = makeFakePrisma({ existing, deleted: existing })
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: undefined,
+      strategy: deleteWriteStrategy('Post', listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toEqual(existing)
+    // Delete runs only validate/field-validate — NO resolveInput.
+    expect(events).toEqual([
+      'db:findUnique',
+      'list:validate',
+      'field:validate',
+      'field:beforeOperation',
+      'list:beforeOperation',
+      'db:delete',
+      'list:afterOperation',
+      'field:afterOperation',
+    ])
+    expect(events).not.toContain('list:resolveInput')
+    expect(events).not.toContain('field:resolveInput')
+    expect(post.delete).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Write Pipeline — short-circuit to null (silent failure)', () => {
+  it('create: access denied short-circuits to null before DB and before beforeOperation', async () => {
+    const { prisma, post } = makeFakePrisma()
+    const listConfig = makeListConfig({ operationAccess: { create: () => false } })
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'hi' },
+      strategy: createWriteStrategy('Post', listConfig, context),
+    })
+
+    expect(result).toBeNull()
+    expect(post.create).not.toHaveBeenCalled()
+    expect(events).not.toContain('list:beforeOperation')
+    expect(events).not.toContain('list:resolveInput')
+  })
+
+  it('update: missing target short-circuits to null before access, hooks, and DB', async () => {
+    const { prisma, post } = makeFakePrisma({ existing: null })
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: 'missing' }),
+    })
+
+    expect(result).toBeNull()
+    expect(post.update).not.toHaveBeenCalled()
+    expect(events).toEqual(['db:findUnique'])
+  })
+
+  it('update: filter non-match short-circuits to null before DB and beforeOperation', async () => {
+    const existing = { id: '1', title: 'old' }
+    // filterMatch null => the access filter does not match the target row.
+    const { prisma, post } = makeFakePrisma({ existing, filterMatch: null })
+    const listConfig = makeListConfig({
+      operationAccess: { update: () => ({ authorId: 'someone-else' }) },
+    })
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toBeNull()
+    expect(post.update).not.toHaveBeenCalled()
+    // Resolution ran findUnique then findFirst (the filter re-check), then bailed.
+    expect(events).toEqual(['db:findUnique', 'db:findFirst'])
+  })
+
+  it('update: a filter that matches the target proceeds through the full pipeline', async () => {
+    const existing = { id: '1', title: 'old' }
+    const { prisma, post } = makeFakePrisma({
+      existing,
+      filterMatch: existing,
+      updated: { id: '1', title: 'new' },
+    })
+    const listConfig = makeListConfig({
+      operationAccess: { update: () => ({ authorId: 'u1' }) },
+    })
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toEqual({ id: '1', title: 'new' })
+    expect(post.findFirst).toHaveBeenCalledTimes(1)
+    expect(post.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('delete: access denied short-circuits to null before DB', async () => {
+    const existing = { id: '1', title: 'x' }
+    const { prisma, post } = makeFakePrisma({ existing })
+    const listConfig = makeListConfig({ operationAccess: { delete: () => false } })
+    const context = makeContext()
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: undefined,
+      strategy: deleteWriteStrategy('Post', listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toBeNull()
+    expect(post.delete).not.toHaveBeenCalled()
+    expect(events).not.toContain('list:beforeOperation')
+  })
+})
+
+describe('Write Pipeline — validation throws (NOT silent)', () => {
+  it('create: a missing required field throws ValidationError and never reaches the DB', async () => {
+    const { prisma, post } = makeFakePrisma()
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    await expect(
+      runWritePipeline({
+        listName: 'Post',
+        listConfig,
+        prisma,
+        context,
+        config: makeConfig(listConfig),
+        inputData: {}, // title is required but absent
+        strategy: createWriteStrategy('Post', listConfig, context),
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+
+    expect(post.create).not.toHaveBeenCalled()
+    // Built-in field rules run AFTER the validate hooks and BEFORE beforeOperation.
+    expect(events).toContain('list:validate')
+    expect(events).not.toContain('list:beforeOperation')
+  })
+})
+
+describe('Write Pipeline — sudo mode', () => {
+  it('create: sudo skips operation-level access checks', async () => {
+    const accessSpy = vi.fn(() => false)
+    const { prisma, post } = makeFakePrisma({ created: { id: '1', title: 'hi' } })
+    const listConfig = makeListConfig({ operationAccess: { create: accessSpy } })
+    const context = makeContext({ isSudo: true })
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'hi' },
+      strategy: createWriteStrategy('Post', listConfig, context),
+    })
+
+    // Access denied would normally null this out; sudo bypasses the check.
+    expect(result).toEqual({ id: '1', title: 'hi' })
+    expect(accessSpy).not.toHaveBeenCalled()
+    expect(post.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('update: sudo skips access and skips the filter re-check', async () => {
+    const accessSpy = vi.fn(() => ({ authorId: 'someone-else' }))
+    const existing = { id: '1', title: 'old' }
+    const { prisma, post } = makeFakePrisma({
+      existing,
+      filterMatch: null,
+      updated: { id: '1', title: 'new' },
+    })
+    const listConfig = makeListConfig({ operationAccess: { update: accessSpy } })
+    const context = makeContext({ isSudo: true })
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: '1' }),
+    })
+
+    expect(result).toEqual({ id: '1', title: 'new' })
+    expect(accessSpy).not.toHaveBeenCalled()
+    expect(post.findFirst).not.toHaveBeenCalled() // no filter re-check under sudo
+    expect(post.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('create: sudo skips writable-field filtering (denied field still written)', async () => {
+    // A field whose create access is false would normally be stripped by
+    // filterWritableFields; under sudo it must survive into the DB payload.
+    const captured: Record<string, unknown>[] = []
+    const post = {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      count: vi.fn(async () => 0),
+      create: vi.fn(async (args: { data: Record<string, unknown> }) => {
+        captured.push(args.data)
+        return { id: '1', ...args.data }
+      }),
+      update: vi.fn(),
+      delete: vi.fn(),
+    }
+    const prisma = { post } as unknown as PrismaClientLike
+
+    const listConfig = {
+      fields: {
+        title: { type: 'text' },
+        locked: { type: 'text', access: { create: async () => false } },
+      },
+      access: { operation: { query: () => true, create: () => true } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as ListConfig<any>
+    const context = makeContext({ isSudo: true })
+
+    const result = await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'hi', locked: 'secret' },
+      strategy: createWriteStrategy('Post', listConfig, context),
+    })
+
+    expect(captured[0]).toEqual({ title: 'hi', locked: 'secret' })
+    expect(result).toMatchObject({ locked: 'secret' })
+  })
+})
+
+describe('Write Pipeline — afterOperation originalItem', () => {
+  it('create: afterOperation receives the persisted row and undefined originalItem', async () => {
+    const persisted = { id: '1', title: 'hi' }
+    const { prisma } = makeFakePrisma({ created: persisted })
+    const afterOp = vi.fn()
+    const listConfig = {
+      fields: { title: { type: 'text' } },
+      access: { operation: { query: () => true, create: () => true } },
+      hooks: { afterOperation: afterOp },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as ListConfig<any>
+    const context = makeContext()
+
+    await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'hi' },
+      strategy: createWriteStrategy('Post', listConfig, context),
+    })
+
+    expect(afterOp).toHaveBeenCalledTimes(1)
+    const arg = afterOp.mock.calls[0][0]
+    expect(arg.operation).toBe('create')
+    expect(arg.item).toEqual(persisted)
+    expect('originalItem' in arg).toBe(false)
+  })
+
+  it('update: afterOperation receives the persisted row and the original row as originalItem', async () => {
+    const existing = { id: '1', title: 'old' }
+    const updated = { id: '1', title: 'new' }
+    const { prisma } = makeFakePrisma({ existing, updated })
+    const afterOp = vi.fn()
+    const listConfig = {
+      fields: { title: { type: 'text' } },
+      access: { operation: { query: () => true, update: () => true } },
+      hooks: { afterOperation: afterOp },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as ListConfig<any>
+    const context = makeContext()
+
+    await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: { title: 'new' },
+      strategy: updateWriteStrategy(listConfig, context, { id: '1' }),
+    })
+
+    const arg = afterOp.mock.calls[0][0]
+    expect(arg.operation).toBe('update')
+    expect(arg.item).toEqual(updated)
+    expect(arg.originalItem).toEqual(existing)
+  })
+
+  it('delete: afterOperation receives the original row as originalItem', async () => {
+    const existing = { id: '1', title: 'doomed' }
+    const { prisma } = makeFakePrisma({ existing, deleted: existing })
+    const afterOp = vi.fn()
+    const listConfig = {
+      fields: { title: { type: 'text' } },
+      access: { operation: { query: () => true, delete: () => true } },
+      hooks: { afterOperation: afterOp },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as ListConfig<any>
+    const context = makeContext()
+
+    await runWritePipeline({
+      listName: 'Post',
+      listConfig,
+      prisma,
+      context,
+      config: makeConfig(listConfig),
+      inputData: undefined,
+      strategy: deleteWriteStrategy('Post', listConfig, context, { id: '1' }),
+    })
+
+    const arg = afterOp.mock.calls[0][0]
+    expect(arg.operation).toBe('delete')
+    expect(arg.originalItem).toEqual(existing)
+  })
+})


### PR DESCRIPTION
Closes #434. Architecture-deepening follow-up (candidate #1 from the `improve-codebase-architecture` review).

## What changed
The secured write sequence was hand-written three times in `createCreate`/`createUpdate`/`createDelete`. It's now a single **Write Pipeline** (`packages/core/src/context/write-pipeline.ts`) that walks the canonical order once; the three factories in `context/index.ts` become thin adapters (that file shrinks by **432 lines**).

**Interface (as grilled):**
- `runWritePipeline({ listName, listConfig, prisma, context, config, inputData, strategy })` — owns the phase order.
- `WriteStrategy` supplies exactly the three variation axes: `resolveTarget(model) → { status:'ok', originalItem } | { status:'denied' }` (axis 1), `runInputPhases: boolean` (axis 2), `persist(model, data) → row` (axis 3). Shared update/delete target resolution lives in one `resolveExistingTarget` helper.

## Contract preserved (behaviour-preserving refactor)
- missing target / operation-access denied / filter non-match → `null` (silent failure), short-circuited **before** the DB call and `beforeOperation`;
- validation failure → **throws `ValidationError`**;
- `_isSudo` skips operation-access + writable-field filtering (singleton-create constraint still enforced under sudo);
- `afterOperation` receives `originalItem` for update/delete (undefined for create);
- `createMany`/`updateMany` keep looping per-item; **reads and `checkFieldAccess` untouched (ADR-0001)**.

## Verification (independently QA'd)
- **Full `packages/core` suite: 602 passed (27 files)** — +15 new tests, zero regressions; re-run independently of the implementer.
- New `packages/core/tests/write-pipeline.test.ts` (15 tests) drives the pipeline through its interface with a fake Prisma model + spy hooks, asserting — once across create/update/delete — phase order; `null` short-circuits never reach the DB/`beforeOperation`; validation throws and never hits the DB; sudo bypass; `afterOperation` row + `originalItem`. Red→green confirmed via a mutation test.
- `CONTEXT.md` gains the **Write Pipeline** glossary term; `@opensaas/stack-core` patch changeset added. `pnpm lint` / `format` / `manypkg check` / core build all clean.

## Reviewer note
`createDelete`'s internal factory signature gained a `config` param (the shared `WritePipelineArgs` carries it; the delete path never runs Field Visibility and still returns the raw deleted row, exactly as before). Internal only — no public API change.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_