### PR TITLE
refactor(core): extract the transform+validate span into a Hook Pipeline

### DIFF
--- a/.changeset/swift-hooks-thread.md
+++ b/.changeset/swift-hooks-thread.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Internal refactor: extract the write transform+validate span into a single Hook Pipeline that the Write Pipeline delegates to. No behaviour change.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,7 @@ _Avoid_: access error, permission error
 **Write Pipeline**:
 The single module that runs the canonical, secured write sequence (hooks → validation → operation-level access → writable-field filtering → nested operations → persistence → after-hooks → Field Visibility) for one create/update/delete. Owns the phase order in one place; per-operation differences (target resolution, which input phases run, the database verb and returned row) are supplied by a per-operation strategy.
 _Avoid_: operation handler, mutation service
+
+**Hook Pipeline**:
+The module that runs the transform+validate span of a write — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — owning that order and the `resolvedData` threading through it. It throws a validation error (never silent) when a validate hook reports via `addValidationError` or a built-in field rule fails, and returns the transformed `resolvedData` on success. The Write Pipeline delegates this span to it; side-effect hooks (`beforeOperation`/`afterOperation`), access, writable-field filtering, persistence and Field Visibility stay in the Write Pipeline.
+_Avoid_: validation service, input resolver

--- a/packages/core/src/context/hook-pipeline.ts
+++ b/packages/core/src/context/hook-pipeline.ts
@@ -1,0 +1,160 @@
+import type { ListConfig } from '../config/types.js'
+import type { AccessContext } from '../access/types.js'
+import {
+  executeResolveInput,
+  executeValidate,
+  executeFieldResolveInputHooks,
+  executeFieldValidateHooks,
+  validateFieldRules,
+  ValidationError,
+} from '../hooks/index.js'
+
+/**
+ * Hook Pipeline — the single module that runs the transform+validate span of a
+ * write: list `resolveInput` → field `resolveInput` → list `validate` → field
+ * `validate` → built-in field rules (`validateFieldRules`). It owns the order of
+ * these phases and the threading of `resolvedData` through them, in one place.
+ *
+ * It is THE place where input is shaped and validated; it throws
+ * {@link ValidationError} on failure exactly as before (validate hooks via
+ * `addValidationError`, then `validateFieldRules`) — validation is never silent.
+ *
+ * Side-effect hooks (`beforeOperation`/`afterOperation`), operation-level access,
+ * writable-field filtering, nested operations, persistence and Field Visibility
+ * are deliberately OUT of this span — they stay in the Write Pipeline. See the
+ * "Hook Pipeline" and "Write Pipeline" glossary terms in CONTEXT.md.
+ */
+
+/**
+ * Arguments for one transform+validate span. Only the create/update operations
+ * run this span (delete skips the input-shaping phases entirely).
+ */
+export interface HookPipelineArgs {
+  operation: 'create' | 'update'
+  listName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>
+  /** The original input data for the write. */
+  inputData: Record<string, unknown>
+  /** The existing row for update; `undefined` for create. */
+  item: Record<string, unknown> | undefined
+  context: AccessContext
+}
+
+/**
+ * Result of a transform+validate span: the fully-resolved write data after the
+ * resolveInput hooks have run and all validation has passed.
+ */
+export interface HookPipelineResult {
+  resolvedData: Record<string, unknown>
+}
+
+/**
+ * The transform+validate span, owning order + `resolvedData` threading.
+ */
+export interface HookPipeline {
+  run(args: HookPipelineArgs): Promise<HookPipelineResult>
+}
+
+/**
+ * Run the transform+validate span once.
+ *
+ * Phase order (owned here, in one place):
+ *   list `resolveInput`
+ *     → field `resolveInput`
+ *     → list `validate`
+ *     → field `validate`
+ *     → built-in field rules (`validateFieldRules`)
+ *
+ * Contract preserved exactly:
+ *   - `resolvedData` starts as `inputData` and is threaded through each phase;
+ *   - validate hooks report failures via `addValidationError` → THROW
+ *     `ValidationError` (never silent);
+ *   - built-in field rule failures THROW `ValidationError`;
+ *   - on success returns the transformed `resolvedData`.
+ */
+async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResult> {
+  const { operation, listName, listConfig, inputData, item, context } = args
+
+  // ── Phase 1: list-level resolveInput ──────────────────────────────────────
+  let resolvedData = await executeResolveInput(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData,
+          resolvedData: inputData,
+          item: undefined,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData,
+          resolvedData: inputData,
+          item,
+          context,
+        },
+  )
+
+  // ── Phase 1.5: field-level resolveInput (e.g. hash passwords) ──────────────
+  resolvedData = await executeFieldResolveInputHooks(
+    inputData,
+    resolvedData,
+    listConfig.fields,
+    operation,
+    context,
+    listName,
+    item,
+  )
+
+  // ── Phase 2: list-level validate ──────────────────────────────────────────
+  await executeValidate(
+    listConfig.hooks,
+    operation === 'create'
+      ? {
+          listKey: listName,
+          operation: 'create',
+          inputData,
+          resolvedData,
+          item: undefined,
+          context,
+        }
+      : {
+          listKey: listName,
+          operation: 'update',
+          inputData,
+          resolvedData,
+          item,
+          context,
+        },
+  )
+
+  // ── Phase 2.5: field-level validate ───────────────────────────────────────
+  await executeFieldValidateHooks(
+    inputData,
+    resolvedData,
+    listConfig.fields,
+    operation,
+    context,
+    listName,
+    item,
+  )
+
+  // ── Phase 3: built-in field rules (isRequired, length, etc.) ──────────────
+  // Validation failures THROW (validation is not silent).
+  const validation = validateFieldRules(resolvedData, listConfig.fields, operation)
+  if (validation.errors.length > 0) {
+    throw new ValidationError(validation.errors, validation.fieldErrors)
+  }
+
+  return { resolvedData }
+}
+
+/**
+ * The default Hook Pipeline instance used by the Write Pipeline.
+ */
+export const hookPipeline: HookPipeline = {
+  run: runHookPipeline,
+}

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -7,17 +7,15 @@ import {
   filterWritableFields,
 } from '../access/index.js'
 import {
-  executeResolveInput,
   executeValidate,
   executeBeforeOperation,
   executeAfterOperation,
-  executeFieldResolveInputHooks,
   executeFieldValidateHooks,
   executeFieldBeforeOperationHooks,
   executeFieldAfterOperationHooks,
-  validateFieldRules,
   ValidationError,
 } from '../hooks/index.js'
+import { hookPipeline } from './hook-pipeline.js'
 import { processNestedOperations } from './nested-operations.js'
 import { getDbKey } from '../lib/case-utils.js'
 
@@ -194,78 +192,18 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
   // input phases). Default to {} only as a defensive measure.
   const input = inputData ?? {}
 
-  // ── Phase 2: list-level resolveInput ──────────────────────────────────────
-  let resolvedData = await executeResolveInput(
-    listConfig.hooks,
-    operation === 'create'
-      ? {
-          listKey: listName,
-          operation: 'create',
-          inputData: input,
-          resolvedData: input,
-          item: undefined,
-          context,
-        }
-      : {
-          listKey: listName,
-          operation: 'update',
-          inputData: input,
-          resolvedData: input,
-          item: originalItem,
-          context,
-        },
-  )
-
-  // ── Phase 2.5: field-level resolveInput (e.g. hash passwords) ──────────────
-  resolvedData = await executeFieldResolveInputHooks(
-    input,
-    resolvedData,
-    listConfig.fields,
-    writeOp,
-    context,
+  // ── Phases 2–4: transform + validate span (Hook Pipeline) ──────────────────
+  // The Hook Pipeline owns the list/field `resolveInput` → list/field `validate`
+  // → built-in field rules span and the `resolvedData` threading through it. It
+  // THROWS `ValidationError` on any validation failure (never silent).
+  const { resolvedData } = await hookPipeline.run({
+    operation: writeOp,
     listName,
-    originalItem,
-  )
-
-  // ── Phase 3: list-level validate ───────────────────────────────────────────
-  await executeValidate(
-    listConfig.hooks,
-    operation === 'create'
-      ? {
-          listKey: listName,
-          operation: 'create',
-          inputData: input,
-          resolvedData,
-          item: undefined,
-          context,
-        }
-      : {
-          listKey: listName,
-          operation: 'update',
-          inputData: input,
-          resolvedData,
-          item: originalItem,
-          context,
-        },
-  )
-
-  // ── Phase 3.5: field-level validate ─────────────────────────────────────────
-  await executeFieldValidateHooks(
-    input,
-    resolvedData,
-    listConfig.fields,
-    writeOp,
+    listConfig,
+    inputData: input,
+    item: originalItem,
     context,
-    listName,
-    originalItem,
-  )
-
-  // ── Phase 4: built-in field rules (isRequired, length, etc.) ────────────────
-  // Validation failures THROW (validation is not silent).
-  const validation = validateFieldRules(resolvedData, listConfig.fields, writeOp)
-  if (validation.errors.length > 0) {
-    throw new ValidationError(validation.errors, validation.fieldErrors)
-  }
+  })
 
   // ── Phase 5: filter writable fields (field-level access, skip if sudo) ──────
   const filteredData = await filterWritableFields(resolvedData, listConfig.fields, writeOp, {

--- a/packages/core/tests/hook-pipeline.test.ts
+++ b/packages/core/tests/hook-pipeline.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { hookPipeline } from '../src/context/hook-pipeline.js'
+import { ValidationError } from '../src/hooks/index.js'
+import { text } from '../src/fields/index.js'
+import type { ListConfig } from '../src/config/types.js'
+import type { AccessContext } from '../src/access/types.js'
+
+/**
+ * Unit tests for the Hook Pipeline — the module that owns the transform+validate
+ * span: list `resolveInput` → field `resolveInput` → list `validate` → field
+ * `validate` → built-in field rules (`validateFieldRules`). These drive
+ * `hookPipeline.run` directly (spy hooks + a list config), so the span order and
+ * the resolvedData threading become the test surface.
+ *
+ * Asserted here:
+ *   - the four hook phases + field rules run in the documented order;
+ *   - a list/field `validate` hook calling `addValidationError` THROWS
+ *     ValidationError (validation is never silent);
+ *   - a built-in field rule failure (isRequired) THROWS ValidationError;
+ *   - on success the pipeline returns the transformed `resolvedData`.
+ */
+
+// Shared ordered log of phase events for order assertions.
+let events: string[]
+
+/**
+ * Build a minimal AccessContext for the pipeline.
+ */
+function makeContext(): AccessContext {
+  return {
+    session: { userId: 'u1' },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prisma: {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db: {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    storage: {} as any,
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+}
+
+/**
+ * A list config with a spy on every span hook, recording its phase into
+ * `events`. `title` is a required field so we can exercise built-in field rules.
+ */
+function makeListConfig(opts?: {
+  listValidateError?: string
+  fieldValidateError?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}): ListConfig<any> {
+  return {
+    fields: {
+      title: text({
+        validation: { isRequired: true },
+        hooks: {
+          resolveInput: async ({ resolvedData, fieldKey }) => {
+            events.push('field:resolveInput')
+            // Uppercase the value so we can assert resolvedData threads through.
+            const value = resolvedData[fieldKey]
+            return typeof value === 'string' ? value.toUpperCase() : value
+          },
+          validate: async ({ addValidationError }) => {
+            events.push('field:validate')
+            if (opts?.fieldValidateError) addValidationError(opts.fieldValidateError)
+          },
+        },
+      }),
+    },
+    access: {
+      operation: { query: () => true, create: () => true, update: () => true },
+    },
+    hooks: {
+      resolveInput: async ({ resolvedData }) => {
+        events.push('list:resolveInput')
+        return resolvedData
+      },
+      validate: async ({ addValidationError }) => {
+        events.push('list:validate')
+        if (opts?.listValidateError) addValidationError(opts.listValidateError)
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as ListConfig<any>
+}
+
+beforeEach(() => {
+  events = []
+})
+
+describe('Hook Pipeline — span order', () => {
+  it('runs create span phases in order: list resolveInput → field resolveInput → list validate → field validate → field rules', async () => {
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    const { resolvedData } = await hookPipeline.run({
+      operation: 'create',
+      listName: 'Post',
+      listConfig,
+      inputData: { title: 'hi' },
+      item: undefined,
+      context,
+    })
+
+    expect(events).toEqual([
+      'list:resolveInput',
+      'field:resolveInput',
+      'list:validate',
+      'field:validate',
+    ])
+    expect(events.indexOf('list:resolveInput')).toBeLessThan(events.indexOf('field:resolveInput'))
+    expect(events.indexOf('field:resolveInput')).toBeLessThan(events.indexOf('list:validate'))
+    expect(events.indexOf('list:validate')).toBeLessThan(events.indexOf('field:validate'))
+    // resolvedData threads through the field resolveInput transform.
+    expect(resolvedData).toEqual({ title: 'HI' })
+  })
+
+  it('runs update span phases in order and passes the existing item through', async () => {
+    const listConfig = makeListConfig()
+    const context = makeContext()
+    const existing = { id: '1', title: 'old' }
+
+    const { resolvedData } = await hookPipeline.run({
+      operation: 'update',
+      listName: 'Post',
+      listConfig,
+      inputData: { title: 'new' },
+      item: existing,
+      context,
+    })
+
+    expect(events).toEqual([
+      'list:resolveInput',
+      'field:resolveInput',
+      'list:validate',
+      'field:validate',
+    ])
+    expect(resolvedData).toEqual({ title: 'NEW' })
+  })
+})
+
+describe('Hook Pipeline — validation throws (NOT silent)', () => {
+  it('throws ValidationError when a list validate hook calls addValidationError', async () => {
+    const listConfig = makeListConfig({ listValidateError: 'list says no' })
+    const context = makeContext()
+
+    await expect(
+      hookPipeline.run({
+        operation: 'create',
+        listName: 'Post',
+        listConfig,
+        inputData: { title: 'hi' },
+        item: undefined,
+        context,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+    // field:validate and field rules never run after a list validate failure.
+    expect(events).not.toContain('field:validate')
+  })
+
+  it('throws ValidationError when a field validate hook calls addValidationError', async () => {
+    const listConfig = makeListConfig({ fieldValidateError: 'field says no' })
+    const context = makeContext()
+
+    await expect(
+      hookPipeline.run({
+        operation: 'create',
+        listName: 'Post',
+        listConfig,
+        inputData: { title: 'hi' },
+        item: undefined,
+        context,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+    expect(events).toContain('field:validate')
+  })
+
+  it('throws ValidationError when a built-in field rule (isRequired) fails', async () => {
+    const listConfig = makeListConfig()
+    const context = makeContext()
+
+    await expect(
+      hookPipeline.run({
+        operation: 'create',
+        listName: 'Post',
+        listConfig,
+        inputData: {}, // title is required but absent
+        item: undefined,
+        context,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+    // The validate hooks ran before the rules threw.
+    expect(events).toContain('list:validate')
+    expect(events).toContain('field:validate')
+  })
+})
+
+describe('Hook Pipeline — resolvedData threading', () => {
+  it('returns the transformed resolvedData merged with list-level resolveInput changes', async () => {
+    const context = makeContext()
+    // List resolveInput injects an extra field; field resolveInput uppercases title.
+    const listConfig = {
+      fields: {
+        title: text({
+          hooks: {
+            resolveInput: async ({ resolvedData, fieldKey }) => {
+              const value = resolvedData[fieldKey]
+              return typeof value === 'string' ? value.toUpperCase() : value
+            },
+          },
+        }),
+        slug: text(),
+      },
+      access: { operation: { query: () => true, create: () => true } },
+      hooks: {
+        resolveInput: async ({ resolvedData }) => ({ ...resolvedData, slug: 'auto-slug' }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as ListConfig<any>
+
+    const { resolvedData } = await hookPipeline.run({
+      operation: 'create',
+      listName: 'Post',
+      listConfig,
+      inputData: { title: 'hello' },
+      item: undefined,
+      context,
+    })
+
+    expect(resolvedData).toEqual({ title: 'HELLO', slug: 'auto-slug' })
+  })
+})


### PR DESCRIPTION
Closes #435. Architecture-deepening follow-up (candidate #2) — successor to the Write Pipeline (#438).

## What changed
Extracted the write path's **transform + validate span** into a single `HookPipeline` (`packages/core/src/context/hook-pipeline.ts`). `runWritePipeline` now delegates that span instead of hand-threading four `execute*` calls + the field-rules block (write-pipeline diff: **+11 / −73**).

`hookPipeline.run({ operation, listName, listConfig, inputData, item, context }) → { resolvedData }` owns the order — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — and **throws `ValidationError`** on any validation failure, exactly as before. Keystone-compliant hook argument shapes are reproduced verbatim. `beforeOperation`/`afterOperation`, operation-level access, writable-field filtering, nested ops, persistence, and Field Visibility are untouched.

## Verification (independently QA'd)
- Full `packages/core` suite **green, zero regressions** (+6 new tests). Re-run independently of the implementer.
- New `packages/core/tests/hook-pipeline.test.ts` drives `hookPipeline.run` with spy hooks: span order (create + update), list-`validate` and field-`validate` `addValidationError` → `ValidationError`, built-in field-rule failure → `ValidationError`, and `resolvedData` threading through both resolveInput layers. Red→green confirmed.
- `CONTEXT.md` gains a **Hook Pipeline** term; `@opensaas/stack-core` patch changeset; lint/format/manypkg/core-build clean. ADR-0001, the two-phase read, and `checkFieldAccess` untouched.

## Reviewer note
`nested-operations.ts` runs a *near-identical but not identical* span (it does **not** run field-level `validate` hooks). Routing it through `HookPipeline` would add a phase it doesn't currently run — a behaviour change — so it was intentionally left as its own sequence. `HookPipeline` is used only by `runWritePipeline` for now.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_