### PR TITLE
refactor(core): dispatch nested operations through a handler registry

### DIFF
--- a/.changeset/nested-handler-registry.md
+++ b/.changeset/nested-handler-registry.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Refactor nested-operation dispatch into a handler registry (internal, no behaviour change)

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -355,6 +355,139 @@ async function processNestedConnectOrCreate(
 }
 
 /**
+ * Arguments passed to every nested-operation handler.
+ *
+ * A handler receives the raw value supplied for a single nested-op kind
+ * (e.g. the contents of `value.create`) alongside everything it needs to apply
+ * hooks, access control, and recursion.
+ */
+interface NestedOpHandlerArgs {
+  /** Raw payload supplied for this nested-op kind (e.g. the value of `value.create`). */
+  value: unknown
+  /** The list name of the related model (e.g. `'User'`). */
+  relatedListName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  relatedListConfig: ListConfig<any>
+  context: AccessContext
+  config: OpenSaasConfig
+  /** Prisma client used for dynamic model access during access checks. */
+  prisma: unknown
+}
+
+/**
+ * A nested-operation handler describes how a single nested-op kind
+ * (`create`, `connect`, …) is processed before it reaches Prisma.
+ *
+ * Adding support for a new nested-op kind means registering a new entry in
+ * {@link nestedOpRegistry}, not editing the dispatch loop.
+ */
+interface NestedOpHandler {
+  /** Produce the processed payload for this nested-op kind. */
+  execute(args: NestedOpHandlerArgs): Promise<unknown>
+}
+
+/**
+ * Registry of nested-operation handlers keyed by nested-op kind.
+ *
+ * The dispatch loop in {@link processNestedOperations} looks handlers up here
+ * instead of branching on each kind. Kinds that require hooks/access control
+ * (`create`, `connect`, `connectOrCreate`, `update`) provide an `execute` that
+ * applies them; pass-through kinds (`disconnect`, `delete`, `deleteMany`,
+ * `set`, `updateMany`) return their value unchanged so Prisma's own
+ * constraints apply.
+ */
+const nestedOpRegistry: Record<string, NestedOpHandler> = {
+  create: {
+    execute: ({ value, relatedListConfig, context, config }) =>
+      processNestedCreate(
+        value as Record<string, unknown> | Array<Record<string, unknown>>,
+        relatedListConfig,
+        context,
+        config,
+      ),
+  },
+  connect: {
+    execute: ({ value, relatedListName, relatedListConfig, context, prisma }) =>
+      processNestedConnect(
+        value as Record<string, unknown> | Array<Record<string, unknown>>,
+        relatedListName,
+        relatedListConfig,
+        context,
+        prisma,
+      ),
+  },
+  connectOrCreate: {
+    execute: ({ value, relatedListName, relatedListConfig, context, config, prisma }) =>
+      processNestedConnectOrCreate(
+        value as Record<string, unknown> | Array<Record<string, unknown>>,
+        relatedListName,
+        relatedListConfig,
+        context,
+        config,
+        prisma,
+      ),
+  },
+  update: {
+    execute: ({ value, relatedListName, relatedListConfig, context, config, prisma }) =>
+      processNestedUpdate(
+        value as Record<string, unknown> | Array<Record<string, unknown>>,
+        relatedListName,
+        relatedListConfig,
+        context,
+        config,
+        prisma,
+      ),
+  },
+  // Pass-through kinds: no hooks/access control, left to Prisma's own constraints.
+  disconnect: { execute: ({ value }) => Promise.resolve(value) },
+  delete: { execute: ({ value }) => Promise.resolve(value) },
+  deleteMany: { execute: ({ value }) => Promise.resolve(value) },
+  set: { execute: ({ value }) => Promise.resolve(value) },
+  updateMany: { execute: ({ value }) => Promise.resolve(value) },
+}
+
+/**
+ * Order in which nested-op kinds are processed for a single relationship field.
+ *
+ * Mirrors the historical in-place dispatch order so behaviour is preserved.
+ */
+const nestedOpOrder = [
+  'create',
+  'connect',
+  'connectOrCreate',
+  'update',
+  'disconnect',
+  'delete',
+  'deleteMany',
+  'set',
+  'updateMany',
+] as const
+
+/**
+ * Process the nested relationship operations supplied for a single
+ * relationship field's value, dispatching each present nested-op kind through
+ * the {@link nestedOpRegistry}.
+ */
+async function processFieldNestedOps(
+  valueRecord: Record<string, unknown>,
+  args: Omit<NestedOpHandlerArgs, 'value'>,
+): Promise<Record<string, unknown>> {
+  const nestedOp: Record<string, unknown> = {}
+
+  for (const kind of nestedOpOrder) {
+    const value = valueRecord[kind]
+    if (value === undefined) {
+      continue
+    }
+
+    const handler = nestedOpRegistry[kind]
+    nestedOp[kind] = await handler.execute({ ...args, value })
+  }
+
+  return nestedOp
+}
+
+/**
  * Process all nested operations in a data payload
  * Recursively handles relationship fields with nested writes
  */
@@ -393,74 +526,14 @@ export async function processNestedOperations(
 
     const { listName: relatedListName, listConfig: relatedListConfig } = relatedConfig
 
-    // Process different nested operation types
-    const nestedOp: Record<string, unknown> = {}
-    const valueRecord = value as Record<string, unknown>
-
-    if (valueRecord.create !== undefined) {
-      nestedOp.create = await processNestedCreate(
-        valueRecord.create as Record<string, unknown> | Array<Record<string, unknown>>,
-        relatedListConfig,
-        context,
-        config,
-      )
-    }
-
-    if (valueRecord.connect !== undefined) {
-      nestedOp.connect = await processNestedConnect(
-        valueRecord.connect as Record<string, unknown> | Array<Record<string, unknown>>,
-        relatedListName,
-        relatedListConfig,
-        context,
-        context.prisma,
-      )
-    }
-
-    if (valueRecord.connectOrCreate !== undefined) {
-      nestedOp.connectOrCreate = await processNestedConnectOrCreate(
-        valueRecord.connectOrCreate as Record<string, unknown> | Array<Record<string, unknown>>,
-        relatedListName,
-        relatedListConfig,
-        context,
-        config,
-        context.prisma,
-      )
-    }
-
-    if (valueRecord.update !== undefined) {
-      nestedOp.update = await processNestedUpdate(
-        valueRecord.update as Record<string, unknown> | Array<Record<string, unknown>>,
-        relatedListName,
-        relatedListConfig,
-        context,
-        config,
-        context.prisma,
-      )
-    }
-
-    // For other operations, pass through (disconnect, delete, set, etc.)
-    // These will be subject to Prisma's own constraints
-    if (valueRecord.disconnect !== undefined) {
-      nestedOp.disconnect = valueRecord.disconnect
-    }
-
-    if (valueRecord.delete !== undefined) {
-      nestedOp.delete = valueRecord.delete
-    }
-
-    if (valueRecord.deleteMany !== undefined) {
-      nestedOp.deleteMany = valueRecord.deleteMany
-    }
-
-    if (valueRecord.set !== undefined) {
-      nestedOp.set = valueRecord.set
-    }
-
-    if (valueRecord.updateMany !== undefined) {
-      nestedOp.updateMany = valueRecord.updateMany
-    }
-
-    processed[fieldName] = nestedOp
+    // Dispatch each present nested-op kind through the handler registry.
+    processed[fieldName] = await processFieldNestedOps(value as Record<string, unknown>, {
+      relatedListName,
+      relatedListConfig,
+      context,
+      config,
+      prisma: context.prisma,
+    })
   }
 
   return processed

--- a/packages/core/tests/nested-operation-registry.test.ts
+++ b/packages/core/tests/nested-operation-registry.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import { config, list } from '../src/config/index.js'
+import { text, relationship } from '../src/fields/index.js'
+
+/**
+ * These tests pin the behaviour of the nested-operation handler registry that
+ * sits behind `processNestedOperations`. Each nested-op kind (create, connect,
+ * connectOrCreate, update) plus the pass-through kinds (disconnect, delete,
+ * deleteMany, set, updateMany) is dispatched via the registry. The tests assert
+ * the exact payload handed to Prisma so a regression in dispatch/ordering is
+ * caught.
+ */
+
+function createMockPrisma() {
+  return {
+    post: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    tag: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  }
+}
+
+function buildConfig() {
+  return config({
+    db: {
+      provider: 'postgresql',
+      url: 'postgresql://localhost:5432/test',
+    },
+    lists: {
+      User: list({
+        fields: {
+          name: text(),
+        },
+        access: {
+          operation: {
+            query: () => true,
+            create: () => true,
+            update: () => true,
+            delete: () => true,
+          },
+        },
+      }),
+      Tag: list({
+        fields: {
+          label: text(),
+        },
+        access: {
+          operation: {
+            query: () => true,
+            create: () => true,
+            update: () => true,
+            delete: () => true,
+          },
+        },
+      }),
+      Post: list({
+        fields: {
+          title: text(),
+          author: relationship({ ref: 'User.posts' }),
+          tags: relationship({ ref: 'Tag', many: true }),
+        },
+        access: {
+          operation: {
+            query: () => true,
+            create: () => true,
+            update: () => true,
+          },
+        },
+      }),
+    },
+  })
+}
+
+describe('Nested Operation Handler Registry', () => {
+  let mockPrisma: ReturnType<typeof createMockPrisma>
+
+  beforeEach(() => {
+    mockPrisma = createMockPrisma()
+    vi.clearAllMocks()
+    mockPrisma.post.findUnique.mockResolvedValue({ id: '1', title: 'Original' })
+    mockPrisma.post.update.mockResolvedValue({ id: '1', title: 'Original' })
+  })
+
+  describe('pass-through kinds', () => {
+    it('passes disconnect through unchanged', async () => {
+      const context = getContext(await buildConfig(), mockPrisma, { userId: '1' })
+
+      await context.db.post.update({
+        where: { id: '1' },
+        data: { author: { disconnect: true } },
+      })
+
+      const passedData = mockPrisma.post.update.mock.calls[0][0].data
+      expect(passedData.author).toEqual({ disconnect: true })
+    })
+
+    it('passes delete, deleteMany, set and updateMany through unchanged', async () => {
+      const context = getContext(await buildConfig(), mockPrisma, { userId: '1' })
+
+      await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          tags: {
+            delete: { id: 'a' },
+            deleteMany: { label: { contains: 'x' } },
+            set: [{ id: 'b' }],
+            updateMany: { where: { id: 'c' }, data: { label: 'renamed' } },
+          },
+        },
+      })
+
+      const passedTags = mockPrisma.post.update.mock.calls[0][0].data.tags
+      expect(passedTags).toEqual({
+        delete: { id: 'a' },
+        deleteMany: { label: { contains: 'x' } },
+        set: [{ id: 'b' }],
+        updateMany: { where: { id: 'c' }, data: { label: 'renamed' } },
+      })
+    })
+  })
+
+  describe('multiple kinds on a single field', () => {
+    it('dispatches create and disconnect together, preserving both', async () => {
+      const context = getContext(await buildConfig(), mockPrisma, { userId: '1' })
+
+      await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          tags: {
+            create: { label: 'new-tag' },
+            disconnect: { id: 'old-tag' },
+          },
+        },
+      })
+
+      const passedTags = mockPrisma.post.update.mock.calls[0][0].data.tags
+      // create is processed through hooks/access (object preserved)
+      expect(passedTags.create).toEqual({ label: 'new-tag' })
+      // disconnect is passed through untouched
+      expect(passedTags.disconnect).toEqual({ id: 'old-tag' })
+    })
+  })
+
+  describe('connectOrCreate kind', () => {
+    it('produces a { where, create } payload via the registry', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null)
+      const context = getContext(await buildConfig(), mockPrisma, { userId: '1' })
+
+      await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          author: {
+            connectOrCreate: {
+              where: { id: '99' },
+              create: { name: 'Created Author' },
+            },
+          },
+        },
+      })
+
+      const passedAuthor = mockPrisma.post.update.mock.calls[0][0].data.author
+      expect(passedAuthor.connectOrCreate).toEqual({
+        where: { id: '99' },
+        create: { name: 'Created Author' },
+      })
+    })
+  })
+
+  describe('non-relationship fields', () => {
+    it('leaves scalar field values untouched', async () => {
+      const context = getContext(await buildConfig(), mockPrisma, { userId: '1' })
+
+      await context.db.post.update({
+        where: { id: '1' },
+        data: { title: 'Updated Title' },
+      })
+
+      const passedData = mockPrisma.post.update.mock.calls[0][0].data
+      expect(passedData.title).toBe('Updated Title')
+    })
+  })
+})


### PR DESCRIPTION
Closes #436. Architecture-deepening follow-up (candidate #3).

## What changed
`processNestedOperations` (`packages/core/src/context/nested-operations.ts`) now dispatches nested relationship writes through a **handler registry** instead of a growing `if (value.create) … else if (value.connect) …` chain. Each kind is a registry entry keyed by name; a per-field helper iterates a fixed order array and calls the matching handler. Adding a kind later = one registry entry, not an edit to the dispatch.

```ts
const nestedOpRegistry: Record<string, NestedOpHandler> = {
  create, connect, connectOrCreate, update,           // real handlers (unchanged)
  disconnect, delete, deleteMany, set, updateMany,     // pass-through to Prisma's constraints
}
```

## Behaviour preservation
- The four real handler functions (`processNestedCreate/Connect/ConnectOrCreate/Update`) are **unchanged** — only the dispatch wrapper was rewritten (confirmed by diff: no edits to the handler bodies).
- Processing order and recursion/validation/access/sudo semantics are identical; `processNestedOperations` keeps its **public signature** (callers in `write-pipeline.ts` untouched).
- No new `any`/casts beyond the pre-existing dynamic-model pattern. ADR-0001 untouched.

## Verification (independently QA'd)
- Clean `packages/core` run (no `dist`): **507 passed across 23 files** (502 baseline + 5 new) — re-run independently.
- New `packages/core/tests/nested-operation-registry.test.ts` pins the seam: pass-through kinds unchanged, multiple kinds on one field, `connectOrCreate` payload shape, scalar fields untouched.
- `@opensaas/stack-core` patch changeset; lint/format/manypkg/core-build clean.

> Note on test counts: vitest also picks up compiled `dist/**/*.test.js` when a build precedes tests (a pre-existing build+test quirk), which inflates the file/test count. The clean figure here is **507/23**.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_