### PR TITLE
feat(core,cli): validate field self-containment at config load, not generation

### DIFF
--- a/.changeset/gentle-fields-guard.md
+++ b/.changeset/gentle-fields-guard.md
@@ -1,0 +1,8 @@
+---
+'@opensaas/stack-core': patch
+'@opensaas/stack-cli': patch
+---
+
+Validate field self-containment at config load instead of failing deep in generation
+
+Core now exports `validateFieldConfig(field, fieldKey, listKey?)` and `validateConfigFields(config)` (plus the `FieldConfigValidationError` type). They check each field implements its generation contract — `getPrismaType`, `getTypeScriptType`, and `getZodSchema` (or `getPrismaRelation` for relationships; virtual fields skip `getPrismaType`) — and return structured per-field errors. `opensaas generate` runs this first and fails fast with a clear message naming the list, field, and missing method, rather than throwing an opaque stack trace mid-generation.

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import type { OpenSaasConfig } from '@opensaas/stack-core'
+import type { OpenSaasConfig, FieldConfig } from '@opensaas/stack-core'
+import { validateConfigFields } from '@opensaas/stack-core'
 import { text } from '@opensaas/stack-core/fields'
 import { writePrismaSchema, writeTypes, writeContext } from '../generator/index.js'
+import { formatFieldValidationErrors } from './generate.js'
 
 // Mock ora module
 vi.mock('ora', () => ({
@@ -277,6 +279,92 @@ describe('Generate Command Integration', () => {
       expect(fs.readdirSync(prismaDir)).toContain('schema.prisma')
       expect(fs.readdirSync(opensaasDir)).toContain('types.ts')
       expect(fs.readdirSync(opensaasDir)).toContain('context.ts')
+    })
+  })
+
+  describe('Field self-containment validation', () => {
+    it('passes a compliant config with no errors', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        lists: {
+          Post: {
+            fields: {
+              title: text({ validation: { isRequired: true } }),
+            },
+          },
+        },
+      }
+
+      expect(validateConfigFields(config)).toEqual([])
+    })
+
+    it('reports a non-compliant field with a friendly message instead of a stack trace', () => {
+      // Simulate a misimplemented (e.g. third-party) field missing getPrismaType.
+      const brokenField = text()
+      delete brokenField.getPrismaType
+
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        lists: {
+          Post: {
+            fields: {
+              title: brokenField as FieldConfig,
+            },
+          },
+        },
+      }
+
+      const errors = validateConfigFields(config)
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        listKey: 'Post',
+        fieldKey: 'title',
+        missingMethod: 'getPrismaType',
+      })
+
+      const message = formatFieldValidationErrors(errors)
+      // Friendly, actionable message naming the list, field, and method...
+      expect(message).toContain('Post.title')
+      expect(message).toContain('getPrismaType')
+      expect(message).toContain('self-containment contract')
+      // ...and explicitly not a raw stack trace.
+      expect(message).not.toContain('at Object.')
+      expect(message).not.toContain('.js:')
+    })
+
+    it('aggregates multiple non-compliant fields across lists into one message', () => {
+      const noPrisma = text()
+      delete noPrisma.getPrismaType
+      const noZod = text()
+      delete noZod.getZodSchema
+
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        lists: {
+          Post: { fields: { title: noPrisma as FieldConfig } },
+          User: { fields: { name: noZod as FieldConfig } },
+        },
+      }
+
+      const errors = validateConfigFields(config)
+      expect(errors).toHaveLength(2)
+
+      const message = formatFieldValidationErrors(errors)
+      expect(message).toContain('2 field(s)')
+      expect(message).toContain('Post.title')
+      expect(message).toContain('User.name')
     })
   })
 })

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -13,7 +13,30 @@ import {
   writePluginTypes,
   writePrismaExtensions,
 } from '../generator/index.js'
-import { OpenSaasConfig } from '@opensaas/stack-core'
+import { OpenSaasConfig, validateConfigFields } from '@opensaas/stack-core'
+import type { FieldConfigValidationError } from '@opensaas/stack-core'
+
+/**
+ * Format field self-containment errors into a friendly, multi-line message.
+ * Each violation names the list, field, and the contract method it omits, so
+ * a misimplemented (often third-party) field is actionable at a glance rather
+ * than surfacing as a deep generator stack trace.
+ */
+export function formatFieldValidationErrors(errors: FieldConfigValidationError[]): string {
+  const lines = errors.map((error) => {
+    const location = error.listKey ? `${error.listKey}.${error.fieldKey}` : error.fieldKey
+    return `  • ${location} (type "${error.fieldType}") is missing ${error.missingMethod}()`
+  })
+
+  return [
+    `${errors.length} field(s) do not satisfy the self-containment contract:`,
+    ...lines,
+    '',
+    'Each field builder must implement getPrismaType, getTypeScriptType, and',
+    'getZodSchema (or getPrismaRelation for relationships) so the generator can',
+    'produce schema and types without inspecting field internals.',
+  ].join('\n')
+}
 
 export async function generateCommand() {
   console.log(chalk.bold('\n🚀 OpenSaas Generator\n'))
@@ -67,6 +90,18 @@ export async function generateCommand() {
         throw err
       }
     }
+
+    // Validate field self-containment up front, before any generation runs.
+    // A misimplemented field surfaces a clear, per-field message here rather
+    // than throwing deep inside schema/type generation.
+    const validationSpinner = ora('Validating field configuration...').start()
+    const fieldErrors = validateConfigFields(config)
+    if (fieldErrors.length > 0) {
+      validationSpinner.fail(chalk.red('Field configuration invalid'))
+      console.error(chalk.red('\n❌ Error:'), formatFieldValidationErrors(fieldErrors))
+      process.exit(1)
+    }
+    validationSpinner.succeed(chalk.green('Field configuration valid'))
 
     // Generate Prisma schema, types, and context
     const generatorSpinner = ora('Generating schema and types...').start()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,3 +33,10 @@ export { getDbKey, getUrlKey, getListKeyFromUrl } from './lib/case-utils.js'
 
 // Validation error surfaced by write operations
 export { ValidationError } from './hooks/index.js'
+
+// Field self-containment validation — checks each field implements the
+// generation contract (getPrismaType / getTypeScriptType / getZodSchema, or
+// getPrismaRelation for relationships) so a misimplemented field fails early
+// with a clear per-field message instead of deep inside generation.
+export { validateFieldConfig, validateConfigFields } from './validation/field-config.js'
+export type { FieldConfigValidationError } from './validation/field-config.js'

--- a/packages/core/src/validation/field-config.test.ts
+++ b/packages/core/src/validation/field-config.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest'
+import { validateFieldConfig, validateConfigFields } from './field-config.js'
+import {
+  text,
+  integer,
+  checkbox,
+  timestamp,
+  password,
+  select,
+  json,
+  relationship,
+  virtual,
+} from '../fields/index.js'
+import type { FieldConfig, OpenSaasConfig } from '../config/types.js'
+
+describe('validateFieldConfig', () => {
+  describe('well-formed fields pass', () => {
+    it.each([
+      ['text', text()],
+      ['integer', integer()],
+      ['checkbox', checkbox()],
+      ['timestamp', timestamp()],
+      ['password', password()],
+      ['select', select({ options: [{ label: 'A', value: 'a' }] })],
+      ['json', json()],
+    ])('a built-in %s field is self-contained', (_name, field) => {
+      expect(validateFieldConfig(field as FieldConfig, 'myField', 'MyList')).toEqual([])
+    })
+
+    it('a relationship field is self-contained via getPrismaRelation', () => {
+      const field = relationship({ ref: 'User.posts' })
+      expect(validateFieldConfig(field as FieldConfig, 'author', 'Post')).toEqual([])
+    })
+
+    it('a virtual field is self-contained without getPrismaType', () => {
+      const field = virtual({
+        type: 'string',
+        hooks: { resolveOutput: () => 'x' },
+      })
+      expect(validateFieldConfig(field as FieldConfig, 'fullName', 'User')).toEqual([])
+    })
+  })
+
+  describe('missing scalar contract methods fail', () => {
+    it('reports a missing getPrismaType naming the list, field, and method', () => {
+      const field = text()
+      delete field.getPrismaType
+
+      const errors = validateFieldConfig(field as FieldConfig, 'title', 'Post')
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        listKey: 'Post',
+        fieldKey: 'title',
+        fieldType: 'text',
+        missingMethod: 'getPrismaType',
+      })
+      expect(errors[0].message).toContain('Post.title')
+      expect(errors[0].message).toContain('getPrismaType')
+      expect(errors[0].message).toContain('not self-contained')
+    })
+
+    it('reports a missing getTypeScriptType naming the method', () => {
+      const field = text()
+      delete field.getTypeScriptType
+
+      const errors = validateFieldConfig(field as FieldConfig, 'title', 'Post')
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].missingMethod).toBe('getTypeScriptType')
+      expect(errors[0].message).toContain('getTypeScriptType')
+    })
+
+    it('reports a missing getZodSchema naming the method', () => {
+      const field = text()
+      delete field.getZodSchema
+
+      const errors = validateFieldConfig(field as FieldConfig, 'title', 'Post')
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].missingMethod).toBe('getZodSchema')
+      expect(errors[0].message).toContain('getZodSchema')
+    })
+
+    it('reports every missing method when a field implements none', () => {
+      const field: FieldConfig = { type: 'custom' }
+
+      const errors = validateFieldConfig(field, 'mystery', 'Widget')
+
+      expect(errors.map((e) => e.missingMethod).sort()).toEqual([
+        'getPrismaType',
+        'getTypeScriptType',
+        'getZodSchema',
+      ])
+      for (const error of errors) {
+        expect(error.message).toContain('Widget.mystery')
+        expect(error.message).toContain('custom')
+      }
+    })
+
+    it('works without a listKey (bare field validation)', () => {
+      const field: FieldConfig = { type: 'custom' }
+      const errors = validateFieldConfig(field, 'mystery')
+      expect(errors).toHaveLength(3)
+      expect(errors[0].listKey).toBeUndefined()
+      expect(errors[0].message).toContain('Field "mystery"')
+    })
+  })
+
+  describe('relationship and virtual variants', () => {
+    it('reports a relationship missing getPrismaRelation', () => {
+      const field: FieldConfig = { type: 'relationship' }
+
+      const errors = validateFieldConfig(field, 'author', 'Post')
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].missingMethod).toBe('getPrismaRelation')
+      expect(errors[0].message).toContain('Post.author')
+    })
+
+    it('reports a virtual field missing getTypeScriptType and getZodSchema', () => {
+      const field: FieldConfig = { type: 'virtual', virtual: true }
+
+      const errors = validateFieldConfig(field, 'fullName', 'User')
+
+      expect(errors.map((e) => e.missingMethod).sort()).toEqual([
+        'getTypeScriptType',
+        'getZodSchema',
+      ])
+    })
+
+    it('does not require getPrismaType for virtual fields', () => {
+      const field: FieldConfig = { type: 'virtual', virtual: true }
+      const errors = validateFieldConfig(field, 'fullName', 'User')
+      expect(errors.some((e) => e.missingMethod === 'getPrismaType')).toBe(false)
+    })
+  })
+})
+
+describe('validateConfigFields', () => {
+  it('returns no errors for a fully compliant config', () => {
+    const config: OpenSaasConfig = {
+      db: {
+        provider: 'sqlite',
+        prismaClientConstructor: () => null as never,
+      },
+      lists: {
+        User: {
+          fields: {
+            name: text({ validation: { isRequired: true } }),
+            posts: relationship({ ref: 'Post.author', many: true }),
+          },
+        },
+        Post: {
+          fields: {
+            title: text(),
+            author: relationship({ ref: 'User.posts' }),
+          },
+        },
+      },
+    }
+
+    expect(validateConfigFields(config)).toEqual([])
+  })
+
+  it('collects per-field errors across every list and names each location', () => {
+    const brokenTitle = text()
+    delete brokenTitle.getPrismaType
+
+    const brokenName = text()
+    delete brokenName.getZodSchema
+
+    const config: OpenSaasConfig = {
+      db: {
+        provider: 'sqlite',
+        prismaClientConstructor: () => null as never,
+      },
+      lists: {
+        User: {
+          fields: {
+            name: brokenName,
+          },
+        },
+        Post: {
+          fields: {
+            title: brokenTitle,
+          },
+        },
+      },
+    }
+
+    const errors = validateConfigFields(config)
+
+    expect(errors).toHaveLength(2)
+    const byField = Object.fromEntries(errors.map((e) => [`${e.listKey}.${e.fieldKey}`, e]))
+    expect(byField['User.name'].missingMethod).toBe('getZodSchema')
+    expect(byField['Post.title'].missingMethod).toBe('getPrismaType')
+  })
+})

--- a/packages/core/src/validation/field-config.ts
+++ b/packages/core/src/validation/field-config.ts
@@ -1,0 +1,145 @@
+import type { FieldConfig, OpenSaasConfig } from '../config/types.js'
+
+/**
+ * A single self-containment violation found on a field.
+ *
+ * Field builders advertise a self-containment contract: every field provides
+ * the generation hooks the schema/type generators delegate to. When a field
+ * (often a third-party one) fails to implement a required method, the
+ * generators historically threw deep inside generation with an opaque stack
+ * trace. This structured error lets the contract be checked up front and
+ * reported per-field with enough context to act on.
+ */
+export interface FieldConfigValidationError {
+  /** The list the offending field belongs to (`undefined` when validating a bare field). */
+  listKey?: string
+  /** The field key (property name) within the list. */
+  fieldKey: string
+  /** The field's declared `type` discriminator (e.g. `'text'`, `'virtual'`). */
+  fieldType: string
+  /** The contract method that is missing. */
+  missingMethod: 'getPrismaType' | 'getTypeScriptType' | 'getZodSchema' | 'getPrismaRelation'
+  /** A human-readable, ready-to-print message naming the list, field, and method. */
+  message: string
+}
+
+/**
+ * Describe a field for an error message. Falls back to a literal when a
+ * `type`-less value slips through (e.g. a malformed third-party field).
+ */
+function describeFieldType(field: FieldConfig): string {
+  return typeof field.type === 'string' && field.type.length > 0 ? field.type : 'unknown'
+}
+
+/**
+ * Type-safe probe for a function-valued property on a field config.
+ *
+ * The three scalar contract methods live on `BaseFieldConfig` and are checked
+ * directly. `getPrismaRelation` only exists on the relationship field variant,
+ * so it is probed structurally here without widening the public type or
+ * reaching for a cast.
+ */
+function hasFieldMethod(field: FieldConfig, method: string): boolean {
+  const value: unknown = Reflect.get(field, method)
+  return typeof value === 'function'
+}
+
+/**
+ * Build the canonical error message for a missing contract method.
+ */
+function buildMessage(
+  fieldType: string,
+  method: FieldConfigValidationError['missingMethod'],
+  fieldKey: string,
+  listKey?: string,
+): string {
+  const location = listKey ? `Field "${listKey}.${fieldKey}"` : `Field "${fieldKey}"`
+  return (
+    `${location} (type "${fieldType}") is not self-contained: it does not implement ` +
+    `${method}(). Field builders must provide this method so the generator can ` +
+    `produce schema and types without inspecting field internals.`
+  )
+}
+
+/**
+ * Validate a single field against the self-containment contract.
+ *
+ * The contract is conditional on field kind, mirroring exactly where the
+ * generators delegate:
+ *
+ *   - `relationship` fields contribute schema via `getPrismaRelation` and are
+ *     skipped by the scalar Prisma/TypeScript/Zod paths, so only
+ *     `getPrismaRelation` is required.
+ *   - `virtual` fields are not stored in the database, so `getPrismaType` is
+ *     legitimately absent; they must still provide `getTypeScriptType` and
+ *     `getZodSchema`.
+ *   - every other (stored scalar) field must provide `getPrismaType`,
+ *     `getTypeScriptType`, and `getZodSchema`.
+ *
+ * @param field - The field config produced by a field builder.
+ * @param fieldKey - The field's key within its list (for messages).
+ * @param listKey - The owning list's key (optional, for messages).
+ * @returns Zero or more structured errors; empty means the field is compliant.
+ */
+export function validateFieldConfig(
+  field: FieldConfig,
+  fieldKey: string,
+  listKey?: string,
+): FieldConfigValidationError[] {
+  const errors: FieldConfigValidationError[] = []
+  const fieldType = describeFieldType(field)
+
+  const requireMethod = (method: FieldConfigValidationError['missingMethod']): void => {
+    if (!hasFieldMethod(field, method)) {
+      errors.push({
+        listKey,
+        fieldKey,
+        fieldType,
+        missingMethod: method,
+        message: buildMessage(fieldType, method, fieldKey, listKey),
+      })
+    }
+  }
+
+  if (field.type === 'relationship') {
+    // Relationships render through the relationship path only.
+    requireMethod('getPrismaRelation')
+    return errors
+  }
+
+  if (field.virtual === true || field.type === 'virtual') {
+    // Virtual fields are not persisted, so getPrismaType is intentionally absent.
+    requireMethod('getTypeScriptType')
+    requireMethod('getZodSchema')
+    return errors
+  }
+
+  // Stored scalar fields must implement the full generation contract.
+  requireMethod('getPrismaType')
+  requireMethod('getTypeScriptType')
+  requireMethod('getZodSchema')
+
+  return errors
+}
+
+/**
+ * Validate every field across every list in a config.
+ *
+ * Intended to run once, before any generation, so a misimplemented field
+ * surfaces a clear per-field message instead of a deep generator stack trace.
+ *
+ * @param config - The fully resolved OpenSaas config.
+ * @returns All self-containment violations, flattened across lists and fields.
+ */
+export function validateConfigFields(config: OpenSaasConfig): FieldConfigValidationError[] {
+  const errors: FieldConfigValidationError[] = []
+
+  for (const [listKey, listConfig] of Object.entries(config.lists)) {
+    if (!listConfig?.fields) continue
+    for (const [fieldKey, fieldConfig] of Object.entries(listConfig.fields)) {
+      errors.push(...validateFieldConfig(fieldConfig, fieldKey, listKey))
+    }
+  }
+
+  return errors
+}


### PR DESCRIPTION
Closes #437. Architecture-deepening follow-up (candidate #4).

## What changed
Field self-containment is now validated **up front** instead of failing deep in generation. New `packages/core/src/validation/field-config.ts`, exported from `@opensaas/stack-core`:
- `validateFieldConfig(field, fieldKey, listKey?)` and `validateConfigFields(config) → FieldConfigValidationError[]`.

The contract is conditional on field kind (mirroring exactly where the generators delegate):
- **relationship** → requires `getPrismaRelation`;
- **virtual** → requires `getTypeScriptType` + `getZodSchema` (no `getPrismaType`, since virtuals aren't persisted);
- **all other (stored scalar)** → requires `getPrismaType` + `getTypeScriptType` + `getZodSchema`.

**Wiring:** `packages/cli/src/commands/generate.ts` runs `validateConfigFields(config)` first — after `beforeGenerate` hooks (so plugin-injected fields are checked), before writing any file — and on failure prints a friendly aggregated message and exits, e.g.:

```
1 field(s) do not satisfy the self-containment contract:
  • Post.title (type "text") is missing getPrismaType()
Each field builder must implement getPrismaType, getTypeScriptType, and
getZodSchema (or getPrismaRelation for relationships)...
```

`dev.ts` delegates to the generate command, so watch mode is covered too. Type-safety note: `getPrismaRelation` is probed via `Reflect.get` (returns `unknown`) since it only exists on the relationship variant — no `any`/cast in the public surface.

## Verification (independently QA'd)
- Clean `packages/core` run: **521 passed** (502 baseline + 19 new) — new `field-config.test.ts` covers every built-in field passing, relationship/virtual variants, each missing method failing with a helpful message, and `validateConfigFields` aggregation.
- Clean `packages/cli` run: **all 12 test files pass** — `generate.test.ts` extended with a compliant config passing, a non-compliant config producing the friendly message (asserted NOT a raw stack trace), and multiple broken fields aggregating into one message.
- Core + CLI `tsc` build clean; lint/format/manypkg clean. Changeset (`@opensaas/stack-core` + `@opensaas/stack-cli`, patch).

## Reviewer notes
- The validator runs in the **generate command**, not inside `config()`, so plugin-injected fields (added during `beforeGenerate`) are included (the issue allowed either).
- The contract exempts `getPrismaType` for virtuals and the scalar trio for relationships, matching the existing generator skip logic — worth confirming no exotic third-party field relies on a different exemption.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_