### PR TITLE
test(core): honest + gated core coverage (exclude dist; per-file thresholds)

### DIFF
--- a/.changeset/quiet-otters-gather.md
+++ b/.changeset/quiet-otters-gather.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Exclude `**/dist/**` from Vitest test discovery and gate coverage on `src/access`, `src/context`, and `src/validation` via per-file thresholds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,23 @@ cd packages/cli && pnpm test
 
 End-to-end tests use Playwright (`pnpm test:e2e` from the repo root).
 
+### Coverage gating
+
+Coverage is reported for every package but **gated only on the
+security-critical core paths** — `src/access/**`, `src/context/**` (the
+read/write path, including the Write Pipeline, Hook Pipeline, and
+nested-operation registry), and `src/validation/**` in `@opensaas/stack-core`.
+These use Vitest per-glob, per-file thresholds set at/just below current levels,
+so `pnpm --filter @opensaas/stack-core test:coverage` exits non-zero (and the PR
+fails) if coverage on those paths regresses. All other packages (`storage`,
+`rag`, `auth`, `ui`, …) stay **report-only** — no thresholds, no forced coverage
+work. The rationale (a ratchet on what matters, not blanket coverage) is recorded
+in [ADR-0002](./docs/adr/0002-testing-and-ci-strategy.md).
+
+Vitest test discovery excludes `**/dist/**`, so a build running before tests
+(via the `test → build` turbo dependency) never inflates the test/file count
+with compiled `dist/**/*.test.js` duplicates.
+
 ## Before you commit
 
 Always run:

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,9 +1,15 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, defaultExclude } from 'vitest/config'
 import path from 'path'
 
 export default defineConfig({
   test: {
     globals: true,
+    // The `test` turbo task depends on `build`, so a `dist/` directory is
+    // present when tests run in CI. Without this exclusion Vitest would also
+    // discover the compiled `dist/**/*.test.js` duplicates and inflate the
+    // reported test/file count. Preserve Vitest's defaults and additionally
+    // ignore `dist`. Rationale: docs/adr/0002-testing-and-ci-strategy.md.
+    exclude: [...defaultExclude, '**/dist/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'json-summary'],
@@ -17,6 +23,42 @@ export default defineConfig({
         'bin/',
         'generator/',
       ],
+      // Per-glob, per-file coverage gates on the security-critical core paths:
+      // the access-control engine (`src/access`), the read/write context
+      // pipeline (`src/context` — Write Pipeline, Hook Pipeline, nested-op
+      // registry), and the config validator (`src/validation`). `perFile: true`
+      // applies each threshold to every covered file in the glob, so the
+      // numbers sit a couple of points below the *current lowest-covered file*
+      // in each group — a real regression fails `test:coverage` (and the PR),
+      // while normal variance does not. Other packages stay report-only.
+      // Rationale: docs/adr/0002-testing-and-ci-strategy.md.
+      thresholds: {
+        perFile: true,
+        // Lowest current file: field-access.ts (stmts/lines 69.76, branch
+        // 56.41, funcs 66.66).
+        'src/access/**': {
+          statements: 65,
+          branches: 50,
+          functions: 62,
+          lines: 65,
+        },
+        // Lowest current file: nested-operations.ts (stmts/lines 89.47,
+        // branch 69.23, funcs 100).
+        'src/context/**': {
+          statements: 85,
+          branches: 65,
+          functions: 90,
+          lines: 85,
+        },
+        // Lowest current file: field-config.ts (stmts 96.42, branch 87.50,
+        // funcs 100, lines 100).
+        'src/validation/**': {
+          statements: 92,
+          branches: 83,
+          functions: 95,
+          lines: 95,
+        },
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Makes `@opensaas/stack-core` coverage **honest**, then **gated**, per ADR-0002 (`docs/adr/0002-testing-and-ci-strategy.md`).

Implements #445. Part of #443.

### 1. Honest test counts — exclude `**/dist/**` from Vitest discovery

The `test` turbo task `dependsOn` `build`, so a `dist/` directory is present when tests run in CI. Vitest was also discovering the compiled `dist/**/*.test.js` duplicates, inflating the reported count. `packages/core/vitest.config.ts` now sets `test.exclude` to `[...defaultExclude, '**/dist/**']`, preserving Vitest's defaults.

**Verified:** core reports **25 files / 532 tests** whether or not a build ran first (previously 30 files / 632 tests with a prior build — 6 compiled `dist` test duplicates, ~100 inflated tests).

### 2. Gated coverage — per-glob, per-file thresholds on the security-critical paths

Added `coverage.thresholds` with `perFile: true` glob keys on `src/access/**`, `src/context/**` (Write Pipeline, Hook Pipeline, nested-operation registry), and `src/validation/**`. Thresholds were measured from current coverage and set a couple of points below each glob's lowest-covered file, so a real regression fails `test:coverage` (and the PR) while normal variance does not.

Measured current per-file minimums → thresholds set:

| glob | lowest file (stmts/branch/func/lines) | thresholds (stmts/branch/func/lines) |
| --- | --- | --- |
| `src/access/**` | `field-access.ts` 69.76 / 56.41 / 66.66 / 69.76 | 65 / 50 / 62 / 65 |
| `src/context/**` | `nested-operations.ts` 89.47 / 69.23 / 100 / 89.47 | 85 / 65 / 90 / 85 |
| `src/validation/**` | `field-config.ts` 96.42 / 87.50 / 100 / 100 | 92 / 83 / 95 / 95 |

`storage` / `rag` / `auth` / `ui` remain **report-only** — no new gating, no forced coverage work.

**Verified the gate bites:** temporarily raising a threshold above the measured level produced exit code 1 with clear per-file `ERROR: Coverage for branches (...) does not meet "src/access/**" threshold ...` messages; reverted. No test is disabled.

### 3. Policy note

Added a "Coverage gating" subsection to `CONTRIBUTING.md` describing the gated paths, the report-only packages, and the `dist` exclusion, linking ADR-0002.

## Test plan

- [x] `pnpm --filter @opensaas/stack-core test` — 25 files / 532 tests pass
- [x] Test/file count identical with and without a prior build (dist exclusion works)
- [x] `pnpm --filter @opensaas/stack-core test:coverage` exits 0 on current code; exits 1 when a threshold is raised above measured coverage
- [x] `pnpm lint` (0 errors), `pnpm format`, `pnpm manypkg check` clean
- [x] Patch changeset for `@opensaas/stack-core` added

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_