### PR TITLE
ci: deterministic builds (examples off the default gate; keyless docs /api/search fallback)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,21 @@ Thanks for working on OpenSaas Stack itself. This guide covers the **monorepo** 
 
 ```bash
 pnpm install      # install all workspace dependencies
-pnpm build        # build all packages (turbo)
+pnpm build        # build publishable packages + the docs site (turbo)
 pnpm dev          # watch-build packages
+```
+
+`pnpm build` is scoped to the publishable `packages/*` and the docs site so it
+stays **deterministic on a clean checkout** — it does not build `examples/*`.
+Each example needs a developer-created `.env` (gitignored) before it can
+`generate`, so building examples from a fresh clone would otherwise fail. The
+template flows are covered instead by the `e2e` job and the scaffold guard. To
+build an example, set up its `.env` first (see [Trying an example](#trying-an-example)),
+then run its build directly:
+
+```bash
+pnpm --filter opensaas-blog-example build   # builds one example (after its .env exists)
+pnpm build:examples                         # builds all examples (each needs its .env)
 ```
 
 ## Repository layout
@@ -36,6 +49,17 @@ pnpm dev
 The `starter` and `starter-auth` examples are the **source of truth** for the
 `create-opensaas-app` templates — they are copied into the published package at
 build time, so changes to them flow to scaffolded projects.
+
+## Building the docs site
+
+```bash
+pnpm --filter opensaas-stack-docs build
+```
+
+The docs site builds **without any secret**. Its `/api/search` route uses
+`OPENAI_API_KEY` for semantic search; when the key is unset the route degrades
+gracefully (search returns empty results) instead of crashing page-data
+collection. Set `OPENAI_API_KEY` to enable live search.
 
 ## Testing
 

--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,13 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createJsonFileStorage } from '@opensaas/stack-rag/storage'
 import { createProviderFromEnv } from '@opensaas/stack-rag/runtime'
+import type { EmbeddingProvider } from '@opensaas/stack-rag/providers'
 import { resolve } from 'node:path'
 
 // Configuration
 const EMBEDDINGS_PATH = resolve(process.cwd(), '.embeddings/docs.json')
 
-// Create provider once (reused across requests)
-const provider = createProviderFromEnv()
+// Search uses OpenAI embeddings by default. Without OPENAI_API_KEY the route
+// degrades gracefully (empty/disabled search) so the docs site builds and runs
+// without a key — instead of throwing during page-data collection at build time.
+const isSearchEnabled = (): boolean =>
+  process.env.EMBEDDING_PROVIDER === 'ollama' || Boolean(process.env.OPENAI_API_KEY)
+
+// Provider is created lazily (per the first request that needs it) rather than at
+// module load, so importing this route during `next build` never throws.
+let cachedProvider: EmbeddingProvider | undefined
+const getProvider = (): EmbeddingProvider => {
+  if (!cachedProvider) {
+    cachedProvider = createProviderFromEnv()
+  }
+  return cachedProvider
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,6 +31,20 @@ export async function POST(request: NextRequest) {
     if (!query || typeof query !== 'string') {
       return NextResponse.json({ error: 'Invalid query parameter' }, { status: 400 })
     }
+
+    // No embedding key configured: return an empty result set so the UI shows
+    // "no results" rather than an error, and builds never require the secret.
+    if (!isSearchEnabled()) {
+      return NextResponse.json({
+        results: [],
+        query,
+        count: 0,
+        totalChunks: 0,
+        searchDisabled: true,
+      })
+    }
+
+    const provider = getProvider()
 
     // Generate embedding for the query using stack utilities
     const queryEmbedding = await provider.embed(query)
@@ -132,6 +160,15 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET() {
+  if (!isSearchEnabled()) {
+    return NextResponse.json({
+      message:
+        'Search is disabled. Set OPENAI_API_KEY (or EMBEDDING_PROVIDER=ollama) to enable it.',
+      searchDisabled: true,
+    })
+  }
+
+  const provider = getProvider()
   return NextResponse.json({
     message: 'POST to this endpoint with { query: string } to search documentation',
     provider: provider.type,

--- a/examples/composable-dashboard/README.md
+++ b/examples/composable-dashboard/README.md
@@ -64,19 +64,25 @@ cd examples/composable-dashboard
 pnpm install
 ```
 
-### 2. Generate Schema and Types
+### 2. Set Up Environment
+
+```bash
+cp .env.example .env
+```
+
+### 3. Generate Schema and Types
 
 ```bash
 pnpm generate
 ```
 
-### 3. Setup Database
+### 4. Setup Database
 
 ```bash
 pnpm db:push
 ```
 
-### 4. Seed Some Data (Optional)
+### 5. Seed Some Data (Optional)
 
 ```bash
 npx tsx seed.ts
@@ -90,7 +96,7 @@ pnpm db:studio
 
 Create a few users and posts to see the dashboard in action.
 
-### 5. Run Development Server
+### 6. Run Development Server
 
 ```bash
 pnpm dev

--- a/examples/custom-field/README.md
+++ b/examples/custom-field/README.md
@@ -63,6 +63,9 @@ fields: {
 # Install dependencies
 pnpm install
 
+# Set up environment (SQLite by default)
+cp .env.example .env
+
 # Generate Prisma schema and types
 pnpm generate
 

--- a/examples/file-upload-demo/README.md
+++ b/examples/file-upload-demo/README.md
@@ -51,25 +51,31 @@ BLOB_READ_WRITE_TOKEN=vercel_blob_rw_...
 pnpm install
 ```
 
-2. Generate Prisma schema and types:
+2. Set up environment (SQLite by default):
+
+```bash
+cp .env.example .env
+```
+
+3. Generate Prisma schema and types:
 
 ```bash
 pnpm generate
 ```
 
-3. Create the database:
+4. Create the database:
 
 ```bash
 pnpm db:push
 ```
 
-4. Start the development server:
+5. Start the development server:
 
 ```bash
 pnpm dev
 ```
 
-5. Open [http://localhost:3000](http://localhost:3000)
+6. Open [http://localhost:3000](http://localhost:3000)
 
 ## Pages
 

--- a/examples/json-demo/README.md
+++ b/examples/json-demo/README.md
@@ -57,6 +57,12 @@ Demonstrates JSON fields for different use cases:
 pnpm install
 ```
 
+### Set Up Environment
+
+```bash
+cp .env.example .env
+```
+
 ### Generate Schema and Types
 
 ```bash

--- a/examples/mcp-demo/.env.example
+++ b/examples/mcp-demo/.env.example
@@ -1,0 +1,5 @@
+# Database
+DATABASE_URL="file:./dev.db"
+
+# App URL (used by the Better-auth client)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/examples/mcp-demo/README.md
+++ b/examples/mcp-demo/README.md
@@ -19,7 +19,13 @@ This example demonstrates how to integrate the Model Context Protocol (MCP) with
 pnpm install
 ```
 
-### 2. Generate Schema
+### 2. Set Up Environment
+
+```bash
+cp .env.example .env
+```
+
+### 3. Generate Schema
 
 ```bash
 pnpm generate
@@ -33,13 +39,13 @@ This generates:
 - `.opensaas/mcp/tools.json` - MCP tool reference (metadata only)
 - `.opensaas/mcp/README.md` - Usage instructions
 
-### 3. Push Schema to Database
+### 4. Push Schema to Database
 
 ```bash
 pnpm db:push
 ```
 
-### 4. Start Development Server
+### 5. Start Development Server
 
 ```bash
 pnpm dev

--- a/examples/rag-ollama-demo/README.md
+++ b/examples/rag-ollama-demo/README.md
@@ -61,7 +61,13 @@ You should see `nomic-embed-text` in the list. Ollama runs as a background servi
 pnpm install
 ```
 
-### 2. Generate Schema and Types
+### 2. Set Up Environment
+
+```bash
+cp .env.example .env
+```
+
+### 3. Generate Schema and Types
 
 ```bash
 pnpm generate
@@ -73,7 +79,7 @@ This creates:
 - `.opensaas/types.ts` - TypeScript types for your lists
 - `.opensaas/context.ts` - Context factory with access control
 
-### 3. Create Database
+### 4. Create Database
 
 ```bash
 pnpm db:push
@@ -81,7 +87,7 @@ pnpm db:push
 
 This creates the SQLite database (`dev.db`) with your schema.
 
-### 4. Run the Test Script
+### 5. Run the Test Script
 
 ```bash
 pnpm test
@@ -124,7 +130,7 @@ Top 3 Results:
   3. Natural Language Processing (similarity: 0.7456)
 ```
 
-### 5. Start the Admin UI
+### 6. Start the Admin UI
 
 ```bash
 pnpm dev

--- a/examples/tiptap-demo/.env.example
+++ b/examples/tiptap-demo/.env.example
@@ -1,0 +1,5 @@
+# Database
+DATABASE_URL="file:./dev.db"
+
+# App
+NEXT_PUBLIC_APP_URL="http://localhost:3002"

--- a/examples/tiptap-demo/README.md
+++ b/examples/tiptap-demo/README.md
@@ -19,25 +19,31 @@ This example demonstrates how to use the `@opensaas/stack-tiptap` package to add
    pnpm install
    ```
 
-2. Generate Prisma schema and types:
+2. Set up environment (SQLite by default):
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Generate Prisma schema and types:
 
    ```bash
    pnpm generate
    ```
 
-3. Push schema to database:
+4. Push schema to database:
 
    ```bash
    pnpm db:push
    ```
 
-4. Start development server:
+5. Start development server:
 
    ```bash
    pnpm dev
    ```
 
-5. Visit http://localhost:3002/admin
+6. Visit http://localhost:3002/admin
 
 ## Key Files
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "pnpm@10.29.1",
   "description": "A modern stack for building admin-heavy applications with Next.js App Router",
   "scripts": {
-    "build": " pnpm turbo build",
+    "build": "pnpm turbo build --filter=./packages/* --filter=opensaas-stack-docs",
+    "build:examples": "pnpm turbo build --filter=./examples/*",
     "dev": "pnpm -r --parallel dev",
     "clean": "pnpm -r clean",
     "lint": "eslint .",


### PR DESCRIPTION
Implements #447. Part of #443.

Makes builds **deterministic** for clean checkouts and keyless local dev, realizing the decisions recorded in [ADR-0002](docs/adr/0002-testing-and-ci-strategy.md).

## What changed

### Examples off the default build gate
- Scoped the root `pnpm build` to publishable `packages/*` + the docs site using turbo filters:
  `pnpm turbo build --filter=./packages/* --filter=opensaas-stack-docs`.
  A clean checkout (no example `.env`) no longer fails when an example tries to `generate`/`db:push` without `DATABASE_URL`.
- Per-example builds are unaffected: `pnpm --filter <example> build` still works once the developer has created that example's `.env`.
- Added `pnpm build:examples` (`turbo build --filter=./examples/*`) for building all examples when their `.env` files exist.

### Keyless docs `/api/search` fallback
- The route created its embedding provider at **module load** (`createProviderFromEnv()`), which threw when `OPENAI_API_KEY` was unset and crashed Next.js page-data collection during `next build`.
- Now the provider is created **lazily** (per first request that needs it), and the handlers degrade gracefully when no embedding key is configured — `POST` returns an empty result set (`searchDisabled: true`) and `GET` reports search disabled, instead of throwing. With `OPENAI_API_KEY` set (or `EMBEDDING_PROVIDER=ollama`), search behaves exactly as before.
- The `SearchModal` consumer already treats a 200 with empty `results` as "no results", so the UX degrades cleanly with no client changes.

### Documentation
- `CONTRIBUTING.md`: clarified that `pnpm build` covers packages + docs (not examples) and why; documented the `cp .env.example .env` prerequisite and a per-example build note; added a "Building the docs site" section explaining the keyless build behavior.
- Added the missing `cp .env.example .env` step to the demo example READMEs that lacked it (composable-dashboard, custom-field, file-upload-demo, json-demo, mcp-demo, rag-ollama-demo, tiptap-demo), with step renumbering.
- Added `examples/tiptap-demo/.env.example` (it was missing) so that example follows the same documented flow.

## Verification
- Clean-checkout `pnpm build` with `OPENAI_API_KEY` **unset** and no example `.env`: succeeds (11 tasks: packages + docs; 0 example builds).
- `pnpm --filter opensaas-stack-docs build` with `OPENAI_API_KEY` **unset**: succeeds (route is dynamic, no crash). With a dummy key set: succeeds, behavior unchanged.
- `pnpm --filter opensaas-blog-example build` with its `.env` present: still succeeds.
- `pnpm lint` (0 errors), `pnpm format:check` (clean), `pnpm manypkg check` (clean).

## Changeset
No publishable `packages/*` were modified (only the docs app, examples, root `package.json`, and docs), so **no changeset is required** per the issue's note.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_