### PR TITLE
docs: rewrite deployment guide for adapter-based config + prisma migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ See [`examples/composable-dashboard`](./examples/composable-dashboard) and the [
 - **[Building with Claude Code](https://stack.opensaas.au/docs/guides/claude-code)** — the AI-assisted workflow
 - **[Access Control](https://stack.opensaas.au/docs/core-concepts/access-control)** · **[Field Types](https://stack.opensaas.au/docs/core-concepts/field-types)** · **[Hooks](https://stack.opensaas.au/docs/core-concepts/hooks)**
 - **[Authentication](https://stack.opensaas.au/docs/guides/authentication)** · **[Storage](https://stack.opensaas.au/docs/guides/storage-setup)** · **[RAG](https://stack.opensaas.au/docs/packages/rag)**
+- **[Deployment](https://stack.opensaas.au/docs/guides/deployment)** — ship to production on Vercel + Postgres with `prisma migrate`
 
 ## Contributing & monorepo development
 

--- a/docs/content/guides/deployment.md
+++ b/docs/content/guides/deployment.md
@@ -2,6 +2,8 @@
 
 This guide walks you through deploying your OpenSaas Stack application to production using Vercel and Neon PostgreSQL.
 
+Locally you develop on SQLite with `prisma db push` for a zero-setup loop. Production runs on **PostgreSQL** with versioned **`prisma migrate`** migrations — these are deliberately two different workflows (see [ADR-0003](https://github.com/OpenSaasAU/stack/blob/main/docs/adr/0003-deployment-uses-postgres-and-prisma-migrate.md)). This guide covers the one-time switch and the production loop.
+
 ## Prerequisites
 
 Before deploying, make sure you have:
@@ -16,12 +18,22 @@ Before deploying, make sure you have:
 The deployment process involves:
 
 1. Setting up a production database (Neon PostgreSQL)
-2. Configuring environment variables
-3. Deploying to Vercel
-4. Running database migrations
-5. Verifying your deployment
+2. Switching your config from SQLite to PostgreSQL (provider + driver adapter)
+3. Configuring environment variables (pooled app URL + direct migration URL)
+4. Deploying to Vercel
+5. Applying database migrations
+6. Verifying your deployment
 
 **Total time:** ~10-15 minutes for first deployment
+
+## How database connections flow
+
+OpenSaas Stack uses Prisma 7, which requires a **driver adapter** at runtime. There are two distinct places a database URL is consumed, and on serverless Postgres they intentionally point at different connection strings:
+
+- **The running app** connects through a driver adapter built in your `prismaClientConstructor` (in `opensaas.config.ts`). On serverless platforms like Vercel this must use the **pooled** `DATABASE_URL` to avoid exhausting connection limits.
+- **The Prisma CLI** (migrations, `db push`, Studio) reads the datasource from the generated `prisma.config.ts`. That file prefers `DIRECT_DATABASE_URL` and falls back to `DATABASE_URL`, so migrations run over a **direct** (non-pooled) connection.
+
+This is the **pooled-app / direct-CLI split**: set `DATABASE_URL` to Neon's pooled URL (used by the app) and `DIRECT_DATABASE_URL` to Neon's direct URL (used by migrations). Locally on SQLite you set neither extra var — the CLI's `DIRECT_DATABASE_URL ?? DATABASE_URL` fallback resolves to `DATABASE_URL` and nothing changes.
 
 ## Step 1: Create Production Database
 
@@ -40,47 +52,56 @@ Neon provides serverless PostgreSQL with automatic scaling and a generous free t
    - Choose Postgres version (16 recommended)
    - Click "Create Project"
 
-3. **Get Connection String**
-   - After creation, you'll see your connection string
+3. **Get Connection Strings**
+   - After creation, Neon shows your connection string
    - It looks like: `postgresql://username:password@ep-xxx.region.aws.neon.tech/dbname?sslmode=require`
-   - **Important:** Copy this string immediately - you'll need it for environment variables
-   - Neon provides different connection strings:
-     - **Pooled connection** (recommended for serverless): Use this for Vercel
-     - **Direct connection**: Use this for migrations and Prisma Studio
+   - Neon provides two flavours — copy **both**:
+     - **Pooled connection** (recommended for serverless): use this for `DATABASE_URL` (the app)
+     - **Direct connection**: use this for `DIRECT_DATABASE_URL` (migrations and Prisma Studio)
 
 4. **Enable Connection Pooling (Recommended)**
    - In your Neon project dashboard, go to "Settings" → "Connection Pooling"
-   - Enable pooling (it's on by default)
-   - Use the pooled connection string for your application
-   - Use the direct connection string for migrations
+   - Pooling is on by default; the pooled string typically contains `-pooler` in the host
+   - Use the **pooled** connection string for `DATABASE_URL`
+   - Use the **direct** connection string for `DIRECT_DATABASE_URL`
 
-## Step 2: Configure Environment Variables
+## Step 2: Switch Your Config to PostgreSQL
 
-### Local Production Testing (Optional)
+Locally your app is configured for SQLite with the `PrismaBetterSqlite3` adapter. For production, switch the `db` block of `opensaas.config.ts` to PostgreSQL — change the `provider` and swap the driver adapter. This is a one-time, well-signposted change.
 
-Create a `.env.production.local` file in your project root:
+### Install the PostgreSQL adapter
+
+For a standard Postgres connection (works with Neon and any Postgres host):
 
 ```bash
-# .env.production.local
-DATABASE_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require&pgbouncer=true"
-DIRECT_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
+pnpm add @prisma/adapter-pg pg
 ```
 
-**Why two URLs?**
+For Neon's serverless driver (uses WebSockets, optimised for serverless/edge):
 
-- `DATABASE_URL`: Pooled connection for your app (faster, scales better)
-- `DIRECT_URL`: Direct connection for migrations (Prisma requires this for schema changes)
+```bash
+pnpm add @prisma/adapter-neon @neondatabase/serverless ws
+```
 
-### Update Prisma Schema (If Using Connection Pooling)
+### Update `opensaas.config.ts`
 
-**Note:** Your Prisma schema is auto-generated by `opensaas generate`, so update your `opensaas.config.ts` instead:
+Replace the SQLite `db` block with a PostgreSQL one. The driver adapter connects using the **pooled** `DATABASE_URL`.
+
+**Option A — `@prisma/adapter-pg` (standard Postgres driver):**
 
 ```typescript
+import { config } from '@opensaas/stack-core'
+import { PrismaPg } from '@prisma/adapter-pg'
+import pg from 'pg'
+
 export default config({
   db: {
     provider: 'postgresql',
-    url: process.env.DATABASE_URL!,
-    directUrl: process.env.DIRECT_URL, // Add this line
+    prismaClientConstructor: (PrismaClient) => {
+      const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+      const adapter = new PrismaPg(pool)
+      return new PrismaClient({ adapter })
+    },
   },
   lists: {
     // ... your lists
@@ -88,28 +109,103 @@ export default config({
 })
 ```
 
-Then regenerate:
+**Option B — `@prisma/adapter-neon` (Neon serverless driver):**
+
+```typescript
+import { config } from '@opensaas/stack-core'
+import { PrismaNeon } from '@prisma/adapter-neon'
+import { neonConfig } from '@neondatabase/serverless'
+import ws from 'ws'
+
+export default config({
+  db: {
+    provider: 'postgresql',
+    prismaClientConstructor: (PrismaClient) => {
+      neonConfig.webSocketConstructor = ws
+      const adapter = new PrismaNeon({
+        connectionString: process.env.DATABASE_URL,
+      })
+      return new PrismaClient({ adapter })
+    },
+  },
+  lists: {
+    // ... your lists
+  },
+})
+```
+
+There is **no** top-level `url` or `directUrl` in the `db` block — Prisma 7 takes the URL through the adapter, and the direct/migration URL lives in `prisma.config.ts` (see below). Don't add fields that no longer exist.
+
+### Regenerate
 
 ```bash
 pnpm generate
 ```
 
-### Environment Variables for Better Auth (If Using)
+This rewrites `prisma/schema.prisma` for the `postgresql` provider and regenerates `prisma.config.ts`. The generated `prisma.config.ts` looks like this — it's CLI-only and prefers the direct URL:
 
-If you're using `@opensaas/stack-auth`, you'll need additional variables:
+```typescript
+import 'dotenv/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
+
+export default defineConfig({
+  schema: 'prisma',
+  datasource: {
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
+  },
+})
+```
+
+You don't edit this file — it's generated. It only affects Prisma CLI commands, never the running app.
+
+## Step 3: Configure Environment Variables
+
+### Local Production Testing (Optional)
+
+Create a `.env.production.local` file in your project root to test against the production database before deploying:
 
 ```bash
 # .env.production.local
-DATABASE_URL="postgresql://..."
-DIRECT_URL="postgresql://..."
 
-# Better Auth Configuration
+# Pooled connection — used by the app (driver adapter)
+DATABASE_URL="postgresql://user:pass@ep-xxx-pooler.region.aws.neon.tech/dbname?sslmode=require"
+
+# Direct connection — used by Prisma CLI (migrations / Studio)
+DIRECT_DATABASE_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
+```
+
+**Why two URLs?**
+
+- `DATABASE_URL` (pooled): the connection your **app** uses at runtime, via the driver adapter. Pooling lets serverless functions share connections instead of exhausting the database's limit.
+- `DIRECT_DATABASE_URL` (direct): the connection the **Prisma CLI** uses for `migrate dev` / `migrate deploy`. Migrations need a direct, non-pooled connection. The generated `prisma.config.ts` reads it as `DIRECT_DATABASE_URL ?? DATABASE_URL`.
+
+### Environment Variables for Better Auth (If Using)
+
+If you're using `@opensaas/stack-auth`, add the auth variables. `BETTER_AUTH_URL` (and `NEXT_PUBLIC_APP_URL`) must be your **deployed** URL in production:
+
+```bash
+# .env.production.local
+
+# Database
+DATABASE_URL="postgresql://user:pass@ep-xxx-pooler.region.aws.neon.tech/dbname?sslmode=require"
+DIRECT_DATABASE_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
+
+# Better Auth
 BETTER_AUTH_SECRET="your-random-secret-here"
 BETTER_AUTH_URL="https://your-app.vercel.app"
+NEXT_PUBLIC_APP_URL="https://your-app.vercel.app"
 
-# OAuth Providers (if using)
+# OAuth providers (optional)
 GITHUB_CLIENT_ID="your-github-client-id"
 GITHUB_CLIENT_SECRET="your-github-client-secret"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
 ```
 
 **Generate a secure secret:**
@@ -118,7 +214,35 @@ GITHUB_CLIENT_SECRET="your-github-client-secret"
 openssl rand -base64 32
 ```
 
-## Step 3: Deploy to Vercel
+### Environment variable checklist
+
+| Variable               | Used by             | Value                                                  | Required          |
+| ---------------------- | ------------------- | ------------------------------------------------------ | ----------------- |
+| `DATABASE_URL`         | App (adapter)       | Neon **pooled** connection string                      | Always            |
+| `DIRECT_DATABASE_URL`  | Prisma CLI          | Neon **direct** connection string                      | Always (Postgres) |
+| `BETTER_AUTH_SECRET`   | Better Auth         | `openssl rand -base64 32`                              | If using auth     |
+| `BETTER_AUTH_URL`      | Better Auth         | Your deployed URL (e.g. `https://your-app.vercel.app`) | If using auth     |
+| `NEXT_PUBLIC_APP_URL`  | Client              | Your deployed URL                                      | If using auth     |
+| `GITHUB_CLIENT_ID`     | Better Auth (OAuth) | From your GitHub OAuth app                             | If using GitHub   |
+| `GITHUB_CLIENT_SECRET` | Better Auth (OAuth) | From your GitHub OAuth app                             | If using GitHub   |
+| `GOOGLE_CLIENT_ID`     | Better Auth (OAuth) | From your Google OAuth client                          | If using Google   |
+| `GOOGLE_CLIENT_SECRET` | Better Auth (OAuth) | From your Google OAuth client                          | If using Google   |
+
+## Step 4: Author the First Migration
+
+Before your first deploy, create the initial migration locally against the production database (or a disposable Postgres) using the **direct** connection.
+
+```bash
+# Ensure DATABASE_URL + DIRECT_DATABASE_URL are set (e.g. via .env.production.local)
+pnpm generate
+pnpm migrate -- --name init
+```
+
+`pnpm migrate` runs `prisma migrate dev`, which creates a versioned migration in `prisma/migrations/` and applies it. Commit the generated migration files to Git — they are your schema history, and the production release step replays them with `prisma migrate deploy`.
+
+> **Local dev vs production.** `prisma db push` (`pnpm db:push`) stays the fast, disposable loop for local SQLite. It has **no migration history** and can drop data on schema changes, so it is **not** a supported path to production. Production always uses `prisma migrate`.
+
+## Step 5: Deploy to Vercel
 
 You have two options: Vercel CLI (faster) or Vercel Dashboard (more visual).
 
@@ -157,12 +281,13 @@ Follow the prompts:
 vercel env add DATABASE_URL production
 # Paste your pooled connection string
 
-vercel env add DIRECT_URL production
+vercel env add DIRECT_DATABASE_URL production
 # Paste your direct connection string
 
 # If using Better Auth:
 vercel env add BETTER_AUTH_SECRET production
 vercel env add BETTER_AUTH_URL production
+vercel env add NEXT_PUBLIC_APP_URL production
 ```
 
 5. **Deploy to Production**
@@ -198,9 +323,10 @@ git push origin main
    - Click "Environment Variables"
    - Add each variable:
      - `DATABASE_URL` → Your pooled connection string
-     - `DIRECT_URL` → Your direct connection string
+     - `DIRECT_DATABASE_URL` → Your direct connection string
      - `BETTER_AUTH_SECRET` → Your random secret (if using auth)
      - `BETTER_AUTH_URL` → `https://your-app.vercel.app` (update after first deploy)
+     - `NEXT_PUBLIC_APP_URL` → `https://your-app.vercel.app` (if using auth)
      - Add any OAuth credentials if using social login
 
 5. **Deploy**
@@ -208,70 +334,73 @@ git push origin main
    - Wait for build to complete (~2-3 minutes)
    - Your app will be live at `https://your-app.vercel.app`
 
-## Step 4: Initialize Production Database
+## Step 6: Apply Migrations to Production
 
-After your first deployment, you need to set up the database schema.
-
-### Using Prisma Migrate (Recommended for Production)
-
-If this is your first production deployment:
+Run your committed migrations against the production database. Because `prisma.config.ts` resolves `DIRECT_DATABASE_URL ?? DATABASE_URL`, `prisma migrate deploy` automatically uses the **direct** connection.
 
 ```bash
-# Generate migration from your schema
-npx prisma migrate dev --name init
-
-# Push migration to production
-npx prisma migrate deploy
+pnpm migrate:deploy
 ```
 
-Set the `DIRECT_URL` environment variable locally before running migrations:
+`pnpm migrate:deploy` runs `prisma migrate deploy`, applying every committed migration in order without prompting. It never generates new migrations, so it's safe to run repeatedly and in CI.
+
+### Running migrations as part of the build (recommended)
+
+To apply migrations automatically on every Vercel deploy, add `prisma migrate deploy` to the build command. The starter templates' `build` script is `pnpm generate && next build`; extend it to:
+
+```json
+{
+  "scripts": {
+    "build": "pnpm generate && prisma migrate deploy && next build"
+  }
+}
+```
+
+Ensure **`DIRECT_DATABASE_URL`** is set in your Vercel environment variables so the build-time migration uses the direct connection.
+
+**Alternative — apply migrations manually before deploying:**
 
 ```bash
-export DIRECT_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
-npx prisma migrate deploy
+# Locally, against the production DB (DIRECT_DATABASE_URL set)
+pnpm migrate:deploy
+
+# Then deploy
+vercel --prod
 ```
-
-### Using Prisma DB Push (Quick Method)
-
-For rapid iteration (not recommended for production with existing data):
-
-```bash
-export DIRECT_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
-npx prisma db push
-```
-
-**Warning:** `db push` can cause data loss. Use migrations for production.
 
 ### Verify Database Setup
 
-Check your database with Prisma Studio:
+Inspect your database with Prisma Studio (uses the direct connection via `prisma.config.ts`):
 
 ```bash
-export DATABASE_URL="postgresql://user:pass@ep-xxx.region.aws.neon.tech/dbname?sslmode=require"
-npx prisma studio
+# DIRECT_DATABASE_URL set in your environment
+pnpm db:studio
 ```
 
 Open [http://localhost:5555](http://localhost:5555) to view your production database.
 
-## Step 5: Verify Deployment
+## Step 7: Verify Deployment
 
 1. **Visit Your App**
    - Go to your Vercel deployment URL
    - You should see your app running
 
 2. **Test Database Connectivity**
-   - If you have an admin UI, try creating a record
+   - If you have an admin UI (`/admin`), try creating a record
    - Verify it appears in Prisma Studio
    - Check for any console errors
 
-3. **Check Vercel Logs**
+3. **Smoke-check access control**
+   - Confirm anonymous vs. authenticated behaviour matches local: e.g. anonymous visitors only see published records, and owner-only rows/fields stay protected. Access control runs identically in production.
+
+4. **Check Vercel Logs**
    - Go to your project in Vercel Dashboard
    - Click "Deployments" → Select latest deployment → "Functions"
    - View logs for any errors
 
-4. **Update Better Auth URL (If Using)**
+5. **Confirm Better Auth URLs (If Using)**
    - Go to Vercel Dashboard → Your Project → Settings → Environment Variables
-   - Update `BETTER_AUTH_URL` to your production URL (e.g., `https://your-app.vercel.app`)
+   - Ensure `BETTER_AUTH_URL` and `NEXT_PUBLIC_APP_URL` are your production URL (e.g., `https://your-app.vercel.app`)
    - Redeploy: `vercel --prod` or push to Git
 
 ## Continuous Deployment
@@ -286,53 +415,34 @@ Once connected to Git, Vercel automatically deploys:
 ### Deploy Workflow
 
 ```bash
-# Make changes locally
+# Make changes locally (SQLite + db push for the fast loop)
 pnpm dev
 
 # Generate updated schema if config changed
 pnpm generate
 
-# Test locally
-# ...
+# When you change the schema, author a migration to ship
+pnpm migrate -- --name describe_your_change
 
-# Commit and push
+# Commit and push (including the new migration files)
 git add .
 git commit -m "Add new feature"
 git push
 
-# Vercel automatically deploys to preview URL
-# Merge PR to deploy to production
+# Vercel deploys; the build step runs `prisma migrate deploy`
+# (if you added it to the build command) using DIRECT_DATABASE_URL
 ```
 
 ### Database Migrations in CI/CD
 
-For schema changes, run migrations before deployment:
-
-1. **Add Migration Step to Vercel**
-   - In `package.json`, update build script:
-
-```json
-{
-  "scripts": {
-    "build": "prisma generate && prisma migrate deploy && next build"
-  }
-}
-```
-
-2. **Ensure DIRECT_URL is Set**
-   - Add `DIRECT_URL` to Vercel environment variables
-   - This allows migrations during build
-
-**Alternative:** Run migrations manually before deploying:
+For schema changes, migrations are applied via `prisma migrate deploy` — either in the Vercel build command (see [Step 6](#running-migrations-as-part-of-the-build-recommended)) or as an explicit step before deploy:
 
 ```bash
-# Locally, run migration against production DB
-export DIRECT_URL="postgresql://..."
-npx prisma migrate deploy
-
-# Then deploy
-vercel --prod
+# In CI, against the production DB (DIRECT_DATABASE_URL set)
+pnpm migrate:deploy
 ```
+
+`migrate deploy` only applies existing committed migrations; it never edits your schema, which makes it safe to run in an automated pipeline.
 
 ## Production Considerations
 
@@ -342,10 +452,11 @@ Serverless functions (like Vercel) create many database connections. Use connect
 
 **Neon provides built-in pooling:**
 
-- Use the pooled connection string for `DATABASE_URL`
+- Use the pooled connection string for `DATABASE_URL` (the app's driver adapter)
+- Use the direct connection string for `DIRECT_DATABASE_URL` (migrations)
 - No additional configuration needed
 
-**Alternative: Prisma Data Proxy**
+**Alternative: Prisma Accelerate**
 
 - [Prisma Accelerate](https://www.prisma.io/accelerate) provides connection pooling
 - Good for multi-region deployments
@@ -360,8 +471,8 @@ Serverless functions (like Vercel) create many database connections. Use connect
 
 **Environment-specific variables:**
 
-- Development: `.env.local`
-- Production: Vercel Dashboard or `vercel env`
+- Development: `.env` / `.env.local` (SQLite `DATABASE_URL`)
+- Production: Vercel Dashboard or `vercel env` (`DATABASE_URL` + `DIRECT_DATABASE_URL`)
 - Preview: Can inherit from Production or set separately
 
 ### Database Backups
@@ -374,11 +485,11 @@ Serverless functions (like Vercel) create many database connections. Use connect
 **Manual backups:**
 
 ```bash
-# Export database to SQL file
-pg_dump "postgresql://..." > backup.sql
+# Export database to SQL file (use the direct connection)
+pg_dump "postgresql://...@ep-xxx.region.aws.neon.tech/dbname?sslmode=require" > backup.sql
 
 # Restore from backup
-psql "postgresql://..." < backup.sql
+psql "postgresql://...@ep-xxx.region.aws.neon.tech/dbname?sslmode=require" < backup.sql
 ```
 
 ### Monitoring & Logging
@@ -400,29 +511,6 @@ psql "postgresql://..." < backup.sql
 - [LogRocket](https://logrocket.com) for session replay
 - [Axiom](https://axiom.co) for structured logging
 
-### Performance Optimization
-
-**Prisma optimizations:**
-
-```typescript
-// In your opensaas.config.ts
-export default config({
-  db: {
-    provider: 'postgresql',
-    url: process.env.DATABASE_URL!,
-    directUrl: process.env.DIRECT_URL,
-    // Add Prisma preview features
-    previewFeatures: ['jsonProtocol'], // Faster queries
-  },
-  // ...
-})
-```
-
-**Caching:**
-
-- Use [Vercel KV](https://vercel.com/storage/kv) for caching
-- Cache expensive queries with `next/cache`
-
 ### Security Checklist
 
 Before going live:
@@ -430,6 +518,7 @@ Before going live:
 - [ ] All secrets are in environment variables (not hardcoded)
 - [ ] `BETTER_AUTH_SECRET` is cryptographically random
 - [ ] Database connection uses SSL (`sslmode=require`)
+- [ ] `DATABASE_URL` is the pooled URL; `DIRECT_DATABASE_URL` is the direct URL
 - [ ] Access control rules are tested and working
 - [ ] CORS is configured if using external APIs
 - [ ] Rate limiting is configured (consider Vercel's built-in protection)
@@ -445,9 +534,9 @@ Before going live:
 **Solutions:**
 
 - Verify `DATABASE_URL` is correct (copy from Neon Console)
-- Check `sslmode=require` is in connection string
-- Ensure Neon project is not paused (happens on free tier after inactivity)
-- Test connection locally: `npx prisma db pull`
+- Check `sslmode=require` is in the connection string
+- Ensure the Neon project is not paused (happens on free tier after inactivity)
+- Test the migration connection: `npx prisma db pull` (uses `DIRECT_DATABASE_URL` via `prisma.config.ts`)
 
 ### "Too many connections"
 
@@ -455,12 +544,12 @@ Before going live:
 
 **Solutions:**
 
-- Use pooled connection string for `DATABASE_URL`
-- Add `connection_limit=10` to connection string:
+- Use the **pooled** connection string for `DATABASE_URL` (the host usually contains `-pooler`)
+- Add `connection_limit=10` to the connection string:
   ```
   postgresql://...?sslmode=require&connection_limit=10
   ```
-- Upgrade Neon plan for more connections
+- Upgrade your Neon plan for more connections
 - Use Prisma Accelerate for connection pooling
 
 ### "Migration failed"
@@ -469,10 +558,10 @@ Before going live:
 
 **Solutions:**
 
-- Ensure you're using `DIRECT_URL` (not pooled connection)
-- Check migration files in `prisma/migrations/` are correct
-- Run `npx prisma migrate resolve` to mark failed migrations
-- For destructive changes, backup data first
+- Ensure `DIRECT_DATABASE_URL` is set to the **direct** (non-pooled) connection — migrations must not run over the pooler
+- Check migration files in `prisma/migrations/` are committed and correct
+- Run `npx prisma migrate resolve` to mark a failed migration
+- For destructive changes, back up data first
 
 ### "Authentication not working"
 
@@ -480,12 +569,12 @@ Before going live:
 
 **Solutions:**
 
-- Verify `BETTER_AUTH_URL` matches your production domain
+- Verify `BETTER_AUTH_URL` and `NEXT_PUBLIC_APP_URL` match your production domain
 - Check `BETTER_AUTH_SECRET` is set in Vercel
 - Ensure OAuth redirect URLs are updated in provider settings:
   - GitHub: `https://your-app.vercel.app/api/auth/callback/github`
   - Google: `https://your-app.vercel.app/api/auth/callback/google`
-- Check browser console for CORS errors
+- Check the browser console for CORS errors
 
 ### "Build failed"
 
@@ -493,10 +582,11 @@ Before going live:
 
 **Solutions:**
 
-- Check Vercel build logs for specific error
+- Check the Vercel build logs for the specific error
 - Ensure `pnpm generate` runs successfully locally
+- If the build runs `prisma migrate deploy`, confirm `DIRECT_DATABASE_URL` is set in Vercel
 - Verify all dependencies are in `package.json` (not just devDependencies)
-- Check Node.js version matches Vercel (use `.nvmrc` or `package.json` engines field)
+- Check the Node.js version matches Vercel (use `.nvmrc` or `package.json` engines field)
 
 ### "Function execution timeout"
 
@@ -507,16 +597,15 @@ Before going live:
 - Optimize slow database queries (add indexes)
 - Use `Promise.all()` for parallel operations
 - Consider background jobs for long-running tasks
-- Upgrade Vercel plan for longer timeout (Pro: 60s, Hobby: 10s)
+- Upgrade your Vercel plan for a longer timeout (Pro: 60s, Hobby: 10s)
 
 ### Getting Help
 
 If you're stuck:
 
-1. Check [OpenSaas Stack GitHub Issues](https://github.com/your-org/opensaas-stack/issues)
+1. Check [OpenSaas Stack GitHub Issues](https://github.com/OpenSaasAU/stack/issues)
 2. Search [Vercel Docs](https://vercel.com/docs)
 3. Check [Neon Docs](https://neon.tech/docs)
-4. Ask in [Discord/Community](your-community-link) (if available)
 
 ## Advanced Topics
 
@@ -525,10 +614,10 @@ If you're stuck:
 1. **Add Domain in Vercel**
    - Go to Project Settings → Domains
    - Add your custom domain (e.g., `app.example.com`)
-   - Follow DNS configuration instructions
+   - Follow the DNS configuration instructions
 
 2. **Update Better Auth URL**
-   - Update `BETTER_AUTH_URL` environment variable
+   - Update the `BETTER_AUTH_URL` and `NEXT_PUBLIC_APP_URL` environment variables
    - Update OAuth redirect URLs in provider settings
 
 ### Multi-Environment Setup
@@ -536,8 +625,8 @@ If you're stuck:
 For staging + production:
 
 ```bash
-# Create staging database in Neon
-# Add to Vercel as staging environment variables
+# Create a staging database in Neon
+# Add its pooled + direct URLs to Vercel as staging environment variables
 
 # Deploy to staging branch
 git push origin staging
@@ -551,53 +640,46 @@ git push origin main
 
 ### Using Different Database Providers
 
-While this guide focuses on Neon, OpenSaas Stack works with any PostgreSQL provider:
+While this guide focuses on Neon, OpenSaas Stack works with any PostgreSQL provider. The pattern is the same: set `provider: 'postgresql'`, build a `PrismaPg` (or provider-specific) adapter in `prismaClientConstructor` with the pooled `DATABASE_URL`, and point `DIRECT_DATABASE_URL` at the direct connection.
 
 **Supabase:**
 
-- Get connection string from Project Settings → Database
-- Use pooler connection string for `DATABASE_URL`
-
-**PlanetScale:**
-
-- Requires MySQL provider in config
-- Get connection string from Dashboard
-- No `DIRECT_URL` needed (PlanetScale uses different migration approach)
+- Get connection strings from Project Settings → Database
+- Use the pooler connection string for `DATABASE_URL` and the direct one for `DIRECT_DATABASE_URL`
 
 **Railway:**
 
-- Provision PostgreSQL addon
-- Copy connection string from Variables tab
-- Use same pooling approach as Neon
+- Provision a PostgreSQL plugin
+- Copy the connection string from the Variables tab
+- Use the same pooled/direct split as Neon
 
 **Render:**
 
-- Create PostgreSQL database
-- Get internal/external connection strings
-- Use external for migrations, internal for app
+- Create a PostgreSQL database
+- Use the external connection string for `DIRECT_DATABASE_URL` (migrations) and a pooled connection for `DATABASE_URL` (app)
 
 ### Docker Deployment (Self-Hosting)
 
-For deploying to your own infrastructure, see the [Self-Hosting Guide](./self-hosting.md) (coming soon).
+For deploying to your own infrastructure, use the `@prisma/adapter-pg` adapter (Option A above) pointed at your Postgres instance, and run `pnpm migrate:deploy` as part of your release process.
 
 ## Next Steps
 
 Now that your app is deployed:
 
-- [Set up monitoring and alerts](./monitoring.md) (coming soon)
-- [Configure custom domain](https://vercel.com/docs/custom-domains)
+- [Configure a custom domain](https://vercel.com/docs/custom-domains)
 - [Add team members](https://vercel.com/docs/teams-and-accounts)
-- [Set up CI/CD testing](./testing.md) (coming soon)
-- [Optimize performance](./performance.md) (coming soon)
+- Review the [Authentication guide](/docs/guides/authentication) for production auth details
+- Revisit [Access Control](/docs/core-concepts/access-control) to harden your rules
 
 ## Summary
 
 You've successfully deployed your OpenSaas Stack application! Here's what you accomplished:
 
-✅ Created a production PostgreSQL database on Neon
-✅ Configured environment variables for production
-✅ Deployed to Vercel with automatic deployments
-✅ Set up database migrations
-✅ Verified your deployment is working
+- Created a production PostgreSQL database on Neon
+- Switched your config to the PostgreSQL driver adapter (pooled `DATABASE_URL`)
+- Configured the pooled-app / direct-CLI environment variable split
+- Deployed to Vercel with automatic deployments
+- Applied versioned migrations with `prisma migrate deploy`
+- Verified your deployment and access control are working
 
 Your app is now live and ready for users. Any pushes to your main branch will automatically deploy to production.


### PR DESCRIPTION
Implements #451. Part of #442. See ADR-0003.

## Problem

`docs/content/guides/deployment.md` was substantial but its config snippet was stale: it showed the pre-adapter `db: { provider, url, directUrl }` block with no `prismaClientConstructor` / driver adapter, which Prisma 7 requires. It also used the old `DIRECT_URL` env var and an invented `previewFeatures` field.

## What changed

Rewrote the deployment guide to match the current adapter-based framework and the `prisma migrate` workflow (built on #450/#456 and ADR-0003), and linked it from the README.

- **Adapter-based config.** Replaced the pre-adapter snippet with `PrismaPg` (`@prisma/adapter-pg` + `pg`) and `PrismaNeon` (`@prisma/adapter-neon` + `@neondatabase/serverless` + `ws`) constructed in `prismaClientConstructor` using the **pooled** `DATABASE_URL`. Snippets mirror the canonical CLAUDE.md / `examples/rag-openai-chatbot` forms exactly. No top-level `url`/`directUrl`, no invented fields.
- **Pooled-app / direct-CLI split documented explicitly.** New "How database connections flow" section: the app connects via the pooled `DATABASE_URL`; the Prisma CLI reads the generated `prisma.config.ts`, which resolves `DIRECT_DATABASE_URL ?? DATABASE_URL` for migrations. Includes the exact generated `prisma.config.ts` shape from #456 (local `env` helper).
- **Env section + checklist table.** Lists `DATABASE_URL` (pooled, app), `DIRECT_DATABASE_URL` (migrations), and the Better-auth vars (`BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` = deployed URL, `NEXT_PUBLIC_APP_URL`, GitHub/Google OAuth) — consistent with the `starter` / `starter-auth` templates.
- **Canonical commands.** Production loop uses `pnpm migrate` (`prisma migrate dev`) to author and `pnpm migrate:deploy` (`prisma migrate deploy`) to release over the direct connection; the build/release step runs `prisma migrate deploy`. `pnpm db:push` is documented as the local-only SQLite loop, not a production path.
- **Links + README.** Fixed stale placeholders (`your-org`, dead community link); internal links use `/docs/...` to existing pages; added a Deployment link to the README "Learn more" section.

## Acceptance criteria

- [x] No pre-adapter `db: { url, directUrl }` snippet remains; uses adapter-based config + the `prisma.config.ts` direct-URL approach from #450.
- [x] Env section lists `DATABASE_URL` (pooled), `DIRECT_DATABASE_URL` (migrations), and the Better-auth vars — consistent with the templates.
- [x] Commands use the canonical set; the build/release step runs `prisma migrate deploy` with the direct connection.
- [x] Pooled-app / direct-CLI split documented explicitly.
- [x] Internal links resolve; `pnpm format` clean. README links to the guide.

## Verification

- `prettier --check` on both changed files: clean.
- `pnpm --filter opensaas-stack-docs build`: succeeds, all 31 pages generated (including the deployment page). The guide uses only bundled fence languages (`bash`/`json`/`typescript`), so it adds no Shiki warnings.
- Internal link targets confirmed to exist (`guides/authentication`, `core-concepts/access-control`) and the in-page anchor resolves.

## Notes

- Docs-only change touching no `packages/*` source, so no changeset is needed.
- Regenerated example `prisma.config.ts` files (a side-effect of running `pnpm build` locally) were reverted to keep this PR docs-only.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_