### PR TITLE
Add nightly workflow: published npm-create e2e + full examples build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,123 @@
+name: Nightly
+
+# Heavier / networked checks deliberately kept OFF the PR gate (see ADR-0002).
+# These run on a schedule and on manual dispatch only — never on pull_request or
+# push — so PR feedback stays fast and isn't gated on registry/network state.
+on:
+  schedule:
+    # 03:17 UTC daily. Off-the-hour to avoid the top-of-hour scheduler backlog.
+    - cron: '17 3 * * *'
+  workflow_dispatch: {}
+
+# Only one nightly run at a time; let a manual dispatch supersede a scheduled one.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # (a) The PUBLISHED `npm create opensaas-app` end-to-end: a real networked
+  # install of the package from npm, then the documented first-run flow
+  # (generate → db:push → build) in a clean temp dir. This is the true e2e the
+  # PR-gate scaffold guard only proxies (the guard borrows the workspace
+  # toolchain offline; this exercises the actual published artifact). See ADR-0002.
+  published-create-e2e:
+    name: Published npm create e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      # Scaffold the published basic (SQLite, no-auth) template fully
+      # non-interactively into an OS temp dir — never the runner's workspace —
+      # so a mid-run failure can't dirty anything. `--no-ai` skips the networked
+      # MCP install; we let the CLI run its own install → generate → db:push.
+      - name: Scaffold published create-opensaas-app into a temp dir
+        run: |
+          set -euo pipefail
+          WORKDIR="$(mktemp -d)"
+          echo "WORKDIR=$WORKDIR" >> "$GITHUB_ENV"
+          cd "$WORKDIR"
+          # Real, networked install of the published package + its template deps.
+          npx --yes create-opensaas-app@latest myapp --no-auth --no-ai
+        env:
+          DATABASE_URL: 'file:./dev.db'
+
+      # The CLI auto-runs install → generate → db:push; re-run them explicitly so
+      # the job fails loudly (and points at the failed step) if any regress, then
+      # exercise a full production build of the scaffolded app.
+      - name: Generate, db:push and build the scaffolded app
+        run: |
+          set -euo pipefail
+          cd "$WORKDIR/myapp"
+          pnpm install
+          pnpm generate
+          pnpm db:push
+          pnpm build
+          test -f .opensaas/context.ts
+          test -f dev.db
+        env:
+          DATABASE_URL: 'file:./dev.db'
+
+  # (b) The FULL `examples/*` build. Examples are off the default build gate
+  # (ADR-0002 / PR #447) because each needs a developer-created `.env` to
+  # `generate`. This job makes that deterministic: it creates every example's
+  # `.env` from its `.env.example` first, forcing SQLite for the two examples
+  # whose config is `provider: 'sqlite'` but whose `.env.example` defaults to a
+  # PostgreSQL URL (`blog`, `composable-dashboard`), then runs `pnpm build:examples`.
+  examples-build:
+    name: Full examples build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup project
+        uses: ./.github/actions/setup
+
+      # Build the publishable packages first so each example's `opensaas generate`
+      # and `next build` resolve against fresh workspace `dist` output.
+      - name: Build packages
+        run: pnpm build
+
+      # Create a runnable `.env` for every example. Examples whose config uses
+      # `provider: 'sqlite'` but whose `.env.example` defaults to a PostgreSQL URL
+      # (blog, composable-dashboard) get DATABASE_URL forced to SQLite so the
+      # Prisma datasource provider matches. All other DB/secret placeholders come
+      # from the .env.example values plus the job-level env below.
+      - name: Create .env for every example
+        run: |
+          set -euo pipefail
+          # sqlite-provider examples that ship a postgres .env.example default
+          force_sqlite="blog composable-dashboard"
+          for dir in examples/*/; do
+            name="$(basename "$dir")"
+            if [ -f "$dir/.env.example" ]; then
+              cp "$dir/.env.example" "$dir/.env"
+              case " $force_sqlite " in
+                *" $name "*)
+                  # Replace the DATABASE_URL line with a SQLite value.
+                  sed -i 's|^DATABASE_URL=.*|DATABASE_URL="file:./dev.db"|' "$dir/.env"
+                  ;;
+              esac
+              echo "prepared .env for $name"
+            fi
+          done
+
+      - name: Build all examples
+        run: pnpm build:examples
+        env:
+          # SQLite by default; the postgres-provider example (rag-openai-chatbot)
+          # keeps its own placeholder URL and never connects during generate/build.
+          DATABASE_URL: 'file:./dev.db'
+          # Placeholder secrets so generate/build don't fail on missing vars.
+          OPENAI_API_KEY: 'sk-testing-key'
+          BETTER_AUTH_SECRET: 'secret-for-testing-in-github-actions-with-numbers1234'
+          BETTER_AUTH_URL: 'http://localhost:3000'
+          NEXT_PUBLIC_APP_URL: 'http://localhost:3000'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,36 @@ cd packages/cli && pnpm test
 
 End-to-end tests use Playwright (`pnpm test:e2e` from the repo root).
 
+### Test lanes
+
+CI is split into lanes so the common feedback loop stays fast and the slower,
+networked checks don't gate every PR. The rationale (gate the security-critical
+core, keep flaky/networked checks off the PR) is recorded in
+[ADR-0002](./docs/adr/0002-testing-and-ci-strategy.md).
+
+| Lane          | Trigger                             | What it guards                                                                                                                                                                                                                                                                                              |
+| ------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fast unit** | every PR (`test.yml` → `test` job)  | `turbo run test` — the Vitest suites across packages, plus lint, format, and browser tests. The quick loop you also run locally with `pnpm test` in a package.                                                                                                                                              |
+| **Coverage**  | every PR (`test.yml`)               | `turbo run test:coverage` plus the `coverage` reporter job. Gated only on the security-critical core paths (see [Coverage gating](#coverage-gating)); other packages are report-only.                                                                                                                       |
+| **e2e**       | every PR (`test.yml` → `e2e` job)   | Builds the core/auth/ui/cli + create-opensaas-app packages, runs the **isolated scaffold first-run guard** (`create-opensaas-app` → `generate` → `db:push` against the workspace toolchain in a temp dir, no network install), and the Playwright auth flow against the starter-auth production build.      |
+| **Nightly**   | `schedule` (cron) + manual dispatch | `nightly.yml` — the heavier/networked checks kept **off** the PR gate: the **published `npm create opensaas-app` e2e** (real `npx create-opensaas-app@latest` install → `generate` → `db:push` → `build` in a temp dir) and the **full `examples/*` build** (`pnpm build:examples`). Failures fail the run. |
+
+The nightly lane runs on `schedule:` + `workflow_dispatch:` only — never on
+`pull_request`/`push` — so a registry/network hiccup or a slow examples build
+never blocks a PR. Trigger it manually from the Actions tab via "Run workflow"
+when you want an on-demand check.
+
+The examples build needs each example's `.env` to `generate` (the same
+developer step documented in [Trying an example](#trying-an-example)). The
+nightly job creates them deterministically: it copies every example's
+`.env.example` to `.env`, forces `DATABASE_URL` to SQLite for the two examples
+whose config is `provider: 'sqlite'` but whose `.env.example` defaults to a
+PostgreSQL URL (`blog`, `composable-dashboard`), and supplies placeholder
+secrets (`OPENAI_API_KEY`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
+`NEXT_PUBLIC_APP_URL`) as job env so `generate`/`build` don't fail on missing
+vars. The one genuinely PostgreSQL example (`rag-openai-chatbot`) keeps its
+placeholder URL — `generate`/`build` never open a connection.
+
 ### Coverage gating
 
 Coverage is reported for every package but **gated only on the


### PR DESCRIPTION
Implements #448. Part of #443. Rationale: [ADR-0002](https://github.com/OpenSaasAU/stack/blob/main/docs/adr/0002-testing-and-ci-strategy.md).

## What this adds

A scheduled (nightly) GitHub Actions workflow (`.github/workflows/nightly.yml`) running the heavier / networked checks deliberately kept **off** the PR gate, plus a CONTRIBUTING "Test lanes" section.

### `nightly.yml` — two jobs

**(a) `published-create-e2e` — published `npm create opensaas-app` end-to-end**
Real, networked `npx --yes create-opensaas-app@latest myapp --no-auth --no-ai` install into an OS temp dir (`mktemp -d`, never the runner workspace), then the documented first-run flow on the scaffolded app: `pnpm install` → `pnpm generate` → `pnpm db:push` → `pnpm build`, asserting `.opensaas/context.ts` and `dev.db` exist. This is the true end-to-end the PR-gate scaffold guard (from #446) only proxies — the guard borrows the workspace toolchain offline, this exercises the actual published artifact.

**(b) `examples-build` — full `examples/*` build**
Runs `pnpm build:examples` (the script added in #447). Examples are off the default build gate because each needs a developer-created `.env` to `generate` — this job makes that deterministic (see below).

### Triggers (NOT on the PR gate)

`on: { schedule: [cron '17 3 * * *'], workflow_dispatch: {} }` — **no** `pull_request` or `push`. A registry/network hiccup or a slow examples build never blocks a PR. Failures fail the run loudly (each job uses `set -euo pipefail` and explicit existence asserts).

### Making the examples build deterministic

The trickiest bit is that `examples/*` need generated artifacts, which need a `.env`. The `examples-build` job:

1. Copies every example's `.env.example` to `.env`.
2. Forces `DATABASE_URL="file:./dev.db"` for the two examples whose `opensaas.config.ts` uses `provider: 'sqlite'` but whose `.env.example` defaults to a PostgreSQL URL — **`blog`** and **`composable-dashboard`** — so the Prisma datasource provider matches.
3. Supplies placeholder secrets as **job env** so `generate`/`build` don't fail on missing vars: `DATABASE_URL=file:./dev.db`, `OPENAI_API_KEY=sk-testing-key`, `BETTER_AUTH_SECRET=...`, `BETTER_AUTH_URL=http://localhost:3000`, `NEXT_PUBLIC_APP_URL=http://localhost:3000` (matching the `test.yml`/`release.yml` env conventions).

The one genuinely PostgreSQL example (`rag-openai-chatbot`) keeps its placeholder URL — `generate`/`build` never open a DB connection.

This approach was validated locally: `pnpm build:examples` with this `.env` setup builds **all 20 example tasks green** (including `rag-ollama-demo` and `rag-openai-chatbot`).

### CONTRIBUTING

Added a "Test lanes" subsection (fast unit / coverage / e2e / nightly) as a table, integrated with the existing **Coverage gating** section (#445) and build-scope/docs sections (#447) rather than duplicating them, and documenting exactly what `.env` values the nightly examples job sets. Links ADR-0002.

## Conventions / house rules

- Matches `test.yml` conventions: `./.github/actions/setup` composite action, `pnpm build` before example builds, `OPENAI_API_KEY: 'sk-testing-key'`-style placeholder env.
- No `packages/*` source changed → **no changeset needed** (workflow + docs only).

## Verification

- `actionlint` (v1.7.12) passes on `nightly.yml` (and on the existing `test.yml`).
- YAML structure confirmed: triggers are exactly `schedule` + `workflow_dispatch`, no `pull_request`/`push`; jobs `published-create-e2e`, `examples-build`.
- `prettier --check` clean on `CONTRIBUTING.md` and `nightly.yml`; `pnpm lint` clean (0 errors).
- `pnpm build:examples` verified green locally with the documented `.env` setup.

A real `workflow_dispatch` run can only happen once the workflow is on `main` — please trigger it from the Actions tab ("Run workflow") after merge to confirm both jobs go green end-to-end.

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_