### PR TITLE
fix(examples): default blog & composable-dashboard .env.example to SQLite

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,9 +67,9 @@ jobs:
   # (b) The FULL `examples/*` build. Examples are off the default build gate
   # (ADR-0002 / PR #447) because each needs a developer-created `.env` to
   # `generate`. This job makes that deterministic: it creates every example's
-  # `.env` from its `.env.example` first, forcing SQLite for the two examples
-  # whose config is `provider: 'sqlite'` but whose `.env.example` defaults to a
-  # PostgreSQL URL (`blog`, `composable-dashboard`), then runs `pnpm build:examples`.
+  # `.env` from its committed `.env.example` first, then runs `pnpm build:examples`.
+  # Each `.env.example` now defaults to a DATABASE_URL that matches its config's
+  # provider (#462), so no per-example overrides are needed here.
   examples-build:
     name: Full examples build
     runs-on: ubuntu-latest
@@ -86,26 +86,18 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      # Create a runnable `.env` for every example. Examples whose config uses
-      # `provider: 'sqlite'` but whose `.env.example` defaults to a PostgreSQL URL
-      # (blog, composable-dashboard) get DATABASE_URL forced to SQLite so the
-      # Prisma datasource provider matches. All other DB/secret placeholders come
-      # from the .env.example values plus the job-level env below.
+      # Create a runnable `.env` for every example by copying its committed
+      # `.env.example`. Each `.env.example` defaults DATABASE_URL to a value that
+      # matches its config's Prisma provider (#462), so no per-example overrides
+      # are needed. Other DB/secret placeholders come from the .env.example values
+      # plus the job-level env below.
       - name: Create .env for every example
         run: |
           set -euo pipefail
-          # sqlite-provider examples that ship a postgres .env.example default
-          force_sqlite="blog composable-dashboard"
           for dir in examples/*/; do
             name="$(basename "$dir")"
             if [ -f "$dir/.env.example" ]; then
               cp "$dir/.env.example" "$dir/.env"
-              case " $force_sqlite " in
-                *" $name "*)
-                  # Replace the DATABASE_URL line with a SQLite value.
-                  sed -i 's|^DATABASE_URL=.*|DATABASE_URL="file:./dev.db"|' "$dir/.env"
-                  ;;
-              esac
               echo "prepared .env for $name"
             fi
           done

--- a/examples/blog/.env.example
+++ b/examples/blog/.env.example
@@ -1,4 +1,5 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_blog?schema=public"
+# SQLite (default) — zero setup, great for local development
+DATABASE_URL="file:./dev.db"
 
-# For SQLite (easier for testing):
-# DATABASE_URL="file:./dev.db"
+# For PostgreSQL, set provider: 'postgresql' in opensaas.config.ts and use:
+# DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_blog?schema=public"

--- a/examples/composable-dashboard/.env.example
+++ b/examples/composable-dashboard/.env.example
@@ -1,4 +1,5 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_blog?schema=public"
+# SQLite (default) — zero setup, great for local development
+DATABASE_URL="file:./dev.db"
 
-# For SQLite (easier for testing):
-# DATABASE_URL="file:./dev.db"
+# For PostgreSQL, set provider: 'postgresql' in opensaas.config.ts and use:
+# DATABASE_URL="postgresql://user:password@localhost:5432/opensaas_composable_dashboard?schema=public"


### PR DESCRIPTION
## Summary

`examples/blog` and `examples/composable-dashboard` ship `opensaas.config.ts` with `provider: 'sqlite'`, but their committed `.env.example` defaulted `DATABASE_URL` to a **Postgres** connection string. Running the documented `cp .env.example .env && pnpm generate && pnpm db:push` in either example hit a Prisma datasource provider mismatch.

This fixes the root cause:

- **`examples/blog/.env.example`** and **`examples/composable-dashboard/.env.example`** now default `DATABASE_URL` to `"file:./dev.db"`, matching their `provider: 'sqlite'` config. The Postgres alternative is kept as a commented-out note, matching the house style of `examples/starter/.env.example` (comment header + commented Postgres line).
- **`.github/workflows/nightly.yml`** — with both `.env.example` files now matching their config provider, no example has a sqlite-config/Postgres-env mismatch, so the `examples-build` job's hardcoded `force_sqlite="blog composable-dashboard"` override is **removed entirely**. The job now simply copies each `.env.example` verbatim. Triggers remain `schedule` + `workflow_dispatch` only.

## Verification

- **Mismatch grep:** Audited every `examples/*/.env.example` vs its `opensaas.config.ts` provider. After this change, the only Postgres `DATABASE_URL` belongs to `rag-openai-chatbot`, which is correctly `provider: 'postgresql'`. No sqlite-config/Postgres-env mismatch remains, so the override could be dropped completely (not just trimmed).
- **`cp .env.example .env && pnpm generate && pnpm db:push`** runs cleanly in **both** examples: generated schema shows `provider = "sqlite"`, SQLite `dev.db` created, no provider mismatch, no manual edits.
- **actionlint** on `nightly.yml`: clean (exit 0). YAML parses; triggers unchanged.
- **`pnpm format`**: clean.
- `DATABASE_URL` is the only DB var in both `.env.example` files; no other required vars to preserve.

## Changeset

No changeset required — docs/examples and CI workflow only, no publishable `packages/*` change.

Closes #462

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_