### PR TITLE
chore(examples): regenerate prisma.config.ts for DIRECT_DATABASE_URL fallback

### DIFF
--- a/examples/auth-demo/prisma.config.ts
+++ b/examples/auth-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/blog/prisma.config.ts
+++ b/examples/blog/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/composable-dashboard/prisma.config.ts
+++ b/examples/composable-dashboard/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/custom-field/prisma.config.ts
+++ b/examples/custom-field/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/file-upload-demo/prisma.config.ts
+++ b/examples/file-upload-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/json-demo/prisma.config.ts
+++ b/examples/json-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/mcp-demo/prisma.config.ts
+++ b/examples/mcp-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/rag-ollama-demo/prisma.config.ts
+++ b/examples/rag-ollama-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/rag-openai-chatbot/prisma.config.ts
+++ b/examples/rag-openai-chatbot/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })

--- a/examples/tiptap-demo/prisma.config.ts
+++ b/examples/tiptap-demo/prisma.config.ts
@@ -1,9 +1,15 @@
 import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config'
+import { defineConfig } from 'prisma/config'
+
+// Read an environment variable, returning undefined when unset so the
+// `??` fallback below can take effect. (The `env` helper from
+// 'prisma/config' throws on missing variables, which would break the
+// fallback.)
+const env = (name: string): string | undefined => process.env[name]
 
 export default defineConfig({
   schema: 'prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
   },
 })


### PR DESCRIPTION
## Summary

Regenerates the committed `prisma.config.ts` for the ten remaining git-tracked examples so they match current `pnpm generate` output after #450 / #456 (ADR-0003).

The `prisma.config.ts` generator (`packages/cli/src/generator/prisma-config.ts`) now emits a local `env` helper plus `url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL')`. The `starter` / `starter-auth` examples were regenerated as part of #456, but these ten still carried the old `import { defineConfig, env } from 'prisma/config'` + `url: env('DATABASE_URL')` form and had drifted from generator output.

## Examples regenerated

- `examples/blog`
- `examples/auth-demo`
- `examples/custom-field`
- `examples/composable-dashboard`
- `examples/mcp-demo`
- `examples/json-demo`
- `examples/file-upload-demo`
- `examples/tiptap-demo`
- `examples/rag-ollama-demo`
- `examples/rag-openai-chatbot`

All ten now match the `starter` example's `prisma.config.ts` byte-for-byte. Each file changed identically: drop the `env` import, add the local `env` helper (returns `undefined` for unset vars so the `??` fallback works), and use the `DIRECT_DATABASE_URL ?? DATABASE_URL` fallback.

## Verification

- Each listed example's committed `prisma.config.ts` now matches `pnpm generate` output.
- Re-running `pnpm generate` is idempotent — confirmed zero further diff in `auth-demo`, `tiptap-demo`, `blog`, and `rag-openai-chatbot`.
- Local SQLite `db:push` still works (verified on `json-demo`): with `DIRECT_DATABASE_URL` unset, the datasource falls back to `DATABASE_URL` and the database syncs — no behaviour change.
- Only the ten `examples/*/prisma.config.ts` files changed. No `packages/*` source changes (regeneration only), so **no changeset is required**.
- `pnpm format` clean; `pnpm manypkg check` passes.

Closes #459

https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBLPYAJ8VvGVmxB2Y5KLMd)_