### PR TITLE
Harden migrate-context-calls skill: where-shape, connect/disconnect, gql.tada, include/select recipes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "name": "opensaas-migration",
       "source": "./claude-plugins/opensaas-migration",
       "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "author": {
         "name": "OpenSaaS Team",
         "url": "https://github.com/OpenSaasAU/stack"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ pnpm-debug.log*
 # Turbo
 .turbo/
 .playwright-mcp
+
+# Background agent worktrees (transient, auto-cleaned)
+.claude/worktrees/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,23 @@ _Avoid_: operation handler, mutation service
 **Hook Pipeline**:
 The module that runs the transform+validate span of a write — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — owning that order and the `resolvedData` threading through it. It throws a validation error (never silent) when a validate hook reports via `addValidationError` or a built-in field rule fails, and returns the transformed `resolvedData` on success. The Write Pipeline delegates this span to it; side-effect hooks (`beforeOperation`/`afterOperation`), access, writable-field filtering, persistence and Field Visibility stay in the Write Pipeline.
 _Avoid_: validation service, input resolver
+
+### Migration & schema generation
+
+**Schema parity**:
+The property that the generator's Prisma schema diffs clean — an empty `prisma migrate diff` in both directions — against a pre-existing (typically Keystone-generated) database, so a project can adopt the stack without a destructive migration. It is the go/no-go gate for every migration phase.
+_Avoid_: schema match, clean diff, byte-compatibility
+
+**Keystone-compat mode**:
+An opt-in generator setting that makes schema output follow Keystone 6 conventions a migrating project depends on but a greenfield project would not want by default (e.g. non-null text columns defaulting to `""`). Conventions that every project wants are the plain default, not part of this mode.
+_Avoid_: legacy mode, compatibility flag, migration mode
+
+### Authentication
+
+**Auth lists**:
+The user/session/account/verification lists the auth plugin derives from the better-auth config — their keys, table/column maps, and database schema all follow that config, so they can be modelled to match (adopt) pre-existing better-auth tables. Distinct from any application domain User.
+_Avoid_: auth tables, auth models, auth schema
+
+**Auth identity**:
+The better-auth-owned record of who a session belongs to (the better-auth user). Separate from, and not assumed to be, the application's own domain User; an app links the two itself when it needs to.
+_Avoid_: auth user, principal, account

--- a/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
+++ b/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opensaas-migration",
   "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "author": {
     "name": "OpenSaaS Team",
     "url": "https://github.com/OpenSaasAU/stack"

--- a/claude-plugins/opensaas-migration/skills/migrate-context-calls/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/migrate-context-calls/SKILL.md
@@ -226,6 +226,285 @@ const allPosts = await context.sudo().graphql.run({ query: '...' })
 const allPosts = await context.sudo().db.post.findMany()
 ```
 
+## Recipe 1 — `where`-shape translation (relation filters → scalar-FK / relation filters)
+
+Keystone's GraphQL `where` nests through the related list even when you are filtering on a foreign key (`{ author: { id: { equals: $id } } }`). Prisma exposes the scalar foreign key directly (`{ authorId: { equals: $id } }`), so the most common rewrite is to **collapse a single-relation `{ id: { equals } }` filter onto the scalar `*Id` field**. Filtering on _other_ fields of the related record stays nested (Prisma calls this a relation filter), and to-many relations use `some` / `every` / `none`.
+
+```typescript
+// Before — Keystone relation filter on the related record's id
+const { posts } = await context.graphql.run({
+  query: `query GetPosts($authorId: ID!) {
+    posts(where: {
+      author: { id: { equals: $authorId } }
+      status: { in: [published, featured] }
+      tags: { some: { name: { equals: "release" } } }
+    }) { id title }
+  }`,
+  variables: { authorId },
+})
+
+// After — collapse the FK relation filter to the scalar field; keep genuine
+// relation filters nested; to-many uses some/every/none
+const posts = await context.db.post.findMany({
+  where: {
+    authorId: { equals: authorId }, // author.id → authorId scalar FK
+    status: { in: ['published', 'featured'] }, // enum string values, not GraphQL idents
+    tags: { some: { name: { equals: 'release' } } }, // to-many relation filter kept nested
+  },
+})
+```
+
+### Translation table
+
+| Keystone `where`                                       | Prisma `where`                                       | Notes                                                                           |
+| ------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `{ author: { id: { equals: $id } } }`                  | `{ authorId: { equals: $id } }`                      | Single relation filtered by `id` → collapse onto scalar FK `<field>Id`.         |
+| `{ author: { id: { equals: $id } } }`                  | `{ authorId: $id }`                                  | Prisma allows the bare value as shorthand for `{ equals: $id }`.                |
+| `{ author: { name: { contains: "x" } } }`              | `{ author: { name: { contains: "x" } } }`            | Filtering a _non-id_ field of a single relation stays a nested relation filter. |
+| `{ author: null }`                                     | `{ authorId: null }` (or `{ author: { is: null } }`) | "No related record" → null scalar FK; `is: null` also works.                    |
+| `{ tags: { some: { name: { equals: "x" } } } }`        | `{ tags: { some: { name: { equals: "x" } } } }`      | To-many: `some` unchanged.                                                      |
+| `{ tags: { every: { archived: { equals: false } } } }` | `{ tags: { every: { archived: false } } }`           | To-many: `every` unchanged.                                                     |
+| `{ tags: { none: { name: { equals: "x" } } } }`        | `{ tags: { none: { name: { equals: "x" } } } }`      | To-many: `none` unchanged.                                                      |
+| `{ AND: [...] }` / `{ OR: [...] }` / `{ NOT: ... }`    | `{ AND: [...] }` / `{ OR: [...] }` / `{ NOT: ... }`  | Logical operators are identical.                                                |
+
+**Scalar operators** map almost 1:1 — the main difference is Keystone wraps even simple equality in `{ equals }`, while Prisma accepts the bare value:
+
+| Keystone scalar filter                                                      | Prisma scalar filter                                                                       |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `{ status: { equals: published } }`                                         | `{ status: 'published' }` or `{ status: { equals: 'published' } }` (enum → string literal) |
+| `{ title: { not: { equals: "x" } } }`                                       | `{ title: { not: 'x' } }`                                                                  |
+| `{ views: { gt: 10, lte: 100 } }`                                           | `{ views: { gt: 10, lte: 100 } }`                                                          |
+| `{ id: { in: [a, b] } }` / `{ notIn: [...] }`                               | `{ id: { in: [a, b] } }` / `{ id: { notIn: [...] } }`                                      |
+| `{ title: { contains: "x" } }`                                              | `{ title: { contains: 'x' } }`                                                             |
+| `{ title: { startsWith / endsWith: "x" } }`                                 | `{ title: { startsWith / endsWith: 'x' } }`                                                |
+| `{ title: { mode: insensitive, contains } }` (Keystone field `_i` variants) | `{ title: { contains: 'x', mode: 'insensitive' } }`                                        |
+
+> **Enum gotcha:** Keystone GraphQL writes enum values as bare identifiers (`status: published`). Prisma/`context.db` uses **string literals** (`status: 'published'`). Always quote them in the rewrite.
+
+## Recipe 2 — `connect` / `disconnect` / `set` nested writes
+
+Keystone relationship mutations use nested-write operators inside `data`. Prisma uses the same _names_ but the shapes differ slightly, and OpenSaaS Stack passes `data` straight through to Prisma — so use Prisma's relation-operation shapes. Field-level access control still filters writable fields, and the foreign-key column is never written directly (use the relation field, not `authorId`).
+
+```typescript
+// Before — Keystone create with a connected author and connected tags
+const { createPost } = await context.graphql.run({
+  query: `mutation CreatePost($data: PostCreateInput!) {
+    createPost(data: $data) { id }
+  }`,
+  variables: {
+    data: {
+      title: 'Hello',
+      author: { connect: { id: authorId } },
+      tags: { connect: [{ id: tagA }, { id: tagB }] },
+    },
+  },
+})
+
+// After — Prisma relation operations on create (note: connect-many takes an array)
+const post = await context.db.post.create({
+  data: {
+    title: 'Hello',
+    author: { connect: { id: authorId } },
+    tags: { connect: [{ id: tagA }, { id: tagB }] },
+  },
+})
+```
+
+```typescript
+// Before — Keystone update: swap author, add/remove tags
+await context.graphql.run({
+  query: `mutation UpdatePost($id: ID!, $data: PostUpdateInput!) {
+    updatePost(where: { id: $id }, data: $data) { id }
+  }`,
+  variables: {
+    id: postId,
+    data: {
+      author: { connect: { id: newAuthorId } }, // reassign single relation
+      tags: {
+        connect: [{ id: tagC }], // add
+        disconnect: [{ id: tagA }], // remove
+      },
+    },
+  },
+})
+
+// After — Prisma update relation operations
+const updated = await context.db.post.update({
+  where: { id: postId },
+  data: {
+    author: { connect: { id: newAuthorId } },
+    tags: {
+      connect: [{ id: tagC }],
+      disconnect: [{ id: tagA }],
+    },
+  },
+})
+if (!updated) {
+  /* access denied or not found — context.db returns null, never throws */
+}
+```
+
+### Nested-write translation table
+
+| Keystone nested write               | Prisma nested write                 | Applies to                                    |
+| ----------------------------------- | ----------------------------------- | --------------------------------------------- |
+| `author: { connect: { id } }`       | `author: { connect: { id } }`       | create / update                               |
+| `author: { disconnect: true }`      | `author: { disconnect: true }`      | update (nullable single relation)             |
+| `tags: { connect: [{ id }, …] }`    | `tags: { connect: [{ id }, …] }`    | create / update (to-many)                     |
+| `tags: { disconnect: [{ id }, …] }` | `tags: { disconnect: [{ id }, …] }` | update (to-many)                              |
+| `tags: { set: [{ id }, …] }`        | `tags: { set: [{ id }, …] }`        | update (to-many — **replaces** the whole set) |
+| `tags: { set: [] }`                 | `tags: { set: [] }`                 | update (clear all to-many links)              |
+| `author: { create: { … } }`         | `author: { create: { … } }`         | create / update (nested create)               |
+
+> **`set` replaces, `connect` adds.** On a to-many relation, Keystone's `set: [...]` and Prisma's `set: [...]` both _replace_ the entire list of links; `connect` only adds. To clear all links use `set: []`.
+>
+> **Never write the scalar FK directly.** Use the relation field (`author: { connect: { id } }`), not `authorId: …`. `filterWritableFields` strips `<field>Id` keys when a relationship field exists, so writing the FK directly is silently dropped.
+
+## Recipe 3 — gql.tada typed documents → `defineFragment` + `ResultOf`
+
+gql.tada projects build typed documents (`TadaDocumentNode`) and derive types with `ResultOf` / `VariablesOf` from the GraphQL schema. OpenSaaS Stack has no GraphQL schema (ADR-0005): replace the typed _document_ with a typed _fragment_ created by `defineFragment`, and replace `ResultOf<typeof Doc>` with `ResultOf<typeof fragment>`. Variables (`VariablesOf`) become plain function parameters / `where` arguments — there is no document to parameterise, so a factory function is the closest equivalent.
+
+```typescript
+// Before — gql.tada typed document + ResultOf / VariablesOf
+import { graphql, type ResultOf, type VariablesOf } from 'gql.tada'
+
+const PostsQuery = graphql(`
+  query GetPosts($authorId: ID!) {
+    posts(where: { author: { id: { equals: $authorId } } }) {
+      id
+      title
+      author {
+        id
+        name
+      }
+    }
+  }
+`)
+
+type PostsResult = ResultOf<typeof PostsQuery> // { posts: { id; title; author: { id; name } | null }[] }
+type PostsVars = VariablesOf<typeof PostsQuery> // { authorId: string }
+
+async function getPosts(vars: PostsVars) {
+  const { posts } = await context.graphql.run({ query: PostsQuery, variables: vars })
+  return posts
+}
+```
+
+```typescript
+// After — defineFragment + ResultOf (no GraphQL schema, no codegen)
+import type { Post, User } from '.prisma/client'
+import { defineFragment, type ResultOf } from '@opensaas/stack-core'
+
+const authorFragment = defineFragment<User>()({ id: true, name: true } as const)
+
+const postFragment = defineFragment<Post>()({
+  id: true,
+  title: true,
+  author: authorFragment,
+} as const)
+
+// ResultOf reads the fragment, not a GraphQL document
+type PostData = ResultOf<typeof postFragment>
+// → { id: string; title: string; author: { id: string; name: string } | null }
+
+// VariablesOf has no equivalent — variables become plain function params + a `where`
+async function getPosts(authorId: string): Promise<PostData[]> {
+  return context.db.post.findMany({
+    query: postFragment,
+    where: { authorId: { equals: authorId } }, // relation filter collapsed (see Recipe 1)
+  })
+}
+```
+
+**Mapping summary:**
+
+| gql.tada                                         | OpenSaaS Stack                                                                                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `graphql('query … { … }')` (`TadaDocumentNode`)  | `defineFragment<Model>()({ … } as const)`                                                                                           |
+| `ResultOf<typeof Doc>`                           | `ResultOf<typeof fragment>`                                                                                                         |
+| `VariablesOf<typeof Doc>`                        | Plain function parameters → `where` / `take` / `orderBy` args (or a fragment **factory** for nested-relation variables — see below) |
+| `context.graphql.run({ query: Doc, variables })` | `context.db.<list>.findMany/findUnique({ query: fragment, where, … })`                                                              |
+| `.graphql` codegen of fragment files             | A shared `fragments.ts` of `defineFragment` definitions                                                                             |
+
+When the old document parameterised a **nested** relationship filter, use a fragment factory so the runtime value is baked into the fragment:
+
+```typescript
+function makePostFragment(commentStatus: string) {
+  return defineFragment<Post>()({
+    id: true,
+    title: true,
+    comments: { query: commentFragment, where: { status: commentStatus } },
+  } as const)
+}
+type PostData = ResultOf<ReturnType<typeof makePostFragment>>
+
+const posts = await context.db.post.findMany({ query: makePostFragment('approved') })
+```
+
+## Recipe 4 — fragment → Prisma `include` / `select` + null-on-access-denied
+
+A `defineFragment` selection maps directly onto a Prisma query under the hood, and the access-control layer applies on top:
+
+- **Scalar fields selected with `true`** need no `include` — Prisma returns all scalar columns by default, and the fragment then **picks** only the selected keys (so `ResultOf` is exactly the shape you get back).
+- **Relationship fields selected with a nested fragment / `RelationSelector`** generate a Prisma `include` entry (recursively). The fragment walker emits `{ include: { author: { include: { … } } } }`; nested `where` / `orderBy` / `take` / `skip` from a `RelationSelector` are attached to that include entry.
+
+```typescript
+import type { Post, User, Comment } from '.prisma/client'
+import { defineFragment, type ResultOf } from '@opensaas/stack-core'
+
+const authorFragment = defineFragment<User>()({ id: true, name: true } as const)
+const commentFragment = defineFragment<Comment>()({ id: true, body: true } as const)
+
+const postFragment = defineFragment<Post>()({
+  id: true, // scalar — picked, no include
+  title: true, // scalar — picked, no include
+  author: authorFragment, // single relation → include: { author: { ... } }
+  comments: {
+    // to-many RelationSelector → include with nested args
+    query: commentFragment,
+    where: { approved: true },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+  },
+} as const)
+
+const post = await context.db.post.findUnique({ where: { id: postId }, query: postFragment })
+```
+
+The fragment above is equivalent to this hand-written Prisma call (which `context.db` builds for you):
+
+```typescript
+await prisma.post.findFirst({
+  where: { id: postId /* + access filter merged in */ },
+  include: {
+    author: true,
+    comments: { where: { approved: true }, orderBy: { createdAt: 'desc' }, take: 5 },
+  },
+})
+// → then only { id, title, author: { id, name }, comments: { id, body }[] } is picked
+```
+
+### Null-on-access-denied semantics for nested relations
+
+Access control runs at **every level**, and denial is silent (no throw):
+
+- **Top-level single read** (`findUnique` / `findFirst`): returns `null` when the operation-level `query` access denies, the access filter excludes the row, or the row does not exist. Always `if (!post) …`.
+- **Top-level list read** (`findMany`): returns `[]` on denial; individual rows the access filter excludes are simply absent from the array.
+- **Nested single relation** (`author`): if the related record is filtered out by its list's access control (or the FK is null), the field comes back as `null` — even though the parent row was returned. `ResultOf` already types single relations as `T | null`, so this is expected:
+
+  ```typescript
+  type PostData = ResultOf<typeof postFragment>
+  // author: { id: string; name: string } | null   ← may be null on access denial
+  const post = await context.db.post.findUnique({ where: { id: postId }, query: postFragment })
+  if (!post) return notFound()
+  const authorName = post.author?.name ?? 'Unknown' // guard the nested null
+  ```
+
+- **Nested to-many relation** (`comments`): records the nested list's access control excludes are dropped from the array — you get a (possibly empty) array, never `null`, for a to-many field.
+- **Field-level access**: a denied _field_ (not a whole record) is filtered out by `filterReadableFields` before the fragment picks fields; if you select a field you cannot read, it is absent from the result rather than throwing.
+
+> **Migration takeaway:** Keystone fragments resolved nested data through the GraphQL layer's own access checks and returned `null` for denied relations. The stack reproduces the same null-on-access-denied behaviour through `context.db` — so keep your Keystone null-guards (`post.author?.name`) when porting fragment consumers; they are still required.
+
 ## Steps
 
 1. Use Grep to find all occurrences of `context.graphql`, `context.query`, and `context.sudo().graphql` in the project (search `.ts`, `.tsx` files, exclude `node_modules`)
@@ -237,7 +516,11 @@ const allPosts = await context.sudo().db.post.findMany()
    - **Create / update / delete** → `context.db.{list}.create()` / `update()` / `delete()`
    - **Count** → `context.db.{list}.count()`
      c. Identify the list name (convert to camelCase for `context.db`)
-     d. Rewrite using the appropriate pattern above
+     d. Rewrite using the appropriate pattern above. Apply the relevant recipe:
+   - **`where` clauses** → translate relation/scalar filters with **Recipe 1** (collapse `{ author: { id: { equals } } }` → `{ authorId: { equals } }`, quote enum values).
+   - **`connect` / `disconnect` / `set` in `data`** → keep Prisma's relation-operation shapes with **Recipe 2**; never write the scalar FK directly.
+   - **gql.tada typed documents** (`graphql(...)`, `ResultOf`, `VariablesOf`) → replace with `defineFragment` + `ResultOf` per **Recipe 3**.
+   - **Nested reads** → map the fragment to `include`/`select` and keep null-guards per **Recipe 4**.
      e. For fragment-based rewrites: create a shared `fragments.ts` file and import from it
-3. After all edits: check that any `import ... from '@keystone-6/core'` imports used only for graphql types are removed or reduced; also remove any GraphQL codegen type imports (replace with `ResultOf<typeof fragment>`)
+3. After all edits: check that any `import ... from '@keystone-6/core'` imports used only for graphql types are removed or reduced; also remove any GraphQL codegen type imports (replace with `ResultOf<typeof fragment>`); for gql.tada surfaces, remove `import { graphql, ResultOf, VariablesOf } from 'gql.tada'`
 4. Report: list every file changed and summarise what was replaced

--- a/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
+++ b/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
@@ -1,0 +1,16 @@
+# The generator emits Keystone-compatible schema defaults
+
+To make Keystone → stack migrations reach Schema parity without per-project `extendPrismaSchema` surgery, the Prisma generator's default output is aligned to Keystone 6 conventions. Most of these are unconditional new defaults (acceptable to change directly while the stack is in beta); the one convention a greenfield project would not want — empty-string text defaults — is gated behind Keystone-compat mode.
+
+## Decisions
+
+- **Fields honour `defaultValue`.** `text()`, `integer()`, and `json()` emit `@default(...)` from their `defaultValue` in `getPrismaType` (matching how `checkbox()`/`decimal()` already behave). Previously these silently dropped the default, forcing migrators to inject it via `extendPrismaSchema`.
+- **Auto-timestamps are off by default.** The generator no longer appends `createdAt`/`updatedAt` to every model. A list opts in by declaring the fields itself or via `db: { timestamps: true }`; when timestamps are enabled and the list also declares its own `createdAt`/`updatedAt`, the auto pair is skipped (no duplicate-field `P1012`). This is a breaking change to existing stack apps and is acceptable in beta.
+- **Singleton `id` is bare.** Singleton lists emit `id Int @id` (no `@default(1)`), matching Keystone 6.
+- **`select()` nullability is explicit.** A `select()` with a `defaultValue` keeps generating `NOT NULL` by default, but `select({ db: { isNullable: true } })` forces the nullable `?`. We chose an explicit opt-in over auto-restoring `?` so the common (required) case is unaffected.
+- **Native-enum names are configurable.** `select({ db: { type: 'enum', enumName: '…' } })` sets the generated enum type name, so a live DB enum (e.g. Keystone's `…Type` suffix) can be matched from config instead of the derived `<List><Field>`.
+- **Keystone-compat mode covers empty-string text defaults.** With the mode enabled, non-null text columns without an explicit `defaultValue` emit `@default("")` (Keystone's implicit behaviour). This stays opt-in because a greenfield project would not want it.
+
+## Why this is worth recording
+
+A future reader will look at the generator and wonder why it deliberately omits `createdAt`/`updatedAt` and the singleton `id` default that earlier versions emitted "to match Keystone 6 behaviour" — these are reversals of long-standing defaults, made specifically to keep migrations non-destructive (Schema parity). Each is a real trade-off between greenfield ergonomics and migration fidelity, and reversing any of them touches the generator, the field builders, and the migration guide together. Supersedes the narrower discussion in issues #301, #303, and #304.

--- a/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
+++ b/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
@@ -1,0 +1,14 @@
+# The stack has no GraphQL layer; Keystone GraphQL migrates via fragments + an agent skill
+
+The OpenSaaS Stack deliberately exposes only `context.db.*` and provides no GraphQL server, schema, or typed-document runtime. A Keystone project's `context.graphql.run`/`context.query.*` surface — including large gql.tada codebases — is migrated to `context.db.*` with `defineFragment`/`ResultOf` for composable typed reads, assisted by the `migrate-context-calls` skill in the `opensaas-migration` plugin.
+
+## Decisions
+
+- **No GraphQL adapter.** We will not ship an optional GraphQL server to preserve existing gql.tada surfaces. It would reintroduce the runtime the stack was designed to drop, carry ongoing schema/maintenance cost, and split the access-control story across two execution paths.
+- **No standalone AST codemod tool.** Mechanical `context.graphql.run` → `context.db.*` rewriting is reliable only for trivial CRUD; nested/relational queries and where-shape differences need judgement. That judgement lives in an agent skill (`migrate-context-calls`), not a deterministic ts-morph CLI.
+- **Fragments are the parity story.** `defineFragment` + `ResultOf` (in `@opensaas/stack-core`) replace GraphQL fragments and codegen — composable, reused, and type-inferred without a build step.
+- **The migration guide and skill carry the specifics** migrators trip on: Keystone-relation-filter → Prisma scalar-FK where-shape translation, `connect`/`disconnect`/`set` nested-write mapping, gql.tada typed-document → `defineFragment` replacement, and fragment → Prisma `include`/`select` with null-on-access-denied semantics.
+
+## Why this is worth recording
+
+"Where's the GraphQL?" is the first question every Keystone migrator asks, and a reasonable reader will assume an adapter should exist or will propose building one. Recording that the absence is deliberate — and that the supported path is fragments plus an agent-assisted rewrite rather than a compatibility layer — stops that work from being reopened, and explains why migration effort is concentrated in a skill and a guide rather than a package.

--- a/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
+++ b/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
@@ -1,0 +1,14 @@
+# Image/file migration prefers non-destructive multi-column parity over JSON consolidation
+
+Keystone stores an image field across seven columns (`<field>_url`, `<field>_width`, `<field>_height`, `<field>_filesize`, `<field>_contentType`, `<field>_contentDisposition`, `<field>_pathname`) and a file field across three. The stack's `image()`/`file()` fields default to a single `Json?` column. To migrate an existing database without breaking **Schema parity**, `image()`/`file()` gain a multi-column mode that maps onto the existing Keystone columns in place, rather than consolidating them into JSON (which drops columns and is destructive).
+
+## Decisions
+
+- **Multi-column mode is the parity path.** `image()`/`file()` can map to the existing per-part Keystone columns (configurable `@map` names) and assemble/split an `ImageMetadata`/`FileMetadata` value across them. A migrating project reaches a clean diff and a functional field with no data migration and no re-upload of existing assets.
+- **JSON consolidation becomes the explicitly-destructive alternative.** The single-`Json?` column remains the default for greenfield projects and is offered to migrators only as an opt-in, clearly-flagged destructive path (drops the old columns; requires a backup). The `migrate-image-fields` skill and `specs/keystone-image-migration.md` are rewritten to lead with the non-destructive multi-column path and demote consolidation.
+- **No re-upload of existing assets.** Both modes treat an already-shaped metadata value (or, in multi-column mode, populated columns) as authoritative and never re-upload — only a `File`-like input triggers a storage upload. This guarantee is locked by a test.
+- **Vercel Blob is a supported provider.** `@opensaas/stack-storage-vercel` already implements the provider interface; it is documented as a first-class option for migrators (not S3-only).
+
+## Why this is worth recording
+
+The stack's own image-migration guidance previously told migrators to consolidate to a JSON column and drop the originals — a destructive operation that contradicts the no-destructive-migration guardrail the whole migration program is gated on. A future reader will wonder why `image()` has a multi-column mode at all when JSON is simpler; the answer is that schema parity over a live Keystone database requires reading the original columns in place. Reversing this (forcing consolidation) would reintroduce a destructive migration, so the trade-off is worth pinning down.

--- a/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
+++ b/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
@@ -1,0 +1,14 @@
+# authPlugin mirrors better-auth config and its lists can adopt existing tables
+
+`authPlugin` is a thin wrapper over better-auth: the OpenSaaS auth lists (user/session/account/verification) are **derived from the better-auth config the developer already writes** — list keys from better-auth's per-model `modelName`, table/column maps from its `fields` — rather than from a separate, stack-invented set of knobs. On top of that, the lists can be placed in a non-`public` database schema. Together this lets a project with pre-existing better-auth tables (e.g. `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in an `auth` Postgres schema) adopt the plugin and reach **Schema parity** with no destructive migration.
+
+## Decisions
+
+- **The plugin mirrors better-auth.** List keys, table `@@map`, and field-name mappings are taken from the standard better-auth config (`modelName`, `fields`, additional fields). The plugin does not introduce a parallel `listKeys` configuration surface. `getAuthLists`/`convertBetterAuthSchema` derive the OpenSaaS lists from that config. The runtime `userListKey` (currently a hardcoded `'user'` TODO) is resolved from the configured user model.
+- **Auth lists are relocatable to a schema.** A plugin-level `schema` option (with a per-list override) places the generated auth lists in a non-`public` Postgres schema via the stack's existing multi-schema support (`@@schema`).
+- **"Adopt" means a clean diff, not ownership.** With keys, schema, and field shapes matching the live tables, the generated auth lists diff clean against the existing database — they are modelled for runtime and types without producing a migration. An "adopt existing better-auth tables" preset/recipe sets these defaults.
+- **The app's User is separate from the auth identity.** The plugin no longer assumes its user list is the application's `User`. An app may keep its own domain `User` (keyed however it likes) distinct from the better-auth user; linking the two is the application's concern (a relationship/field it declares), not the plugin's.
+
+## Why this is worth recording
+
+The plugin previously hardcoded the four list keys and the `public` schema, and silently `extendList`-ed any existing `User` — which would overwrite an app's own `User` and force a destructive auth migration. A future reader will wonder why the auth lists are derived from better-auth config and freely renamable/relocatable rather than fixed; the answer is that adopting a real, pre-existing better-auth installation on a separate schema is a first-class requirement, and reversing it (re-fixing the keys/schema) would reintroduce the destructive-migration blocker. This was the key blocker reported during the migration.


### PR DESCRIPTION
Implements #488
Part of #486

Adds four migration recipes to the `migrate-context-calls` skill (`claude-plugins/opensaas-migration`), each with a before (Keystone/gql.tada) and after (`context.db.*` / `defineFragment`) fixture that compiles conceptually against the real API in `packages/core/src/query/index.ts`:

1. **`where`-shape translation** — collapses Keystone relation filters (`{ author: { id: { equals } } }`) onto Prisma scalar FKs (`{ authorId: { equals } }`), with a translation table covering relation filters, scalar filters, common operators, and the enum-string-literal gotcha.
2. **`connect` / `disconnect` / `set` nested writes** — maps Keystone nested-write mutations to Prisma relation operations on both create and update, with a nested-write table and the "never write the scalar FK directly" / "`set` replaces, `connect` adds" caveats.
3. **gql.tada typed documents** — replaces `TadaDocumentNode` + `ResultOf`/`VariablesOf` with `defineFragment` + `ResultOf` (and a fragment factory for the `VariablesOf` case), plus a mapping summary.
4. **fragment → `include`/`select` + null semantics** — shows how a fragment maps to a Prisma `include` and documents null-on-access-denied for top-level reads, nested single relations (`T | null`), nested to-many relations (empty array, never null), and field-level access.

The Steps section now references each recipe so the agent applies them during migration.

No GraphQL adapter is built (ADR-0005); fragments + this skill are the parity path.

Plugin version bumped: `opensaas-migration` 0.2.3 → 0.3.0 (new capability) in both `plugin.json` and the `marketplace.json` entry. Marketplace `metadata.version` left unchanged (no marketplace-structure change). `pnpm manypkg fix` and `prettier` run clean.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_