### PR TITLE
feat(core,cli): honour field defaultValue via formatPrismaDefault module

### DIFF
--- a/.changeset/silver-falcons-gather.md
+++ b/.changeset/silver-falcons-gather.md
@@ -1,0 +1,23 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Honour `defaultValue` for `text()`, `integer()`, and `json()` fields in the generated Prisma schema
+
+These three field builders previously dropped `defaultValue` and emitted no `@default(...)`. They now serialise the configured default into a Prisma `@default(...)` literal via a new shared, pure `formatPrismaDefault` module, matching Keystone 6 conventions. The nullable `?` modifier is preserved independently of the default, and fields without a `defaultValue` still emit no `@default(...)`.
+
+```typescript
+fields: {
+  // Int @default(3550)
+  quota: integer({ defaultValue: 3550 }),
+  // String @default("PLEASE_UPDATE")
+  status: text({ defaultValue: 'PLEASE_UPDATE' }),
+  // Json? @default("[1,2,3,4,5]") — Keystone's space-free JSON literal
+  limits: json({ defaultValue: [1, 2, 3, 4, 5] }),
+  // Json? @default("[]")
+  tags: json({ defaultValue: [] }),
+}
+```
+
+See ADR-0004 for the Keystone-compatibility rationale.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,23 @@ _Avoid_: operation handler, mutation service
 **Hook Pipeline**:
 The module that runs the transform+validate span of a write — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — owning that order and the `resolvedData` threading through it. It throws a validation error (never silent) when a validate hook reports via `addValidationError` or a built-in field rule fails, and returns the transformed `resolvedData` on success. The Write Pipeline delegates this span to it; side-effect hooks (`beforeOperation`/`afterOperation`), access, writable-field filtering, persistence and Field Visibility stay in the Write Pipeline.
 _Avoid_: validation service, input resolver
+
+### Migration & schema generation
+
+**Schema parity**:
+The property that the generator's Prisma schema diffs clean — an empty `prisma migrate diff` in both directions — against a pre-existing (typically Keystone-generated) database, so a project can adopt the stack without a destructive migration. It is the go/no-go gate for every migration phase.
+_Avoid_: schema match, clean diff, byte-compatibility
+
+**Keystone-compat mode**:
+An opt-in generator setting that makes schema output follow Keystone 6 conventions a migrating project depends on but a greenfield project would not want by default (e.g. non-null text columns defaulting to `""`). Conventions that every project wants are the plain default, not part of this mode.
+_Avoid_: legacy mode, compatibility flag, migration mode
+
+### Authentication
+
+**Auth lists**:
+The user/session/account/verification lists the auth plugin derives from the better-auth config — their keys, table/column maps, and database schema all follow that config, so they can be modelled to match (adopt) pre-existing better-auth tables. Distinct from any application domain User.
+_Avoid_: auth tables, auth models, auth schema
+
+**Auth identity**:
+The better-auth-owned record of who a session belongs to (the better-auth user). Separate from, and not assumed to be, the application's own domain User; an app links the two itself when it needs to.
+_Avoid_: auth user, principal, account

--- a/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
+++ b/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
@@ -1,0 +1,16 @@
+# The generator emits Keystone-compatible schema defaults
+
+To make Keystone → stack migrations reach Schema parity without per-project `extendPrismaSchema` surgery, the Prisma generator's default output is aligned to Keystone 6 conventions. Most of these are unconditional new defaults (acceptable to change directly while the stack is in beta); the one convention a greenfield project would not want — empty-string text defaults — is gated behind Keystone-compat mode.
+
+## Decisions
+
+- **Fields honour `defaultValue`.** `text()`, `integer()`, and `json()` emit `@default(...)` from their `defaultValue` in `getPrismaType` (matching how `checkbox()`/`decimal()` already behave). Previously these silently dropped the default, forcing migrators to inject it via `extendPrismaSchema`.
+- **Auto-timestamps are off by default.** The generator no longer appends `createdAt`/`updatedAt` to every model. A list opts in by declaring the fields itself or via `db: { timestamps: true }`; when timestamps are enabled and the list also declares its own `createdAt`/`updatedAt`, the auto pair is skipped (no duplicate-field `P1012`). This is a breaking change to existing stack apps and is acceptable in beta.
+- **Singleton `id` is bare.** Singleton lists emit `id Int @id` (no `@default(1)`), matching Keystone 6.
+- **`select()` nullability is explicit.** A `select()` with a `defaultValue` keeps generating `NOT NULL` by default, but `select({ db: { isNullable: true } })` forces the nullable `?`. We chose an explicit opt-in over auto-restoring `?` so the common (required) case is unaffected.
+- **Native-enum names are configurable.** `select({ db: { type: 'enum', enumName: '…' } })` sets the generated enum type name, so a live DB enum (e.g. Keystone's `…Type` suffix) can be matched from config instead of the derived `<List><Field>`.
+- **Keystone-compat mode covers empty-string text defaults.** With the mode enabled, non-null text columns without an explicit `defaultValue` emit `@default("")` (Keystone's implicit behaviour). This stays opt-in because a greenfield project would not want it.
+
+## Why this is worth recording
+
+A future reader will look at the generator and wonder why it deliberately omits `createdAt`/`updatedAt` and the singleton `id` default that earlier versions emitted "to match Keystone 6 behaviour" — these are reversals of long-standing defaults, made specifically to keep migrations non-destructive (Schema parity). Each is a real trade-off between greenfield ergonomics and migration fidelity, and reversing any of them touches the generator, the field builders, and the migration guide together. Supersedes the narrower discussion in issues #301, #303, and #304.

--- a/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
+++ b/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
@@ -1,0 +1,14 @@
+# The stack has no GraphQL layer; Keystone GraphQL migrates via fragments + an agent skill
+
+The OpenSaaS Stack deliberately exposes only `context.db.*` and provides no GraphQL server, schema, or typed-document runtime. A Keystone project's `context.graphql.run`/`context.query.*` surface — including large gql.tada codebases — is migrated to `context.db.*` with `defineFragment`/`ResultOf` for composable typed reads, assisted by the `migrate-context-calls` skill in the `opensaas-migration` plugin.
+
+## Decisions
+
+- **No GraphQL adapter.** We will not ship an optional GraphQL server to preserve existing gql.tada surfaces. It would reintroduce the runtime the stack was designed to drop, carry ongoing schema/maintenance cost, and split the access-control story across two execution paths.
+- **No standalone AST codemod tool.** Mechanical `context.graphql.run` → `context.db.*` rewriting is reliable only for trivial CRUD; nested/relational queries and where-shape differences need judgement. That judgement lives in an agent skill (`migrate-context-calls`), not a deterministic ts-morph CLI.
+- **Fragments are the parity story.** `defineFragment` + `ResultOf` (in `@opensaas/stack-core`) replace GraphQL fragments and codegen — composable, reused, and type-inferred without a build step.
+- **The migration guide and skill carry the specifics** migrators trip on: Keystone-relation-filter → Prisma scalar-FK where-shape translation, `connect`/`disconnect`/`set` nested-write mapping, gql.tada typed-document → `defineFragment` replacement, and fragment → Prisma `include`/`select` with null-on-access-denied semantics.
+
+## Why this is worth recording
+
+"Where's the GraphQL?" is the first question every Keystone migrator asks, and a reasonable reader will assume an adapter should exist or will propose building one. Recording that the absence is deliberate — and that the supported path is fragments plus an agent-assisted rewrite rather than a compatibility layer — stops that work from being reopened, and explains why migration effort is concentrated in a skill and a guide rather than a package.

--- a/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
+++ b/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
@@ -1,0 +1,14 @@
+# Image/file migration prefers non-destructive multi-column parity over JSON consolidation
+
+Keystone stores an image field across seven columns (`<field>_url`, `<field>_width`, `<field>_height`, `<field>_filesize`, `<field>_contentType`, `<field>_contentDisposition`, `<field>_pathname`) and a file field across three. The stack's `image()`/`file()` fields default to a single `Json?` column. To migrate an existing database without breaking **Schema parity**, `image()`/`file()` gain a multi-column mode that maps onto the existing Keystone columns in place, rather than consolidating them into JSON (which drops columns and is destructive).
+
+## Decisions
+
+- **Multi-column mode is the parity path.** `image()`/`file()` can map to the existing per-part Keystone columns (configurable `@map` names) and assemble/split an `ImageMetadata`/`FileMetadata` value across them. A migrating project reaches a clean diff and a functional field with no data migration and no re-upload of existing assets.
+- **JSON consolidation becomes the explicitly-destructive alternative.** The single-`Json?` column remains the default for greenfield projects and is offered to migrators only as an opt-in, clearly-flagged destructive path (drops the old columns; requires a backup). The `migrate-image-fields` skill and `specs/keystone-image-migration.md` are rewritten to lead with the non-destructive multi-column path and demote consolidation.
+- **No re-upload of existing assets.** Both modes treat an already-shaped metadata value (or, in multi-column mode, populated columns) as authoritative and never re-upload — only a `File`-like input triggers a storage upload. This guarantee is locked by a test.
+- **Vercel Blob is a supported provider.** `@opensaas/stack-storage-vercel` already implements the provider interface; it is documented as a first-class option for migrators (not S3-only).
+
+## Why this is worth recording
+
+The stack's own image-migration guidance previously told migrators to consolidate to a JSON column and drop the originals — a destructive operation that contradicts the no-destructive-migration guardrail the whole migration program is gated on. A future reader will wonder why `image()` has a multi-column mode at all when JSON is simpler; the answer is that schema parity over a live Keystone database requires reading the original columns in place. Reversing this (forcing consolidation) would reintroduce a destructive migration, so the trade-off is worth pinning down.

--- a/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
+++ b/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
@@ -1,0 +1,14 @@
+# authPlugin mirrors better-auth config and its lists can adopt existing tables
+
+`authPlugin` is a thin wrapper over better-auth: the OpenSaaS auth lists (user/session/account/verification) are **derived from the better-auth config the developer already writes** — list keys from better-auth's per-model `modelName`, table/column maps from its `fields` — rather than from a separate, stack-invented set of knobs. On top of that, the lists can be placed in a non-`public` database schema. Together this lets a project with pre-existing better-auth tables (e.g. `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in an `auth` Postgres schema) adopt the plugin and reach **Schema parity** with no destructive migration.
+
+## Decisions
+
+- **The plugin mirrors better-auth.** List keys, table `@@map`, and field-name mappings are taken from the standard better-auth config (`modelName`, `fields`, additional fields). The plugin does not introduce a parallel `listKeys` configuration surface. `getAuthLists`/`convertBetterAuthSchema` derive the OpenSaaS lists from that config. The runtime `userListKey` (currently a hardcoded `'user'` TODO) is resolved from the configured user model.
+- **Auth lists are relocatable to a schema.** A plugin-level `schema` option (with a per-list override) places the generated auth lists in a non-`public` Postgres schema via the stack's existing multi-schema support (`@@schema`).
+- **"Adopt" means a clean diff, not ownership.** With keys, schema, and field shapes matching the live tables, the generated auth lists diff clean against the existing database — they are modelled for runtime and types without producing a migration. An "adopt existing better-auth tables" preset/recipe sets these defaults.
+- **The app's User is separate from the auth identity.** The plugin no longer assumes its user list is the application's `User`. An app may keep its own domain `User` (keyed however it likes) distinct from the better-auth user; linking the two is the application's concern (a relationship/field it declares), not the plugin's.
+
+## Why this is worth recording
+
+The plugin previously hardcoded the four list keys and the `public` schema, and silently `extendList`-ed any existing `User` — which would overwrite an app's own `User` and force a destructive auth migration. A future reader will wonder why the auth lists are derived from better-auth config and freely renamable/relocatable rather than fixed; the answer is that adopting a real, pre-existing better-auth installation on a separate schema is a first-class requirement, and reversing it (re-fixing the keys/schema) would reintroduce the destructive-migration blocker. This was the key blocker reported during the migration.

--- a/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Prisma Schema Generator > field defaultValue → @default(...) > generates a representative multi-field model with mixed defaults 1`] = `
+"generator client {
+  provider = "prisma-client"
+  output   = "../.opensaas/prisma-client"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model Config {
+  id        String   @id @default(cuid())
+  label        String? @default("PLEASE_UPDATE")
+  retries      Int? @default(3)
+  limits       Json? @default("[1,2,3,4,5]")
+  empty        Json? @default("[]")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+}
+"
+`;
+
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate basic schema with datasource and generator 1`] = `
 "generator client {
   provider = "prisma-client"

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -8,6 +8,7 @@ import {
   checkbox,
   timestamp,
   select,
+  json,
 } from '@opensaas/stack-core/fields'
 
 describe('Prisma Schema Generator', () => {
@@ -1626,6 +1627,164 @@ describe('Prisma Schema Generator', () => {
 
       expect(schema).toContain('id        String   @id @default(cuid())')
       expect(schema).not.toContain('id        Int      @id @default(1)')
+    })
+  })
+
+  describe('field defaultValue → @default(...)', () => {
+    it('emits a bare numeric @default for integer fields', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Widget: {
+            fields: {
+              quota: integer({ defaultValue: 3550 }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toMatch(/quota\s+Int\?\s+@default\(3550\)/)
+      expect(schema).not.toContain('@default("3550")')
+    })
+
+    it('keeps the nullable ? independent of the integer default', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Widget: {
+            fields: {
+              // Required → non-nullable, but still carries a default
+              required: integer({ validation: { isRequired: true }, defaultValue: 1 }),
+              // Optional → nullable, also carries a default
+              optional: integer({ defaultValue: 2 }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Required keeps no `?` but still gets @default
+      expect(schema).toMatch(/required\s+Int\s+@default\(1\)/)
+      // Optional keeps its `?` and gets @default
+      expect(schema).toMatch(/optional\s+Int\?\s+@default\(2\)/)
+    })
+
+    it('emits a quoted string @default for text fields', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Account: {
+            fields: {
+              status: text({ defaultValue: 'PLEASE_UPDATE' }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@default("PLEASE_UPDATE")')
+    })
+
+    it('emits Keystone JSON-literal @default for json array fields', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Setting: {
+            fields: {
+              numbers: json({ defaultValue: [1, 2, 3, 4, 5] }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toMatch(/numbers\s+Json\?\s+@default\("\[1,2,3,4,5\]"\)/)
+    })
+
+    it('emits @default("[]") for an empty json array default', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Setting: {
+            fields: {
+              tags: json({ defaultValue: [] }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@default("[]")')
+    })
+
+    it('emits @default("{}") for an empty json object default', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Setting: {
+            fields: {
+              meta: json({ defaultValue: {} }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@default("{}")')
+    })
+
+    it('emits no @default for fields without a defaultValue', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Plain: {
+            fields: {
+              name: text(),
+              count: integer(),
+              data: json(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // None of these scalar fields should carry a @default(...)
+      expect(schema).toMatch(/name\s+String\?\s*$/m)
+      expect(schema).toMatch(/count\s+Int\?\s*$/m)
+      expect(schema).toMatch(/data\s+Json\?\s*$/m)
+      expect(schema).not.toContain('@default("')
+      // Only the system-field defaults (id/createdAt/updatedAt) remain
+      expect(schema).not.toMatch(/name\s+String\?\s+@default/)
+      expect(schema).not.toMatch(/count\s+Int\?\s+@default/)
+      expect(schema).not.toMatch(/data\s+Json\?\s+@default/)
+    })
+
+    it('generates a representative multi-field model with mixed defaults', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Config: {
+            fields: {
+              label: text({ defaultValue: 'PLEASE_UPDATE' }),
+              retries: integer({ defaultValue: 3 }),
+              limits: json({ defaultValue: [1, 2, 3, 4, 5] }),
+              empty: json({ defaultValue: [] }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toMatchSnapshot()
     })
   })
 })

--- a/packages/core/src/fields/format-prisma-default.test.ts
+++ b/packages/core/src/fields/format-prisma-default.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { formatPrismaDefault, type PrismaDefaultFieldType } from './format-prisma-default.js'
+
+describe('formatPrismaDefault', () => {
+  describe('table-driven serialisation', () => {
+    const cases: Array<{
+      name: string
+      value: unknown
+      fieldType: PrismaDefaultFieldType
+      expected: string | undefined
+    }> = [
+      // text
+      {
+        name: 'non-empty string',
+        value: 'PLEASE_UPDATE',
+        fieldType: 'text',
+        expected: '"PLEASE_UPDATE"',
+      },
+      { name: 'empty string', value: '', fieldType: 'text', expected: '""' },
+      {
+        name: 'string with embedded quotes',
+        value: 'say "hi"',
+        fieldType: 'text',
+        expected: '"say \\"hi\\""',
+      },
+      // integer
+      { name: 'integer', value: 3550, fieldType: 'integer', expected: '3550' },
+      { name: 'zero integer', value: 0, fieldType: 'integer', expected: '0' },
+      { name: 'negative integer', value: -7, fieldType: 'integer', expected: '-7' },
+      // json
+      { name: 'JSON array', value: [1, 2, 3, 4, 5], fieldType: 'json', expected: '"[1,2,3,4,5]"' },
+      {
+        name: 'JSON object',
+        value: { a: 1, b: 'two' },
+        fieldType: 'json',
+        expected: '"{\\"a\\":1,\\"b\\":\\"two\\"}"',
+      },
+      { name: 'empty array', value: [], fieldType: 'json', expected: '"[]"' },
+      { name: 'empty object', value: {}, fieldType: 'json', expected: '"{}"' },
+      // undefined → no default for every field type
+      { name: 'undefined text', value: undefined, fieldType: 'text', expected: undefined },
+      { name: 'undefined integer', value: undefined, fieldType: 'integer', expected: undefined },
+      { name: 'undefined json', value: undefined, fieldType: 'json', expected: undefined },
+    ]
+
+    it.each(cases)('serialises $name → $expected', ({ value, fieldType, expected }) => {
+      expect(formatPrismaDefault(value, fieldType)).toBe(expected)
+    })
+  })
+
+  it('produces canonical space-free JSON (no extra whitespace)', () => {
+    // Guards against pretty-printed JSON sneaking into the literal.
+    expect(formatPrismaDefault([1, 2, 3], 'json')).toBe('"[1,2,3]"')
+    expect(formatPrismaDefault({ nested: { x: [1] } }, 'json')).toBe(
+      '"{\\"nested\\":{\\"x\\":[1]}}"',
+    )
+  })
+
+  it('wraps a JSON string default in escaped quotes around the JSON text', () => {
+    // A string value under the json field type is itself valid JSON; it gets
+    // double-serialised: inner JSON.stringify("hi") = "\"hi\"", then wrapped.
+    expect(formatPrismaDefault('hi', 'json')).toBe('"\\"hi\\""')
+  })
+})

--- a/packages/core/src/fields/format-prisma-default.ts
+++ b/packages/core/src/fields/format-prisma-default.ts
@@ -1,0 +1,67 @@
+/**
+ * Field types that {@link formatPrismaDefault} knows how to serialise.
+ *
+ * Kept narrow on purpose: only the scalar fields whose `defaultValue` maps to a
+ * Prisma `@default(...)` literal via this shared helper. Other fields (e.g.
+ * `checkbox`, `decimal`, `timestamp`) format their own defaults inline because
+ * their literal forms diverge (`@default(now())`, bare booleans, etc.).
+ */
+export type PrismaDefaultFieldType = 'text' | 'integer' | 'json'
+
+/**
+ * Serialise a field's `defaultValue` into the inner literal of a Prisma
+ * `@default(...)` attribute.
+ *
+ * Pure: no I/O, no field-builder coupling. Returns just the literal (the caller
+ * wraps it in `@default(...)`), so it composes with whatever modifier string a
+ * field builder assembles. Returns `undefined` when there is nothing to emit, so
+ * a field with no `defaultValue` produces no `@default(...)` at all.
+ *
+ * Serialisation rules (Keystone 6 compatible):
+ * - `integer` → bare numeric literal, e.g. `3550` → `@default(3550)`.
+ * - `text` → double-quoted string literal, e.g. `PLEASE_UPDATE` → `@default("PLEASE_UPDATE")`.
+ * - `json` → Keystone's JSON-literal form: `JSON.stringify` the value with no
+ *   extra whitespace, then wrap the result in escaped double quotes, e.g.
+ *   `[1,2,3,4,5]` → `@default("[1,2,3,4,5]")` and `[]` → `@default("[]")`.
+ *
+ * Nullability (the `?` modifier) is the caller's concern and is handled
+ * independently of the default — this function never touches it.
+ *
+ * @param value - The configured `defaultValue` (the field builder's `defaultValue`).
+ * @param fieldType - The field's discriminator, selecting the serialisation rule.
+ * @returns The literal to place inside `@default(...)`, or `undefined` when
+ *   `value` is `undefined` (no default to emit).
+ */
+export function formatPrismaDefault(
+  value: unknown,
+  fieldType: PrismaDefaultFieldType,
+): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  switch (fieldType) {
+    case 'integer':
+      // Bare numeric literal — Prisma expects no quotes for Int defaults.
+      return String(value)
+
+    case 'text':
+      // Double-quoted string literal. The value is escaped via JSON.stringify so
+      // embedded quotes/backslashes are handled correctly.
+      return JSON.stringify(String(value))
+
+    case 'json': {
+      // Keystone's JSON-literal form: canonical, space-free JSON.stringify of the
+      // value, then wrap the whole serialised string in escaped double quotes so
+      // Prisma stores the JSON text as the column default. The outer
+      // JSON.stringify produces the escaped, double-quoted wrapper.
+      const serialised = JSON.stringify(value)
+      // JSON.stringify can return undefined for unserialisable values (e.g. a
+      // function). Treat that as "no default" rather than emitting `@default()`.
+      if (serialised === undefined) {
+        return undefined
+      }
+      return JSON.stringify(serialised)
+    }
+  }
+}

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -16,6 +16,7 @@ import type {
   PrismaRelationResult,
 } from '../config/types.js'
 import { hashPassword, isHashedPassword, HashedPassword } from '../utils/password.js'
+import { formatPrismaDefault } from './format-prisma-default.js'
 
 // Field-config types live here, alongside the builders that produce them.
 // (The umbrella `FieldConfig` and authoring `BaseFieldConfig` stay on the root
@@ -104,6 +105,13 @@ export function text<
         modifiers += ` @db.${db.nativeType}`
       }
 
+      // Default value if provided (quoted string literal). Independent of the
+      // nullable `?` modifier above — the default never overwrites nullability.
+      const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'text')
+      if (defaultLiteral !== undefined) {
+        modifiers += ` @default(${defaultLiteral})`
+      }
+
       // Unique/index modifiers
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
@@ -180,6 +188,13 @@ export function integer<
       // Native type modifier (e.g., @db.SmallInt, @db.BigInt)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
+      }
+
+      // Default value if provided (bare numeric literal). Independent of the
+      // nullable `?` modifier above — the default never overwrites nullability.
+      const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'integer')
+      if (defaultLiteral !== undefined) {
+        modifiers += ` @default(${defaultLiteral})`
       }
 
       // Map modifier
@@ -1298,6 +1313,14 @@ export function json<
       // Native type modifier
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
+      }
+
+      // Default value if provided. Uses Keystone's JSON-literal form: canonical
+      // (space-free) JSON wrapped in escaped double quotes. Independent of the
+      // nullable `?` modifier above — the default never overwrites nullability.
+      const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'json')
+      if (defaultLiteral !== undefined) {
+        modifiers += ` @default(${defaultLiteral})`
       }
 
       // Map modifier


### PR DESCRIPTION
## Summary

Implements #471 (Part of #470). Adds a shared, pure `formatPrismaDefault(value, fieldType)` module that serialises a field's `defaultValue` into a Prisma `@default(...)` literal, and wires `text()`, `integer()`, and `json()` `getPrismaType` to use it. These three builders previously dropped `defaultValue` and emitted no `@default(...)`, forcing migrators to inject defaults via `extendPrismaSchema`. See ADR-0004 for the Keystone-compatibility rationale.

## Serialisation rules

- `integer({ defaultValue: 3550 })` → `@default(3550)` (bare numeric literal)
- `text({ defaultValue: 'PLEASE_UPDATE' })` → `@default("PLEASE_UPDATE")` (quoted string literal, escaped via `JSON.stringify`)
- `json({ defaultValue: [1,2,3,4,5] })` → `@default("[1,2,3,4,5]")` and `json({ defaultValue: [] })` → `@default("[]")` — Keystone's JSON-literal form

### How JSON serialisation is handled

The `json` case applies `JSON.stringify` twice: first to produce canonical, space-free JSON of the value (`[1,2,3,4,5]`), then a second `JSON.stringify` over that string to wrap it in escaped double quotes (`"[1,2,3,4,5]"`). This yields exactly Keystone's JSON-literal form and stays space-free regardless of value shape. Unserialisable values (e.g. a function, where the inner `JSON.stringify` returns `undefined`) emit no `@default(...)`.

### How nullability is preserved

`formatPrismaDefault` only ever returns the inner `@default(...)` literal (or `undefined`) — it never touches the `?` modifier. Each field builder appends the default to its `modifiers` string after the nullability/native-type modifiers, so the `?` is assembled independently of the default and is never overwritten. A required field still emits `Int @default(1)` (no `?`); an optional one emits `Int? @default(2)`. Fields with no `defaultValue` get `undefined` back and emit no `@default(...)`, so existing snapshots do not regress.

## Module design

`packages/core/src/fields/format-prisma-default.ts` is a standalone pure function (no I/O, no field-builder coupling). It is deliberately scoped to the three field types whose default literal maps through this shared helper; `checkbox`/`decimal`/`timestamp` keep formatting their own divergent literals inline. No field-type switch was added to the generator or UI — behaviour stays inside the field builders.

## Tests

- `packages/core/src/fields/format-prisma-default.test.ts` — table-driven unit tests: string, non-empty string, empty string, integer (incl. zero/negative), JSON array, JSON object, empty array, empty object, plus `undefined` → no default, canonical space-free JSON, and embedded-quote escaping.
- `packages/cli/src/generator/prisma.test.ts` — generator output tests asserting the produced schema strings: integer/text/json defaults, nullable `?` preserved independently of the default, no `@default` without a `defaultValue`, and a representative mixed-default model snapshot.

## Verification

- `pnpm build` (tsc typecheck) — pass for all packages
- `packages/core` tests — 547 passed
- `packages/cli` tests — 212 passed (no snapshot regressions)
- `pnpm lint` — 0 errors (4 pre-existing unrelated warnings)
- `pnpm manypkg fix` and `pnpm format` — clean

## Changeset

Minor bump for `@opensaas/stack-core` and `@opensaas/stack-cli` (new feature, beta — no major bump).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_