### PR TITLE
docs: fix migration docs 404s and add link-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ pnpm-debug.log*
 # Turbo
 .turbo/
 .playwright-mcp
+
+# Background agent worktrees (transient, auto-cleaned)
+.claude/worktrees/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,23 @@ _Avoid_: operation handler, mutation service
 **Hook Pipeline**:
 The module that runs the transform+validate span of a write — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — owning that order and the `resolvedData` threading through it. It throws a validation error (never silent) when a validate hook reports via `addValidationError` or a built-in field rule fails, and returns the transformed `resolvedData` on success. The Write Pipeline delegates this span to it; side-effect hooks (`beforeOperation`/`afterOperation`), access, writable-field filtering, persistence and Field Visibility stay in the Write Pipeline.
 _Avoid_: validation service, input resolver
+
+### Migration & schema generation
+
+**Schema parity**:
+The property that the generator's Prisma schema diffs clean — an empty `prisma migrate diff` in both directions — against a pre-existing (typically Keystone-generated) database, so a project can adopt the stack without a destructive migration. It is the go/no-go gate for every migration phase.
+_Avoid_: schema match, clean diff, byte-compatibility
+
+**Keystone-compat mode**:
+An opt-in generator setting that makes schema output follow Keystone 6 conventions a migrating project depends on but a greenfield project would not want by default (e.g. non-null text columns defaulting to `""`). Conventions that every project wants are the plain default, not part of this mode.
+_Avoid_: legacy mode, compatibility flag, migration mode
+
+### Authentication
+
+**Auth lists**:
+The user/session/account/verification lists the auth plugin derives from the better-auth config — their keys, table/column maps, and database schema all follow that config, so they can be modelled to match (adopt) pre-existing better-auth tables. Distinct from any application domain User.
+_Avoid_: auth tables, auth models, auth schema
+
+**Auth identity**:
+The better-auth-owned record of who a session belongs to (the better-auth user). Separate from, and not assumed to be, the application's own domain User; an app links the two itself when it needs to.
+_Avoid_: auth user, principal, account

--- a/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
+++ b/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
@@ -1,0 +1,16 @@
+# The generator emits Keystone-compatible schema defaults
+
+To make Keystone → stack migrations reach Schema parity without per-project `extendPrismaSchema` surgery, the Prisma generator's default output is aligned to Keystone 6 conventions. Most of these are unconditional new defaults (acceptable to change directly while the stack is in beta); the one convention a greenfield project would not want — empty-string text defaults — is gated behind Keystone-compat mode.
+
+## Decisions
+
+- **Fields honour `defaultValue`.** `text()`, `integer()`, and `json()` emit `@default(...)` from their `defaultValue` in `getPrismaType` (matching how `checkbox()`/`decimal()` already behave). Previously these silently dropped the default, forcing migrators to inject it via `extendPrismaSchema`.
+- **Auto-timestamps are off by default.** The generator no longer appends `createdAt`/`updatedAt` to every model. A list opts in by declaring the fields itself or via `db: { timestamps: true }`; when timestamps are enabled and the list also declares its own `createdAt`/`updatedAt`, the auto pair is skipped (no duplicate-field `P1012`). This is a breaking change to existing stack apps and is acceptable in beta.
+- **Singleton `id` is bare.** Singleton lists emit `id Int @id` (no `@default(1)`), matching Keystone 6.
+- **`select()` nullability is explicit.** A `select()` with a `defaultValue` keeps generating `NOT NULL` by default, but `select({ db: { isNullable: true } })` forces the nullable `?`. We chose an explicit opt-in over auto-restoring `?` so the common (required) case is unaffected.
+- **Native-enum names are configurable.** `select({ db: { type: 'enum', enumName: '…' } })` sets the generated enum type name, so a live DB enum (e.g. Keystone's `…Type` suffix) can be matched from config instead of the derived `<List><Field>`.
+- **Keystone-compat mode covers empty-string text defaults.** With the mode enabled, non-null text columns without an explicit `defaultValue` emit `@default("")` (Keystone's implicit behaviour). This stays opt-in because a greenfield project would not want it.
+
+## Why this is worth recording
+
+A future reader will look at the generator and wonder why it deliberately omits `createdAt`/`updatedAt` and the singleton `id` default that earlier versions emitted "to match Keystone 6 behaviour" — these are reversals of long-standing defaults, made specifically to keep migrations non-destructive (Schema parity). Each is a real trade-off between greenfield ergonomics and migration fidelity, and reversing any of them touches the generator, the field builders, and the migration guide together. Supersedes the narrower discussion in issues #301, #303, and #304.

--- a/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
+++ b/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
@@ -1,0 +1,14 @@
+# The stack has no GraphQL layer; Keystone GraphQL migrates via fragments + an agent skill
+
+The OpenSaaS Stack deliberately exposes only `context.db.*` and provides no GraphQL server, schema, or typed-document runtime. A Keystone project's `context.graphql.run`/`context.query.*` surface — including large gql.tada codebases — is migrated to `context.db.*` with `defineFragment`/`ResultOf` for composable typed reads, assisted by the `migrate-context-calls` skill in the `opensaas-migration` plugin.
+
+## Decisions
+
+- **No GraphQL adapter.** We will not ship an optional GraphQL server to preserve existing gql.tada surfaces. It would reintroduce the runtime the stack was designed to drop, carry ongoing schema/maintenance cost, and split the access-control story across two execution paths.
+- **No standalone AST codemod tool.** Mechanical `context.graphql.run` → `context.db.*` rewriting is reliable only for trivial CRUD; nested/relational queries and where-shape differences need judgement. That judgement lives in an agent skill (`migrate-context-calls`), not a deterministic ts-morph CLI.
+- **Fragments are the parity story.** `defineFragment` + `ResultOf` (in `@opensaas/stack-core`) replace GraphQL fragments and codegen — composable, reused, and type-inferred without a build step.
+- **The migration guide and skill carry the specifics** migrators trip on: Keystone-relation-filter → Prisma scalar-FK where-shape translation, `connect`/`disconnect`/`set` nested-write mapping, gql.tada typed-document → `defineFragment` replacement, and fragment → Prisma `include`/`select` with null-on-access-denied semantics.
+
+## Why this is worth recording
+
+"Where's the GraphQL?" is the first question every Keystone migrator asks, and a reasonable reader will assume an adapter should exist or will propose building one. Recording that the absence is deliberate — and that the supported path is fragments plus an agent-assisted rewrite rather than a compatibility layer — stops that work from being reopened, and explains why migration effort is concentrated in a skill and a guide rather than a package.

--- a/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
+++ b/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
@@ -1,0 +1,14 @@
+# Image/file migration prefers non-destructive multi-column parity over JSON consolidation
+
+Keystone stores an image field across seven columns (`<field>_url`, `<field>_width`, `<field>_height`, `<field>_filesize`, `<field>_contentType`, `<field>_contentDisposition`, `<field>_pathname`) and a file field across three. The stack's `image()`/`file()` fields default to a single `Json?` column. To migrate an existing database without breaking **Schema parity**, `image()`/`file()` gain a multi-column mode that maps onto the existing Keystone columns in place, rather than consolidating them into JSON (which drops columns and is destructive).
+
+## Decisions
+
+- **Multi-column mode is the parity path.** `image()`/`file()` can map to the existing per-part Keystone columns (configurable `@map` names) and assemble/split an `ImageMetadata`/`FileMetadata` value across them. A migrating project reaches a clean diff and a functional field with no data migration and no re-upload of existing assets.
+- **JSON consolidation becomes the explicitly-destructive alternative.** The single-`Json?` column remains the default for greenfield projects and is offered to migrators only as an opt-in, clearly-flagged destructive path (drops the old columns; requires a backup). The `migrate-image-fields` skill and `specs/keystone-image-migration.md` are rewritten to lead with the non-destructive multi-column path and demote consolidation.
+- **No re-upload of existing assets.** Both modes treat an already-shaped metadata value (or, in multi-column mode, populated columns) as authoritative and never re-upload — only a `File`-like input triggers a storage upload. This guarantee is locked by a test.
+- **Vercel Blob is a supported provider.** `@opensaas/stack-storage-vercel` already implements the provider interface; it is documented as a first-class option for migrators (not S3-only).
+
+## Why this is worth recording
+
+The stack's own image-migration guidance previously told migrators to consolidate to a JSON column and drop the originals — a destructive operation that contradicts the no-destructive-migration guardrail the whole migration program is gated on. A future reader will wonder why `image()` has a multi-column mode at all when JSON is simpler; the answer is that schema parity over a live Keystone database requires reading the original columns in place. Reversing this (forcing consolidation) would reintroduce a destructive migration, so the trade-off is worth pinning down.

--- a/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
+++ b/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
@@ -1,0 +1,14 @@
+# authPlugin mirrors better-auth config and its lists can adopt existing tables
+
+`authPlugin` is a thin wrapper over better-auth: the OpenSaaS auth lists (user/session/account/verification) are **derived from the better-auth config the developer already writes** — list keys from better-auth's per-model `modelName`, table/column maps from its `fields` — rather than from a separate, stack-invented set of knobs. On top of that, the lists can be placed in a non-`public` database schema. Together this lets a project with pre-existing better-auth tables (e.g. `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in an `auth` Postgres schema) adopt the plugin and reach **Schema parity** with no destructive migration.
+
+## Decisions
+
+- **The plugin mirrors better-auth.** List keys, table `@@map`, and field-name mappings are taken from the standard better-auth config (`modelName`, `fields`, additional fields). The plugin does not introduce a parallel `listKeys` configuration surface. `getAuthLists`/`convertBetterAuthSchema` derive the OpenSaaS lists from that config. The runtime `userListKey` (currently a hardcoded `'user'` TODO) is resolved from the configured user model.
+- **Auth lists are relocatable to a schema.** A plugin-level `schema` option (with a per-list override) places the generated auth lists in a non-`public` Postgres schema via the stack's existing multi-schema support (`@@schema`).
+- **"Adopt" means a clean diff, not ownership.** With keys, schema, and field shapes matching the live tables, the generated auth lists diff clean against the existing database — they are modelled for runtime and types without producing a migration. An "adopt existing better-auth tables" preset/recipe sets these defaults.
+- **The app's User is separate from the auth identity.** The plugin no longer assumes its user list is the application's `User`. An app may keep its own domain `User` (keyed however it likes) distinct from the better-auth user; linking the two is the application's concern (a relationship/field it declares), not the plugin's.
+
+## Why this is worth recording
+
+The plugin previously hardcoded the four list keys and the `public` schema, and silently `extendList`-ed any existing `User` — which would overwrite an app's own `User` and force a destructive auth migration. A future reader will wonder why the auth lists are derived from better-auth config and freely renamable/relocatable rather than fixed; the answer is that adopting a real, pre-existing better-auth installation on a separate schema is a first-class requirement, and reversing it (re-fixing the keys/schema) would reintroduce the destructive-migration blocker. This was the key blocker reported during the migration.

--- a/docs/content/core-concepts/fields.md
+++ b/docs/content/core-concepts/fields.md
@@ -1,0 +1,13 @@
+# Fields
+
+{% callout type="info" %}
+This page has moved. The field-types reference now lives at **[Field Types](/docs/core-concepts/field-types)**.
+{% /callout %}
+
+The full reference for every built-in field type — `text`, `integer`, `checkbox`, `timestamp`, `password`, `select`, `relationship`, `json`, and `virtual` — including their validation, access-control, and UI options, is documented on the [Field Types](/docs/core-concepts/field-types) page.
+
+See also:
+
+- **[Field Types](/docs/core-concepts/field-types)** — the canonical field reference.
+- **[Fields API Reference](/docs/api-reference/fields)** — the field builder API surface.
+- **[Custom Fields](/docs/guides/custom-fields)** — building your own field types.

--- a/docs/content/core-concepts/queries.md
+++ b/docs/content/core-concepts/queries.md
@@ -1,0 +1,178 @@
+# Queries & Fragments
+
+OpenSaaS Stack has **no GraphQL layer**. Instead of `context.graphql.run()`, it provides first-class, type-safe query utilities that give you the same benefits KeystoneJS users relied on — fragment reuse, composability, and inferred result types — without GraphQL at runtime.
+
+The building blocks are:
+
+- **`defineFragment`** — declare a reusable, composable field selection for a model.
+- **`runQuery` / `runQueryOne`** — standalone helpers that execute a fragment against a list.
+- **`ResultOf`** — a type utility that infers the exact result shape from a fragment (no codegen step).
+
+All fragment queries run through `context.db` under the hood, so your [access control](/docs/core-concepts/access-control) rules are always enforced.
+
+{% callout type="info" %}
+Migrating from Keystone? See the [Migrating from KeystoneJS](/docs/guides/migrating-from-keystone) guide and the [`context.graphql.run` quick reference](/docs/guides/migration#migrating-contextgraphqlrun) for a side-by-side translation table.
+{% /callout %}
+
+## `defineFragment`
+
+`defineFragment` creates a reusable field-selection descriptor for a model type. It is curried so TypeScript can infer both the model type (from the type parameter) and the field selection (from the argument).
+
+Each key in the selection maps to:
+
+- `true` — include the scalar field as-is.
+- A `Fragment` — include a relationship and recurse (shorthand).
+- A `RelationSelector` — include a relationship with optional Prisma `where`/`orderBy`/`take`/`skip`.
+
+```typescript
+import type { User, Post } from '.prisma/client'
+import { defineFragment } from '@opensaas/stack-core'
+
+export const userFragment = defineFragment<User>()({
+  id: true,
+  name: true,
+  email: true,
+} as const)
+
+// Compose fragments by referencing one inside another
+export const postFragment = defineFragment<Post>()({
+  id: true,
+  title: true,
+  publishedAt: true,
+  author: userFragment, // nested — access-controlled include
+} as const)
+```
+
+{% callout type="info" %}
+Always close the selection object with `as const`. This preserves the literal field selection so `ResultOf` can narrow the result type precisely.
+{% /callout %}
+
+## `ResultOf`
+
+`ResultOf` infers the TypeScript result type from a fragment — analogous to `gql.tada`'s `ResultOf`, but built-in and with no codegen step.
+
+- Scalar fields selected with `true` keep their original Prisma type.
+- Relationship fields selected with a nested fragment are recursively narrowed.
+- Nullability and array wrappers from the original model are preserved.
+
+```typescript
+import { type ResultOf } from '@opensaas/stack-core'
+
+type UserData = ResultOf<typeof userFragment>
+// → { id: string; name: string; email: string }
+
+type PostData = ResultOf<typeof postFragment>
+// → { id: string; title: string; publishedAt: Date | null;
+//     author: { id: string; name: string; email: string } | null }
+```
+
+## Running queries
+
+There are two equivalent ways to execute a fragment.
+
+### Via `context.db` (primary API)
+
+Pass the fragment to any `context.db` read operation as the `query` argument:
+
+```typescript
+// List query with where / orderBy / pagination
+const posts = await context.db.post.findMany({
+  query: postFragment,
+  where: { published: true },
+  orderBy: { publishedAt: 'desc' },
+  take: 10,
+})
+// posts: PostData[]
+
+// Single record — null means "not found OR access denied"
+const post = await context.db.post.findUnique({
+  where: { id: postId },
+  query: postFragment,
+})
+if (!post) return notFound()
+// post: PostData
+```
+
+### Via `runQuery` / `runQueryOne` (standalone helpers)
+
+When you don't have direct access to `context.db` (for example inside a hook or a shared utility), use the standalone helpers. They take the `context`, the PascalCase list key, the fragment, and query args:
+
+```typescript
+import { runQuery, runQueryOne } from '@opensaas/stack-core'
+
+// Equivalent to context.db.post.findMany({ query: postFragment, where, ... })
+const posts = await runQuery(context, 'Post', postFragment, {
+  where: { published: true },
+  orderBy: { publishedAt: 'desc' },
+  take: 10,
+})
+// posts: ResultOf<typeof postFragment>[]
+
+// Equivalent to context.db.post.findFirst({ where: { id }, query: postFragment })
+const post = await runQueryOne(context, 'Post', postFragment, { id: postId })
+// post: ResultOf<typeof postFragment> | null
+if (!post) return notFound()
+```
+
+Both forms produce the same result and enforce the same access control.
+
+## Nested relationship filtering with `RelationSelector`
+
+To filter, sort, or paginate a nested relationship **within the same query**, use a `RelationSelector` object — `{ query, where?, orderBy?, take?, skip? }` — instead of a plain fragment:
+
+```typescript
+import type { Post, Comment } from '.prisma/client'
+import { defineFragment, type ResultOf } from '@opensaas/stack-core'
+
+const commentFragment = defineFragment<Comment>()({ id: true, body: true } as const)
+
+const postWithApprovedComments = defineFragment<Post>()({
+  id: true,
+  title: true,
+  comments: {
+    query: commentFragment, // nested fragment
+    where: { approved: true }, // Prisma filter on the relationship
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+  },
+} as const)
+
+type PostWithComments = ResultOf<typeof postWithApprovedComments>
+// → { id: string; title: string; comments: { id: string; body: string }[] }
+
+const posts = await context.db.post.findMany({ query: postWithApprovedComments })
+```
+
+## Variables via factory functions
+
+Fragments are plain objects, so for runtime filter values just wrap `defineFragment` in a factory function and infer the type from its return:
+
+```typescript
+function makePostFragment(status: string) {
+  return defineFragment<Post>()({
+    id: true,
+    title: true,
+    comments: { query: commentFragment, where: { status } },
+  } as const)
+}
+
+type PostData = ResultOf<ReturnType<typeof makePostFragment>>
+
+const posts = await context.db.post.findMany({
+  query: makePostFragment('approved'),
+  where: { published: true },
+})
+```
+
+## Coming from `context.graphql.run`?
+
+| Keystone                                             | OpenSaaS Stack                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------ |
+| GraphQL fragment string                              | `defineFragment<T>()(fields)`                                      |
+| `ResultOf<typeof query>` (codegen)                   | `ResultOf<typeof fragment>` (built-in)                             |
+| `context.graphql.run({ query, variables })` — list   | `context.db.post.findMany({ query: fragment, where?, ... })`       |
+| `context.graphql.run({ query, variables })` — single | `context.db.post.findUnique({ where: { id }, query: fragment })`   |
+| Standalone GraphQL client call                       | `runQuery(context, listKey, fragment, args)` / `runQueryOne(...)`  |
+| Nested relationship filtering                        | `RelationSelector`: `{ query: fragment, where?, orderBy?, take? }` |
+
+For the complete set of migration recipes (deeply nested fragments, many-to-many, reuse across parents), see [Migrating from KeystoneJS](/docs/guides/migrating-from-keystone) and the [Migrating context.graphql.run](/docs/guides/migration#migrating-contextgraphqlrun) section of the Migration Guide.

--- a/docs/content/guides/migrating-from-keystone.md
+++ b/docs/content/guides/migrating-from-keystone.md
@@ -1,0 +1,47 @@
+# Migrating from KeystoneJS
+
+This is the canonical guide for migrating a KeystoneJS project to OpenSaaS Stack. KeystoneJS and OpenSaaS Stack share a config-first philosophy, Keystone-compliant hooks, and the same access-control shape, so most concepts map across directly.
+
+{% callout type="info" %}
+This page is the canonical entry point for Keystone migrations. The full step-by-step instructions live in the [Migration Guide](/docs/guides/migration), which covers KeystoneJS, Prisma, and Next.js sources. This page summarises the Keystone-specific parts and links to the detail.
+{% /callout %}
+
+## What maps across directly
+
+| KeystoneJS concept                | OpenSaaS Stack equivalent                                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------- |
+| `config({ lists })`               | `config({ lists })`                                                                 |
+| `list({ fields, access, hooks })` | `list({ fields, access, hooks })`                                                   |
+| Field builders (`text()`, …)      | Field builders (`text()`, …) — see [Field Types](/docs/core-concepts/field-types)   |
+| Access control functions          | Access control functions — see [Access Control](/docs/core-concepts/access-control) |
+| List & field hooks                | List & field hooks — see [Hooks System](/docs/core-concepts/hooks)                  |
+| `context.graphql.run()`           | Fragment-based queries — see [Queries & Fragments](/docs/core-concepts/queries)     |
+| GraphQL codegen (`ResultOf`)      | Built-in TypeScript inference via `ResultOf`                                        |
+
+## Migration steps
+
+1. **Run the migration command.** From your Keystone project root:
+
+   ```bash
+   npx @opensaas/stack-cli migrate --type keystone
+   ```
+
+   This detects your `keystone.config.ts`, counts your lists, and (with `--with-ai`) sets up Claude Code integration. See [Quick Start (AI-Assisted Migration)](/docs/guides/migration#quick-start-ai-assisted-migration).
+
+2. **Translate your config.** Lists, fields, access control, and hooks map across with minimal changes. See [Manual Migration](/docs/guides/migration#manual-migration) and the [KeystoneJS field mapping table](/docs/guides/migration#keystonejs--opensaas).
+
+3. **Replace `context.graphql.run`.** OpenSaaS Stack has no GraphQL layer. Replace GraphQL queries with type-safe fragments — `defineFragment`, `runQuery`/`runQueryOne`, and `ResultOf`. See [Queries & Fragments](/docs/core-concepts/queries) and [Migrating context.graphql.run](/docs/guides/migration#migrating-contextgraphqlrun).
+
+4. **Preserve your data.** Keystone and Prisma use different many-to-many join-table naming conventions. Use `joinTableNaming: 'keystone'` or per-field `db.relationName` to keep your existing tables. See the [KeystoneJS Projects](/docs/guides/migration#keystonejs-projects) notes.
+
+5. **Adopt auth (optional).** If your Keystone project used `@keystone-6/auth`, swap it for the [auth plugin](/docs/guides/authentication).
+
+## Where to go next
+
+- **[Migration Guide](/docs/guides/migration)** — the complete, step-by-step walkthrough for all project types.
+- **[Queries & Fragments](/docs/core-concepts/queries)** — the `context.graphql.run` replacement (`defineFragment`, `runQuery`, `ResultOf`).
+- **[Field Types](/docs/core-concepts/field-types)** — the OpenSaaS field builders.
+- **[Access Control](/docs/core-concepts/access-control)** — access patterns shared with Keystone.
+- **[Hooks System](/docs/core-concepts/hooks)** — Keystone-compliant hooks.
+
+For the detailed design notes and exhaustive recipes, see the [Keystone migration spec](https://github.com/OpenSaasAU/stack/blob/main/specs/keystone-migration.md).

--- a/docs/content/guides/migration.md
+++ b/docs/content/guides/migration.md
@@ -2,6 +2,10 @@
 
 This guide covers how to migrate your existing Prisma, Next.js, or KeystoneJS projects to OpenSaaS Stack using AI-powered tools.
 
+{% callout type="info" %}
+Migrating specifically from KeystoneJS? Start with the canonical [Migrating from KeystoneJS](/docs/guides/migrating-from-keystone) guide, then return here for the full step-by-step walkthrough. For the `context.graphql.run` replacement, see [Queries & Fragments](/docs/core-concepts/queries).
+{% /callout %}
+
 ## Introduction
 
 OpenSaaS Stack provides an intelligent migration system that helps you transition existing projects with minimal manual work. The migration assistant:
@@ -999,7 +1003,7 @@ const posts = await context.db.post.findMany({
 })
 ```
 
-All operations go through `context.db` under the hood, so access control is enforced automatically. See the full [Keystone migration spec](../../../specs/keystone-migration.md) for more patterns.
+All operations go through `context.db` under the hood, so access control is enforced automatically. For a dedicated reference on `defineFragment`, `runQuery`/`runQueryOne`, and `ResultOf`, see [Queries & Fragments](/docs/core-concepts/queries). The full [Keystone migration spec](https://github.com/OpenSaasAU/stack/blob/main/specs/keystone-migration.md) has additional patterns.
 
 ## Best Practices
 

--- a/docs/lib/navigation.ts
+++ b/docs/lib/navigation.ts
@@ -30,6 +30,10 @@ export const navigation: NavItem[] = [
         href: '/docs/core-concepts/field-types',
       },
       {
+        title: 'Queries & Fragments',
+        href: '/docs/core-concepts/queries',
+      },
+      {
         title: 'Hooks System',
         href: '/docs/core-concepts/hooks',
       },
@@ -78,6 +82,10 @@ export const navigation: NavItem[] = [
       {
         title: 'Claude Code Plugin',
         href: '/docs/guides/claude-code',
+      },
+      {
+        title: 'Migrating from Keystone',
+        href: '/docs/guides/migrating-from-keystone',
       },
       {
         title: 'Migration Guide',

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
+    "link-check": "tsx scripts/link-check.ts",
+    "prebuild": "tsx scripts/link-check.ts",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/docs/scripts/link-check.ts
+++ b/docs/scripts/link-check.ts
@@ -1,0 +1,130 @@
+/**
+ * Documentation link-check
+ *
+ * Two jobs:
+ *
+ *   1. Assert that a set of "must resolve" doc paths exist as real pages.
+ *      These are paths referenced from external docs, agents, and the CLI that
+ *      previously 404'd (see issue #487). If any of them goes missing, fail.
+ *
+ *   2. Walk the migration docs and flag any internal `/docs/...` link that
+ *      points at a page that does not exist, so broken cross-references don't
+ *      silently regress.
+ *
+ * Run with: `pnpm --filter opensaas-stack-docs link-check`
+ * (or directly: `tsx scripts/link-check.ts`)
+ *
+ * Exits non-zero on any failure so it can gate CI / the docs build.
+ */
+
+import { getAllDocSlugs, getDocBySlug } from '../lib/content.js'
+
+/**
+ * Doc paths that MUST resolve. Expressed as the slug array the docs route uses
+ * (i.e. everything after `/docs/`). These are the previously-404 paths from
+ * issue #487 plus the canonical targets they depend on.
+ */
+const MUST_RESOLVE: ReadonlyArray<readonly string[]> = [
+  ['guides', 'migrating-from-keystone'],
+  ['core-concepts', 'queries'],
+  ['core-concepts', 'fields'],
+  // Canonical targets the above pages link to — keep them honest too.
+  ['guides', 'migration'],
+  ['core-concepts', 'field-types'],
+]
+
+/**
+ * Docs whose internal links we lint for breakage. These are the migration
+ * surface — the pages most likely to reference paths that move or 404.
+ */
+const LINK_CHECK_DOCS: ReadonlyArray<readonly string[]> = [
+  ['guides', 'migration'],
+  ['guides', 'migrating-from-keystone'],
+  ['core-concepts', 'queries'],
+  ['core-concepts', 'fields'],
+]
+
+/** Build a fast lookup of every slug the site can render. */
+function buildSlugSet(): Set<string> {
+  const set = new Set<string>()
+  for (const slug of getAllDocSlugs()) {
+    set.add(slug.join('/'))
+  }
+  return set
+}
+
+/**
+ * Extract internal doc links from markdown.
+ *
+ * Matches markdown links `[text](href)` where href is an internal `/docs/...`
+ * path. External URLs (http/https/mailto) and same-page anchors (`#...`) are
+ * ignored. Any `#fragment` on an internal link is stripped before resolution
+ * (we only verify the page exists, not the heading anchor).
+ */
+function extractInternalDocLinks(markdown: string): string[] {
+  const links: string[] = []
+  const linkRegex = /\[[^\]]*\]\(([^)]+)\)/g
+  let match: RegExpExecArray | null
+  while ((match = linkRegex.exec(markdown)) !== null) {
+    const href = match[1].trim()
+    if (href.startsWith('/docs/')) {
+      links.push(href)
+    }
+  }
+  return links
+}
+
+/** Turn `/docs/core-concepts/queries#anchor` into the slug `core-concepts/queries`. */
+function hrefToSlug(href: string): string {
+  const withoutFragment = href.split('#')[0]
+  const withoutQuery = withoutFragment.split('?')[0]
+  return withoutQuery.replace(/^\/docs\//, '').replace(/\/$/, '')
+}
+
+function main(): void {
+  const slugSet = buildSlugSet()
+  const errors: string[] = []
+
+  // ── 1. Must-resolve paths ────────────────────────────────────────────────
+  for (const slug of MUST_RESOLVE) {
+    const key = slug.join('/')
+    if (!slugSet.has(key) || getDocBySlug([...slug]) === null) {
+      errors.push(`Missing required doc page: /docs/${key}`)
+    }
+  }
+
+  // ── 2. Broken internal links in the migration docs ───────────────────────
+  for (const docSlug of LINK_CHECK_DOCS) {
+    const doc = getDocBySlug([...docSlug])
+    if (doc === null) {
+      // Covered by the must-resolve check above if it's required; skip here.
+      continue
+    }
+    const fromKey = docSlug.join('/')
+    for (const href of extractInternalDocLinks(doc.content)) {
+      const targetSlug = hrefToSlug(href)
+      if (targetSlug === '') continue // bare `/docs/` → home, always valid
+      if (!slugSet.has(targetSlug)) {
+        errors.push(
+          `Broken internal link in /docs/${fromKey}: ${href} → /docs/${targetSlug} does not exist`,
+        )
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('✖ Docs link-check failed:\n')
+    for (const error of errors) {
+      console.error(`  - ${error}`)
+    }
+    console.error(`\n${errors.length} problem(s) found.`)
+    process.exit(1)
+  }
+
+  console.log(
+    `✓ Docs link-check passed: ${MUST_RESOLVE.length} required pages resolve, ` +
+      `internal links in ${LINK_CHECK_DOCS.length} migration docs are valid.`,
+  )
+}
+
+main()


### PR DESCRIPTION
Implements #487
Part of #486

## What changed

Makes the referenced-but-404 documentation paths resolve and adds a link-check so they don't silently regress.

### New / aliased pages (all under `docs/content/`)

- **`guides/migrating-from-keystone`** — new canonical Keystone→stack landing page. Summarises the Keystone-specific mapping (config, fields, access control, hooks, `context.graphql.run`, codegen) and links to the full [Migration Guide](docs/content/guides/migration.md), Queries & Fragments, Field Types, Access Control, and Hooks.
- **`core-concepts/queries`** — new page documenting `defineFragment`, `runQuery`/`runQueryOne`, and `ResultOf` (the `context.graphql.run` replacement). Examples are sourced from `packages/core/src/query/index.ts` and `specs/keystone-migration.md` §2/§9, including `RelationSelector` nested filtering and factory-function variables.
- **`core-concepts/fields`** — alias page that redirects readers to the canonical `core-concepts/field-types` reference (older references no longer 404).

### Link-check

- **`docs/scripts/link-check.ts`** — verifies the previously-404 paths resolve (`guides/migrating-from-keystone`, `core-concepts/queries`, `core-concepts/fields`, plus the canonical targets they link to) and flags broken internal `/docs/...` links in the migration docs. Exits non-zero on failure.
- Wired into the docs build via a `prebuild` script (so a broken/missing path fails `next build`) and also exposed as `pnpm --filter opensaas-stack-docs link-check`.

### Nav

- Added "Migrating from Keystone" (Guides) and "Queries & Fragments" (Core Concepts) to `docs/lib/navigation.ts`. The `fields` alias is intentionally kept out of the sidebar to avoid duplicating Field Types.

### Existing migration guide

- Added a callout pointing Keystone migrators to the new canonical guide and queries page, and replaced a broken relative `../../../specs/...` link with an internal link to Queries & Fragments plus an absolute GitHub link to the spec.

## Verification

- `pnpm --filter opensaas-stack-docs link-check` → passes (5 required pages resolve, internal links in 4 migration docs valid).
- `pnpm turbo build --filter opensaas-stack-docs` → succeeds; the three previously-404 pages are emitted as static HTML (`core-concepts/queries`, `core-concepts/fields`, `guides/migrating-from-keystone`). The prebuild link-check runs as part of the build.
- `pnpm lint` (0 errors), `pnpm manypkg fix` (no changes), `pnpm format` / `format:check` clean.

No `packages/*` were touched, so no changeset is required.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_