### PR TITLE
feat(auth): derive Auth lists from better-auth config

### DIFF
--- a/.changeset/auth-derive-from-better-auth.md
+++ b/.changeset/auth-derive-from-better-auth.md
@@ -1,0 +1,25 @@
+---
+'@opensaas/stack-auth': minor
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Derive the auth plugin's Auth lists from the better-auth config
+
+`authPlugin` now mirrors the better-auth config a developer writes instead of hardcoding the keys `User`/`Session`/`Account`/`Verification`. Per-model `modelName` becomes the OpenSaaS list key (and a table `@@map`), and the `fields` column map becomes per-field `@map`s. The plugin only ever adds/extends its own derived keys, so an app's separate domain `User` is never overwritten. The runtime `getUser`/`getCurrentUser` helpers now resolve the user list key from the configured user model instead of a hardcoded `'user'`.
+
+Default behaviour (no overrides) is unchanged: the lists are still keyed `User`/`Session`/`Account`/`Verification` with the original field shapes and no `@@map`.
+
+```typescript
+// Adopt existing better-auth tables without a destructive migration
+authPlugin({
+  user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
+  session: { modelName: 'AuthSession', fields: { userId: 'user_id' } },
+  account: { modelName: 'AuthAccount' },
+  verification: { modelName: 'AuthVerification' },
+})
+// -> lists keyed AuthUser/AuthSession/AuthAccount/AuthVerification
+//    with @@map + column @map matching the live tables
+```
+
+Lists also gain a model-level `db.map` option, which emits a `@@map("...")` on the generated Prisma model so a list key can differ from its physical table name.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,23 @@ _Avoid_: operation handler, mutation service
 **Hook Pipeline**:
 The module that runs the transform+validate span of a write — list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules — owning that order and the `resolvedData` threading through it. It throws a validation error (never silent) when a validate hook reports via `addValidationError` or a built-in field rule fails, and returns the transformed `resolvedData` on success. The Write Pipeline delegates this span to it; side-effect hooks (`beforeOperation`/`afterOperation`), access, writable-field filtering, persistence and Field Visibility stay in the Write Pipeline.
 _Avoid_: validation service, input resolver
+
+### Migration & schema generation
+
+**Schema parity**:
+The property that the generator's Prisma schema diffs clean — an empty `prisma migrate diff` in both directions — against a pre-existing (typically Keystone-generated) database, so a project can adopt the stack without a destructive migration. It is the go/no-go gate for every migration phase.
+_Avoid_: schema match, clean diff, byte-compatibility
+
+**Keystone-compat mode**:
+An opt-in generator setting that makes schema output follow Keystone 6 conventions a migrating project depends on but a greenfield project would not want by default (e.g. non-null text columns defaulting to `""`). Conventions that every project wants are the plain default, not part of this mode.
+_Avoid_: legacy mode, compatibility flag, migration mode
+
+### Authentication
+
+**Auth lists**:
+The user/session/account/verification lists the auth plugin derives from the better-auth config — their keys, table/column maps, and database schema all follow that config, so they can be modelled to match (adopt) pre-existing better-auth tables. Distinct from any application domain User.
+_Avoid_: auth tables, auth models, auth schema
+
+**Auth identity**:
+The better-auth-owned record of who a session belongs to (the better-auth user). Separate from, and not assumed to be, the application's own domain User; an app links the two itself when it needs to.
+_Avoid_: auth user, principal, account

--- a/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
+++ b/docs/adr/0004-generator-emits-keystone-compatible-defaults.md
@@ -1,0 +1,16 @@
+# The generator emits Keystone-compatible schema defaults
+
+To make Keystone → stack migrations reach Schema parity without per-project `extendPrismaSchema` surgery, the Prisma generator's default output is aligned to Keystone 6 conventions. Most of these are unconditional new defaults (acceptable to change directly while the stack is in beta); the one convention a greenfield project would not want — empty-string text defaults — is gated behind Keystone-compat mode.
+
+## Decisions
+
+- **Fields honour `defaultValue`.** `text()`, `integer()`, and `json()` emit `@default(...)` from their `defaultValue` in `getPrismaType` (matching how `checkbox()`/`decimal()` already behave). Previously these silently dropped the default, forcing migrators to inject it via `extendPrismaSchema`.
+- **Auto-timestamps are off by default.** The generator no longer appends `createdAt`/`updatedAt` to every model. A list opts in by declaring the fields itself or via `db: { timestamps: true }`; when timestamps are enabled and the list also declares its own `createdAt`/`updatedAt`, the auto pair is skipped (no duplicate-field `P1012`). This is a breaking change to existing stack apps and is acceptable in beta.
+- **Singleton `id` is bare.** Singleton lists emit `id Int @id` (no `@default(1)`), matching Keystone 6.
+- **`select()` nullability is explicit.** A `select()` with a `defaultValue` keeps generating `NOT NULL` by default, but `select({ db: { isNullable: true } })` forces the nullable `?`. We chose an explicit opt-in over auto-restoring `?` so the common (required) case is unaffected.
+- **Native-enum names are configurable.** `select({ db: { type: 'enum', enumName: '…' } })` sets the generated enum type name, so a live DB enum (e.g. Keystone's `…Type` suffix) can be matched from config instead of the derived `<List><Field>`.
+- **Keystone-compat mode covers empty-string text defaults.** With the mode enabled, non-null text columns without an explicit `defaultValue` emit `@default("")` (Keystone's implicit behaviour). This stays opt-in because a greenfield project would not want it.
+
+## Why this is worth recording
+
+A future reader will look at the generator and wonder why it deliberately omits `createdAt`/`updatedAt` and the singleton `id` default that earlier versions emitted "to match Keystone 6 behaviour" — these are reversals of long-standing defaults, made specifically to keep migrations non-destructive (Schema parity). Each is a real trade-off between greenfield ergonomics and migration fidelity, and reversing any of them touches the generator, the field builders, and the migration guide together. Supersedes the narrower discussion in issues #301, #303, and #304.

--- a/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
+++ b/docs/adr/0005-no-graphql-layer-migrate-via-fragments.md
@@ -1,0 +1,14 @@
+# The stack has no GraphQL layer; Keystone GraphQL migrates via fragments + an agent skill
+
+The OpenSaaS Stack deliberately exposes only `context.db.*` and provides no GraphQL server, schema, or typed-document runtime. A Keystone project's `context.graphql.run`/`context.query.*` surface — including large gql.tada codebases — is migrated to `context.db.*` with `defineFragment`/`ResultOf` for composable typed reads, assisted by the `migrate-context-calls` skill in the `opensaas-migration` plugin.
+
+## Decisions
+
+- **No GraphQL adapter.** We will not ship an optional GraphQL server to preserve existing gql.tada surfaces. It would reintroduce the runtime the stack was designed to drop, carry ongoing schema/maintenance cost, and split the access-control story across two execution paths.
+- **No standalone AST codemod tool.** Mechanical `context.graphql.run` → `context.db.*` rewriting is reliable only for trivial CRUD; nested/relational queries and where-shape differences need judgement. That judgement lives in an agent skill (`migrate-context-calls`), not a deterministic ts-morph CLI.
+- **Fragments are the parity story.** `defineFragment` + `ResultOf` (in `@opensaas/stack-core`) replace GraphQL fragments and codegen — composable, reused, and type-inferred without a build step.
+- **The migration guide and skill carry the specifics** migrators trip on: Keystone-relation-filter → Prisma scalar-FK where-shape translation, `connect`/`disconnect`/`set` nested-write mapping, gql.tada typed-document → `defineFragment` replacement, and fragment → Prisma `include`/`select` with null-on-access-denied semantics.
+
+## Why this is worth recording
+
+"Where's the GraphQL?" is the first question every Keystone migrator asks, and a reasonable reader will assume an adapter should exist or will propose building one. Recording that the absence is deliberate — and that the supported path is fragments plus an agent-assisted rewrite rather than a compatibility layer — stops that work from being reopened, and explains why migration effort is concentrated in a skill and a guide rather than a package.

--- a/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
+++ b/docs/adr/0006-image-file-migration-prefers-multi-column-parity.md
@@ -1,0 +1,14 @@
+# Image/file migration prefers non-destructive multi-column parity over JSON consolidation
+
+Keystone stores an image field across seven columns (`<field>_url`, `<field>_width`, `<field>_height`, `<field>_filesize`, `<field>_contentType`, `<field>_contentDisposition`, `<field>_pathname`) and a file field across three. The stack's `image()`/`file()` fields default to a single `Json?` column. To migrate an existing database without breaking **Schema parity**, `image()`/`file()` gain a multi-column mode that maps onto the existing Keystone columns in place, rather than consolidating them into JSON (which drops columns and is destructive).
+
+## Decisions
+
+- **Multi-column mode is the parity path.** `image()`/`file()` can map to the existing per-part Keystone columns (configurable `@map` names) and assemble/split an `ImageMetadata`/`FileMetadata` value across them. A migrating project reaches a clean diff and a functional field with no data migration and no re-upload of existing assets.
+- **JSON consolidation becomes the explicitly-destructive alternative.** The single-`Json?` column remains the default for greenfield projects and is offered to migrators only as an opt-in, clearly-flagged destructive path (drops the old columns; requires a backup). The `migrate-image-fields` skill and `specs/keystone-image-migration.md` are rewritten to lead with the non-destructive multi-column path and demote consolidation.
+- **No re-upload of existing assets.** Both modes treat an already-shaped metadata value (or, in multi-column mode, populated columns) as authoritative and never re-upload — only a `File`-like input triggers a storage upload. This guarantee is locked by a test.
+- **Vercel Blob is a supported provider.** `@opensaas/stack-storage-vercel` already implements the provider interface; it is documented as a first-class option for migrators (not S3-only).
+
+## Why this is worth recording
+
+The stack's own image-migration guidance previously told migrators to consolidate to a JSON column and drop the originals — a destructive operation that contradicts the no-destructive-migration guardrail the whole migration program is gated on. A future reader will wonder why `image()` has a multi-column mode at all when JSON is simpler; the answer is that schema parity over a live Keystone database requires reading the original columns in place. Reversing this (forcing consolidation) would reintroduce a destructive migration, so the trade-off is worth pinning down.

--- a/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
+++ b/docs/adr/0007-auth-plugin-mirrors-better-auth-and-adopts-existing-tables.md
@@ -1,0 +1,14 @@
+# authPlugin mirrors better-auth config and its lists can adopt existing tables
+
+`authPlugin` is a thin wrapper over better-auth: the OpenSaaS auth lists (user/session/account/verification) are **derived from the better-auth config the developer already writes** — list keys from better-auth's per-model `modelName`, table/column maps from its `fields` — rather than from a separate, stack-invented set of knobs. On top of that, the lists can be placed in a non-`public` database schema. Together this lets a project with pre-existing better-auth tables (e.g. `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in an `auth` Postgres schema) adopt the plugin and reach **Schema parity** with no destructive migration.
+
+## Decisions
+
+- **The plugin mirrors better-auth.** List keys, table `@@map`, and field-name mappings are taken from the standard better-auth config (`modelName`, `fields`, additional fields). The plugin does not introduce a parallel `listKeys` configuration surface. `getAuthLists`/`convertBetterAuthSchema` derive the OpenSaaS lists from that config. The runtime `userListKey` (currently a hardcoded `'user'` TODO) is resolved from the configured user model.
+- **Auth lists are relocatable to a schema.** A plugin-level `schema` option (with a per-list override) places the generated auth lists in a non-`public` Postgres schema via the stack's existing multi-schema support (`@@schema`).
+- **"Adopt" means a clean diff, not ownership.** With keys, schema, and field shapes matching the live tables, the generated auth lists diff clean against the existing database — they are modelled for runtime and types without producing a migration. An "adopt existing better-auth tables" preset/recipe sets these defaults.
+- **The app's User is separate from the auth identity.** The plugin no longer assumes its user list is the application's `User`. An app may keep its own domain `User` (keyed however it likes) distinct from the better-auth user; linking the two is the application's concern (a relationship/field it declares), not the plugin's.
+
+## Why this is worth recording
+
+The plugin previously hardcoded the four list keys and the `public` schema, and silently `extendList`-ed any existing `User` — which would overwrite an app's own `User` and force a destructive auth migration. A future reader will wonder why the auth lists are derived from better-auth config and freely renamable/relocatable rather than fixed; the answer is that adopting a real, pre-existing better-auth installation on a separate schema is a first-class requirement, and reversing it (re-fixing the keys/schema) would reintroduce the destructive-migration blocker. This was the key blocker reported during the migration.

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -62,6 +62,37 @@ config({
 // Result: { lists: { User, Session, Account, Verification, Post } }
 ```
 
+### Deriving Auth lists from better-auth config
+
+The four Auth lists are **derived** from the better-auth model config the
+developer writes — not hardcoded. The pure derivation lives in
+`src/config/derive-auth-lists.ts` (`deriveAuthLists`), which `getAuthLists`
+and the plugin's add-vs-extend logic consume:
+
+- per-model `modelName` → list key + table `@@map`
+- per-model `fields` (better-auth field → column) → field-level `@map`
+- the `userId` column override → the `user` relationship foreign-key `@map`
+- relationship refs between the Auth lists follow the derived keys
+  (e.g. `Session.user → AuthUser.sessions`)
+
+With no `modelName`/`fields` overrides the output is unchanged
+(`User`/`Session`/`Account`/`Verification`, original field shapes, no `@@map`).
+
+```typescript
+// Adopt an existing better-auth installation (Auth lists ≠ app User)
+authPlugin({
+  user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
+  session: { modelName: 'AuthSession', fields: { userId: 'user_id' } },
+})
+// Adds AuthUser/AuthSession/... and leaves an app's own `User` untouched.
+```
+
+Because the plugin only ever adds/extends its **derived** keys, an app's own
+domain `User` (a different model from the better-auth user) is never extended
+or overwritten when the user model is renamed. The runtime `getUser`/
+`getCurrentUser` helpers resolve the user list's `context.db` key from the
+configured user `modelName`.
+
 ### Session Provider
 
 Better-auth provides session to context via custom `prismaClientConstructor`:

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -1,0 +1,306 @@
+/**
+ * Pure `better-auth config → Auth lists` derivation.
+ *
+ * This module is intentionally free of side effects and plugin/runtime
+ * concerns: given the resolved better-auth model config (per-model `modelName`
+ * and `fields` column maps) plus any custom User fields, it produces the four
+ * OpenSaaS Auth lists (user/session/account/verification) with:
+ *
+ *  - list keys taken from each model's `modelName`
+ *  - a table `@@map` (list-level `db.map`) when the key differs from the
+ *    default better-auth model name
+ *  - field-level `@map` (`db.map`) for any better-auth field → column override
+ *  - relationship refs between the auth lists wired to the *derived* keys
+ *    (e.g. `Session.user → AuthUser.sessions`)
+ *
+ * When the developer supplies no `modelName`/`fields` overrides, the output is
+ * byte-for-byte the historical default set keyed `User`/`Session`/`Account`/
+ * `Verification` with the original field shapes — see the unit tests.
+ *
+ * `getAuthLists`/`convertBetterAuthSchema` (and the runtime user-key
+ * resolution) consume this module so derivation lives in exactly one place.
+ */
+
+import { list } from '@opensaas/stack-core'
+import { text, timestamp, checkbox, relationship } from '@opensaas/stack-core/fields'
+import type { ListConfig } from '@opensaas/stack-core'
+import type { ExtendUserListConfig } from '../lists/index.js'
+import type { NormalizedAuthModelConfig, NormalizedAuthModels } from './types.js'
+
+/**
+ * Default better-auth model names — used to decide whether a `@@map` is needed
+ * (only when the configured `modelName` differs from the default).
+ */
+const DEFAULT_MODEL_NAMES = {
+  user: 'User',
+  session: 'Session',
+  account: 'Account',
+  verification: 'Verification',
+} as const
+
+/**
+ * The derived Auth list set together with the keys each list was placed under.
+ * Keys are surfaced separately so callers (plugin add-vs-extend logic, runtime
+ * user-key resolution) don't have to re-derive them.
+ */
+export type DerivedAuthLists = {
+  /** Derived list keys, one per better-auth model. */
+  keys: {
+    user: string
+    session: string
+    account: string
+    verification: string
+  }
+  /** The derived list configs, keyed by their derived list keys. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  lists: Record<string, ListConfig<any>>
+}
+
+/**
+ * Build the `db.map` for a derived list.
+ *
+ * When the developer renames the model (e.g. `modelName: 'AuthUser'`), we pin
+ * the physical table name to that model name via `@@map("AuthUser")` so the
+ * generated list adopts the developer's live table exactly. When no override is
+ * given we emit no `@@map`, leaving the default `User`/`Session`/... output
+ * byte-for-byte unchanged.
+ */
+function listDb(
+  model: NormalizedAuthModelConfig,
+  defaultModelName: string,
+): { map: string } | undefined {
+  return model.modelName !== defaultModelName ? { map: model.modelName } : undefined
+}
+
+/**
+ * Resolve the `db.map` (`@map` column override) for a better-auth field, or
+ * `undefined` when there is no override (so default output is unchanged).
+ *
+ * The field builders capture `options.db` in a closure when generating Prisma
+ * types, so the column map MUST be passed through the builder's `db` option
+ * rather than patched onto the returned field object.
+ */
+function fieldDb(fieldName: string, fields: Record<string, string>): { map: string } | undefined {
+  const column = fields[fieldName]
+  return column ? { map: column } : undefined
+}
+
+/**
+ * Build the foreign-key `db` config for a `user` relationship, honouring a
+ * `userId` column override from the better-auth `fields` map.
+ */
+function userForeignKeyDb(
+  fields: Record<string, string>,
+): { foreignKey: { map: string } } | undefined {
+  const column = fields.userId
+  return column ? { foreignKey: { map: column } } : undefined
+}
+
+/**
+ * Create the Auth user list, applying derived field column maps + table map and
+ * wiring the session/account relationships to the derived keys.
+ */
+function createUserList(
+  model: NormalizedAuthModelConfig,
+  keys: DerivedAuthLists['keys'],
+  userConfig: ExtendUserListConfig,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): ListConfig<any> {
+  const f = model.fields
+  return list({
+    fields: {
+      name: text({ validation: { isRequired: true }, db: fieldDb('name', f) }),
+      email: text({
+        validation: { isRequired: true },
+        isIndexed: 'unique',
+        db: fieldDb('email', f),
+      }),
+      emailVerified: checkbox({ defaultValue: false, db: fieldDb('emailVerified', f) }),
+      image: text({ db: fieldDb('image', f) }),
+
+      // Relationships to the other auth lists — refs follow the derived keys.
+      sessions: relationship({ ref: `${keys.session}.user`, many: true }),
+      accounts: relationship({ ref: `${keys.account}.user`, many: true }),
+
+      // Custom fields from user config
+      ...(userConfig.fields || {}),
+    },
+    db: listDb(model, DEFAULT_MODEL_NAMES.user),
+    access: userConfig.access || {
+      operation: {
+        query: () => true,
+        create: () => true,
+        update: ({ session, item }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          const itemId = (item as { id?: string })?.id
+          return userId === itemId
+        },
+        delete: ({ session, item }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          const itemId = (item as { id?: string })?.id
+          return userId === itemId
+        },
+      },
+    },
+    hooks: userConfig.hooks,
+  })
+}
+
+/**
+ * Create the Auth session list.
+ */
+function createSessionList(
+  model: NormalizedAuthModelConfig,
+  keys: DerivedAuthLists['keys'],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): ListConfig<any> {
+  const f = model.fields
+  return list({
+    fields: {
+      token: text({
+        validation: { isRequired: true },
+        isIndexed: 'unique',
+        db: fieldDb('token', f),
+      }),
+      expiresAt: timestamp({ db: fieldDb('expiresAt', f) }),
+      ipAddress: text({ db: fieldDb('ipAddress', f) }),
+      userAgent: text({ db: fieldDb('userAgent', f) }),
+      user: relationship({
+        ref: `${keys.user}.sessions`,
+        db: userForeignKeyDb(f),
+      }),
+    },
+    db: listDb(model, DEFAULT_MODEL_NAMES.session),
+    access: {
+      operation: {
+        query: ({ session }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          if (!userId) return false
+          return {
+            user: { id: { equals: userId } },
+          } as Record<string, unknown>
+        },
+        create: () => true,
+        update: () => false,
+        delete: ({ session, item }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          const itemUserId = (item as { user?: { id?: string } })?.user?.id
+          return userId === itemUserId
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Create the Auth account list.
+ */
+function createAccountList(
+  model: NormalizedAuthModelConfig,
+  keys: DerivedAuthLists['keys'],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): ListConfig<any> {
+  const f = model.fields
+  return list({
+    fields: {
+      accountId: text({ validation: { isRequired: true }, db: fieldDb('accountId', f) }),
+      providerId: text({ validation: { isRequired: true }, db: fieldDb('providerId', f) }),
+      user: relationship({
+        ref: `${keys.user}.accounts`,
+        db: userForeignKeyDb(f),
+      }),
+      accessToken: text({ db: fieldDb('accessToken', f) }),
+      refreshToken: text({ db: fieldDb('refreshToken', f) }),
+      accessTokenExpiresAt: timestamp({ db: fieldDb('accessTokenExpiresAt', f) }),
+      refreshTokenExpiresAt: timestamp({ db: fieldDb('refreshTokenExpiresAt', f) }),
+      scope: text({ db: fieldDb('scope', f) }),
+      idToken: text({ db: fieldDb('idToken', f) }),
+      password: text({ db: fieldDb('password', f) }),
+    },
+    db: listDb(model, DEFAULT_MODEL_NAMES.account),
+    access: {
+      operation: {
+        query: ({ session }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          if (!userId) return false
+          return {
+            user: { id: { equals: userId } },
+          } as Record<string, unknown>
+        },
+        create: () => true,
+        update: ({ session, item }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          const itemUserId = (item as { user?: { id?: string } })?.user?.id
+          return userId === itemUserId
+        },
+        delete: ({ session, item }) => {
+          if (!session) return false
+          const userId = (session as { userId?: string }).userId
+          const itemUserId = (item as { user?: { id?: string } })?.user?.id
+          return userId === itemUserId
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Create the Auth verification list.
+ */
+function createVerificationList(
+  model: NormalizedAuthModelConfig,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): ListConfig<any> {
+  const f = model.fields
+  return list({
+    fields: {
+      identifier: text({ validation: { isRequired: true }, db: fieldDb('identifier', f) }),
+      value: text({ validation: { isRequired: true }, db: fieldDb('value', f) }),
+      expiresAt: timestamp({ db: fieldDb('expiresAt', f) }),
+    },
+    db: listDb(model, DEFAULT_MODEL_NAMES.verification),
+    access: {
+      operation: {
+        query: () => false,
+        create: () => true,
+        update: () => false,
+        delete: () => true,
+      },
+    },
+  })
+}
+
+/**
+ * Derive the OpenSaaS Auth lists from the resolved better-auth model config.
+ *
+ * @param models - Resolved better-auth per-model config (modelName + field column maps)
+ * @param userConfig - Extra User-list fields/access/hooks supplied via `extendUserList`
+ * @returns The derived list keys and the four Auth list configs keyed by those keys
+ */
+export function deriveAuthLists(
+  models: NormalizedAuthModels,
+  userConfig: ExtendUserListConfig = {},
+): DerivedAuthLists {
+  const keys = {
+    user: models.user.modelName,
+    session: models.session.modelName,
+    account: models.account.modelName,
+    verification: models.verification.modelName,
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  const lists: Record<string, ListConfig<any>> = {
+    [keys.user]: createUserList(models.user, keys, userConfig),
+    [keys.session]: createSessionList(models.session, keys),
+    [keys.account]: createAccountList(models.account, keys),
+    [keys.verification]: createVerificationList(models.verification),
+  }
+
+  return { keys, lists }
+}

--- a/packages/auth/src/config/index.ts
+++ b/packages/auth/src/config/index.ts
@@ -1,10 +1,51 @@
 import type {
   AuthConfig,
+  AuthModelConfig,
   NormalizedAuthConfig,
+  NormalizedAuthModelConfig,
+  NormalizedAuthModels,
   EmailPasswordConfig,
   EmailVerificationConfig,
   PasswordResetConfig,
 } from './types.js'
+
+/**
+ * Default better-auth model names. Used when the developer does not override
+ * `modelName`, preserving the historical `User`/`Session`/`Account`/`Verification`
+ * keys exactly.
+ */
+const DEFAULT_MODEL_NAMES = {
+  user: 'User',
+  session: 'Session',
+  account: 'Account',
+  verification: 'Verification',
+} as const
+
+/**
+ * Resolve a single better-auth model config block into its normalized form,
+ * falling back to the better-auth default model name and an empty column map.
+ */
+function normalizeModelConfig(
+  config: AuthModelConfig | undefined,
+  defaultModelName: string,
+): NormalizedAuthModelConfig {
+  return {
+    modelName: config?.modelName || defaultModelName,
+    fields: config?.fields || {},
+  }
+}
+
+/**
+ * Resolve the better-auth model config for all four auth models.
+ */
+function normalizeAuthModels(config: AuthConfig): NormalizedAuthModels {
+  return {
+    user: normalizeModelConfig(config.user, DEFAULT_MODEL_NAMES.user),
+    session: normalizeModelConfig(config.session, DEFAULT_MODEL_NAMES.session),
+    account: normalizeModelConfig(config.account, DEFAULT_MODEL_NAMES.account),
+    verification: normalizeModelConfig(config.verification, DEFAULT_MODEL_NAMES.verification),
+  }
+}
 
 /**
  * Normalize auth configuration with defaults
@@ -47,12 +88,17 @@ export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
   // Session fields defaults
   const sessionFields = config.sessionFields || ['userId', 'email', 'name']
 
+  // Resolve better-auth per-model config (modelName + field column maps).
+  // Defaults preserve the historical User/Session/Account/Verification keys.
+  const models = normalizeAuthModels(config)
+
   return {
     emailAndPassword,
     emailVerification,
     passwordReset,
     socialProviders: config.socialProviders || {},
     session,
+    models,
     sessionFields,
     extendUserList: config.extendUserList || {},
     sendEmail:

--- a/packages/auth/src/config/plugin.ts
+++ b/packages/auth/src/config/plugin.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from '@opensaas/stack-core/extend'
+import { getDbKey } from '@opensaas/stack-core'
 import type { AuthConfig, NormalizedAuthConfig } from './types.js'
 import { normalizeAuthConfig } from './index.js'
 import { getAuthLists } from '../lists/index.js'
@@ -38,8 +39,12 @@ export function authPlugin(config: AuthConfig): Plugin {
     },
 
     init: async (context) => {
-      // Get auth lists from base Better Auth schema
-      const authLists = getAuthLists(normalized.extendUserList)
+      // Derive the auth lists from the better-auth model config (modelName +
+      // field column maps). With no overrides this yields the historical
+      // User/Session/Account/Verification keys; with overrides (e.g.
+      // user.modelName: 'AuthUser') the lists are keyed and column-mapped to
+      // match the developer's live better-auth tables.
+      const authLists = getAuthLists(normalized.extendUserList, normalized.models)
 
       // Extract additional lists from Better Auth plugins
       for (const plugin of normalized.betterAuthPlugins) {
@@ -66,10 +71,18 @@ export function authPlugin(config: AuthConfig): Plugin {
         }
       }
 
-      // Add all auth lists
+      // Add all auth lists.
+      //
+      // The plugin only ever touches its OWN derived keys. When a developer
+      // renames the auth user model (e.g. user.modelName: 'AuthUser'), the
+      // derived key is 'AuthUser' and an app's separate 'User' list is left
+      // untouched — the plugin never extends/overwrites a list it didn't
+      // derive. Extending only kicks in when an existing list shares the
+      // derived key (e.g. the default 'User'), which is the intended
+      // "merge auth fields into my User" behaviour.
       for (const [listName, listConfig] of Object.entries(authLists)) {
         if (context.config.lists[listName]) {
-          // If user defined a User list, extend it with auth fields
+          // A list already exists under this derived key — merge auth fields in.
           context.extendList(listName, {
             fields: listConfig.fields,
             hooks: listConfig.hooks,
@@ -88,6 +101,10 @@ export function authPlugin(config: AuthConfig): Plugin {
     },
 
     runtime: (context) => {
+      // Resolve the user list's context.db key from the configured user model.
+      // context.db is keyed camelCase, so 'User' -> 'user', 'AuthUser' -> 'authUser'.
+      const userDbKey = getDbKey(normalized.models.user.modelName)
+
       // Provide auth-related utilities at runtime
       return {
         /**
@@ -95,9 +112,7 @@ export function authPlugin(config: AuthConfig): Plugin {
          * Uses the access-controlled context to fetch user data
          */
         getUser: async (userId: string) => {
-          // Use 'authUser' if custom User list name was provided, otherwise 'user'
-          const userListKey = 'user' // TODO: Make this configurable based on list name
-          return await context.db[userListKey].findUnique({
+          return await context.db[userDbKey].findUnique({
             where: { id: userId },
           })
         },
@@ -110,8 +125,7 @@ export function authPlugin(config: AuthConfig): Plugin {
           if (!context.session?.userId) {
             return null
           }
-          const userListKey = 'user'
-          return await context.db[userListKey].findUnique({
+          return await context.db[userDbKey].findUnique({
             where: { id: context.session.userId },
           })
         },

--- a/packages/auth/src/config/types.ts
+++ b/packages/auth/src/config/types.ts
@@ -83,6 +83,43 @@ export type SessionConfig = {
 }
 
 /**
+ * Per-model better-auth configuration block.
+ *
+ * Mirrors better-auth's own `BetterAuthDBOptions` (the `user`/`session`/
+ * `account`/`verification` config a developer already writes): `modelName`
+ * renames the table/list and `fields` maps individual better-auth field names
+ * to database column names. The auth plugin derives its Auth lists from this
+ * config so the generated lists carry the same keys and column maps as the
+ * developer's live better-auth tables.
+ *
+ * @example
+ * ```typescript
+ * authPlugin({
+ *   user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
+ *   session: { modelName: 'AuthSession' },
+ * })
+ * ```
+ */
+export type AuthModelConfig = {
+  /**
+   * The table/list name for this model.
+   * Becomes the OpenSaaS list key (and Prisma model name) and the table `@@map`.
+   * @default the default better-auth model name (e.g. 'User', 'Session')
+   */
+  modelName?: string
+  /**
+   * Map better-auth field names to database column names.
+   * Each entry generates a `@map("column")` on the derived field.
+   *
+   * @example
+   * ```typescript
+   * fields: { name: 'full_name', emailVerified: 'email_verified' }
+   * ```
+   */
+  fields?: Record<string, string>
+}
+
+/**
  * Auth configuration options
  */
 export type AuthConfig = {
@@ -107,9 +144,31 @@ export type AuthConfig = {
   socialProviders?: SocialProvidersConfig
 
   /**
-   * Session configuration
+   * Session configuration.
+   *
+   * Carries session expiry settings as well as the better-auth `session` model
+   * config (`modelName` + field column `fields` maps) used to derive the Auth
+   * session list.
    */
-  session?: SessionConfig
+  session?: SessionConfig & AuthModelConfig
+
+  /**
+   * better-auth `user` model configuration (modelName + field column maps).
+   * Used to derive the Auth user list's key, table `@@map`, and field `@map`s.
+   *
+   * Custom fields beyond the better-auth basics are added via `extendUserList`.
+   */
+  user?: AuthModelConfig
+
+  /**
+   * better-auth `account` model configuration (modelName + field column maps).
+   */
+  account?: AuthModelConfig
+
+  /**
+   * better-auth `verification` model configuration (modelName + field column maps).
+   */
+  verification?: AuthModelConfig
 
   /**
    * Which fields to include in the session object
@@ -203,18 +262,51 @@ export type AuthConfig = {
 }
 
 /**
+ * Resolved per-model auth configuration after normalization.
+ * Always carries a concrete `modelName` (the developer's override or the
+ * better-auth default) and a (possibly empty) `fields` column map.
+ */
+export type NormalizedAuthModelConfig = {
+  modelName: string
+  fields: Record<string, string>
+}
+
+/**
+ * Resolved auth model configuration for all four better-auth models.
+ * Consumed by the Auth-list derivation and the runtime user-key resolution.
+ */
+export type NormalizedAuthModels = {
+  user: NormalizedAuthModelConfig
+  session: NormalizedAuthModelConfig
+  account: NormalizedAuthModelConfig
+  verification: NormalizedAuthModelConfig
+}
+
+/**
  * Internal normalized auth configuration
  * Used after parsing user config
  */
 export type NormalizedAuthConfig = Required<
   Omit<
     AuthConfig,
-    'emailAndPassword' | 'emailVerification' | 'passwordReset' | 'betterAuthPlugins' | 'rateLimit'
+    | 'emailAndPassword'
+    | 'emailVerification'
+    | 'passwordReset'
+    | 'betterAuthPlugins'
+    | 'rateLimit'
+    | 'session'
+    | 'user'
+    | 'account'
+    | 'verification'
   >
 > & {
   emailAndPassword: Required<EmailPasswordConfig>
   emailVerification: Required<EmailVerificationConfig>
   passwordReset: Required<PasswordResetConfig>
+  /** Resolved session expiry settings (model config lives under `models.session`). */
+  session: Required<SessionConfig>
+  /** Resolved better-auth model config (modelName + field column maps) for all auth models. */
+  models: NormalizedAuthModels
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin types are not exposed, must use any
   betterAuthPlugins: any[]
   rateLimit?: {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -34,6 +34,10 @@ export { authPlugin } from './config/plugin.js'
 export type { AuthConfig, NormalizedAuthConfig } from './config/index.js'
 export type * from './config/types.js'
 
+// Pure better-auth config -> Auth lists derivation (advanced use cases)
+export { deriveAuthLists } from './config/derive-auth-lists.js'
+export type { DerivedAuthLists } from './config/derive-auth-lists.js'
+
 // Runtime type exports
 export type { AuthRuntimeServices } from './runtime/types.js'
 

--- a/packages/auth/src/lists/index.ts
+++ b/packages/auth/src/lists/index.ts
@@ -1,6 +1,6 @@
-import { list } from '@opensaas/stack-core'
-import { text, timestamp, checkbox, relationship } from '@opensaas/stack-core/fields'
 import type { ListConfig, FieldConfig } from '@opensaas/stack-core'
+import type { NormalizedAuthModels } from '../config/types.js'
+import { deriveAuthLists } from '../config/derive-auth-lists.js'
 
 /**
  * Configuration for extending the auto-generated User list
@@ -25,229 +25,69 @@ export type ExtendUserListConfig = {
 }
 
 /**
- * Create the base User list with better-auth required fields
- * This matches the better-auth user schema
+ * The default better-auth model config (no `modelName`/`fields` overrides).
+ * Produces the historical `User`/`Session`/`Account`/`Verification` keys with
+ * their original field shapes. Used by the backwards-compatible
+ * `createUserList`/`getAuthLists` helpers.
  */
-export function createUserList(
-  config?: ExtendUserListConfig, // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
-): ListConfig<any> {
-  return list({
-    fields: {
-      // Better-auth required fields
-      name: text({
-        validation: { isRequired: true },
-      }),
-      email: text({
-        validation: { isRequired: true },
-        isIndexed: 'unique',
-      }),
-      emailVerified: checkbox({
-        defaultValue: false,
-      }),
-      image: text(),
-
-      // Relationships to other auth tables
-      sessions: relationship({
-        ref: 'Session.user',
-        many: true,
-      }),
-      accounts: relationship({
-        ref: 'Account.user',
-        many: true,
-      }),
-
-      // Custom fields from user config
-      ...(config?.fields || {}),
-    },
-    access: config?.access || {
-      operation: {
-        // Anyone can query users (for displaying names, etc.)
-        query: () => true,
-        // Anyone can create a user (sign up)
-        create: () => true,
-        // Only update your own user record
-        update: ({ session, item }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          const itemId = (item as { id?: string })?.id
-          return userId === itemId
-        },
-        // Only delete your own user record
-        delete: ({ session, item }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          const itemId = (item as { id?: string })?.id
-          return userId === itemId
-        },
-      },
-    },
-    hooks: config?.hooks,
-  })
+const DEFAULT_MODELS: NormalizedAuthModels = {
+  user: { modelName: 'User', fields: {} },
+  session: { modelName: 'Session', fields: {} },
+  account: { modelName: 'Account', fields: {} },
+  verification: { modelName: 'Verification', fields: {} },
 }
 
 /**
- * Create the Session list for better-auth
- * Stores active user sessions
+ * Create the base User list with better-auth required fields.
+ *
+ * Backwards-compatible helper: derives the default `User` list (keyed `User`,
+ * default field shapes) via {@link deriveAuthLists}.
+ */
+export function createUserList(
+  config?: ExtendUserListConfig,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): ListConfig<any> {
+  return deriveAuthLists(DEFAULT_MODELS, config).lists.User
+}
+
+/**
+ * Create the Session list for better-auth (default `Session` key).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function createSessionList(): ListConfig<any> {
-  return list({
-    fields: {
-      // Session token (stored in cookie, used as primary key)
-      token: text({
-        validation: { isRequired: true },
-        isIndexed: 'unique',
-      }),
-      // Expiration timestamp
-      expiresAt: timestamp(),
-      // Optional: IP address for security
-      ipAddress: text(),
-      // Optional: User agent for security
-      userAgent: text(),
-      // Relationship to user (userId will be auto-generated)
-      user: relationship({
-        ref: 'User.sessions',
-      }),
-    },
-    access: {
-      operation: {
-        // Only the session owner can query their sessions
-        query: ({ session }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          if (!userId) return false
-          // Return Prisma filter for nested relationship
-          return {
-            user: {
-              id: { equals: userId },
-            },
-          } as Record<string, unknown>
-        },
-        // Better-auth handles session creation
-        create: () => true,
-        // No manual updates
-        update: () => false,
-        // Better-auth handles session deletion (logout)
-        delete: ({ session, item }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          const itemUserId = (item as { user?: { id?: string } })?.user?.id
-          return userId === itemUserId
-        },
-      },
-    },
-  })
+  return deriveAuthLists(DEFAULT_MODELS).lists.Session
 }
 
 /**
- * Create the Account list for better-auth
- * Stores OAuth provider accounts and credentials
+ * Create the Account list for better-auth (default `Account` key).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function createAccountList(): ListConfig<any> {
-  return list({
-    fields: {
-      // Account identifier from provider
-      accountId: text({
-        validation: { isRequired: true },
-      }),
-      // Provider identifier (e.g., 'github', 'google', 'credentials')
-      providerId: text({
-        validation: { isRequired: true },
-      }),
-      // Relationship to user (userId will be auto-generated)
-      user: relationship({
-        ref: 'User.accounts',
-      }),
-      // OAuth tokens
-      accessToken: text(),
-      refreshToken: text(),
-      accessTokenExpiresAt: timestamp(),
-      refreshTokenExpiresAt: timestamp(),
-      scope: text(),
-      idToken: text(),
-      // Password hash for credential provider (better-auth stores in account table)
-      password: text(),
-    },
-    access: {
-      operation: {
-        // Only the account owner can query their accounts
-        query: ({ session }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          if (!userId) return false
-          // Return Prisma filter for nested relationship
-          return {
-            user: {
-              id: { equals: userId },
-            },
-          } as Record<string, unknown>
-        },
-        // Better-auth handles account creation
-        create: () => true,
-        // Better-auth handles account updates (token refresh)
-        update: ({ session, item }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          const itemUserId = (item as { user?: { id?: string } })?.user?.id
-          return userId === itemUserId
-        },
-        // Account owner can delete their accounts
-        delete: ({ session, item }) => {
-          if (!session) return false
-          const userId = (session as { userId?: string }).userId
-          const itemUserId = (item as { user?: { id?: string } })?.user?.id
-          return userId === itemUserId
-        },
-      },
-    },
-  })
+  return deriveAuthLists(DEFAULT_MODELS).lists.Account
 }
 
 /**
- * Create the Verification list for better-auth
- * Stores email verification tokens, password reset tokens, etc.
+ * Create the Verification list for better-auth (default `Verification` key).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function createVerificationList(): ListConfig<any> {
-  return list({
-    fields: {
-      // Identifier (e.g., email address)
-      identifier: text({
-        validation: { isRequired: true },
-      }),
-      // Token value
-      value: text({
-        validation: { isRequired: true },
-      }),
-      // Expiration timestamp
-      expiresAt: timestamp(),
-    },
-    access: {
-      operation: {
-        // No public querying (better-auth handles verification internally)
-        query: () => false,
-        // Better-auth creates verification tokens
-        create: () => true,
-        // No updates
-        update: () => false,
-        // Better-auth deletes used/expired tokens
-        delete: () => true,
-      },
-    },
-  })
+  return deriveAuthLists(DEFAULT_MODELS).lists.Verification
 }
 
 /**
- * Get all auth lists required by better-auth
- * This is the main export used by authPlugin()
+ * Get all auth lists required by better-auth.
+ *
+ * Derives the Auth lists from the resolved better-auth model config. When no
+ * `models` are supplied (or none carry overrides), the result is the historical
+ * default set keyed `User`/`Session`/`Account`/`Verification`.
+ *
+ * @param userConfig - Extra User-list fields/access/hooks (from `extendUserList`)
+ * @param models - Resolved better-auth model config; defaults to the better-auth defaults
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
-export function getAuthLists(userConfig?: ExtendUserListConfig): Record<string, ListConfig<any>> {
-  return {
-    User: createUserList(userConfig),
-    Session: createSessionList(),
-    Account: createAccountList(),
-    Verification: createVerificationList(),
-  }
+export function getAuthLists(
+  userConfig?: ExtendUserListConfig,
+  models: NormalizedAuthModels = DEFAULT_MODELS,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): Record<string, ListConfig<any>> {
+  return deriveAuthLists(models, userConfig || {}).lists
 }

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -3,7 +3,7 @@ import { prismaAdapter } from 'better-auth/adapters/prisma'
 import type { BetterAuthOptions } from 'better-auth'
 import type { OpenSaasConfig, AccessContext } from '@opensaas/stack-core'
 import type { DatabaseConfig } from '@opensaas/stack-core/internal'
-import type { NormalizedAuthConfig } from '../config/types.js'
+import type { NormalizedAuthConfig, NormalizedAuthModelConfig } from '../config/types.js'
 
 /**
  * Get better-auth database configuration from OpenSaas config
@@ -15,6 +15,22 @@ function getDatabaseConfig(
   return prismaAdapter(context.prisma, {
     provider: dbConfig.provider,
   })
+}
+
+/**
+ * Translate a normalized OpenSaaS auth model config into the better-auth
+ * per-model options (`modelName` + `fields` column map). Returns `undefined`
+ * when there is nothing to override so the running auth instance keeps
+ * better-auth's own defaults untouched.
+ */
+function toBetterAuthModelOptions(
+  model: NormalizedAuthModelConfig,
+): { modelName?: string; fields?: Record<string, string> } | undefined {
+  const hasFields = Object.keys(model.fields).length > 0
+  const options: { modelName?: string; fields?: Record<string, string> } = {}
+  if (model.modelName) options.modelName = model.modelName
+  if (hasFields) options.fields = model.fields
+  return Object.keys(options).length > 0 ? options : undefined
 }
 
 /**
@@ -64,6 +80,20 @@ export function createAuth(
         const betterAuthConfig: BetterAuthOptions = {
           database: getDatabaseConfig(resolvedConfig.db, resolvedContext),
 
+          // Mirror the per-model config (modelName + field column maps) back to
+          // better-auth so the running auth instance reads/writes the same
+          // tables/columns the OpenSaaS Auth lists were derived from.
+          user: toBetterAuthModelOptions(authConfig.models.user),
+          session: {
+            ...toBetterAuthModelOptions(authConfig.models.session),
+            expiresIn: authConfig.session.expiresIn || 604800,
+            updateAge: authConfig.session.updateAge
+              ? (authConfig.session.expiresIn || 604800) / 10
+              : 0,
+          },
+          account: toBetterAuthModelOptions(authConfig.models.account),
+          verification: toBetterAuthModelOptions(authConfig.models.verification),
+
           // Enable email and password if configured
           emailAndPassword: authConfig.emailAndPassword.enabled
             ? {
@@ -71,14 +101,6 @@ export function createAuth(
                 requireEmailVerification: authConfig.emailVerification.enabled,
               }
             : undefined,
-
-          // Configure session
-          session: {
-            expiresIn: authConfig.session.expiresIn || 604800,
-            updateAge: authConfig.session.updateAge
-              ? (authConfig.session.expiresIn || 604800) / 10
-              : 0,
-          },
 
           // Trust host (required for production)
           trustedOrigins: process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',') || [],

--- a/packages/auth/tests/derive-auth-lists.test.ts
+++ b/packages/auth/tests/derive-auth-lists.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { deriveAuthLists } from '../src/config/derive-auth-lists.js'
+import type { NormalizedAuthModels } from '../src/config/types.js'
+
+const defaultModels: NormalizedAuthModels = {
+  user: { modelName: 'User', fields: {} },
+  session: { modelName: 'Session', fields: {} },
+  account: { modelName: 'Account', fields: {} },
+  verification: { modelName: 'Verification', fields: {} },
+}
+
+describe('deriveAuthLists - default behaviour (no overrides)', () => {
+  it('keeps the historical User/Session/Account/Verification keys', () => {
+    const { keys, lists } = deriveAuthLists(defaultModels)
+
+    expect(keys).toEqual({
+      user: 'User',
+      session: 'Session',
+      account: 'Account',
+      verification: 'Verification',
+    })
+    expect(Object.keys(lists).sort()).toEqual(['Account', 'Session', 'User', 'Verification'])
+  })
+
+  it('keeps the original User field shape', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+    const user = lists.User
+
+    expect(user.fields).toHaveProperty('name')
+    expect(user.fields).toHaveProperty('email')
+    expect(user.fields).toHaveProperty('emailVerified')
+    expect(user.fields).toHaveProperty('image')
+    expect(user.fields).toHaveProperty('sessions')
+    expect(user.fields).toHaveProperty('accounts')
+    expect(user.fields.email.isIndexed).toBe('unique')
+    expect(user.fields.name.validation?.isRequired).toBe(true)
+  })
+
+  it('wires relationship refs to the default keys', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+    expect(lists.Session.fields.user.ref).toBe('User.sessions')
+    expect(lists.Account.fields.user.ref).toBe('User.accounts')
+    expect(lists.User.fields.sessions.ref).toBe('Session.user')
+    expect(lists.User.fields.accounts.ref).toBe('Account.user')
+  })
+
+  it('emits no table @@map and no scalar @map for default keys', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+
+    expect(lists.User.db?.map).toBeUndefined()
+    expect(lists.Session.db?.map).toBeUndefined()
+    expect(lists.Account.db?.map).toBeUndefined()
+    expect(lists.Verification.db?.map).toBeUndefined()
+
+    expect(lists.User.fields.name.db?.map).toBeUndefined()
+    expect(lists.Session.fields.token.db?.map).toBeUndefined()
+    // FK column not overridden -> no foreignKey map on the relationship
+    expect(lists.Session.fields.user.db).toBeUndefined()
+  })
+})
+
+describe('deriveAuthLists - custom modelName overrides', () => {
+  const customModels: NormalizedAuthModels = {
+    user: { modelName: 'AuthUser', fields: {} },
+    session: { modelName: 'AuthSession', fields: {} },
+    account: { modelName: 'AuthAccount', fields: {} },
+    verification: { modelName: 'AuthVerification', fields: {} },
+  }
+
+  it('derives list keys from modelName', () => {
+    const { keys, lists } = deriveAuthLists(customModels)
+
+    expect(keys).toEqual({
+      user: 'AuthUser',
+      session: 'AuthSession',
+      account: 'AuthAccount',
+      verification: 'AuthVerification',
+    })
+    expect(Object.keys(lists).sort()).toEqual([
+      'AuthAccount',
+      'AuthSession',
+      'AuthUser',
+      'AuthVerification',
+    ])
+    // The app's own `User` key must NOT be produced by the plugin
+    expect(lists).not.toHaveProperty('User')
+  })
+
+  it('wires relationship refs to the derived keys', () => {
+    const { lists } = deriveAuthLists(customModels)
+    expect(lists.AuthSession.fields.user.ref).toBe('AuthUser.sessions')
+    expect(lists.AuthAccount.fields.user.ref).toBe('AuthUser.accounts')
+    expect(lists.AuthUser.fields.sessions.ref).toBe('AuthSession.user')
+    expect(lists.AuthUser.fields.accounts.ref).toBe('AuthAccount.user')
+  })
+
+  it('pins each renamed list to a table @@map equal to the model name', () => {
+    const { lists } = deriveAuthLists(customModels)
+
+    expect(lists.AuthUser.db?.map).toBe('AuthUser')
+    expect(lists.AuthSession.db?.map).toBe('AuthSession')
+    expect(lists.AuthAccount.db?.map).toBe('AuthAccount')
+    expect(lists.AuthVerification.db?.map).toBe('AuthVerification')
+  })
+})
+
+describe('deriveAuthLists - custom field column maps', () => {
+  const models: NormalizedAuthModels = {
+    user: { modelName: 'AuthUser', fields: { name: 'full_name', emailVerified: 'is_verified' } },
+    session: { modelName: 'AuthSession', fields: { token: 'session_token', userId: 'user_id' } },
+    account: { modelName: 'AuthAccount', fields: { userId: 'user_id' } },
+    verification: { modelName: 'AuthVerification', fields: {} },
+  }
+
+  it('applies @map column overrides to scalar fields', () => {
+    const { lists } = deriveAuthLists(models)
+
+    expect(lists.AuthUser.fields.name.db?.map).toBe('full_name')
+    expect(lists.AuthUser.fields.emailVerified.db?.map).toBe('is_verified')
+    expect(lists.AuthSession.fields.token.db?.map).toBe('session_token')
+  })
+
+  it('applies the userId column override to the relationship foreign key', () => {
+    const { lists } = deriveAuthLists(models)
+
+    expect(lists.AuthSession.fields.user.db?.foreignKey).toEqual({ map: 'user_id' })
+    expect(lists.AuthAccount.fields.user.db?.foreignKey).toEqual({ map: 'user_id' })
+  })
+
+  it('only maps fields that have an override, leaving others unmapped', () => {
+    const { lists } = deriveAuthLists(models)
+    // name is mapped, email is not
+    expect(lists.AuthUser.fields.name.db?.map).toBe('full_name')
+    expect(lists.AuthUser.fields.email.db?.map).toBeUndefined()
+  })
+})
+
+describe('deriveAuthLists - extendUserList', () => {
+  it('adds custom fields to the derived user list', () => {
+    const { lists } = deriveAuthLists(
+      { ...defaultModels, user: { modelName: 'AuthUser', fields: {} } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal custom field config for test
+      { fields: { role: { type: 'text' } as any } },
+    )
+
+    expect(lists.AuthUser.fields).toHaveProperty('role')
+    // Base fields still present
+    expect(lists.AuthUser.fields).toHaveProperty('email')
+  })
+})

--- a/packages/auth/tests/plugin-derived-keys.test.ts
+++ b/packages/auth/tests/plugin-derived-keys.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { config, list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import type { AccessContext } from '@opensaas/stack-core'
+import { authPlugin } from '../src/config/plugin.js'
+import type { AuthRuntimeServices } from '../src/runtime/types.js'
+
+describe('authPlugin - add-vs-extend with derived keys', () => {
+  it("does NOT extend or overwrite an app's own User when keys are customised", async () => {
+    // The app declares its own domain `User` (a different model from the
+    // better-auth user). The plugin renames its user model to `AuthUser`.
+    const appUserHook = vi.fn()
+    const result = await config({
+      db: { provider: 'sqlite' },
+      plugins: [
+        authPlugin({
+          user: { modelName: 'AuthUser' },
+          session: { modelName: 'AuthSession' },
+          account: { modelName: 'AuthAccount' },
+          verification: { modelName: 'AuthVerification' },
+        }),
+      ],
+      lists: {
+        User: list({
+          fields: {
+            subjectId: text({ validation: { isRequired: true } }),
+          },
+          hooks: { beforeOperation: appUserHook },
+        }),
+      },
+    })
+
+    // The plugin adds its own AuthUser/AuthSession/... lists
+    expect(result.lists).toHaveProperty('AuthUser')
+    expect(result.lists).toHaveProperty('AuthSession')
+    expect(result.lists).toHaveProperty('AuthAccount')
+    expect(result.lists).toHaveProperty('AuthVerification')
+
+    // The app's own `User` is left completely untouched: its field shape is
+    // preserved and NOT merged with auth fields (no email/name/sessions).
+    const appUser = result.lists.User
+    expect(appUser.fields).toHaveProperty('subjectId')
+    expect(appUser.fields).not.toHaveProperty('email')
+    expect(appUser.fields).not.toHaveProperty('emailVerified')
+    expect(appUser.fields).not.toHaveProperty('sessions')
+    // Its hooks are preserved (not replaced by the auth user's hooks)
+    expect(appUser.hooks?.beforeOperation).toBe(appUserHook)
+
+    // And the auth user list (AuthUser) is the one carrying auth fields
+    expect(result.lists.AuthUser.fields).toHaveProperty('email')
+    expect(result.lists.AuthUser.fields).toHaveProperty('sessions')
+  })
+
+  it('still merges auth fields into an existing list that shares the default key', async () => {
+    // Default keys: the plugin's user key is `User`, so an existing `User`
+    // is intentionally extended with auth fields (the historical behaviour).
+    const result = await config({
+      db: { provider: 'sqlite' },
+      plugins: [authPlugin({})],
+      lists: {
+        User: list({
+          fields: {
+            bio: text(),
+          },
+        }),
+      },
+    })
+
+    const user = result.lists.User
+    expect(user.fields).toHaveProperty('bio') // app field preserved
+    expect(user.fields).toHaveProperty('email') // auth field merged in
+    expect(user.fields).toHaveProperty('sessions')
+  })
+})
+
+describe('authPlugin - runtime user-key resolution', () => {
+  /**
+   * Build a minimal AccessContext whose `db` records which model key was
+   * accessed, so we can assert the runtime resolves the configured user model.
+   */
+  function makeFakeContext(session: { userId?: string } | null) {
+    const accessedKeys: string[] = []
+    const db = new Proxy(
+      {},
+      {
+        get(_target, key: string) {
+          accessedKeys.push(key)
+          return {
+            findUnique: async ({ where }: { where: { id: string } }) => ({
+              id: where.id,
+              __model: key,
+            }),
+          }
+        },
+      },
+    )
+    const context = { session, db } as unknown as AccessContext
+    return { context, accessedKeys }
+  }
+
+  it('getUser uses the default `user` db key when no modelName override', () => {
+    const plugin = authPlugin({})
+    const { context, accessedKeys } = makeFakeContext({ userId: 'u1' })
+    const services = plugin.runtime?.(context) as AuthRuntimeServices
+
+    void services.getUser('u1')
+    expect(accessedKeys).toContain('user')
+  })
+
+  it('getUser uses the configured user model db key (AuthUser -> authUser)', async () => {
+    const plugin = authPlugin({ user: { modelName: 'AuthUser' } })
+    const { context, accessedKeys } = makeFakeContext({ userId: 'u1' })
+    const services = plugin.runtime?.(context) as AuthRuntimeServices
+
+    const user = (await services.getUser('u1')) as { __model: string }
+    expect(accessedKeys).toContain('authUser')
+    expect(accessedKeys).not.toContain('user')
+    expect(user.__model).toBe('authUser')
+  })
+
+  it('getCurrentUser uses the configured user model db key', async () => {
+    const plugin = authPlugin({ user: { modelName: 'AuthUser' } })
+    const { context, accessedKeys } = makeFakeContext({ userId: 'u1' })
+    const services = plugin.runtime?.(context) as AuthRuntimeServices
+
+    const user = (await services.getCurrentUser()) as { __model: string }
+    expect(accessedKeys).toContain('authUser')
+    expect(user.__model).toBe('authUser')
+  })
+
+  it('getCurrentUser returns null when there is no session', async () => {
+    const plugin = authPlugin({ user: { modelName: 'AuthUser' } })
+    const { context } = makeFakeContext(null)
+    const services = plugin.runtime?.(context) as AuthRuntimeServices
+
+    expect(await services.getCurrentUser()).toBeNull()
+  })
+})

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -817,6 +817,46 @@ describe('Prisma Schema Generator', () => {
       expect(schema).not.toContain('@@unique([authorId])')
     })
 
+    it('should generate @@map for a list-level db.map', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+        },
+        lists: {
+          AuthUser: {
+            fields: {
+              name: text(),
+            },
+            db: { map: 'AuthUser' },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('model AuthUser {')
+      expect(schema).toContain('@@map("AuthUser")')
+    })
+
+    it('should not generate @@map when no list-level db.map is set', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).not.toContain('@@map')
+    })
+
     it('should generate indexes for multiple foreign keys', () => {
       const config: OpenSaasConfig = {
         db: {

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -189,6 +189,12 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
       }
     }
 
+    // Map the model to a custom table name when configured (e.g. adopting
+    // existing tables whose physical name differs from the list key).
+    if (listConfig.db?.map) {
+      lines.push(`  @@map("${listConfig.db.map}")`)
+    }
+
     lines.push('}')
     lines.push('')
   }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1200,6 +1200,26 @@ export type ListConfig<TTypeInfo extends TypeInfo> = {
   }
   hooks?: Hooks<TTypeInfo['item'], TTypeInfo['inputs']['create'], TTypeInfo['inputs']['update']>
   /**
+   * Database configuration for this list (model level)
+   */
+  db?: {
+    /**
+     * Custom database table name.
+     * Adds a `@@map` attribute to the generated Prisma model.
+     *
+     * Useful when the Prisma model name (the list key) must differ from the
+     * physical table name — e.g. adopting an existing better-auth installation
+     * whose tables were created under a different name.
+     *
+     * @example
+     * ```typescript
+     * AuthUser: list({ fields: { ... }, db: { map: 'user' } })
+     * // Generates: model AuthUser { ... @@map("user") }
+     * ```
+     */
+    map?: string
+  }
+  /**
    * MCP server configuration for this list
    */
   mcp?: ListMcpConfig


### PR DESCRIPTION
Implements #481

Part of #480

## What this does

Makes `authPlugin` derive its Auth lists (user/session/account/verification) from the better-auth config the developer writes, instead of hardcoding the keys `User`/`Session`/`Account`/`Verification`.

### New pure derivation module
`packages/auth/src/config/derive-auth-lists.ts` (`deriveAuthLists`) maps the resolved better-auth model config to the four OpenSaaS Auth lists:
- per-model `modelName` → list key + table `@@map`
- per-model `fields` (better-auth field → column) → field-level `@map`
- the `userId` column override → the `user` relationship foreign-key `@map`
- relationship refs between the Auth lists follow the derived keys (e.g. `Session.user → AuthUser.sessions`)

`getAuthLists`/`createUserList`/... and the plugin's add-vs-extend logic all consume this single module.

### Add-vs-extend uses derived keys (no-overwrite guarantee)
The plugin only ever adds/extends its **own derived keys**. When the user model is renamed (e.g. `user.modelName: 'AuthUser'`), the plugin adds `AuthUser` and leaves an app's separate domain `User` completely untouched — it never extends a list it didn't derive. Extending only kicks in when an existing list shares the derived key (the default `User`), which is the intended "merge auth fields into my User" behaviour.

### Runtime key resolution
`getUser`/`getCurrentUser` resolve the user list's `context.db` key from the configured user model (`getDbKey(modelName)` → `authUser`), replacing the hardcoded `userListKey = 'user' // TODO`.

### Supporting changes
- `createAuth()` mirrors the per-model config (`modelName` + `fields`) back to the running better-auth instance so it reads/writes the same tables/columns the Auth lists were derived from.
- core `ListConfig` gains a model-level `db.map`; the Prisma generator emits `@@map("...")` for it.

## How default behaviour is preserved

When no `modelName`/`fields` overrides are given, the derivation produces the historical default set keyed `User`/`Session`/`Account`/`Verification`, original field shapes, no `@@map`, and the existing FK `@map("user")` convention. Verified end-to-end: regenerating the `examples/auth-demo` Prisma schema produces **zero diff**.

## Usage (adoption)

```typescript
authPlugin({
  user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
  session: { modelName: 'AuthSession', fields: { userId: 'user_id' } },
  account: { modelName: 'AuthAccount' },
  verification: { modelName: 'AuthVerification' },
})
// -> lists keyed AuthUser/AuthSession/AuthAccount/AuthVerification
//    with @@map + column @map matching the live tables; app's own User untouched
```

## Tests

- **Derivation unit tests** (`tests/derive-auth-lists.test.ts`): custom `modelName`/`fields` → expected keys, `@@map`, field `@map`, FK `@map`, relationship refs; default-unchanged assertions.
- **No-overwrite + add-vs-extend** (`tests/plugin-derived-keys.test.ts`): custom keys do NOT extend an app's own `User`; default keys still merge auth fields.
- **Runtime key** (`tests/plugin-derived-keys.test.ts`): `getUser`/`getCurrentUser` use the configured user model db key.
- **Generator `@@map`** (`packages/cli/src/generator/prisma.test.ts`): list-level `db.map` emits `@@map`.

## Verification

- `pnpm build` — all 11 packages pass (tsc)
- `packages/auth`: 117 tests pass (was 100)
- `packages/cli`: 206 tests pass
- `packages/core`: 532 tests pass
- `pnpm lint` — 0 errors; `pnpm manypkg fix` / `pnpm format` clean

Changeset added (minor; auth/core/cli).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_