### PR TITLE
feat(cli,core): configurable generator output paths via output config block

### DIFF
--- a/.changeset/bright-foxes-relocate.md
+++ b/.changeset/bright-foxes-relocate.md
@@ -1,0 +1,23 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Add an `output` config block so `opensaas generate` can relocate the generated Prisma schema and `.opensaas` bundle (e.g. to coexist with an existing Keystone `prisma/` during migration)
+
+Set `output.prismaSchema` and/or `output.opensaasDir` in `opensaas.config.ts` to move where the generator writes. Defaults are unchanged (`prisma/schema.prisma`, `.opensaas/`) when the block is omitted. The generated files' cross-references follow the configured locations: `context.ts`/`prisma-extensions.ts` import `opensaas.config` from the resolved bundle, the Prisma client `generator { output }` points back at the relocated bundle, and the top-level `prisma.config.ts` references the configured schema directory so `prisma` CLI commands keep working.
+
+```typescript
+export default config({
+  output: {
+    prismaSchema: 'prisma-opensaas/schema.prisma',
+    opensaasDir: 'generated/opensaas',
+  },
+  db: {
+    /* ... */
+  },
+  lists: {
+    /* ... */
+  },
+})
+```

--- a/.changeset/bright-foxes-relocate.md
+++ b/.changeset/bright-foxes-relocate.md
@@ -7,6 +7,8 @@ Add an `output` config block so `opensaas generate` can relocate the generated P
 
 Set `output.prismaSchema` and/or `output.opensaasDir` in `opensaas.config.ts` to move where the generator writes. Defaults are unchanged (`prisma/schema.prisma`, `.opensaas/`) when the block is omitted. The generated files' cross-references follow the configured locations: `context.ts`/`prisma-extensions.ts` import `opensaas.config` from the resolved bundle, the Prisma client `generator { output }` points back at the relocated bundle, and the top-level `prisma.config.ts` references the configured schema directory so `prisma` CLI commands keep working.
 
+The pre-existing top-level `opensaasPath` option is preserved: the effective `.opensaas` bundle directory resolves as `output.opensaasDir` > `opensaasPath` > the default `.opensaas`. Setting `opensaasPath` alone still relocates the bundle through the CLI exactly as before; `output.opensaasDir` overrides it when both are set.
+
 ```typescript
 export default config({
   output: {

--- a/docs/content/api-reference/config.md
+++ b/docs/content/api-reference/config.md
@@ -79,6 +79,7 @@ export default config({
   mcp?: McpConfig,
   storage?: StorageConfig,
   opensaasPath?: string,
+  output?: OutputConfig,
   plugins?: Plugin[],
 })
 ```
@@ -133,16 +134,69 @@ File/image upload storage provider configuration.
 
 ##### `opensaasPath`
 
-Directory where generated files are placed (context, types, patched Prisma client).
+Directory where the generated `.opensaas` bundle is placed (context, types, lists, plugin types, prisma extensions, and the patched Prisma client).
 
 **Type:** `string`
 **Default:** `".opensaas"`
+
+> **Precedence:** This option still works exactly as before. When [`output.opensaasDir`](#outputconfig) is set, it takes precedence over `opensaasPath`. The effective bundle directory is `output.opensaasDir` (if set), else `opensaasPath` (if set), else the default `.opensaas`.
+
+##### `output`
+
+Relocate the generator's output so `opensaas generate` can coexist with an existing `prisma/` directory (for example during a KeystoneJS → stack migration) without clobbering it.
+
+**Type:** [`OutputConfig`](#outputconfig)
 
 ##### `plugins`
 
 Array of plugins to extend stack functionality.
 
 **Type:** [`Plugin[]`](#plugin)
+
+---
+
+### `OutputConfig`
+
+Configures where `opensaas generate` writes its output. All paths are resolved relative to the project root (the directory the CLI runs in). When omitted, defaults are unchanged: the schema is written to `prisma/schema.prisma` and the bundle to `.opensaas/`.
+
+The generated files' cross-references follow these locations automatically — `context.ts` and `prisma-extensions.ts` import the project's `opensaas.config` from the resolved bundle directory, and the top-level `prisma.config.ts` points the Prisma CLI at the configured schema directory.
+
+```typescript
+output: {
+  prismaSchema?: string,
+  opensaasDir?: string,
+}
+```
+
+#### Properties
+
+##### `prismaSchema`
+
+Path to the generated Prisma schema file.
+
+**Type:** `string`
+**Default:** `"prisma/schema.prisma"`
+
+##### `opensaasDir`
+
+Directory for the generated `.opensaas` bundle (types, lists, context, plugin types, prisma extensions, and the patched Prisma client).
+
+**Type:** `string`
+**Default:** `".opensaas"`
+
+> **Precedence with `opensaasPath`:** The effective bundle directory is resolved as `output.opensaasDir` > [`opensaasPath`](#opensaaspath) > the default `.opensaas`. `output.opensaasDir` overrides the pre-existing top-level `opensaasPath` when both are set; setting `opensaasPath` alone continues to relocate the bundle exactly as before.
+
+**Example:**
+
+```typescript
+export default config({
+  output: {
+    prismaSchema: 'prisma-opensaas/schema.prisma',
+    opensaasDir: 'generated/opensaas',
+  },
+  // ...
+})
+```
 
 ---
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -431,6 +431,67 @@ describe('Generate Command Integration', () => {
     })
   })
 
+  describe('opensaasPath / output.opensaasDir precedence', () => {
+    /**
+     * Drive the generator exactly as the CLI does, forwarding the pre-existing
+     * top-level `opensaasPath` as the bundle-directory fallback.
+     */
+    function generateWithResolvedPaths(cfg: OpenSaasConfig) {
+      const { paths, crossReferences } = resolveOutputPaths(tempDir, cfg.output, cfg.opensaasPath)
+      writePrismaSchema(cfg, paths.prismaSchema, crossReferences.prismaClientOutput)
+      writeContext(cfg, paths.context, crossReferences.configImport)
+      return { paths, crossReferences }
+    }
+
+    it('relocates the bundle via opensaasPath alone (the pre-existing option) through the CLI', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        opensaasPath: '.custom',
+        lists: { User: { fields: { name: text() } } },
+      }
+
+      const { paths } = generateWithResolvedPaths(config)
+
+      // The bundle lands under .custom/, not the default .opensaas/.
+      expect(paths.opensaasDir).toBe(path.join(tempDir, '.custom'))
+      expect(fs.existsSync(path.join(tempDir, '.custom', 'context.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(tempDir, '.opensaas'))).toBe(false)
+
+      // The prisma client output cross-reference follows opensaasPath, so the
+      // emitted schema points at the relocated bundle (no longer a no-op).
+      const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
+      expect(schema).toContain('output   = "../.custom/prisma-client"')
+    })
+
+    it('lets output.opensaasDir override opensaasPath when both are set', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        opensaasPath: '.custom',
+        output: { opensaasDir: 'generated/opensaas' },
+        lists: { User: { fields: { name: text() } } },
+      }
+
+      const { paths } = generateWithResolvedPaths(config)
+
+      // output.opensaasDir wins; opensaasPath is ignored.
+      expect(paths.opensaasDir).toBe(path.join(tempDir, 'generated', 'opensaas'))
+      expect(fs.existsSync(path.join(tempDir, 'generated', 'opensaas', 'context.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(tempDir, '.custom'))).toBe(false)
+      expect(fs.existsSync(path.join(tempDir, '.opensaas'))).toBe(false)
+
+      const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
+      expect(schema).toContain('output   = "../generated/opensaas/prisma-client"')
+    })
+  })
+
   describe('Field self-containment validation', () => {
     it('passes a compliant config with no errors', () => {
       const config: OpenSaasConfig = {

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -5,7 +5,16 @@ import * as os from 'os'
 import type { OpenSaasConfig, FieldConfig } from '@opensaas/stack-core'
 import { validateConfigFields } from '@opensaas/stack-core'
 import { text } from '@opensaas/stack-core/fields'
-import { writePrismaSchema, writeTypes, writeContext } from '../generator/index.js'
+import {
+  writePrismaSchema,
+  writePrismaConfig,
+  writeTypes,
+  writeLists,
+  writeContext,
+  writePluginTypes,
+  writePrismaExtensions,
+  resolveOutputPaths,
+} from '../generator/index.js'
 import { formatFieldValidationErrors } from './generate.js'
 
 // Mock ora module
@@ -279,6 +288,146 @@ describe('Generate Command Integration', () => {
       expect(fs.readdirSync(prismaDir)).toContain('schema.prisma')
       expect(fs.readdirSync(opensaasDir)).toContain('types.ts')
       expect(fs.readdirSync(opensaasDir)).toContain('context.ts')
+    })
+  })
+
+  describe('Configurable output paths', () => {
+    const config: OpenSaasConfig = {
+      db: {
+        provider: 'sqlite',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        prismaClientConstructor: (() => null) as any,
+      },
+      output: {
+        prismaSchema: 'prisma-opensaas/schema.prisma',
+        opensaasDir: 'generated/opensaas',
+      },
+      lists: {
+        User: {
+          fields: {
+            name: text({ validation: { isRequired: true } }),
+          },
+        },
+      },
+    }
+
+    /**
+     * Drive the generator exactly as the CLI does: resolve paths from the
+     * `output` block and forward the cross-references into each writer.
+     */
+    function generateWithResolvedPaths(cfg: OpenSaasConfig) {
+      const { paths, crossReferences } = resolveOutputPaths(tempDir, cfg.output)
+      writePrismaSchema(cfg, paths.prismaSchema, crossReferences.prismaClientOutput)
+      writePrismaConfig(cfg, paths.prismaConfig, crossReferences.prismaConfigSchema)
+      writeTypes(cfg, paths.types)
+      writeLists(cfg, paths.lists)
+      writeContext(cfg, paths.context, crossReferences.configImport)
+      writePluginTypes(cfg, paths.pluginTypes)
+      writePrismaExtensions(cfg, paths.prismaExtensions, crossReferences.configImport)
+      return { paths, crossReferences }
+    }
+
+    it('writes the schema and bundle files to the configured locations', () => {
+      generateWithResolvedPaths(config)
+
+      expect(fs.existsSync(path.join(tempDir, 'prisma-opensaas', 'schema.prisma'))).toBe(true)
+      // The default prisma/ dir must be untouched so an existing Keystone setup
+      // can coexist.
+      expect(fs.existsSync(path.join(tempDir, 'prisma', 'schema.prisma'))).toBe(false)
+
+      const bundleDir = path.join(tempDir, 'generated', 'opensaas')
+      for (const file of [
+        'types.ts',
+        'lists.ts',
+        'context.ts',
+        'plugin-types.ts',
+        'prisma-extensions.ts',
+      ]) {
+        expect(fs.existsSync(path.join(bundleDir, file))).toBe(true)
+      }
+      // The default .opensaas/ dir is never created.
+      expect(fs.existsSync(path.join(tempDir, '.opensaas'))).toBe(false)
+    })
+
+    it('generates prisma.config.ts at the root pointing at the configured schema dir', () => {
+      generateWithResolvedPaths(config)
+
+      const prismaConfigPath = path.join(tempDir, 'prisma.config.ts')
+      expect(fs.existsSync(prismaConfigPath)).toBe(true)
+
+      const prismaConfig = fs.readFileSync(prismaConfigPath, 'utf-8')
+      expect(prismaConfig).toContain("schema: 'prisma-opensaas'")
+
+      // The schema directory the config points at exists and holds the schema.
+      const schemaDir = path.resolve(tempDir, 'prisma-opensaas')
+      expect(fs.existsSync(path.join(schemaDir, 'schema.prisma'))).toBe(true)
+    })
+
+    it('context.ts and prisma-extensions.ts import opensaas.config via a path that resolves', () => {
+      const { paths, crossReferences } = generateWithResolvedPaths(config)
+
+      // Place a stand-in opensaas.config at the project root so the relative
+      // import target genuinely exists on disk.
+      const configFile = path.join(tempDir, 'opensaas.config.ts')
+      fs.writeFileSync(configFile, 'export default {}\n')
+
+      const context = fs.readFileSync(paths.context, 'utf-8')
+      const extensions = fs.readFileSync(paths.prismaExtensions, 'utf-8')
+
+      // Both files use the resolved relative specifier.
+      expect(context).toContain(`from '${crossReferences.configImport}'`)
+      expect(extensions).toContain(`from '${crossReferences.configImport}'`)
+
+      // The specifier, resolved from the bundle dir, lands on the real config.
+      const resolvedFromContext = path.resolve(
+        path.dirname(paths.context),
+        `${crossReferences.configImport}.ts`,
+      )
+      expect(resolvedFromContext).toBe(configFile)
+      expect(fs.existsSync(resolvedFromContext)).toBe(true)
+    })
+
+    it('points the prisma client generator output at the relocated bundle', () => {
+      const { paths, crossReferences } = generateWithResolvedPaths(config)
+
+      const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
+      expect(schema).toContain(`output   = "${crossReferences.prismaClientOutput}"`)
+
+      // Resolved from the schema file's directory, the output lands inside the
+      // configured bundle directory.
+      const resolvedClientDir = path.resolve(
+        path.dirname(paths.prismaSchema),
+        crossReferences.prismaClientOutput,
+      )
+      expect(resolvedClientDir).toBe(path.join(paths.opensaasDir, 'prisma-client'))
+    })
+
+    it('leaves defaults unchanged when no output block is set', () => {
+      const defaultConfig: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          prismaClientConstructor: (() => null) as any,
+        },
+        lists: { User: { fields: { name: text() } } },
+      }
+
+      const { paths } = resolveOutputPaths(tempDir, defaultConfig.output)
+      writePrismaSchema(defaultConfig, paths.prismaSchema)
+      writePrismaConfig(defaultConfig, paths.prismaConfig)
+      writeContext(defaultConfig, paths.context)
+
+      expect(fs.existsSync(path.join(tempDir, 'prisma', 'schema.prisma'))).toBe(true)
+      expect(fs.existsSync(path.join(tempDir, '.opensaas', 'context.ts'))).toBe(true)
+
+      const schema = fs.readFileSync(path.join(tempDir, 'prisma', 'schema.prisma'), 'utf-8')
+      expect(schema).toContain('output   = "../.opensaas/prisma-client"')
+
+      const context = fs.readFileSync(path.join(tempDir, '.opensaas', 'context.ts'), 'utf-8')
+      expect(context).toContain("from '../opensaas.config'")
+
+      const prismaConfig = fs.readFileSync(path.join(tempDir, 'prisma.config.ts'), 'utf-8')
+      expect(prismaConfig).toContain("schema: 'prisma'")
     })
   })
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -12,6 +12,7 @@ import {
   writeContext,
   writePluginTypes,
   writePrismaExtensions,
+  resolveOutputPaths,
 } from '../generator/index.js'
 import { OpenSaasConfig, validateConfigFields } from '@opensaas/stack-core'
 import type { FieldConfigValidationError } from '@opensaas/stack-core'
@@ -106,21 +107,27 @@ export async function generateCommand() {
     // Generate Prisma schema, types, and context
     const generatorSpinner = ora('Generating schema and types...').start()
     try {
-      const prismaSchemaPath = path.join(cwd, 'prisma', 'schema.prisma')
-      const prismaConfigPath = path.join(cwd, 'prisma.config.ts')
-      const typesPath = path.join(cwd, '.opensaas', 'types.ts')
-      const listsPath = path.join(cwd, '.opensaas', 'lists.ts')
-      const contextPath = path.join(cwd, '.opensaas', 'context.ts')
-      const pluginTypesPath = path.join(cwd, '.opensaas', 'plugin-types.ts')
-      const prismaExtensionsPath = path.join(cwd, '.opensaas', 'prisma-extensions.ts')
+      // Resolve write paths and the relative cross-references between generated
+      // files from the (optional) `output` config block. With no `output`
+      // block this yields the historical defaults (`prisma/schema.prisma`,
+      // `.opensaas/`) byte-for-byte.
+      const { paths, crossReferences } = resolveOutputPaths(cwd, config.output)
 
-      writePrismaSchema(config, prismaSchemaPath)
-      writePrismaConfig(config, prismaConfigPath)
+      const prismaSchemaPath = paths.prismaSchema
+      const prismaConfigPath = paths.prismaConfig
+      const typesPath = paths.types
+      const listsPath = paths.lists
+      const contextPath = paths.context
+      const pluginTypesPath = paths.pluginTypes
+      const prismaExtensionsPath = paths.prismaExtensions
+
+      writePrismaSchema(config, prismaSchemaPath, crossReferences.prismaClientOutput)
+      writePrismaConfig(config, prismaConfigPath, crossReferences.prismaConfigSchema)
       writeTypes(config, typesPath)
       writeLists(config, listsPath)
-      writeContext(config, contextPath)
+      writeContext(config, contextPath, crossReferences.configImport)
       writePluginTypes(config, pluginTypesPath)
-      writePrismaExtensions(config, prismaExtensionsPath)
+      writePrismaExtensions(config, prismaExtensionsPath, crossReferences.configImport)
 
       generatorSpinner.succeed(chalk.green('Schema generation complete'))
       console.log(chalk.green('✅ Prisma schema generated'))
@@ -162,7 +169,7 @@ export async function generateCommand() {
           // Write any additional files plugins generated
           for (const [filename, content] of Object.entries(modifiedFiles)) {
             if (!['prismaSchema', 'types', 'context'].includes(filename)) {
-              const filePath = path.join(cwd, '.opensaas', filename)
+              const filePath = path.join(paths.opensaasDir, filename)
               fs.writeFileSync(filePath, content)
               console.log(chalk.green(`✅ Plugin generated: ${filename}`))
             }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -108,10 +108,13 @@ export async function generateCommand() {
     const generatorSpinner = ora('Generating schema and types...').start()
     try {
       // Resolve write paths and the relative cross-references between generated
-      // files from the (optional) `output` config block. With no `output`
-      // block this yields the historical defaults (`prisma/schema.prisma`,
-      // `.opensaas/`) byte-for-byte.
-      const { paths, crossReferences } = resolveOutputPaths(cwd, config.output)
+      // files from the (optional) `output` config block. The pre-existing
+      // top-level `opensaasPath` option is forwarded as the bundle-directory
+      // fallback so it keeps working through the CLI when `output.opensaasDir`
+      // is not set (precedence: `output.opensaasDir` > `opensaasPath` >
+      // default). With neither set this yields the historical defaults
+      // (`prisma/schema.prisma`, `.opensaas/`) byte-for-byte.
+      const { paths, crossReferences } = resolveOutputPaths(cwd, config.output, config.opensaasPath)
 
       const prismaSchemaPath = paths.prismaSchema
       const prismaConfigPath = paths.prismaConfig

--- a/packages/cli/src/generator/context.ts
+++ b/packages/cli/src/generator/context.ts
@@ -8,7 +8,13 @@ import * as path from 'path'
  * Creates a simple API with getContext() and getContextWithSession(session)
  * that internally handles Prisma singleton and config imports.
  */
-export function generateContext(config: OpenSaasConfig): string {
+export function generateContext(config: OpenSaasConfig, configImport?: string): string {
+  // Module specifier for importing the project's opensaas.config from inside
+  // the `.opensaas` bundle. Defaults to the legacy `../opensaas.config` (bundle
+  // one level below the project root); the output-path resolver supplies a
+  // recomputed value when the bundle is relocated via the `output` config block.
+  const configImportPath = configImport ?? '../opensaas.config'
+
   // Check if custom Prisma client constructor is provided
   const hasCustomConstructor = !!config.db.prismaClientConstructor
 
@@ -122,7 +128,7 @@ import type { Session as OpensaasSession, OpenSaasConfig } from '@opensaas/stack
 import { PrismaClient } from './prisma-client/client'
 import type { Context } from './types'
 import { prismaExtensions } from './prisma-extensions'
-import configOrPromise from '../opensaas.config'
+import configOrPromise from '${configImportPath}'
 
 // Resolve config if it's a Promise (when plugins are present)
 const configPromise = Promise.resolve(configOrPromise)
@@ -211,9 +217,16 @@ export const config = getConfig()
 
 /**
  * Write context factory to file
+ *
+ * @param configImport - Optional override for the `opensaas.config` import
+ *   specifier, forwarded to {@link generateContext}.
  */
-export function writeContext(config: OpenSaasConfig, outputPath: string): void {
-  const content = generateContext(config)
+export function writeContext(
+  config: OpenSaasConfig,
+  outputPath: string,
+  configImport?: string,
+): void {
+  const content = generateContext(config, configImport)
 
   // Ensure directory exists
   const dir = path.dirname(outputPath)

--- a/packages/cli/src/generator/index.ts
+++ b/packages/cli/src/generator/index.ts
@@ -5,3 +5,14 @@ export { generateListsNamespace, writeLists } from './lists.js'
 export { generateContext, writeContext } from './context.js'
 export { generatePluginTypes, writePluginTypes } from './plugin-types.js'
 export { generatePrismaExtensions, writePrismaExtensions } from './prisma-extensions.js'
+export {
+  resolveOutputPaths,
+  DEFAULT_PRISMA_SCHEMA,
+  DEFAULT_OPENSAAS_DIR,
+  OPENSAAS_FILES,
+} from './output-paths.js'
+export type {
+  ResolvedOutputPaths,
+  ResolvedWritePaths,
+  ResolvedCrossReferences,
+} from './output-paths.js'

--- a/packages/cli/src/generator/output-paths.test.ts
+++ b/packages/cli/src/generator/output-paths.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import * as path from 'path'
+import { resolveOutputPaths } from './output-paths.js'
+
+const CWD = path.resolve('/project')
+
+describe('resolveOutputPaths', () => {
+  describe('defaults (no output block)', () => {
+    it('writes the schema to prisma/schema.prisma and the bundle to .opensaas/', () => {
+      const { paths } = resolveOutputPaths(CWD)
+
+      expect(paths.prismaSchema).toBe(path.join(CWD, 'prisma', 'schema.prisma'))
+      expect(paths.opensaasDir).toBe(path.join(CWD, '.opensaas'))
+      expect(paths.types).toBe(path.join(CWD, '.opensaas', 'types.ts'))
+      expect(paths.lists).toBe(path.join(CWD, '.opensaas', 'lists.ts'))
+      expect(paths.context).toBe(path.join(CWD, '.opensaas', 'context.ts'))
+      expect(paths.pluginTypes).toBe(path.join(CWD, '.opensaas', 'plugin-types.ts'))
+      expect(paths.prismaExtensions).toBe(path.join(CWD, '.opensaas', 'prisma-extensions.ts'))
+    })
+
+    it('always keeps prisma.config.ts at the project root', () => {
+      const { paths } = resolveOutputPaths(CWD)
+      expect(paths.prismaConfig).toBe(path.join(CWD, 'prisma.config.ts'))
+    })
+
+    it('produces the historical cross-references byte-for-byte', () => {
+      const { crossReferences } = resolveOutputPaths(CWD)
+
+      expect(crossReferences.prismaConfigSchema).toBe('prisma')
+      expect(crossReferences.prismaClientOutput).toBe('../.opensaas/prisma-client')
+      expect(crossReferences.configImport).toBe('../opensaas.config')
+    })
+
+    it('treats an empty output block as defaults', () => {
+      const withDefaults = resolveOutputPaths(CWD)
+      const withEmpty = resolveOutputPaths(CWD, {})
+      expect(withEmpty).toEqual(withDefaults)
+    })
+  })
+
+  describe('relocated schema only', () => {
+    const { paths, crossReferences } = resolveOutputPaths(CWD, {
+      prismaSchema: 'prisma-opensaas/schema.prisma',
+    })
+
+    it('writes the schema to the configured path', () => {
+      expect(paths.prismaSchema).toBe(path.join(CWD, 'prisma-opensaas', 'schema.prisma'))
+    })
+
+    it('points prisma.config.ts at the configured schema directory', () => {
+      expect(crossReferences.prismaConfigSchema).toBe('prisma-opensaas')
+    })
+
+    it('recomputes the prisma client output relative to the new schema dir', () => {
+      // From prisma-opensaas/ back up to the (unchanged) .opensaas/prisma-client.
+      expect(crossReferences.prismaClientOutput).toBe('../.opensaas/prisma-client')
+    })
+
+    it('keeps the bundle and config import unchanged', () => {
+      expect(paths.opensaasDir).toBe(path.join(CWD, '.opensaas'))
+      expect(crossReferences.configImport).toBe('../opensaas.config')
+    })
+  })
+
+  describe('relocated bundle only', () => {
+    const { paths, crossReferences } = resolveOutputPaths(CWD, {
+      opensaasDir: 'generated/opensaas',
+    })
+
+    it('writes the bundle files to the configured directory', () => {
+      expect(paths.opensaasDir).toBe(path.join(CWD, 'generated', 'opensaas'))
+      expect(paths.types).toBe(path.join(CWD, 'generated', 'opensaas', 'types.ts'))
+      expect(paths.context).toBe(path.join(CWD, 'generated', 'opensaas', 'context.ts'))
+    })
+
+    it('recomputes the prisma client output to point at the new bundle', () => {
+      // From the default prisma/ schema dir to generated/opensaas/prisma-client.
+      expect(crossReferences.prismaClientOutput).toBe('../generated/opensaas/prisma-client')
+    })
+
+    it('recomputes the config import to climb back to the project root', () => {
+      // generated/opensaas/ is two levels below the root.
+      expect(crossReferences.configImport).toBe('../../opensaas.config')
+    })
+
+    it('leaves the schema path at the default', () => {
+      expect(paths.prismaSchema).toBe(path.join(CWD, 'prisma', 'schema.prisma'))
+      expect(crossReferences.prismaConfigSchema).toBe('prisma')
+    })
+  })
+
+  describe('relocated schema and bundle', () => {
+    const { paths, crossReferences } = resolveOutputPaths(CWD, {
+      prismaSchema: 'prisma-opensaas/schema.prisma',
+      opensaasDir: 'generated/opensaas',
+    })
+
+    it('writes both to their configured locations', () => {
+      expect(paths.prismaSchema).toBe(path.join(CWD, 'prisma-opensaas', 'schema.prisma'))
+      expect(paths.opensaasDir).toBe(path.join(CWD, 'generated', 'opensaas'))
+    })
+
+    it('cross-references resolve between the two relocated locations', () => {
+      expect(crossReferences.prismaConfigSchema).toBe('prisma-opensaas')
+      // From prisma-opensaas/ to generated/opensaas/prisma-client.
+      expect(crossReferences.prismaClientOutput).toBe('../generated/opensaas/prisma-client')
+      // From generated/opensaas/ up to the root.
+      expect(crossReferences.configImport).toBe('../../opensaas.config')
+    })
+  })
+
+  describe('schema at the project root', () => {
+    it('emits a relative config-schema reference for a root-level schema dir', () => {
+      const { crossReferences } = resolveOutputPaths(CWD, {
+        prismaSchema: 'schema.prisma',
+      })
+      // The schema dir is the project root itself; Prisma rejects an empty
+      // `schema` value, so the resolver emits `.`.
+      expect(crossReferences.prismaConfigSchema).toBe('.')
+      // From the root to .opensaas/prisma-client.
+      expect(crossReferences.prismaClientOutput).toBe('.opensaas/prisma-client')
+    })
+  })
+})

--- a/packages/cli/src/generator/output-paths.test.ts
+++ b/packages/cli/src/generator/output-paths.test.ts
@@ -109,6 +109,34 @@ describe('resolveOutputPaths', () => {
     })
   })
 
+  describe('opensaasPath fallback precedence', () => {
+    it('uses opensaasPath for the bundle dir when no output.opensaasDir is set', () => {
+      const { paths, crossReferences } = resolveOutputPaths(CWD, undefined, '.custom')
+
+      expect(paths.opensaasDir).toBe(path.join(CWD, '.custom'))
+      expect(paths.context).toBe(path.join(CWD, '.custom', 'context.ts'))
+      // The client output cross-reference follows opensaasPath.
+      expect(crossReferences.prismaClientOutput).toBe('../.custom/prisma-client')
+    })
+
+    it('prefers output.opensaasDir over opensaasPath when both are set', () => {
+      const { paths, crossReferences } = resolveOutputPaths(
+        CWD,
+        { opensaasDir: 'generated/opensaas' },
+        '.custom',
+      )
+
+      expect(paths.opensaasDir).toBe(path.join(CWD, 'generated', 'opensaas'))
+      expect(crossReferences.prismaClientOutput).toBe('../generated/opensaas/prisma-client')
+      expect(crossReferences.configImport).toBe('../../opensaas.config')
+    })
+
+    it('falls back to the default .opensaas when neither is set', () => {
+      const { paths } = resolveOutputPaths(CWD, undefined, undefined)
+      expect(paths.opensaasDir).toBe(path.join(CWD, '.opensaas'))
+    })
+  })
+
   describe('schema at the project root', () => {
     it('emits a relative config-schema reference for a root-level schema dir', () => {
       const { crossReferences } = resolveOutputPaths(CWD, {

--- a/packages/cli/src/generator/output-paths.ts
+++ b/packages/cli/src/generator/output-paths.ts
@@ -104,6 +104,13 @@ function toModuleSpecifier(relative: string, { allowBare }: { allowBare: boolean
  * where every generated file is written and the relative cross-references that
  * tie them together. Performs no I/O.
  *
+ * `.opensaas` bundle directory precedence (highest first):
+ * 1. `output.opensaasDir` (the new `output` block)
+ * 2. `opensaasPathFallback` — the pre-existing top-level `config.opensaasPath`
+ *    option, preserved so setting it alone still relocates the bundle through
+ *    the CLI exactly as before
+ * 3. the default `.opensaas`
+ *
  * Cross-reference computation:
  * - `prismaConfigSchema` — the schema *directory* relative to the project root,
  *   so the top-level `prisma.config.ts` points the Prisma CLI at the relocated
@@ -114,10 +121,17 @@ function toModuleSpecifier(relative: string, { allowBare }: { allowBare: boolean
  * - `configImport` — `opensaas.config` relative to the `.opensaas` directory,
  *   since `context.ts`/`prisma-extensions.ts` live inside the bundle and import
  *   the project's config by relative path.
+ *
+ * @param opensaasPathFallback - The pre-existing `config.opensaasPath` value,
+ *   used as the bundle directory when no `output.opensaasDir` is set.
  */
-export function resolveOutputPaths(cwd: string, output?: OutputConfig): ResolvedOutputPaths {
+export function resolveOutputPaths(
+  cwd: string,
+  output?: OutputConfig,
+  opensaasPathFallback?: string,
+): ResolvedOutputPaths {
   const prismaSchemaRel = output?.prismaSchema ?? DEFAULT_PRISMA_SCHEMA
-  const opensaasDirRel = output?.opensaasDir ?? DEFAULT_OPENSAAS_DIR
+  const opensaasDirRel = output?.opensaasDir ?? opensaasPathFallback ?? DEFAULT_OPENSAAS_DIR
 
   const prismaSchemaAbs = path.resolve(cwd, prismaSchemaRel)
   const opensaasDirAbs = path.resolve(cwd, opensaasDirRel)

--- a/packages/cli/src/generator/output-paths.ts
+++ b/packages/cli/src/generator/output-paths.ts
@@ -1,0 +1,153 @@
+import * as path from 'path'
+import type { OutputConfig } from '@opensaas/stack-core'
+
+/**
+ * Default output locations, relative to the project root. Keeping these here
+ * (rather than scattering string literals across the generator) means the
+ * "no `output` block" path is byte-identical to the historical behaviour.
+ */
+export const DEFAULT_PRISMA_SCHEMA = 'prisma/schema.prisma'
+export const DEFAULT_OPENSAAS_DIR = '.opensaas'
+
+/**
+ * The five files written into the `.opensaas` bundle directory, plus the
+ * sub-path of the patched Prisma client. These names are not configurable —
+ * only the directory that holds them moves.
+ */
+export const OPENSAAS_FILES = {
+  types: 'types.ts',
+  lists: 'lists.ts',
+  context: 'context.ts',
+  pluginTypes: 'plugin-types.ts',
+  prismaExtensions: 'prisma-extensions.ts',
+  prismaClient: 'prisma-client',
+} as const
+
+/**
+ * Absolute write paths for every file the generator emits.
+ */
+export interface ResolvedWritePaths {
+  /** Absolute path to the Prisma schema file. */
+  prismaSchema: string
+  /** Absolute path to the top-level `prisma.config.ts` (never relocated). */
+  prismaConfig: string
+  /** Absolute path to the resolved `.opensaas` bundle directory. */
+  opensaasDir: string
+  /** Absolute path to `<opensaasDir>/types.ts`. */
+  types: string
+  /** Absolute path to `<opensaasDir>/lists.ts`. */
+  lists: string
+  /** Absolute path to `<opensaasDir>/context.ts`. */
+  context: string
+  /** Absolute path to `<opensaasDir>/plugin-types.ts`. */
+  pluginTypes: string
+  /** Absolute path to `<opensaasDir>/prisma-extensions.ts`. */
+  prismaExtensions: string
+}
+
+/**
+ * Relative cross-references baked into the generated files. These follow the
+ * configured locations so the emitted code resolves regardless of where the
+ * schema and bundle live.
+ */
+export interface ResolvedCrossReferences {
+  /**
+   * Module specifier for `prisma.config.ts`'s `schema` field — the schema
+   * *directory* relative to the project root (Prisma resolves a directory or a
+   * `.prisma` file). POSIX separators so the value is stable across platforms.
+   * @example "prisma" | "prisma-opensaas"
+   */
+  prismaConfigSchema: string
+  /**
+   * Module specifier for the Prisma client `generator { output }` block — the
+   * patched client directory relative to the schema *file's* directory.
+   * @example "../.opensaas/prisma-client"
+   */
+  prismaClientOutput: string
+  /**
+   * Module specifier for importing `opensaas.config` from inside the bundle
+   * (used by `context.ts` and `prisma-extensions.ts`) — relative to the
+   * `.opensaas` directory.
+   * @example "../opensaas.config"
+   */
+  configImport: string
+}
+
+/**
+ * Resolved output paths plus the cross-references the generated files embed.
+ */
+export interface ResolvedOutputPaths {
+  paths: ResolvedWritePaths
+  crossReferences: ResolvedCrossReferences
+}
+
+/**
+ * Convert a (possibly Windows) relative path into a POSIX module specifier and
+ * ensure it stays explicitly relative where a bare segment would otherwise be
+ * read as a bare module specifier.
+ */
+function toModuleSpecifier(relative: string, { allowBare }: { allowBare: boolean }): string {
+  const posix = relative.split(path.sep).join('/')
+  if (allowBare) {
+    // A directory reference for prisma.config's `schema` field — bare is fine,
+    // but a schema at the project root yields an empty relative path, which
+    // Prisma would reject; emit `.` instead.
+    return posix === '' ? '.' : posix
+  }
+  // An import specifier — must be explicitly relative so it isn't treated as a
+  // node_modules package.
+  return posix.startsWith('.') ? posix : `./${posix}`
+}
+
+/**
+ * Pure resolver: given the project root and the user's `output` config, compute
+ * where every generated file is written and the relative cross-references that
+ * tie them together. Performs no I/O.
+ *
+ * Cross-reference computation:
+ * - `prismaConfigSchema` — the schema *directory* relative to the project root,
+ *   so the top-level `prisma.config.ts` points the Prisma CLI at the relocated
+ *   schema.
+ * - `prismaClientOutput` — the patched client directory relative to the schema
+ *   *file's* directory, since Prisma's `generator { output }` is resolved from
+ *   the schema file.
+ * - `configImport` — `opensaas.config` relative to the `.opensaas` directory,
+ *   since `context.ts`/`prisma-extensions.ts` live inside the bundle and import
+ *   the project's config by relative path.
+ */
+export function resolveOutputPaths(cwd: string, output?: OutputConfig): ResolvedOutputPaths {
+  const prismaSchemaRel = output?.prismaSchema ?? DEFAULT_PRISMA_SCHEMA
+  const opensaasDirRel = output?.opensaasDir ?? DEFAULT_OPENSAAS_DIR
+
+  const prismaSchemaAbs = path.resolve(cwd, prismaSchemaRel)
+  const opensaasDirAbs = path.resolve(cwd, opensaasDirRel)
+  const schemaDirAbs = path.dirname(prismaSchemaAbs)
+  const prismaClientAbs = path.join(opensaasDirAbs, OPENSAAS_FILES.prismaClient)
+
+  const paths: ResolvedWritePaths = {
+    prismaSchema: prismaSchemaAbs,
+    // prisma.config.ts is always written at the project root (not configurable).
+    prismaConfig: path.resolve(cwd, 'prisma.config.ts'),
+    opensaasDir: opensaasDirAbs,
+    types: path.join(opensaasDirAbs, OPENSAAS_FILES.types),
+    lists: path.join(opensaasDirAbs, OPENSAAS_FILES.lists),
+    context: path.join(opensaasDirAbs, OPENSAAS_FILES.context),
+    pluginTypes: path.join(opensaasDirAbs, OPENSAAS_FILES.pluginTypes),
+    prismaExtensions: path.join(opensaasDirAbs, OPENSAAS_FILES.prismaExtensions),
+  }
+
+  const crossReferences: ResolvedCrossReferences = {
+    prismaConfigSchema: toModuleSpecifier(path.relative(cwd, schemaDirAbs), { allowBare: true }),
+    prismaClientOutput: toModuleSpecifier(path.relative(schemaDirAbs, prismaClientAbs), {
+      allowBare: false,
+    }),
+    configImport: toModuleSpecifier(
+      path.join(path.relative(opensaasDirAbs, cwd), 'opensaas.config'),
+      {
+        allowBare: false,
+      },
+    ),
+  }
+
+  return { paths, crossReferences }
+}

--- a/packages/cli/src/generator/prisma-config.ts
+++ b/packages/cli/src/generator/prisma-config.ts
@@ -25,8 +25,14 @@ import * as path from 'path'
  * the `??` fallback. The local helper returns `undefined` for missing variables
  * so the fallback can take effect.
  */
-export function generatePrismaConfig(_config: OpenSaasConfig): string {
+export function generatePrismaConfig(_config: OpenSaasConfig, schemaPath?: string): string {
   const lines: string[] = []
+
+  // The schema path Prisma's CLI resolves (a directory or a `.prisma` file).
+  // Defaults to the historical `prisma` directory so existing projects are
+  // unaffected; the output-path resolver supplies the configured location when
+  // the schema is relocated via the `output` config block.
+  const schema = schemaPath ?? 'prisma'
 
   // Import dotenv for environment variable loading
   lines.push("import 'dotenv/config'")
@@ -39,7 +45,7 @@ export function generatePrismaConfig(_config: OpenSaasConfig): string {
   lines.push('const env = (name: string): string | undefined => process.env[name]')
   lines.push('')
   lines.push('export default defineConfig({')
-  lines.push("  schema: 'prisma',")
+  lines.push(`  schema: '${schema}',`)
   lines.push('  datasource: {')
   lines.push("    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),")
   lines.push('  },')
@@ -51,9 +57,16 @@ export function generatePrismaConfig(_config: OpenSaasConfig): string {
 
 /**
  * Write Prisma config to file
+ *
+ * @param schemaPath - Optional override for the `schema` field, forwarded to
+ *   {@link generatePrismaConfig}.
  */
-export function writePrismaConfig(config: OpenSaasConfig, outputPath: string): void {
-  const prismaConfig = generatePrismaConfig(config)
+export function writePrismaConfig(
+  config: OpenSaasConfig,
+  outputPath: string,
+  schemaPath?: string,
+): void {
+  const prismaConfig = generatePrismaConfig(config, schemaPath)
 
   // Ensure directory exists
   const dir = path.dirname(outputPath)

--- a/packages/cli/src/generator/prisma-extensions.ts
+++ b/packages/cli/src/generator/prisma-extensions.ts
@@ -6,8 +6,14 @@ import * as path from 'path'
  * Generate Prisma result extensions configuration
  * This creates a Prisma client extension that calls field resolveOutput hooks
  */
-export function generatePrismaExtensions(config: OpenSaasConfig): string {
+export function generatePrismaExtensions(config: OpenSaasConfig, configImport?: string): string {
   const lines: string[] = []
+
+  // Module specifier for importing the project's opensaas.config from inside
+  // the `.opensaas` bundle. Defaults to the legacy `../opensaas.config`; the
+  // output-path resolver supplies a recomputed value when the bundle is
+  // relocated via the `output` config block.
+  const configImportPath = configImport ?? '../opensaas.config'
 
   // Add header comment
   lines.push('/**')
@@ -18,7 +24,7 @@ export function generatePrismaExtensions(config: OpenSaasConfig): string {
 
   // Add imports
   lines.push("import { Prisma } from './prisma-client/client'")
-  lines.push("import configOrPromise from '../opensaas.config'")
+  lines.push(`import configOrPromise from '${configImportPath}'`)
   lines.push('')
 
   // Resolve config synchronously if possible (will be resolved by context.ts anyway)
@@ -145,9 +151,16 @@ export function generatePrismaExtensions(config: OpenSaasConfig): string {
 
 /**
  * Write Prisma extensions configuration to file
+ *
+ * @param configImport - Optional override for the `opensaas.config` import
+ *   specifier, forwarded to {@link generatePrismaExtensions}.
  */
-export function writePrismaExtensions(config: OpenSaasConfig, outputPath: string): void {
-  const extensions = generatePrismaExtensions(config)
+export function writePrismaExtensions(
+  config: OpenSaasConfig,
+  outputPath: string,
+  configImport?: string,
+): void {
+  const extensions = generatePrismaExtensions(config, configImport)
 
   // Ensure directory exists
   const dir = path.dirname(outputPath)

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -43,16 +43,23 @@ function getFieldModifiers(
 
 /**
  * Generate Prisma schema from OpenSaas config
+ *
+ * @param prismaClientOutput - Module specifier for the patched Prisma client's
+ *   `generator { output }`, relative to the schema file's directory. Defaults to
+ *   the legacy `../<opensaasPath>/prisma-client` so existing projects are
+ *   unaffected; the output-path resolver supplies a recomputed value when the
+ *   schema or `.opensaas` dir is relocated via the `output` config block.
  */
-export function generatePrismaSchema(config: OpenSaasConfig): string {
+export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?: string): string {
   const lines: string[] = []
 
   const opensaasPath = config.opensaasPath || '.opensaas'
+  const clientOutput = prismaClientOutput ?? `../${opensaasPath}/prisma-client`
 
   // Generator and datasource
   lines.push('generator client {')
   lines.push('  provider = "prisma-client"')
-  lines.push(`  output   = "../${opensaasPath}/prisma-client"`)
+  lines.push(`  output   = "${clientOutput}"`)
   lines.push('}')
   lines.push('')
   lines.push('datasource db {')
@@ -209,9 +216,16 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
 
 /**
  * Write Prisma schema to file
+ *
+ * @param prismaClientOutput - Optional override for the patched Prisma client
+ *   output path, forwarded to {@link generatePrismaSchema}.
  */
-export function writePrismaSchema(config: OpenSaasConfig, outputPath: string): void {
-  const schema = generatePrismaSchema(config)
+export function writePrismaSchema(
+  config: OpenSaasConfig,
+  outputPath: string,
+  prismaClientOutput?: string,
+): void {
+  const schema = generatePrismaSchema(config, prismaClientOutput)
 
   // Ensure directory exists
   const dir = path.dirname(outputPath)

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -122,6 +122,7 @@ export function list<TTypeInfo extends import('./types.js').TypeInfo>(
 // Re-export all types
 export type {
   OpenSaasConfig,
+  OutputConfig,
   ListConfig,
   ListConfigInput,
   ListAccessControl,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1821,6 +1821,34 @@ export type Plugin = {
  * Main configuration type
  * Using interface instead of type to allow module augmentation
  */
+/**
+ * Configurable generator output locations.
+ *
+ * Lets a project relocate the generated Prisma schema and the `.opensaas`
+ * bundle directory. Paths are interpreted relative to the project root.
+ *
+ * @example
+ * ```typescript
+ * output: {
+ *   prismaSchema: 'prisma-opensaas/schema.prisma',
+ *   opensaasDir: '.opensaas',
+ * }
+ * ```
+ */
+export interface OutputConfig {
+  /**
+   * Path to the generated Prisma schema file.
+   * @default "prisma/schema.prisma"
+   */
+  prismaSchema?: string
+  /**
+   * Directory for the generated `.opensaas` bundle (types, lists, context,
+   * plugin-types, prisma-extensions, and the patched Prisma client).
+   * @default ".opensaas"
+   */
+  opensaasDir?: string
+}
+
 export interface OpenSaasConfig {
   db: DatabaseConfig
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Config must accept any list configuration
@@ -1841,6 +1869,20 @@ export interface OpenSaasConfig {
    * @default ".opensaas"
    */
   opensaasPath?: string
+  /**
+   * Relocate the generator's output so `opensaas generate` can coexist with an
+   * existing `prisma/` directory (e.g. during a Keystone → stack migration).
+   *
+   * Both fields are resolved relative to the project root (the directory the
+   * CLI runs in). When omitted, defaults are unchanged: the schema is written to
+   * `prisma/schema.prisma` and the `.opensaas` bundle to `.opensaas/`.
+   *
+   * The generated files' cross-references follow these locations — `context.ts`
+   * imports the generated types/lists from the resolved `.opensaas` dir, and the
+   * top-level `prisma.config.ts` points at the configured schema path so the
+   * `prisma` CLI keeps working.
+   */
+  output?: OutputConfig
   /**
    * Plugins to extend the stack
    * Executed in array order (or dependency order if dependencies specified)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,13 @@ export { config, list } from './config/index.js'
 // Config types a consumer annotates with.
 // Concrete field-config types (TextField, …) live on '@opensaas/stack-core/fields'
 // alongside their builders.
-export type { OpenSaasConfig, ListConfig, FieldConfig, OperationAccess } from './config/index.js'
+export type {
+  OpenSaasConfig,
+  OutputConfig,
+  ListConfig,
+  FieldConfig,
+  OperationAccess,
+} from './config/index.js'
 
 // Access control — the types a consumer writes against
 export type {


### PR DESCRIPTION
Implements #485
Part of #484

## What

Adds an `output` block to `opensaas.config.ts` so `opensaas generate` can relocate the generated Prisma schema and the `.opensaas` bundle — letting it coexist with an existing Keystone `prisma/` during migration without clobbering it. Defaults are unchanged for greenfield projects.

```typescript
export default config({
  output: {
    prismaSchema: 'prisma-opensaas/schema.prisma',
    opensaasDir: 'generated/opensaas',
  },
  // ...
})
```

## How

- **`OutputConfig` type** added to `@opensaas/stack-core` (`output.prismaSchema`, `output.opensaasDir`; defaults `prisma/schema.prisma` and `.opensaas`).
- **New pure resolver** `packages/cli/src/generator/output-paths.ts` — `resolveOutputPaths(cwd, output)` performs no I/O and returns absolute write paths plus the relative cross-references the generated files embed:
  - `prismaConfigSchema` — the schema *directory* relative to the project root, written into `prisma.config.ts`'s `schema` field so the Prisma CLI resolves the relocated schema.
  - `prismaClientOutput` — the patched Prisma client dir relative to the **schema file's** directory (Prisma resolves `generator { output }` from the schema file).
  - `configImport` — `opensaas.config` relative to the **`.opensaas` bundle** dir (used by `context.ts` and `prisma-extensions.ts`, which live inside the bundle).
- `generate.ts` consumes the resolver instead of the hardcoded paths.
- The generator functions (`prisma`, `prisma-config`, `context`, `prisma-extensions`) take optional cross-reference overrides that default to byte-identical historical output.

## Cross-reference computation (the tricky part)

Each cross-reference is computed from the resolved locations so the emitted code still resolves when paths move:

| relocation | `prismaConfigSchema` | `prismaClientOutput` | `configImport` |
|---|---|---|---|
| default | `prisma` | `../.opensaas/prisma-client` | `../opensaas.config` |
| schema → `prisma-opensaas/schema.prisma` | `prisma-opensaas` | `../.opensaas/prisma-client` | `../opensaas.config` |
| bundle → `generated/opensaas` | `prisma` | `../generated/opensaas/prisma-client` | `../../opensaas.config` |
| both relocated | `prisma-opensaas` | `../generated/opensaas/prisma-client` | `../../opensaas.config` |

Paths are emitted with POSIX separators for cross-platform stability; a schema at the project root yields `.` (not an empty string Prisma would reject).

## Tests

- **Resolver unit tests** (`output-paths.test.ts`): defaults, schema-only, bundle-only, both-relocated, and root-schema edge case → resolved paths + cross-references.
- **Generate-into-non-default-paths** (`generate.test.ts`): asserts files land in the configured locations, the default `prisma/` and `.opensaas/` dirs are untouched, `context.ts`/`prisma-extensions.ts` import `opensaas.config` via a path that resolves on disk, `prisma.config.ts` references the configured schema dir, and the Prisma client output resolves into the relocated bundle. Plus a regression test that defaults are unchanged.

## Verification

- `pnpm build` (full repo): pass
- `packages/cli` tests: 224 pass (existing snapshots unchanged → defaults byte-identical)
- `packages/core` tests: 532 pass
- `pnpm lint`: 0 errors; `pnpm manypkg fix`; `pnpm format`: clean
- Changeset added (minor, both packages)

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_