### PR TITLE
feat(core,cli): opt-in db.keystoneCompat empty-string text defaults

### DIFF
--- a/.changeset/proud-otters-compat.md
+++ b/.changeset/proud-otters-compat.md
@@ -1,0 +1,36 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Add opt-in `db.keystoneCompat` mode for Keystone-compatible empty-string text defaults
+
+When migrating from Keystone 6, every non-null text column carries an implicit empty-string default. Set `db: { keystoneCompat: true }` to mirror that: any non-null `text()` column without an explicit `defaultValue` now generates `String @default("")`, so a migrating schema reaches parity without hand-setting `defaultValue: ''` on dozens of columns.
+
+The mode is off by default (greenfield schemas stay clean) and never affects nullable text, fields with an explicit `defaultValue`, or any non-text field — an explicit `text({ defaultValue: 'x' })` always wins.
+
+```typescript
+export default config({
+  db: {
+    provider: 'postgresql',
+    keystoneCompat: true, // non-null text without a default → @default("")
+    prismaClientConstructor: (PrismaClient) => {
+      // ... adapter setup
+    },
+  },
+  lists: {
+    Account: list({
+      fields: {
+        // required text → String @default("")
+        name: text({ validation: { isRequired: true } }),
+        // explicit default still wins → String @default("PLEASE_UPDATE")
+        status: text({ validation: { isRequired: true }, defaultValue: 'PLEASE_UPDATE' }),
+        // nullable text is untouched → String?
+        bio: text(),
+      },
+    }),
+  },
+})
+```
+
+See ADR-0004 for the full Keystone-compatible generator defaults.

--- a/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Prisma Schema Generator > Keystone-compat mode (db.keystoneCompat) > emits @default("") for non-null text without an explicit default (snapshot) 1`] = `
+"generator client {
+  provider = "prisma-client"
+  output   = "../.opensaas/prisma-client"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model Account {
+  id        String   @id @default(cuid())
+  name         String @default("")
+  status       String @default("PLEASE_UPDATE")
+  nickname     String?
+  note         String?
+  loginCount   Int
+  isActive     Boolean @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+}
+"
+`;
+
 exports[`Prisma Schema Generator > field defaultValue → @default(...) > generates a representative multi-field model with mixed defaults 1`] = `
 "generator client {
   provider = "prisma-client"

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1787,4 +1787,70 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toMatchSnapshot()
     })
   })
+
+  describe('Keystone-compat mode (db.keystoneCompat)', () => {
+    // A representative model exercising every branch of the empty-string rule:
+    // required text (compat default applies), required text with an explicit
+    // default (explicit wins), optional/nullable text (untouched), and non-text
+    // fields (untouched). The same lists are generated with the flag off below
+    // so the on/off contrast is part of the proof.
+    const representativeLists: OpenSaasConfig['lists'] = {
+      Account: {
+        fields: {
+          // Required, no default → @default("") under keystoneCompat
+          name: text({ validation: { isRequired: true } }),
+          // Required, explicit default → explicit value wins
+          status: text({ validation: { isRequired: true }, defaultValue: 'PLEASE_UPDATE' }),
+          // Optional → nullable → never gets the compat default
+          nickname: text(),
+          // Explicitly nullable despite isRequired → never gets the compat default
+          note: text({ validation: { isRequired: true }, db: { isNullable: true } }),
+          // Non-text fields are unaffected by the flag
+          loginCount: integer({ validation: { isRequired: true } }),
+          isActive: checkbox({ defaultValue: true }),
+        },
+      },
+    }
+
+    it('emits @default("") for non-null text without an explicit default (snapshot)', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'postgresql', keystoneCompat: true },
+        lists: representativeLists,
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // The migrating-developer guarantee: required text reaches Schema parity
+      // with Keystone's implicit empty-string default.
+      expect(schema).toMatch(/name\s+String\s+@default\(""\)/)
+      // Explicit default still wins over the compat empty-string default.
+      expect(schema).toMatch(/status\s+String\s+@default\("PLEASE_UPDATE"\)/)
+      // Nullable text is untouched (no default at all).
+      expect(schema).toMatch(/nickname\s+String\?\s*$/m)
+      expect(schema).toMatch(/note\s+String\?\s*$/m)
+      // Non-text fields keep their own behaviour.
+      expect(schema).toMatch(/loginCount\s+Int\s*$/m)
+      expect(schema).toMatch(/isActive\s+Boolean\s+@default\(true\)/)
+
+      expect(schema).toMatchSnapshot()
+    })
+
+    it('emits no implicit text default when keystoneCompat is off (default)', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'postgresql' },
+        lists: representativeLists,
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Greenfield default: required text stays clean — String with no default.
+      expect(schema).toMatch(/name\s+String\s*$/m)
+      expect(schema).not.toMatch(/name\s+String\s+@default/)
+      // Explicit defaults are still honoured regardless of the flag.
+      expect(schema).toMatch(/status\s+String\s+@default\("PLEASE_UPDATE"\)/)
+      // The only empty-string default present is the explicit none — i.e. there
+      // is no @default("") anywhere when the flag is off.
+      expect(schema).not.toContain('@default("")')
+    })
+  })
 })

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -11,10 +11,11 @@ function mapFieldTypeToPrisma(
   field: FieldConfig,
   provider?: string,
   listName?: string,
+  keystoneCompat?: boolean,
 ): string | null {
   // Use field's own Prisma type generator if available
   if (field.getPrismaType) {
-    const result = field.getPrismaType(fieldName, provider, listName)
+    const result = field.getPrismaType(fieldName, provider, listName, keystoneCompat)
     return result.type
   }
 
@@ -30,10 +31,11 @@ function getFieldModifiers(
   field: FieldConfig,
   provider?: string,
   listName?: string,
+  keystoneCompat?: boolean,
 ): string {
   // Use field's own Prisma type generator if available
   if (field.getPrismaType) {
-    const result = field.getPrismaType(fieldName, provider, listName)
+    const result = field.getPrismaType(fieldName, provider, listName, keystoneCompat)
     return result.modifiers || ''
   }
 
@@ -48,6 +50,10 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
   const lines: string[] = []
 
   const opensaasPath = config.opensaasPath || '.opensaas'
+  // Keystone-compat mode: when on, non-null text without an explicit default
+  // gets Keystone's implicit empty-string default. Threaded to fields via
+  // getPrismaType, the same way provider/listName already reach them.
+  const keystoneCompat = config.db.keystoneCompat ?? false
 
   // Generator and datasource
   lines.push('generator client {')
@@ -66,7 +72,12 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
     for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
       if (fieldConfig.type === 'relationship' || fieldConfig.virtual) continue
       if (fieldConfig.getPrismaType) {
-        const result = fieldConfig.getPrismaType(fieldName, config.db.provider, listName)
+        const result = fieldConfig.getPrismaType(
+          fieldName,
+          config.db.provider,
+          listName,
+          keystoneCompat,
+        )
         if (result.enumValues && result.enumValues.length > 0) {
           enumDefinitions.set(result.type, result.enumValues)
         }
@@ -145,10 +156,22 @@ export function generatePrismaSchema(config: OpenSaasConfig): string {
         continue
       }
 
-      const prismaType = mapFieldTypeToPrisma(fieldName, fieldConfig, config.db.provider, listName)
+      const prismaType = mapFieldTypeToPrisma(
+        fieldName,
+        fieldConfig,
+        config.db.provider,
+        listName,
+        keystoneCompat,
+      )
       if (!prismaType) continue // Skip if no type returned
 
-      const modifiers = getFieldModifiers(fieldName, fieldConfig, config.db.provider, listName)
+      const modifiers = getFieldModifiers(
+        fieldName,
+        fieldConfig,
+        config.db.provider,
+        listName,
+        keystoneCompat,
+      )
 
       // Format with proper spacing: '?' attaches to type directly, other modifiers get a space
       const paddedName = fieldName.padEnd(12)

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -462,12 +462,16 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
    * @param fieldName - The name of the field (for generating modifiers)
    * @param provider - Optional database provider ('sqlite', 'postgresql', 'mysql', etc.)
    * @param listName - Optional list name (used for generating enum type names)
+   * @param keystoneCompat - Whether Keystone-compat mode is enabled (db.keystoneCompat).
+   *   When true, non-null text columns without an explicit defaultValue emit
+   *   `@default("")` to match Keystone 6's implicit empty-string text default.
    * @returns Prisma type string, optional modifiers, and optional enum values
    */
   getPrismaType?: (
     fieldName: string,
     provider?: string,
     listName?: string,
+    keystoneCompat?: boolean,
   ) => {
     type: string
     modifiers?: string
@@ -1331,6 +1335,34 @@ export type DatabaseConfig = {
    * ```
    */
   joinTableNaming?: 'prisma' | 'keystone'
+  /**
+   * Opt into Keystone-compat mode for generated schema defaults.
+   *
+   * Keystone 6 gives every non-null text column an implicit empty-string
+   * default. With `keystoneCompat: true`, the generator mirrors that: any
+   * non-null `text()` column that has no explicit `defaultValue` emits
+   * `@default("")`, so a migrating project reaches Schema parity without
+   * hand-setting `defaultValue: ''` on dozens of columns.
+   *
+   * Stays opt-in (default `false`) because a greenfield project would not want
+   * implicit empty-string text defaults cluttering its schema. The flag never
+   * affects nullable text, fields with an explicit `defaultValue`, or any
+   * non-text field — an explicit `text({ defaultValue: 'x' })` always wins.
+   *
+   * @default false
+   *
+   * @example Reach Schema parity when migrating from Keystone
+   * ```typescript
+   * db: {
+   *   provider: 'postgresql',
+   *   keystoneCompat: true, // non-null text without a default → @default("")
+   *   // ... rest of config
+   * }
+   * ```
+   *
+   * @see ADR-0004 (Keystone-compatible generator defaults)
+   */
+  keystoneCompat?: boolean
   /**
    * Optional function to extend or modify the generated Prisma schema
    * Receives the generated schema as a string and should return the modified schema

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -88,7 +88,12 @@ export function text<
 
       return !isRequired ? withMax.optional().nullable() : withMax
     },
-    getPrismaType: (_fieldName: string) => {
+    getPrismaType: (
+      _fieldName: string,
+      _provider?: string,
+      _listName?: string,
+      keystoneCompat?: boolean,
+    ) => {
       const validation = options?.validation
       const db = options?.db
       const isRequired = validation?.isRequired
@@ -105,9 +110,19 @@ export function text<
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Default value if provided (quoted string literal). Independent of the
-      // nullable `?` modifier above — the default never overwrites nullability.
-      const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'text')
+      // Default value. An explicit `defaultValue` always wins. When none is set
+      // and Keystone-compat mode is on, a non-null text column gets Keystone's
+      // implicit empty-string default. Both go through formatPrismaDefault, so
+      // the empty-string literal (`""`) is produced the same way as any other
+      // text default. Independent of the nullable `?` modifier above — the
+      // default never overwrites nullability.
+      const defaultSource =
+        options?.defaultValue !== undefined
+          ? options.defaultValue
+          : keystoneCompat && !isNullable
+            ? ''
+            : undefined
+      const defaultLiteral = formatPrismaDefault(defaultSource, 'text')
       if (defaultLiteral !== undefined) {
         modifiers += ` @default(${defaultLiteral})`
       }

--- a/packages/core/src/fields/text-keystone-compat.test.ts
+++ b/packages/core/src/fields/text-keystone-compat.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { text, integer } from './index.js'
+
+/**
+ * Unit coverage for Keystone-compat mode on text() (issue #475).
+ *
+ * Keystone 6 gives every non-null text column an implicit empty-string default.
+ * The `keystoneCompat` flag (db.keystoneCompat) reaches text()'s getPrismaType as
+ * the 4th positional argument — the same way provider/listName already do — and
+ * emits `@default("")` for a non-null text column that has no explicit default.
+ *
+ * These tests pin the precise on/off/explicit-default/nullable/non-text matrix
+ * from the issue's acceptance criteria.
+ */
+describe('text() Keystone-compat empty-string default', () => {
+  const KEYSTONE_COMPAT = true
+
+  describe('with keystoneCompat ON', () => {
+    it('emits @default("") for a required (non-null) text field without an explicit default', () => {
+      const field = text({ validation: { isRequired: true } })
+
+      const result = field.getPrismaType!('name', 'sqlite', 'User', KEYSTONE_COMPAT)
+
+      expect(result.type).toBe('String')
+      expect(result.modifiers).toBe('@default("")')
+    })
+
+    it('emits @default("") for a non-null text field made non-null via db.isNullable: false', () => {
+      // Non-null at the DB level even though validation does not mark it required.
+      const field = text({ db: { isNullable: false } })
+
+      const result = field.getPrismaType!('phone', 'sqlite', 'User', KEYSTONE_COMPAT)
+
+      expect(result.modifiers).toBe('@default("")')
+    })
+
+    it('does NOT emit a default for a nullable text field', () => {
+      // Optional → nullable; Keystone-compat must leave it alone.
+      const field = text()
+
+      const result = field.getPrismaType!('bio', 'sqlite', 'User', KEYSTONE_COMPAT)
+
+      expect(result.modifiers).toBe('?')
+      expect(result.modifiers).not.toContain('@default')
+    })
+
+    it('does NOT emit a default for a text field made nullable via db.isNullable: true', () => {
+      // Required validation, but explicitly nullable at the DB level.
+      const field = text({ validation: { isRequired: true }, db: { isNullable: true } })
+
+      const result = field.getPrismaType!('note', 'sqlite', 'User', KEYSTONE_COMPAT)
+
+      expect(result.modifiers).toBe('?')
+      expect(result.modifiers).not.toContain('@default')
+    })
+
+    it('lets an explicit defaultValue win over the compat empty-string default', () => {
+      const field = text({ validation: { isRequired: true }, defaultValue: 'PLEASE_UPDATE' })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Account', KEYSTONE_COMPAT)
+
+      expect(result.modifiers).toBe('@default("PLEASE_UPDATE")')
+      expect(result.modifiers).not.toContain('@default("")')
+    })
+
+    it('honours an explicit empty-string defaultValue without double-emitting', () => {
+      const field = text({ validation: { isRequired: true }, defaultValue: '' })
+
+      const result = field.getPrismaType!('label', 'sqlite', 'Account', KEYSTONE_COMPAT)
+
+      // A single @default("") — the explicit default, not a duplicate.
+      expect(result.modifiers).toBe('@default("")')
+      expect(result.modifiers!.match(/@default/g)).toHaveLength(1)
+    })
+
+    it('places @default("") alongside other modifiers in the expected order', () => {
+      const field = text({
+        validation: { isRequired: true },
+        isIndexed: 'unique',
+        db: { nativeType: 'Text', map: 'full_name' },
+      })
+
+      const result = field.getPrismaType!('fullName', 'postgresql', 'User', KEYSTONE_COMPAT)
+
+      // nativeType → default → unique → map, matching the builder's modifier order.
+      expect(result.modifiers).toBe('@db.Text @default("") @unique @map("full_name")')
+    })
+  })
+
+  describe('with keystoneCompat OFF (default)', () => {
+    it('emits no default for a required text field when the flag is omitted', () => {
+      const field = text({ validation: { isRequired: true } })
+
+      const result = field.getPrismaType!('name', 'sqlite', 'User')
+
+      expect(result.modifiers).toBeUndefined()
+    })
+
+    it('emits no default for a required text field when the flag is explicitly false', () => {
+      const field = text({ validation: { isRequired: true } })
+
+      const result = field.getPrismaType!('name', 'sqlite', 'User', false)
+
+      expect(result.modifiers).toBeUndefined()
+    })
+
+    it('still honours an explicit defaultValue when the flag is off', () => {
+      const field = text({ validation: { isRequired: true }, defaultValue: 'PLEASE_UPDATE' })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Account', false)
+
+      expect(result.modifiers).toBe('@default("PLEASE_UPDATE")')
+    })
+  })
+
+  describe('non-text fields are unaffected by the flag', () => {
+    it('does not give a required integer field an empty-string default under keystoneCompat', () => {
+      const field = integer({ validation: { isRequired: true } })
+
+      const result = field.getPrismaType!('count', 'sqlite', 'Widget', KEYSTONE_COMPAT)
+
+      expect(result.type).toBe('Int')
+      expect(result.modifiers ?? '').not.toContain('@default')
+    })
+  })
+})


### PR DESCRIPTION
Implements #475
Part of #470

## What changed

Adds an opt-in `db: { keystoneCompat: true }` setting (the **Keystone-compat mode**). When enabled, every non-null `text()` column that has **no** explicit `defaultValue` emits `String @default("")` — Keystone 6's implicit empty-string text default — so a migrating project reaches **Schema parity** without hand-setting `defaultValue: ''` on dozens of columns.

When off (the default), no implicit text default is emitted, keeping greenfield schemas clean.

The flag:
- only affects **non-null** `text()` **without** an explicit `defaultValue`
- never affects nullable text, fields with an explicit `defaultValue` (which always wins, including an explicit `''`), or any non-text field

## Implementation notes

- `db.keystoneCompat?: boolean` added to `DatabaseConfig` with JSDoc referencing ADR-0004.
- Threaded to `text()`'s `getPrismaType` as a 4th positional argument — the same way `provider`/`listName` already reach fields — via the generator in `packages/cli/src/generator/prisma.ts`. `getPrismaType`'s type signature gains the optional `keystoneCompat` param.
- Builds on the existing `text()` default-emission path: the empty-string literal is produced through the existing pure `formatPrismaDefault` module (no new default-emission code).
- No field-type switch statements; field stays self-contained.

## Tests

- **Keystone-compat generator snapshot** in `packages/cli/src/generator/prisma.test.ts` proving empty-string text defaults across a representative model (required text → `@default("")`, explicit default wins, nullable text untouched, non-text untouched), plus an off-by-default contrast assertion.
- **Unit coverage** in `packages/core/src/fields/text-keystone-compat.test.ts` of the on / off / explicit-default / nullable / non-text matrix on `text().getPrismaType`.

## Verification

- `pnpm build` — pass
- `packages/core`: 558 tests pass
- `packages/cli`: 214 tests pass (1 new snapshot)
- `pnpm lint` — 0 errors (only pre-existing warnings)
- `pnpm manypkg fix` / `pnpm format` — clean

Changeset added (minor, beta) for `@opensaas/stack-core` and `@opensaas/stack-cli`.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_