### PR TITLE
Re-export query API (defineFragment / runQuery / runQueryOne / ResultOf) from @opensaas/stack-core root

### DIFF
--- a/.changeset/calm-otters-gather.md
+++ b/.changeset/calm-otters-gather.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Re-export the fragment query API (`defineFragment`, `runQuery`, `runQueryOne`, and the `ResultOf`, `RelationSelector`, `QueryArgs` types) from the package root so the documented `import { defineFragment, runQuery, runQueryOne, type ResultOf } from '@opensaas/stack-core'` resolves.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+// Import from the package root entry point exactly as the docs / CHANGELOG /
+// migrate-context-calls skill instruct consumers to. If the root `index.ts`
+// stops re-exporting the query API, this file fails to type-check / run,
+// preventing a silent regression (issue #496).
+import { defineFragment, runQuery, runQueryOne } from './index.js'
+import type { ResultOf, RelationSelector, QueryArgs } from './index.js'
+
+// ─────────────────────────────────────────────────────────────
+// Stand-in model type (mirrors a Prisma-generated type)
+// ─────────────────────────────────────────────────────────────
+
+type User = {
+  id: string
+  name: string
+  email: string
+}
+
+describe('@opensaas/stack-core root entry point — query API re-exports (issue #496)', () => {
+  it('re-exports the runtime query functions from the package root', () => {
+    expect(typeof defineFragment).toBe('function')
+    expect(typeof runQuery).toBe('function')
+    expect(typeof runQueryOne).toBe('function')
+  })
+
+  it('defineFragment imported from the root produces a usable fragment', () => {
+    const userFragment = defineFragment<User>()({ id: true, name: true } as const)
+
+    expect(userFragment._type).toBe('fragment')
+    expect(userFragment._fields).toEqual({ id: true, name: true })
+  })
+
+  it('exposes ResultOf as a usable type alias from the root', () => {
+    const userFragment = defineFragment<User>()({ id: true, name: true } as const)
+    expect(userFragment._type).toBe('fragment')
+
+    // Type-level assertion: ResultOf<typeof fragment> narrows to the selection.
+    expectTypeOf<ResultOf<typeof userFragment>>().toEqualTypeOf<{ id: string; name: string }>()
+  })
+
+  it('exposes QueryArgs and RelationSelector as usable types from the root', () => {
+    // Type-level usage — these annotations only compile if the types resolve
+    // from the root entry point.
+    const args: QueryArgs = { where: { id: 'abc' }, take: 5 }
+    expect(args.take).toBe(5)
+
+    const selector: RelationSelector<User> = defineFragment<User>()({ id: true } as const)
+    expectTypeOf(selector).not.toBeNever()
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,3 +40,12 @@ export { ValidationError } from './hooks/index.js'
 // with a clear per-field message instead of deep inside generation.
 export { validateFieldConfig, validateConfigFields } from './validation/field-config.js'
 export type { FieldConfigValidationError } from './validation/field-config.js'
+
+// Fragment-based query API — composable, type-safe reads that mirror
+// Keystone's GraphQL fragments without a GraphQL runtime. The migration
+// guide, CHANGELOG, and migrate-context-calls skill all advertise importing
+// these from the root entry point. The internal runtime helpers (isFragment,
+// buildInclude, pickFields) and the Fragment/FieldSelection types stay off the
+// root surface — those live on '@opensaas/stack-core/internal'.
+export { defineFragment, runQuery, runQueryOne } from './query/index.js'
+export type { ResultOf, RelationSelector, QueryArgs } from './query/index.js'


### PR DESCRIPTION
Fixes #496

## Problem

The migration guide (`specs/keystone-migration.md`), the `@opensaas/stack-core` CHANGELOG, the query module's JSDoc, and the `migrate-context-calls` skill all instruct users to:

```ts
import { defineFragment, runQuery, runQueryOne, type ResultOf } from '@opensaas/stack-core'
```

But the package root (`packages/core/src/index.ts`) did not re-export `./query/index.js`, so that import did not resolve. The runtime functions and the `ResultOf` type were unreachable from the public root entry point.

## Change

Re-export the intended public query surface from the root entry point:

- Runtime: `defineFragment`, `runQuery`, `runQueryOne`
- Types: `ResultOf`, `RelationSelector`, `QueryArgs`

These are exactly the symbols advertised by the docs / CHANGELOG / skill. Internal-only helpers (`isFragment`, `buildInclude`, `pickFields`, marked `@internal`) and the `Fragment` / `FieldSelection` types remain off the root surface (the latter stay on `@opensaas/stack-core/internal`, where they already live). No `any` / type-casts were added to public types, and there are no name collisions with existing root exports.

## Regression guard

Added `packages/core/src/index.test.ts` — imports the four documented symbols from the package root and asserts both at runtime (functions are present, `defineFragment` produces a usable fragment) and at the type level (`ResultOf` narrows correctly; `QueryArgs` / `RelationSelector` resolve). If the root stops re-exporting the query API, this fails to compile / run.

## Verification

- `pnpm build` (incl. `tsc` typecheck of core) — pass
- `cd packages/core && pnpm test` — 551 passed (27 files), including the new 4-test file
- `pnpm lint` — no new warnings/errors on changed files
- `pnpm manypkg fix` / `pnpm format` — clean
- Changeset added (`@opensaas/stack-core`: patch)

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_