### PR TITLE
feat(core,cli): select() db.isNullable + db.enumName

### DIFF
--- a/.changeset/select-db-nullable-enumname.md
+++ b/.changeset/select-db-nullable-enumname.md
@@ -1,0 +1,47 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Add `select()` db options for Keystone schema parity: `db.isNullable` and `db.enumName`.
+
+`db.isNullable: true` forces the nullable `?` on the generated column even when a
+`defaultValue` is present. The default behaviour is unchanged — a select with a
+`defaultValue` still generates NOT NULL unless you opt in explicitly:
+
+```typescript
+// Optional select with a default, kept nullable for data containing NULLs
+status: select({
+  options: [
+    { label: 'Draft', value: 'draft' },
+    { label: 'Published', value: 'published' },
+  ],
+  defaultValue: 'draft',
+  db: { isNullable: true },
+})
+// Generates: status String? @default("draft")
+
+// Enum-backed equivalent
+status: select({
+  options: [{ label: 'Open', value: 'open' }],
+  defaultValue: 'open',
+  db: { type: 'enum', isNullable: true },
+})
+// Generates: status <Enum>? @default(open)
+```
+
+`db.enumName` overrides the derived `<List><Field>` name of the generated Prisma
+enum for native-enum selects, renaming both the `enum` block and every reference
+to it in the owning model — useful for matching a live DB enum (e.g. Keystone's
+`…Type` suffix):
+
+```typescript
+status: select({
+  options: [
+    { label: 'Open', value: 'open' },
+    { label: 'Closed', value: 'closed' },
+  ],
+  db: { type: 'enum', enumName: 'AccountNoteStatusType' },
+})
+// Generates: enum AccountNoteStatusType { ... } and the column references it
+```

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1577,6 +1577,136 @@ describe('Prisma Schema Generator', () => {
       }).not.toThrow()
     })
 
+    it('should rename the enum block and the column reference with db.enumName', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          AccountNote: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Open', value: 'open' },
+                  { label: 'Closed', value: 'closed' },
+                ],
+                db: { type: 'enum', enumName: 'AccountNoteStatusType' },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // The enum block uses the custom name
+      expect(schema).toContain('enum AccountNoteStatusType {')
+      expect(schema).toContain('  open')
+      expect(schema).toContain('  closed')
+      // The column references the custom enum name
+      expect(schema).toMatch(/status\s+AccountNoteStatusType/)
+      // The derived name is not emitted anywhere
+      expect(schema).not.toContain('enum AccountNoteStatus {')
+      expect(schema).not.toMatch(/status\s+AccountNoteStatus\b/)
+    })
+
+    it('should emit String? @default("X") for optional string select with default + db.isNullable', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                defaultValue: 'draft',
+                db: { isNullable: true },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toMatch(/status\s+String\? @default\("draft"\)/)
+    })
+
+    it('should emit <Enum>? @default(X) for optional enum select with default + db.isNullable', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                defaultValue: 'draft',
+                db: { type: 'enum', isNullable: true },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('enum PostStatus {')
+      expect(schema).toMatch(/status\s+PostStatus\? @default\(draft\)/)
+    })
+
+    it('should keep optional-select-with-default NOT NULL without db.isNullable (string)', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                defaultValue: 'draft',
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Unchanged behaviour: a default makes the column NOT NULL
+      expect(schema).toMatch(/status\s+String @default\("draft"\)/)
+      expect(schema).not.toMatch(/status\s+String\?/)
+    })
+
+    it('should keep optional-select-with-default NOT NULL without db.isNullable (enum)', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                defaultValue: 'draft',
+                db: { type: 'enum' },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toMatch(/status\s+PostStatus @default\(draft\)/)
+      expect(schema).not.toMatch(/status\s+PostStatus\?/)
+    })
+
     it('should generate enum field with @map modifier', () => {
       const config: OpenSaasConfig = {
         db: { provider: 'sqlite' },

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -591,6 +591,46 @@ export type SelectField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig
      */
     type?: 'string' | 'enum'
     map?: string
+    /**
+     * Force the generated column to be nullable (`?`) even when a `defaultValue`
+     * is present. By default a select with a `defaultValue` generates NOT NULL;
+     * set this to `true` for an explicit opt-in to a nullable column with a
+     * default (e.g. `String? @default("X")` or `<Enum>? @default(X)`), so that
+     * a live column containing NULLs migrates without a NOT NULL failure.
+     *
+     * @default undefined (NOT NULL when a default is present — unchanged behaviour)
+     *
+     * @example
+     * ```typescript
+     * // Optional select with a default, but keep the column nullable
+     * status: select({
+     *   options: [{ label: 'Draft', value: 'draft' }],
+     *   defaultValue: 'draft',
+     *   db: { isNullable: true },
+     * })
+     * // Generates: String? @default("draft")
+     * ```
+     */
+    isNullable?: boolean
+    /**
+     * Override the generated Prisma enum type name for native-enum selects
+     * (only applies when `type: 'enum'`). By default the enum is named
+     * `<List><Field>` (e.g. `AccountNoteStatus`); set this to match a live DB
+     * enum type whose name differs (e.g. Keystone's `…Type` suffix).
+     *
+     * The custom name is applied to both the generated `enum` block and every
+     * reference to it in the owning model.
+     *
+     * @example
+     * ```typescript
+     * status: select({
+     *   options: [{ label: 'Open', value: 'open' }],
+     *   db: { type: 'enum', enumName: 'AccountNoteStatusType' },
+     * })
+     * // Generates: enum AccountNoteStatusType { ... } and the column references it
+     * ```
+     */
+    enumName?: string
   }
   validation?: {
     isRequired?: boolean

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -853,21 +853,35 @@ export function select<
     },
     getPrismaType: (fieldName: string, _provider?: string, listName?: string) => {
       const isRequired = options.validation?.isRequired
+      const hasDefault = options.defaultValue !== undefined
+      // Nullability rules (Keystone parity):
+      //  - `db.isNullable` is an explicit override and always wins. Setting it
+      //    `true` forces the `?` even when a `defaultValue` is present.
+      //  - Otherwise a select is nullable only when it is neither required nor
+      //    carrying a default: a `defaultValue` makes the column NOT NULL (the
+      //    long-standing default behaviour). This mirrors the previous logic
+      //    where a present default overwrote the `?`.
+      // Nullability and the default are assembled independently with `+=`
+      // (mirroring text/integer) so the default never overwrites the `?`.
+      const isNullable = options.db?.isNullable ?? (!isRequired && !hasDefault)
       let modifiers = ''
 
-      if (isNativeEnum) {
-        // Derive enum name from list name + field name in PascalCase
-        const capitalizedField = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
-        const enumName = listName ? `${listName}${capitalizedField}` : capitalizedField
+      // Optional modifier
+      if (isNullable) {
+        modifiers += '?'
+      }
 
-        // Required fields don't get the ? modifier
-        if (!isRequired) {
-          modifiers = '?'
-        }
+      if (isNativeEnum) {
+        // Enum type name: explicit `db.enumName` wins, otherwise derive from
+        // list name + field name in PascalCase. The same name is used for the
+        // generated enum block (via `result.type`) and the column reference.
+        const capitalizedField = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
+        const derivedEnumName = listName ? `${listName}${capitalizedField}` : capitalizedField
+        const enumName = options.db?.enumName ?? derivedEnumName
 
         // Add default value if provided (no quotes for enum values)
-        if (options.defaultValue !== undefined) {
-          modifiers = ` @default(${options.defaultValue})`
+        if (hasDefault) {
+          modifiers += ` @default(${options.defaultValue})`
         }
 
         // Map modifier
@@ -884,14 +898,9 @@ export function select<
 
       // String type (default)
 
-      // Required fields don't get the ? modifier
-      if (!isRequired) {
-        modifiers = '?'
-      }
-
       // Add default value if provided
-      if (options.defaultValue !== undefined) {
-        modifiers = ` @default("${options.defaultValue}")`
+      if (hasDefault) {
+        modifiers += ` @default("${options.defaultValue}")`
       }
 
       // Map modifier

--- a/packages/core/src/fields/select.test.ts
+++ b/packages/core/src/fields/select.test.ts
@@ -52,6 +52,48 @@ describe('select field builder', () => {
       expect(result.modifiers).toBe(' @default("draft")')
     })
 
+    it('should emit NOT NULL (no ?) for optional string select with a default', () => {
+      const field = select({
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+        defaultValue: 'draft',
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Post')
+      // Default behaviour: a present default makes the column NOT NULL
+      expect(result.modifiers).toBe(' @default("draft")')
+      expect(result.modifiers).not.toContain('?')
+    })
+
+    it('should force ? with db.isNullable even when a default is present (string)', () => {
+      const field = select({
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+        defaultValue: 'draft',
+        db: { isNullable: true },
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Post')
+      expect(result.type).toBe('String')
+      expect(result.modifiers).toBe('? @default("draft")')
+    })
+
+    it('should keep ? from db.isNullable for a required string select with default', () => {
+      const field = select({
+        options: [{ label: 'Draft', value: 'draft' }],
+        defaultValue: 'draft',
+        validation: { isRequired: true },
+        db: { isNullable: true },
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Post')
+      expect(result.modifiers).toBe('? @default("draft")')
+    })
+
     it('should generate union TypeScript type from options', () => {
       const field = select({
         options: [
@@ -203,6 +245,63 @@ describe('select field builder', () => {
       expect(result.modifiers).toBe(' @default(draft)')
       // Explicitly check there are no quotes
       expect(result.modifiers).not.toContain('"')
+    })
+
+    it('should emit NOT NULL (no ?) for optional enum select with a default', () => {
+      const field = select({
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+        db: { type: 'enum' },
+        defaultValue: 'draft',
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Post')
+      expect(result.modifiers).toBe(' @default(draft)')
+      expect(result.modifiers).not.toContain('?')
+    })
+
+    it('should force ? with db.isNullable even when a default is present (enum)', () => {
+      const field = select({
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+        db: { type: 'enum', isNullable: true },
+        defaultValue: 'draft',
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'Post')
+      expect(result.type).toBe('PostStatus')
+      expect(result.modifiers).toBe('? @default(draft)')
+    })
+
+    it('should override the derived enum name with db.enumName', () => {
+      const field = select({
+        options: [
+          { label: 'Open', value: 'open' },
+          { label: 'Closed', value: 'closed' },
+        ],
+        db: { type: 'enum', enumName: 'AccountNoteStatusType' },
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'AccountNote')
+      // result.type drives both the enum block name and the column reference
+      expect(result.type).toBe('AccountNoteStatusType')
+      expect(result.enumValues).toEqual(['open', 'closed'])
+    })
+
+    it('should ignore db.enumName for string (non-enum) selects', () => {
+      const field = select({
+        options: [{ label: 'Open', value: 'open' }],
+        // enumName only applies to native-enum selects; string selects stay String
+        db: { enumName: 'ShouldBeIgnored' },
+      })
+
+      const result = field.getPrismaType!('status', 'sqlite', 'AccountNote')
+      expect(result.type).toBe('String')
+      expect(result.enumValues).toBeUndefined()
     })
 
     it('should include @map modifier for enum field with map option', () => {


### PR DESCRIPTION
Implements #474. Part of #470.

## What changed

Two additive `select()` `db` options for Keystone schema parity:

1. **`db: { isNullable: true }`** forces the nullable `?` on the generated column even when a `defaultValue` is present, so an optional select with a default generates `String? @default("X")` (or `<Enum>? @default(X)` for enum-backed). The default behaviour (NOT NULL once a default is present) is **unchanged** when `isNullable` is not set — explicit opt-in, not auto-restoration of `?`.
2. **`db: { type: 'enum', enumName: '...' }`** overrides the derived `<List><Field>` Prisma enum type name, renaming both the generated `enum` block and every reference to it in the owning model.

## Implementation notes

- `packages/core/src/config/types.ts`: added `isNullable?: boolean` and `enumName?: string` to the `SelectField` `db` config (documented).
- `packages/core/src/fields/index.ts` (`select().getPrismaType`): nullability is now assembled independently of the default with `+=` (mirroring `text`/`integer`), so a default never overwrites the `?`. Rule: `isNullable = db.isNullable ?? (!isRequired && !hasDefault)` — a present `defaultValue` still yields NOT NULL unless `db.isNullable` is set. For native-enum selects, the type name is `db.enumName ?? <List><Field>`; since the generator derives the enum block name from `result.type`, this renames the block and the column reference together. No generator changes were needed.

## Tests

- `packages/core/src/fields/select.test.ts`: unit tests for NOT-NULL-with-default (unchanged), `db.isNullable` forcing `?` (string + enum), `db.enumName` override, and `enumName` ignored for string selects.
- `packages/cli/src/generator/prisma.test.ts`: generator output tests — `enumName` renames the enum block + column reference; optional select + default + `db.isNullable` emits `String? @default("X")` and `<Enum>? @default(draft)`; without `isNullable` the column stays NOT NULL (string + enum).

## Verification

- `pnpm build` (full monorepo typecheck): pass
- `packages/core`: 565 tests pass
- `packages/cli`: 221 tests pass (no snapshot churn)
- `pnpm lint`: 0 errors (4 pre-existing unrelated warnings); `pnpm manypkg fix`; `pnpm format`: clean

Changeset added (`minor`, beta): `@opensaas/stack-core`, `@opensaas/stack-cli`.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_