### PR TITLE
feat(cli): surface migration guide + opensaas-migration plugin from opensaas migrate

### DIFF
--- a/.changeset/migrate-guide-discoverability.md
+++ b/.changeset/migrate-guide-discoverability.md
@@ -1,0 +1,21 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Surface the canonical Keystone migration guide and the `opensaas-migration` plugin install steps from `opensaas migrate`
+
+`opensaas migrate` now prints the published Keystone → stack guide URL and how to install the `opensaas-migration` Claude Code plugin (its skills and commands). The same pointers are available via `opensaas migrate --help` without running a migration. The CLI links to the canonical guide rather than embedding its text.
+
+```bash
+# Both surface the guide URL + plugin install steps
+opensaas migrate
+opensaas migrate --help
+```
+
+Output points at:
+
+- Guide: https://stack.opensaas.au/docs/guides/migrating-from-keystone
+- Plugin (automatic): `npx @opensaas/stack-cli migrate --with-ai`
+- Plugin (manual, inside Claude Code):
+  - `/plugin marketplace add OpenSaasAU/stack`
+  - `/plugin install opensaas-migration@opensaas-stack-marketplace`

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See [`examples/composable-dashboard`](./examples/composable-dashboard) and the [
 ## Learn more
 
 - **[Quick Start](https://stack.opensaas.au/docs/quick-start)** — build a working app
+- **[Migrating from Keystone](https://stack.opensaas.au/docs/guides/migrating-from-keystone)** — the canonical Keystone → stack guide (run `npx @opensaas/stack-cli migrate` to get started)
 - **[Building with Claude Code](https://stack.opensaas.au/docs/guides/claude-code)** — the AI-assisted workflow
 - **[Access Control](https://stack.opensaas.au/docs/core-concepts/access-control)** · **[Field Types](https://stack.opensaas.au/docs/core-concepts/field-types)** · **[Hooks](https://stack.opensaas.au/docs/core-concepts/hooks)**
 - **[Authentication](https://stack.opensaas.au/docs/guides/authentication)** · **[Storage](https://stack.opensaas.au/docs/guides/storage-setup)** · **[RAG](https://stack.opensaas.au/docs/packages/rag)**

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  MIGRATION_GUIDE_URL,
+  MIGRATION_PLUGIN_ID,
+  MIGRATION_PLUGIN_INSTALL_STEPS,
+  printMigrationResources,
+  createMigrateCommand,
+} from './migrate.js'
+
+// chalk is mocked to a pass-through so assertions see plain text without ANSI codes.
+vi.mock('chalk', () => {
+  const passthrough = (str: string) => str
+  return {
+    default: {
+      bold: Object.assign(passthrough, { cyan: passthrough }),
+      cyan: passthrough,
+      dim: passthrough,
+      gray: passthrough,
+      red: passthrough,
+      yellow: passthrough,
+      green: passthrough,
+    },
+  }
+})
+
+describe('migrate command discoverability', () => {
+  describe('canonical pointers', () => {
+    it('points at the published Keystone migration guide', () => {
+      expect(MIGRATION_GUIDE_URL).toBe(
+        'https://stack.opensaas.au/docs/guides/migrating-from-keystone',
+      )
+    })
+
+    it('identifies the opensaas-migration plugin from the stack marketplace', () => {
+      expect(MIGRATION_PLUGIN_ID).toBe('opensaas-migration@opensaas-stack-marketplace')
+    })
+
+    it('manual install steps add the marketplace and install the plugin', () => {
+      expect(MIGRATION_PLUGIN_INSTALL_STEPS).toEqual([
+        '/plugin marketplace add OpenSaasAU/stack',
+        '/plugin install opensaas-migration@opensaas-stack-marketplace',
+      ])
+    })
+  })
+
+  describe('printMigrationResources', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+      logSpy.mockRestore()
+    })
+
+    function capturedOutput(): string {
+      return logSpy.mock.calls.map((call) => call.join(' ')).join('\n')
+    }
+
+    it('prints the published guide URL', () => {
+      printMigrationResources()
+      expect(capturedOutput()).toContain(MIGRATION_GUIDE_URL)
+    })
+
+    it('prints the opensaas-migration plugin install pointer', () => {
+      printMigrationResources()
+      const output = capturedOutput()
+      // The plugin id and the manual install command must both be surfaced.
+      expect(output).toContain(MIGRATION_PLUGIN_ID)
+      expect(output).toContain(`/plugin install ${MIGRATION_PLUGIN_ID}`)
+      expect(output).toContain('/plugin marketplace add OpenSaasAU/stack')
+      // ...and the automatic path that wires the plugin up.
+      expect(output).toContain('npx @opensaas/stack-cli migrate --with-ai')
+    })
+  })
+
+  describe('migrate --help output', () => {
+    it('includes the guide URL and the plugin install pointer', () => {
+      const command = createMigrateCommand()
+
+      // addHelpText('after', ...) is appended when help is rendered via
+      // outputHelp(), so capture what the command actually writes.
+      let helpText = ''
+      command.configureOutput({
+        writeOut: (str) => {
+          helpText += str
+        },
+      })
+      command.outputHelp()
+
+      expect(helpText).toContain(MIGRATION_GUIDE_URL)
+      expect(helpText).toContain(`/plugin install ${MIGRATION_PLUGIN_ID}`)
+      expect(helpText).toContain('/plugin marketplace add OpenSaasAU/stack')
+    })
+  })
+})

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -15,6 +15,49 @@ interface MigrateOptions {
 }
 
 /**
+ * Canonical published Keystone → OpenSaaS Stack migration guide URL.
+ *
+ * The CLI points migrators at this page rather than embedding the guide text,
+ * so the binary stays small and the docs stay the single source of truth.
+ */
+export const MIGRATION_GUIDE_URL = 'https://stack.opensaas.au/docs/guides/migrating-from-keystone'
+
+/**
+ * Claude Code marketplace + plugin identifiers used to install the
+ * `opensaas-migration` plugin (its skills, commands, and agent).
+ */
+export const MIGRATION_PLUGIN_ID = 'opensaas-migration@opensaas-stack-marketplace'
+export const MIGRATION_MARKETPLACE = 'OpenSaasAU/stack'
+
+/**
+ * Manual install steps for the `opensaas-migration` Claude Code plugin.
+ * These are slash commands run inside Claude Code; `opensaas migrate --with-ai`
+ * wires them up automatically instead.
+ */
+export const MIGRATION_PLUGIN_INSTALL_STEPS: readonly string[] = [
+  `/plugin marketplace add ${MIGRATION_MARKETPLACE}`,
+  `/plugin install ${MIGRATION_PLUGIN_ID}`,
+]
+
+/**
+ * Print the published migration guide URL and how to install the
+ * `opensaas-migration` plugin. Kept lightweight on purpose — it points at the
+ * canonical guide instead of duplicating its contents.
+ */
+export function printMigrationResources(): void {
+  console.log(chalk.bold('\n📚 Migration guide:\n'))
+  console.log(chalk.cyan(`   ${MIGRATION_GUIDE_URL}`))
+
+  console.log(chalk.bold('\n🔌 Install the opensaas-migration plugin (skills + commands):\n'))
+  console.log(chalk.dim('   Automatic (sets up Claude Code for you):'))
+  console.log(chalk.cyan('     npx @opensaas/stack-cli migrate --with-ai'))
+  console.log(chalk.dim('   Manual (run inside Claude Code):'))
+  for (const step of MIGRATION_PLUGIN_INSTALL_STEPS) {
+    console.log(chalk.cyan(`     ${step}`))
+  }
+}
+
+/**
  * Detect what type of project this is
  */
 async function detectProjectType(cwd: string): Promise<ProjectType[]> {
@@ -234,7 +277,7 @@ When you open this project in Claude Code, the MCP server will be automatically 
 ## Resources
 
 - [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
-- [Migration Guide](https://stack.opensaas.au/docs/guides/migration)
+- [Migrating from Keystone (canonical guide)](${MIGRATION_GUIDE_URL})
 - [GitHub Repository](https://github.com/OpenSaasAU/stack)
 
 ---
@@ -337,10 +380,11 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
     console.log(chalk.bold('📝 Next Steps:\n'))
     console.log(chalk.cyan('   1. Run with --with-ai for AI-guided migration'))
     console.log(chalk.cyan('   2. Or manually create opensaas.config.ts'))
-    console.log(chalk.dim('\n   See: https://stack.opensaas.au/docs/guides/migration'))
   }
 
-  console.log(chalk.dim(`\n📚 Documentation: https://stack.opensaas.au/docs/guides/migration\n`))
+  // Always surface the canonical guide + plugin install pointers.
+  printMigrationResources()
+  console.log()
 }
 
 /**
@@ -349,6 +393,22 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
 export function createMigrateCommand(): Command {
   const migrate = new Command('migrate')
   migrate.description('Migrate an existing project to OpenSaaS Stack')
+
+  // Surface the canonical guide + plugin install pointers in `--help`, so the
+  // resources are discoverable without running a full migration.
+  migrate.addHelpText(
+    'after',
+    [
+      '',
+      'Migration guide:',
+      `  ${MIGRATION_GUIDE_URL}`,
+      '',
+      'Install the opensaas-migration plugin (skills + commands):',
+      '  Automatic: npx @opensaas/stack-cli migrate --with-ai',
+      '  Manual (inside Claude Code):',
+      ...MIGRATION_PLUGIN_INSTALL_STEPS.map((step) => `    ${step}`),
+    ].join('\n'),
+  )
 
   migrate
     .option('--with-ai', 'Enable AI-guided migration with Claude Code')


### PR DESCRIPTION
Implements #489

Part of #486

## What changed

Makes the Keystone migration guide and tooling discoverable from where a migrator starts.

- `opensaas migrate` now always prints the canonical published guide URL (`https://stack.opensaas.au/docs/guides/migrating-from-keystone`) and how to install the `opensaas-migration` Claude Code plugin (skills + commands), via a new exported `printMigrationResources()` helper.
- `opensaas migrate --help` surfaces the same pointers via `addHelpText`, so they are discoverable without running a migration.
- The CLI points at the canonical guide rather than embedding its text — replaced the stale `guides/migration` URLs with `guides/migrating-from-keystone`.
- README "Learn more" section now links the migration guide prominently (docs nav already lists "Migrating from Keystone" from #494).
- Added a CLI test (`packages/cli/src/commands/migrate.test.ts`) asserting both the `migrate` output and `--help` contain the guide URL and the plugin install pointer.
- Changeset added (minor, `@opensaas/stack-cli`).

## Verification

- `pnpm build` — pass (11/11 tasks)
- `cd packages/cli && pnpm test` — pass (222/222)
- `tsc --noEmit` (CLI) — pass
- `pnpm lint` — 0 errors (only pre-existing unrelated warnings)
- `pnpm manypkg fix` / `pnpm format` — clean

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_