### PR TITLE
Fix stale guides/migration doc links to canonical migrating-from-keystone URL

### DIFF
--- a/.changeset/stale-migration-wizard-link.md
+++ b/.changeset/stale-migration-wizard-link.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix stale migration guide link in the MCP migration wizard's config-generation failure message; it now reuses the canonical `MIGRATION_GUIDE_URL` (`https://stack.opensaas.au/docs/guides/migrating-from-keystone`) instead of the old 404 path.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "name": "opensaas-migration",
       "source": "./claude-plugins/opensaas-migration",
       "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "OpenSaaS Team",
         "url": "https://github.com/OpenSaasAU/stack"

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -120,5 +120,5 @@ plugin/
 ## Links
 
 - [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
-- [Migration Guide](https://stack.opensaas.au/guides/migration)
+- [Migration Guide](https://stack.opensaas.au/docs/guides/migrating-from-keystone)
 - [GitHub Repository](https://github.com/OpenSaasAU/stack)

--- a/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
+++ b/claude-plugins/opensaas-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opensaas-migration",
   "description": "OpenSaaS Stack migration assistant with AI-guided configuration, schema analysis, and code generation support",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "OpenSaaS Team",
     "url": "https://github.com/OpenSaasAU/stack"

--- a/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
@@ -551,6 +551,6 @@ The agent will create a detailed GitHub issue with reproduction steps and propos
 ## Resources
 
 - [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
-- [Migration Guide](https://stack.opensaas.au/guides/migration)
+- [Migration Guide](https://stack.opensaas.au/docs/guides/migrating-from-keystone)
 - [Access Control Guide](https://stack.opensaas.au/core-concepts/access-control)
 - [Field Types](https://stack.opensaas.au/core-concepts/field-types)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -217,7 +217,7 @@ opensaas migrate --type prisma --with-ai
 
 Without `--with-ai`, the command provides project analysis and you create the config manually.
 
-**See also:** [Migration Guide](https://stack.opensaas.au/docs/guides/migration)
+**See also:** [Migration Guide](https://stack.opensaas.au/docs/guides/migrating-from-keystone)
 
 ## Usage in Projects
 

--- a/packages/cli/src/mcp/lib/wizards/migration-wizard.test.ts
+++ b/packages/cli/src/mcp/lib/wizards/migration-wizard.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { MigrationWizard } from './migration-wizard.js'
+import { MigrationGenerator } from '../../../migration/generators/migration-generator.js'
+import { MIGRATION_GUIDE_URL } from '../../../commands/migrate.js'
+
+function getSessionId(text: string): string {
+  const match = text.match(/sessionId`?:?\s*"(migration_[^"]+)"/)
+  if (!match) {
+    throw new Error(`Could not find sessionId in wizard output:\n${text}`)
+  }
+  return match[1]
+}
+
+describe('MigrationWizard config-generation failure', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('points users at the canonical Keystone migration guide when generation fails', async () => {
+    // Force the underlying generator to throw so we exercise the catch branch.
+    vi.spyOn(MigrationGenerator.prototype, 'generate').mockRejectedValue(new Error('boom'))
+
+    const wizard = new MigrationWizard()
+
+    // Keystone fast-path: db_provider, enable_auth, (auth_methods skipped), confirm.
+    const start = await wizard.startMigration('keystone')
+    const sessionId = getSessionId(start.content[0].text)
+
+    await wizard.answerQuestion(sessionId, 'sqlite') // db_provider
+    await wizard.answerQuestion(sessionId, false) // enable_auth (skips auth_methods)
+    const final = await wizard.answerQuestion(sessionId, true) // confirm -> generates
+
+    const text = final.content[0].text
+    expect(text).toContain('Failed to generate config')
+    // Uses the shared canonical constant, not the stale (404) path.
+    expect(text).toContain(MIGRATION_GUIDE_URL)
+    expect(text).not.toContain('https://stack.opensaas.au/guides/migration')
+  })
+})

--- a/packages/cli/src/mcp/lib/wizards/migration-wizard.ts
+++ b/packages/cli/src/mcp/lib/wizards/migration-wizard.ts
@@ -10,6 +10,7 @@ import type {
   MigrationQuestion,
 } from '../../../migration/types.js'
 import { MigrationGenerator } from '../../../migration/generators/migration-generator.js'
+import { MIGRATION_GUIDE_URL } from '../../../commands/migrate.js'
 
 interface MigrationSessionStorage {
   [sessionId: string]: MigrationSession & { questions?: MigrationQuestion[] }
@@ -472,7 +473,7 @@ Documentation: https://stack.opensaas.au/`,
 
 Please try again or create the config manually.
 
-📚 See: https://stack.opensaas.au/guides/migration`,
+📚 See: ${MIGRATION_GUIDE_URL}`,
           },
         ],
       }


### PR DESCRIPTION
Implements #506

Part of #486

Replaces the remaining stale `guides/migration` doc links with the canonical `https://stack.opensaas.au/docs/guides/migrating-from-keystone` URL in the four files called out in the issue:

- `packages/cli/src/mcp/lib/wizards/migration-wizard.ts` — the config-generation failure message now reuses the exported `MIGRATION_GUIDE_URL` constant (from `packages/cli/src/commands/migrate.ts`) instead of hardcoding a path that was missing `/docs` and 404'd.
- `packages/cli/README.md`
- `claude-plugins/README.md`
- `claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md`

Also adds a focused test (`migration-wizard.test.ts`) asserting the wizard surfaces the canonical URL (and not the stale path) when generation fails.

Out of scope: the remaining `guides/migration` hits are in `docs/` (the live docs page source `docs/content/guides/migration.md` and `docs/lib/navigation.ts`), which back an existing docs page and are not part of this issue.

Includes a patch changeset for `@opensaas/stack-cli` and a patch plugin version bump (`opensaas-migration` 0.3.0 → 0.3.1) since `SKILL.md` changed.

Checks: `pnpm build` pass, `packages/cli` tests pass (248), `pnpm lint` pass (0 errors), `pnpm manypkg check` pass, `pnpm format:check` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_