### PR TITLE
fix(create-opensaas-app): cache templates/ in turbo build outputs (fixes red e2e scaffold guard)

### DIFF
--- a/.changeset/turbo-templates-cache.md
+++ b/.changeset/turbo-templates-cache.md
@@ -1,0 +1,5 @@
+---
+'create-opensaas-app': patch
+---
+
+Include `templates/**` in the turbo `build` outputs so a cached build restores the generated templates instead of only `dist/`, fixing the e2e scaffold guard's "Template basic not found" failure on a cache hit.

--- a/packages/create-opensaas-app/turbo.json
+++ b/packages/create-opensaas-app/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**", "tsconfig.tsbuildinfo", "templates/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The `e2e` CI job is RED on every open PR. It fails fast (~30s), before Playwright, at the **Run scaffold first-run guard** step with:

```
✖ Template basic not found
Expected template at: .../packages/create-opensaas-app/templates/basic
Run "pnpm build" in packages/create-opensaas-app to generate templates
```

## Root cause

`create-opensaas-app`'s `build` produces two outputs: `dist/` (via `tsc`) and `templates/` (via `copy-templates.js`, which copies `examples/starter` → `templates/basic` and `examples/starter-auth` → `templates/with-auth`).

The root `turbo.json` `build` task only declared:

```json
"outputs": ["dist/**", "tsconfig.tsbuildinfo"]
```

`templates/**` was missing. So on a turbo **cache hit** (which is what happens in CI now that the cache is warm — the failing run shows `create-opensaas-app:build: cache hit, replaying logs 259cf14763ec4012`), turbo restores `dist/` and **replays** the "Copying templates…" log, but never actually writes the `templates/` directory to disk. The scaffold guard then can't find `templates/basic`.

This is **not** caused by the recent generator/config work (#471/#472/#474/#475/#481/#485). Those don't touch template resolution, and the build succeeds. It's a turbo-cache-correctness bug: the missing `templates/**` output predates the scaffold guard, but only became load-bearing in CI when the guard was added in #458.

## Fix

Add a package-level `packages/create-opensaas-app/turbo.json` that extends the root config and adds `templates/**` to the `build` outputs, so cached builds restore the generated templates alongside `dist/`.

## Local proof

Reproduced the exact CI failure locally (turbo cache hit, identical `259cf14763ec4012` key, `templates/` missing → guard fails with "Template basic not found"). After the fix:

- A cache hit now restores **both** `dist/` and `templates/` (verified by deleting both, re-running build, and seeing `cache hit, replaying logs` with `templates/` restored).
- `RUN_SCAFFOLD_GUARD=1 DATABASE_URL=file:./dev.db pnpm --filter create-opensaas-app test run scaffold-first-run-guard` → **2 passed, 1 skipped** (the skip is the prerequisites-absent branch, correctly inactive).
- `pnpm lint` (0 errors), `pnpm format:check`, `pnpm manypkg check` all green.

Changeset added (`create-opensaas-app`: patch).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_