### PR TITLE
authPlugin: adoptBetterAuthTables() recipe + adoption docs (app User vs Auth identity)

### DIFF
--- a/.changeset/auth-adopt-better-auth-tables.md
+++ b/.changeset/auth-adopt-better-auth-tables.md
@@ -1,0 +1,35 @@
+---
+'@opensaas/stack-auth': minor
+---
+
+Add `adoptBetterAuthTables()` recipe for adopting an existing better-auth installation
+
+A migrating project that already runs better-auth (its `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` tables live in a separate `auth` Postgres schema, and its app `User` is a different model) can now adopt those live tables without rebuilding the auth config by hand. The recipe presets the plugin-level `schema` plus each model's `modelName` (and optional column `fields` maps) to the conventions of a standard separate-schema better-auth install, so the derived Auth lists diff clean (Schema parity) against the live database — no destructive auth migration. The app's own domain `User` is left untouched; linking it to the Auth identity is the application's concern.
+
+```typescript
+import { config } from '@opensaas/stack-core'
+import { authPlugin, adoptBetterAuthTables } from '@opensaas/stack-auth'
+
+export default config({
+  db: { provider: 'postgresql', url: process.env.DATABASE_URL },
+  plugins: [
+    authPlugin({
+      // Defaults: AuthUser/AuthSession/AuthAccount/AuthVerification in the
+      // `auth` schema, pinned to your live table names (@@map) + schema (@@schema).
+      ...adoptBetterAuthTables(),
+      emailAndPassword: { enabled: true },
+    }),
+  ],
+  lists: {
+    // Your own domain User stays in `public` and is NOT touched by the plugin.
+    User: list({ fields: { subjectId: text({ validation: { isRequired: true } }) } }),
+  },
+})
+
+// Customise when your live tables diverge from the defaults:
+adoptBetterAuthTables({
+  schema: 'identity', // default: 'auth'
+  modelNamePrefix: 'BA', // default: 'Auth'
+  fields: { user: { name: 'full_name' }, session: { userId: 'user_id' } },
+})
+```

--- a/docs/content/guides/authentication.md
+++ b/docs/content/guides/authentication.md
@@ -917,6 +917,137 @@ Verification link: http://localhost:3000/api/auth/verify-email?token=abc123def45
 4. Better-auth verifies token and updates password
 5. User can sign in with new password
 
+## Adopting an Existing better-auth Installation
+
+If you are migrating a project that **already runs better-auth** — its tables
+exist, hold live data, and you don't want a destructive auth migration — the
+plugin can adopt those tables instead of recreating them. This is the common
+case when migrating an established app to OpenSaaS Stack.
+
+### App `User` vs the Auth identity
+
+A migrating app almost always has **two** distinct concepts, and conflating them
+is the main pitfall:
+
+- **The application's domain `User`** — your own model (`public.User`), keyed
+  however your app likes (e.g. a `subjectId`), carrying your domain fields
+  (profile, billing, roles, relationships to your other lists).
+- **The Auth identity** — the better-auth-owned user record (`AuthUser`), the
+  thing a session belongs to. It owns sessions, OAuth accounts, and credentials.
+
+The auth plugin models the **Auth identity** (the `User`/`Session`/`Account`/
+`Verification` lists better-auth needs). It does **not** assume its user list is
+your app's `User`. As long as the plugin's user model key differs from your app
+list's key (e.g. the plugin uses `AuthUser` while your app keeps `User`), your
+domain `User` is left completely untouched — never extended, never overwritten.
+
+{% callout type="info" %}
+Keep these separate. The plugin owns the Auth identity; your app owns its domain
+`User`. **Linking the two is your application's concern** — see [Linking your
+app User to the Auth identity](#linking-your-app-user-to-the-auth-identity)
+below.
+{% /callout %}
+
+### The `adoptBetterAuthTables()` recipe
+
+Rather than hand-write the four `modelName`s and a `schema` on every model, use
+the `adoptBetterAuthTables()` recipe. It returns an auth-config fragment with the
+adoption knobs already set to the conventions of a standard separate-schema
+better-auth install, and you spread it into `authPlugin` alongside the rest of
+your config:
+
+```typescript
+import { config } from '@opensaas/stack-core'
+import { authPlugin, adoptBetterAuthTables } from '@opensaas/stack-auth'
+
+export default config({
+  db: { provider: 'postgresql', url: process.env.DATABASE_URL },
+  plugins: [
+    authPlugin({
+      // Adoption defaults: AuthUser/AuthSession/AuthAccount/AuthVerification
+      // in the `auth` Postgres schema — matching a live better-auth install.
+      ...adoptBetterAuthTables(),
+
+      // The rest of your auth config composes as normal:
+      emailAndPassword: { enabled: true },
+      sessionFields: ['userId', 'email', 'name'],
+    }),
+  ],
+  lists: {
+    // Your own domain User stays in `public` and is NOT touched by the plugin.
+    User: list({
+      fields: {
+        subjectId: text({ validation: { isRequired: true } }),
+        // ...your domain fields
+      },
+    }),
+  },
+})
+```
+
+With these defaults the plugin derives `AuthUser`/`AuthSession`/`AuthAccount`/
+`AuthVerification`, pins each to its live table name (`@@map`) and the `auth`
+schema (`@@schema`), and wires Postgres multi-schema automatically. The generated
+Auth lists therefore reach **Schema parity** — they diff clean against your live
+tables, so adding the plugin produces **no destructive auth migration**. The
+lists are modelled for runtime and types, not migrated.
+
+Verify with a schema diff after generating:
+
+```bash
+pnpm generate
+# Diff the generated schema against your live database — the auth tables should
+# report no changes (Schema parity). See your project's prisma migrate diff setup.
+```
+
+### Customising the recipe
+
+The recipe takes options when your live tables diverge from the defaults:
+
+```typescript
+adoptBetterAuthTables({
+  // Postgres schema the live tables live in (default: 'auth')
+  schema: 'identity',
+
+  // Prefix applied to each model name (default: 'Auth' → AuthUser/AuthSession/…)
+  modelNamePrefix: 'BA', // → BAUser/BASession/BAAccount/BAVerification
+
+  // Column renames, only where your live columns differ from better-auth defaults
+  fields: {
+    user: { name: 'full_name', emailVerified: 'is_verified' },
+    session: { userId: 'user_id' },
+  },
+})
+```
+
+The recipe is just a convenience over the plugin's own `schema` / per-model
+`modelName` / `fields` options — anything it sets you can also set directly on
+`authPlugin`, or override after spreading it in.
+
+### Linking your app User to the Auth identity
+
+Because the Auth identity (`AuthUser`) and your domain `User` are separate
+models, **your application declares the link** — the plugin never imposes a
+single-User-model assumption. Add a relationship from your domain `User` to the
+Auth identity:
+
+```typescript
+lists: {
+  User: list({
+    fields: {
+      subjectId: text({ validation: { isRequired: true } }),
+      // The app owns the link to the Auth identity:
+      authIdentity: relationship({ ref: 'AuthUser' }),
+    },
+  }),
+}
+```
+
+Then resolve from a session's `userId` (the Auth identity's id) to your domain
+`User` in your own code — e.g. look up the domain `User` whose `authIdentity`
+points at `session.userId`. How you key and resolve that link is entirely up to
+your app.
+
 ## Auto-Generated Lists
 
 The auth plugin automatically creates these lists in your database:

--- a/docs/content/guides/migrating-from-keystone.md
+++ b/docs/content/guides/migrating-from-keystone.md
@@ -34,7 +34,7 @@ This page is the canonical entry point for Keystone migrations. The full step-by
 
 4. **Preserve your data.** Keystone and Prisma use different many-to-many join-table naming conventions. Use `joinTableNaming: 'keystone'` or per-field `db.relationName` to keep your existing tables. See the [KeystoneJS Projects](/docs/guides/migration#keystonejs-projects) notes.
 
-5. **Adopt auth (optional).** If your Keystone project used `@keystone-6/auth`, swap it for the [auth plugin](/docs/guides/authentication).
+5. **Adopt auth (optional).** If your Keystone project used `@keystone-6/auth`, swap it for the [auth plugin](/docs/guides/authentication). If you already run **better-auth** (separate `auth`-schema tables, an app `User` distinct from the auth user), adopt the live tables with the `adoptBetterAuthTables()` recipe — it models them for runtime/types with no destructive auth migration, and keeps your domain `User` separate from the auth identity. See [Adopting an Existing better-auth Installation](/docs/guides/authentication#adopting-an-existing-better-auth-installation).
 
 ## Where to go next
 

--- a/docs/content/guides/migration.md
+++ b/docs/content/guides/migration.md
@@ -116,6 +116,16 @@ Add authentication if needed:
 pnpm add @opensaas/stack-auth better-auth
 ```
 
+{% callout type="info" %}
+**Already running better-auth?** If your project has live better-auth tables
+(typically `AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in a separate
+`auth` schema, with an app `User` that is a distinct model), don't recreate them.
+Adopt the existing tables with the `adoptBetterAuthTables()` recipe so the
+generated Auth lists diff clean against your live database — no destructive auth
+migration — and keep your domain `User` separate from the auth identity. See
+[Adopting an Existing better-auth Installation](/docs/guides/authentication#adopting-an-existing-better-auth-installation).
+{% /callout %}
+
 ### 3. Create Configuration
 
 Create `opensaas.config.ts` in your project root. Use your existing Prisma schema as reference.

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -126,6 +126,40 @@ How it wires up (Postgres multi-schema):
 - With no `schema` option the Auth lists stay in `public` and no `@@schema` /
   `schemas` / preview feature is emitted (greenfield default unchanged).
 
+### Adopting an existing better-auth install (`adoptBetterAuthTables`)
+
+`adoptBetterAuthTables()` (`src/config/adopt-better-auth-tables.ts`) is a thin
+recipe that returns the `AuthConfig` adoption knobs — the plugin-level `schema`
+plus a per-model `modelName` (and optional column `fields` maps) — preset to the
+conventions of a standard separate-schema better-auth install. It ties together
+the keys/field derivation and schema placement so a migrator doesn't rebuild the
+config by hand. Spread it into `authPlugin`:
+
+```typescript
+import { authPlugin, adoptBetterAuthTables } from '@opensaas/stack-auth'
+
+authPlugin({
+  ...adoptBetterAuthTables(), // schema: 'auth', AuthUser/AuthSession/AuthAccount/AuthVerification
+  emailAndPassword: { enabled: true },
+})
+// Options: adoptBetterAuthTables({ schema, modelNamePrefix, fields })
+```
+
+It is pure config (no side effects): everything it sets can also be written
+directly on `authPlugin`, and spreading it before your own keys lets you
+override per model. Because the derived user key is `AuthUser` (not `User`), an
+app's own domain `User` is left untouched — the plugin only ever adds/extends
+its derived keys. Combined with the derivation + schema placement above, the
+generated Auth lists reach **Schema parity** (clean `schema:diff`) against a live
+`auth`-schema install — they are modelled for runtime/types, not migrated.
+
+**App User ≠ Auth identity.** The plugin models the **Auth identity** (the
+better-auth user); it does not assume that list is the app's domain `User`.
+Linking an app's `User` to the Auth identity (e.g. a `relationship({ ref:
+'AuthUser' })` the app declares) is the application's concern. See the
+[Authentication guide](../../docs/content/guides/authentication.md) (“Adopting an
+existing better-auth installation”) for the end-to-end migrator walkthrough.
+
 ### Session Provider
 
 Better-auth provides session to context via custom `prismaClientConstructor`:

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -203,6 +203,39 @@ authPlugin({
 })
 ```
 
+## Adopting an Existing better-auth Installation
+
+Migrating a project that **already runs better-auth**? The plugin can adopt your
+live tables rather than recreating them, so there's no destructive auth
+migration. Use the `adoptBetterAuthTables()` recipe to preset the model/schema
+knobs that match a standard separate-schema better-auth install:
+
+```typescript
+import { authPlugin, adoptBetterAuthTables } from '@opensaas/stack-auth'
+
+authPlugin({
+  // Defaults: AuthUser/AuthSession/AuthAccount/AuthVerification in the `auth`
+  // Postgres schema — pinned to your live table names + schema (@@map/@@schema).
+  ...adoptBetterAuthTables(),
+  emailAndPassword: { enabled: true },
+})
+
+// Customise when your live tables diverge from the defaults:
+adoptBetterAuthTables({
+  schema: 'identity', // default: 'auth'
+  modelNamePrefix: 'BA', // default: 'Auth' (→ AuthUser/AuthSession/…)
+  fields: { user: { name: 'full_name' }, session: { userId: 'user_id' } },
+})
+```
+
+**App `User` vs the Auth identity.** The plugin models the **Auth identity** (the
+better-auth user, e.g. `AuthUser`). It does not assume that list is your app's
+own domain `User` — when the keys differ, your `User` is never extended or
+overwritten. **Linking your domain `User` to the Auth identity is your app's
+concern** (declare a `relationship({ ref: 'AuthUser' })` on your `User`). See the
+[Authentication guide](https://stack.opensaas.au/docs/guides/authentication) for
+the full migrator walkthrough and a Schema-parity (clean-diff) check.
+
 ## UI Components
 
 ### SignInForm

--- a/packages/auth/src/config/adopt-better-auth-tables.ts
+++ b/packages/auth/src/config/adopt-better-auth-tables.ts
@@ -1,0 +1,146 @@
+/**
+ * "Adopt existing better-auth tables" recipe.
+ *
+ * A migrating project usually already has a working, hand-wired better-auth
+ * installation: its tables are `AuthUser`/`AuthSession`/`AuthAccount`/
+ * `AuthVerification`, mapped into a separate `auth` Postgres schema, and its
+ * application `User` (`public.User`) is a *different* model. Reconstructing the
+ * matching {@link AuthConfig} by hand — four `modelName`s plus a `schema` on each
+ * model — is repetitive and easy to get wrong.
+ *
+ * {@link adoptBetterAuthTables} produces that {@link AuthConfig} fragment from a
+ * couple of options so the migrator doesn't rebuild it from scratch. It only
+ * sets the *adoption* knobs (per-model `modelName` + the plugin-level `schema`);
+ * the developer composes it with the rest of their auth config (providers,
+ * session fields, `extendUserList`, etc.):
+ *
+ * ```typescript
+ * authPlugin({
+ *   ...adoptBetterAuthTables(),
+ *   emailAndPassword: { enabled: true },
+ *   sessionFields: ['userId', 'email', 'name'],
+ * })
+ * ```
+ *
+ * Combined with the keys/field derivation (`deriveAuthLists`) and schema
+ * placement, the generated Auth lists reach **Schema parity** with the live
+ * tables — they are modelled for runtime/types without producing a destructive
+ * auth migration. The recipe never touches the application's own domain `User`:
+ * its model names are `Auth`-prefixed by default and the plugin only ever
+ * adds/extends its *derived* keys.
+ */
+
+import type { AuthConfig, AuthModelConfig } from './types.js'
+
+/**
+ * Options for {@link adoptBetterAuthTables}.
+ *
+ * All options are optional and default to the conventions of a standard
+ * separate-schema better-auth install (an `auth` Postgres schema with
+ * `Auth`-prefixed model names).
+ */
+export type AdoptBetterAuthTablesOptions = {
+  /**
+   * The Postgres schema the live better-auth tables live in.
+   *
+   * Applied as the plugin-level {@link AuthConfig.schema}, placing every Auth
+   * list in this schema via `@@schema(...)`. Pass `'public'` (or any single
+   * schema) for an install that is not on a separate schema; pass an explicit
+   * value to match your layout.
+   *
+   * @default 'auth'
+   */
+  schema?: string
+
+  /**
+   * Prefix applied to each better-auth model name to derive the list key /
+   * table name (e.g. prefix `'Auth'` → `AuthUser`/`AuthSession`/...).
+   *
+   * A live better-auth install with `modelName: 'AuthUser'` etc. is the common
+   * case; override this if your tables use a different prefix. Set to `''` to
+   * keep the default better-auth names (`User`/`Session`/...) — but note that an
+   * unprefixed `User` will share the app's `User` key, so prefer a prefix when
+   * your domain `User` is a separate model (see {@link AuthConfig.user}).
+   *
+   * @default 'Auth'
+   */
+  modelNamePrefix?: string
+
+  /**
+   * Per-model better-auth field → column maps, keyed by model.
+   *
+   * Only needed when your live tables renamed columns away from the better-auth
+   * defaults (e.g. `name → full_name`). Merged into the matching model config so
+   * the derived field-level `@map`s match your live columns.
+   *
+   * @example
+   * ```typescript
+   * adoptBetterAuthTables({
+   *   fields: {
+   *     user: { name: 'full_name' },
+   *     session: { userId: 'user_id' },
+   *   },
+   * })
+   * ```
+   */
+  fields?: {
+    user?: Record<string, string>
+    session?: Record<string, string>
+    account?: Record<string, string>
+    verification?: Record<string, string>
+  }
+}
+
+/** The four better-auth models and their default (unprefixed) model names. */
+const MODEL_DEFAULT_NAMES = {
+  user: 'User',
+  session: 'Session',
+  account: 'Account',
+  verification: 'Verification',
+} as const
+
+/**
+ * The adoption-relevant slice of {@link AuthConfig}: the plugin-level `schema`
+ * and the per-model `modelName`/`fields`. Returned (not the full `AuthConfig`)
+ * so it spreads cleanly into the developer's own `authPlugin` config.
+ */
+export type AdoptBetterAuthTablesConfig = Pick<
+  AuthConfig,
+  'schema' | 'user' | 'session' | 'account' | 'verification'
+>
+
+/**
+ * Build the adoption {@link AuthConfig} fragment for a pre-existing better-auth
+ * installation.
+ *
+ * Returns only the model/schema knobs needed to adopt the live tables; spread it
+ * into {@link authPlugin} alongside your own auth config.
+ *
+ * @param options - Adoption conventions (schema, model-name prefix, column maps)
+ * @returns An {@link AuthConfig} fragment with `schema` + per-model `modelName`
+ *   (and any field column maps) set to match the live tables
+ */
+export function adoptBetterAuthTables(
+  options: AdoptBetterAuthTablesOptions = {},
+): AdoptBetterAuthTablesConfig {
+  const { schema = 'auth', modelNamePrefix = 'Auth', fields = {} } = options
+
+  const buildModel = (model: keyof typeof MODEL_DEFAULT_NAMES): AuthModelConfig => {
+    const config: AuthModelConfig = {
+      modelName: `${modelNamePrefix}${MODEL_DEFAULT_NAMES[model]}`,
+    }
+    const fieldMap = fields[model]
+    if (fieldMap && Object.keys(fieldMap).length > 0) {
+      config.fields = fieldMap
+    }
+    return config
+  }
+
+  return {
+    schema,
+    user: buildModel('user'),
+    session: buildModel('session'),
+    account: buildModel('account'),
+    verification: buildModel('verification'),
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -38,6 +38,15 @@ export type * from './config/types.js'
 export { deriveAuthLists } from './config/derive-auth-lists.js'
 export type { DerivedAuthLists } from './config/derive-auth-lists.js'
 
+// "Adopt existing better-auth tables" recipe — sets the model/schema knobs that
+// match a pre-existing separate-schema better-auth install so a migrating
+// project reaches Schema parity without rebuilding the config by hand.
+export { adoptBetterAuthTables } from './config/adopt-better-auth-tables.js'
+export type {
+  AdoptBetterAuthTablesOptions,
+  AdoptBetterAuthTablesConfig,
+} from './config/adopt-better-auth-tables.js'
+
 // Runtime type exports
 export type { AuthRuntimeServices } from './runtime/types.js'
 

--- a/packages/auth/tests/adopt-better-auth-tables.test.ts
+++ b/packages/auth/tests/adopt-better-auth-tables.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import { config, list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import type { OpenSaasConfig } from '@opensaas/stack-core'
+import type { Plugin } from '@opensaas/stack-core/extend'
+import { authPlugin } from '../src/config/plugin.js'
+import { adoptBetterAuthTables } from '../src/config/adopt-better-auth-tables.js'
+
+/**
+ * Run a config through plugin `init` (via `config()`) and then the auth
+ * plugin's `beforeGenerate` hook — mirroring the CLI generate pipeline — to
+ * observe the final config the generator would consume. Mirrors the helper in
+ * `plugin-schema-placement.test.ts`.
+ */
+async function generationConfig(userConfig: OpenSaasConfig): Promise<OpenSaasConfig> {
+  const resolved = await config(userConfig)
+  let current = resolved
+  const plugins: Plugin[] = resolved.plugins ?? []
+  for (const plugin of plugins) {
+    if (plugin.beforeGenerate) {
+      current = await plugin.beforeGenerate(current)
+    }
+  }
+  return current
+}
+
+describe('adoptBetterAuthTables - recipe defaults', () => {
+  it('produces the standard separate-schema better-auth defaults', () => {
+    const fragment = adoptBetterAuthTables()
+
+    expect(fragment).toEqual({
+      schema: 'auth',
+      user: { modelName: 'AuthUser' },
+      session: { modelName: 'AuthSession' },
+      account: { modelName: 'AuthAccount' },
+      verification: { modelName: 'AuthVerification' },
+    })
+  })
+
+  it('honours a custom schema and model-name prefix', () => {
+    const fragment = adoptBetterAuthTables({ schema: 'identity', modelNamePrefix: 'BA' })
+
+    expect(fragment).toEqual({
+      schema: 'identity',
+      user: { modelName: 'BAUser' },
+      session: { modelName: 'BASession' },
+      account: { modelName: 'BAAccount' },
+      verification: { modelName: 'BAVerification' },
+    })
+  })
+
+  it('merges per-model field column maps when provided', () => {
+    const fragment = adoptBetterAuthTables({
+      fields: {
+        user: { name: 'full_name', emailVerified: 'is_verified' },
+        session: { userId: 'user_id' },
+      },
+    })
+
+    expect(fragment.user).toEqual({
+      modelName: 'AuthUser',
+      fields: { name: 'full_name', emailVerified: 'is_verified' },
+    })
+    expect(fragment.session).toEqual({
+      modelName: 'AuthSession',
+      fields: { userId: 'user_id' },
+    })
+    // Models without a field map carry no `fields` key (no empty object)
+    expect(fragment.account).toEqual({ modelName: 'AuthAccount' })
+    expect(fragment.verification).toEqual({ modelName: 'AuthVerification' })
+  })
+
+  it('omits the schema when explicitly set to public', () => {
+    const fragment = adoptBetterAuthTables({ schema: 'public' })
+    expect(fragment.schema).toBe('public')
+  })
+})
+
+describe('adoptBetterAuthTables - composes with authPlugin', () => {
+  it('spreads into authPlugin alongside the rest of the auth config', async () => {
+    const result = await config({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          ...adoptBetterAuthTables(),
+          emailAndPassword: { enabled: true },
+          sessionFields: ['userId', 'email', 'name'],
+        }),
+      ],
+      lists: {},
+    })
+
+    // The recipe's derived Auth lists are present...
+    expect(result.lists).toHaveProperty('AuthUser')
+    expect(result.lists).toHaveProperty('AuthSession')
+    expect(result.lists).toHaveProperty('AuthAccount')
+    expect(result.lists).toHaveProperty('AuthVerification')
+    // ...keyed off the recipe's model names, not the default `User`/`Session`.
+    expect(result.lists).not.toHaveProperty('User')
+    expect(result.lists).not.toHaveProperty('Session')
+
+    // The rest of the auth config still applies (stored for runtime).
+    const authData = result._pluginData?.auth as { emailAndPassword?: { enabled?: boolean } }
+    expect(authData?.emailAndPassword?.enabled).toBe(true)
+  })
+})
+
+describe('adoptBetterAuthTables - clean-diff adoption (Auth lists ≠ app User)', () => {
+  it('lands every Auth list in the auth schema with @@map + @@schema and leaves the app User untouched', async () => {
+    const result = await generationConfig({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          ...adoptBetterAuthTables(),
+          emailAndPassword: { enabled: true },
+        }),
+      ],
+      // The migrating app keeps its own domain User (public.User), keyed by
+      // its own subjectId — a DIFFERENT model from the better-auth user.
+      lists: {
+        User: list({
+          fields: {
+            subjectId: text({ validation: { isRequired: true } }),
+          },
+        }),
+      },
+    })
+
+    // Each Auth list is pinned to its live table name (@@map) and the `auth`
+    // schema (@@schema), with auto-timestamps preserved (ADR-0004) — exactly the
+    // shape that diffs CLEAN against a live separate-schema better-auth install.
+    expect(result.lists.AuthUser.db).toEqual({ timestamps: true, map: 'AuthUser', schema: 'auth' })
+    expect(result.lists.AuthSession.db).toEqual({
+      timestamps: true,
+      map: 'AuthSession',
+      schema: 'auth',
+    })
+    expect(result.lists.AuthAccount.db).toEqual({
+      timestamps: true,
+      map: 'AuthAccount',
+      schema: 'auth',
+    })
+    expect(result.lists.AuthVerification.db).toEqual({
+      timestamps: true,
+      map: 'AuthVerification',
+      schema: 'auth',
+    })
+
+    // The app's own domain User is preserved: its field shape is intact, NOT
+    // merged with auth fields, and it stays in `public` (not the auth schema).
+    const appUser = result.lists.User
+    expect(appUser.fields).toHaveProperty('subjectId')
+    expect(appUser.fields).not.toHaveProperty('email')
+    expect(appUser.fields).not.toHaveProperty('emailVerified')
+    expect(appUser.fields).not.toHaveProperty('sessions')
+    expect(appUser.db?.schema).toBe('public')
+
+    // The datasource lists both schemas so the multi-schema Prisma schema is valid.
+    expect(result.db.schemas).toEqual(['public', 'auth'])
+  })
+
+  it('carries field column maps through to the derived Auth lists for renamed columns', async () => {
+    const result = await config({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          ...adoptBetterAuthTables({
+            fields: {
+              user: { name: 'full_name' },
+              session: { userId: 'user_id' },
+            },
+          }),
+        }),
+      ],
+      lists: {},
+    })
+
+    // Renamed columns flow through to the derived field-level @map / FK @map so
+    // the lists match the live columns.
+    expect(result.lists.AuthUser.fields.name.db?.map).toBe('full_name')
+    expect(result.lists.AuthSession.fields.user.db?.foreignKey).toEqual({ map: 'user_id' })
+  })
+})


### PR DESCRIPTION
Implements #483
Part of #480

## What this adds (D3 of PRD #480)

A convenience "adopt existing better-auth tables" recipe plus documentation that ties together the keys/field derivation (#481) and schema placement (#482) into a one-stop adoption path.

- **`adoptBetterAuthTables()` recipe** (`packages/auth/src/config/adopt-better-auth-tables.ts`): a pure function returning the `AuthConfig` adoption fragment — the plugin-level `schema` plus each model's `modelName` (and optional column `fields` maps) — preset to the conventions of a standard separate-schema better-auth install (`AuthUser`/`AuthSession`/`AuthAccount`/`AuthVerification` in an `auth` schema). Spread it into `authPlugin` alongside the rest of your config. Options: `schema`, `modelNamePrefix`, per-model `fields`.
- Exported from the package root (`adoptBetterAuthTables`, `AdoptBetterAuthTablesOptions`, `AdoptBetterAuthTablesConfig`).
- **App `User` ≠ Auth identity**: because the recipe's derived user key is `AuthUser` (not `User`), the plugin only ever adds/extends its derived keys — an app's own domain `User` is never extended or overwritten. Linking the app `User` to the Auth identity is documented as the application's concern (a `relationship({ ref: 'AuthUser' })` the app declares).

## Documentation

- Authentication guide: new "Adopting an Existing better-auth Installation" section (app `User` vs Auth identity, the recipe + customisation, Schema-parity / clean-diff check, and linking the two).
- `packages/auth/CLAUDE.md` + `README.md`: adoption-recipe subsection.
- Migration guides (`migrating-from-keystone.md`, `migration.md`): reference the adoption path (no destructive auth migration).

## Tests (`packages/auth/tests/adopt-better-auth-tables.test.ts`)

- Recipe defaults and `schema`/`modelNamePrefix`/`fields` options.
- Composition: spreads into `authPlugin` alongside the rest of the auth config.
- **Clean-diff adoption assertion**: every Auth list lands in the `auth` schema with `@@map` + `@@schema` (auto-timestamps preserved) while the app's separate `public.User` stays untouched; the datasource lists both schemas.
- Field column maps flow through to the derived field-level `@map` / FK `@map`.

## Verification

- `pnpm build` — pass
- `packages/auth` tests — 133 passed (8 files); `packages/core` — 562 passed; `packages/cli` — 266 passed
- `pnpm lint` — 0 errors (4 pre-existing warnings in untouched files)
- `pnpm manypkg check` — pass
- `pnpm format:check` — pass
- docs `link-check` — pass

Changeset: minor for `@opensaas/stack-auth`. No `claude-plugins/*` changes, so no plugin-version bump.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_