### PR TITLE
Singleton lists emit bare `id Int @id` (drop @default(1))

### DIFF
--- a/.changeset/singleton-id-bare.md
+++ b/.changeset/singleton-id-bare.md
@@ -1,0 +1,25 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Singleton lists now emit a bare `id Int @id` (no `@default(1)`) to match Keystone 6, so singletons reach Schema parity from config alone instead of needing `extendPrismaSchema` to strip the column default (see ADR-0004).
+
+```ts
+lists: {
+  Settings: list({
+    isSingleton: true,
+    fields: { siteName: text() },
+  }),
+}
+```
+
+Generated Prisma schema:
+
+```prisma
+model Settings {
+  id        Int      @id
+  siteName  String
+}
+```
+
+Non-singleton lists are unaffected and continue to emit `id String @id @default(cuid())`.

--- a/examples/blog/prisma/schema.prisma
+++ b/examples/blog/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model Settings {
-  id              Int      @id @default(1)
+  id              Int      @id
   siteName        String   @default("My Blog")
   maintenanceMode Boolean  @default(false)
   maxUploadSize   Int?     @default(10)

--- a/examples/blog/test-singleton.ts
+++ b/examples/blog/test-singleton.ts
@@ -41,8 +41,12 @@ async function main() {
     // Test 3: Try to create a second record - should fail
     console.log('✅ Test 3: Try to create a second record - should fail')
     try {
+      // Singleton ids are now a bare `id Int @id` with no column default (see
+      // ADR-0004), so Prisma's CreateInput requires `id`. The stack still injects
+      // `id: 1` at runtime; this create is rejected by the singleton constraint
+      // before reaching the database, so the supplied id is never used.
       await context.db.settings.create({
-        data: { siteName: 'Second Blog' },
+        data: { id: 2, siteName: 'Second Blog' },
       })
       throw new Error('Should have thrown an error when creating second record')
     } catch (error) {

--- a/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
@@ -197,7 +197,7 @@ datasource db {
 "
 `;
 
-exports[`Prisma Schema Generator > select field with enum type > should generate singleton model with Int @id @default(1) 1`] = `
+exports[`Prisma Schema Generator > select field with enum type > should generate singleton model with bare Int @id (no @default) 1`] = `
 "generator client {
   provider = "prisma-client"
   output   = "../.opensaas/prisma-client"
@@ -208,7 +208,7 @@ datasource db {
 }
 
 model Settings {
-  id        Int      @id @default(1)
+  id        Int      @id
   siteName     String
   maintenanceMode Boolean @default(false)
 }

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -2087,7 +2087,7 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toMatchSnapshot()
     })
 
-    it('should generate singleton model with Int @id @default(1)', () => {
+    it('should generate singleton model with bare Int @id (no @default)', () => {
       const config: OpenSaasConfig = {
         db: {
           provider: 'sqlite',
@@ -2105,7 +2105,10 @@ describe('Prisma Schema Generator', () => {
 
       const schema = generatePrismaSchema(config)
 
-      expect(schema).toContain('id        Int      @id @default(1)')
+      // Singleton ids are bare `id Int @id` to match Keystone 6 (see ADR-0004),
+      // which emits no column default for singleton ids.
+      expect(schema).toContain('id        Int      @id\n')
+      expect(schema).not.toContain('@default(1)')
       expect(schema).not.toContain('id        String   @id @default(cuid())')
       expect(schema).toMatchSnapshot()
     })
@@ -2126,8 +2129,9 @@ describe('Prisma Schema Generator', () => {
 
       const schema = generatePrismaSchema(config)
 
+      // Non-singleton ids are unaffected by the singleton bare-id change.
       expect(schema).toContain('id        String   @id @default(cuid())')
-      expect(schema).not.toContain('id        Int      @id @default(1)')
+      expect(schema).not.toContain('id        Int      @id')
     })
   })
 

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -193,9 +193,11 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
   for (const [listName, listConfig] of Object.entries(config.lists)) {
     lines.push(`model ${listName} {`)
 
-    // Add id field - singleton lists use Int @id (always 1) to match Keystone 6 behaviour
+    // Add id field - singleton lists emit a bare `id Int @id` (no `@default(1)`) to
+    // match Keystone 6, which emits no column default for singleton ids (see ADR-0004).
+    // Non-singleton lists are unchanged: `id String @id @default(cuid())`.
     if (listConfig.isSingleton) {
-      lines.push('  id        Int      @id @default(1)')
+      lines.push('  id        Int      @id')
     } else {
       lines.push('  id        String   @id @default(cuid())')
     }

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -136,7 +136,8 @@ function generateModelOutputType(
   const lines: string[] = []
 
   lines.push(`export type ${listName}Output = {`)
-  // Singleton lists use Int @id (always 1) matching Keystone 6 behaviour
+  // Singleton lists use an Int id (bare `id Int @id`, see ADR-0004) matching
+  // Keystone 6, so the TypeScript id type is `number` rather than `string`.
   lines.push(isSingleton ? '  id: number' : '  id: string')
 
   for (const [fieldName, fieldConfig] of Object.entries(fields)) {


### PR DESCRIPTION
Implements #473

Part of #470

## What changed

Singleton lists now generate a bare `id Int @id` with no `@default(1)`, matching Keystone 6 (which emits no column default for singleton ids). This lets singletons reach **Schema parity** from config alone instead of forcing migrators to strip the default via `extendPrismaSchema` (see ADR-0004).

Non-singleton lists are completely unaffected and still emit `id String @id @default(cuid())`.

### Current vs new singleton id output

```prisma
// before
model Settings {
  id        Int      @id @default(1)
  ...
}

// after
model Settings {
  id        Int      @id
  ...
}
```

## Notes

- The stack already injects `id: 1` for singleton creates at runtime (`packages/core/src/context/write-pipeline.ts`), so dropping the Prisma column default is runtime-safe.
- Because a bare `Int @id` has no default, Prisma's generated `CreateInput` now requires `id`. The blog example's `test-singleton.ts` (which deliberately attempts a forbidden second create) was updated to supply an `id`; that create is still rejected by the singleton constraint before reaching the database.

## Tests

- Generator output test asserts a singleton emits bare `id Int @id` (no default) and a normal list's `id String @id @default(cuid())` is unchanged. Snapshot updated accordingly.

## Acceptance criteria

- [x] A singleton list generates `id Int @id` (no `@default(1)`).
- [x] Non-singleton lists are unaffected (still `id String @id @default(cuid())`).
- [x] Generator output test asserts the singleton id line.
- [x] Changeset added (minor, `@opensaas/stack-cli`).

## Verification

- `pnpm build` — pass
- `packages/cli` tests — 271 pass
- `packages/core` tests — 569 pass
- `pnpm turbo run test` (incl. example builds) — pass
- `pnpm lint` — 0 errors (4 pre-existing unrelated warnings)
- `pnpm manypkg check` — valid
- `pnpm format:check` — clean

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_