### PR TITLE
image()/file() multi-column mode: read/write existing Keystone columns (non-destructive parity)

### DIFF
--- a/.changeset/mighty-otters-march.md
+++ b/.changeset/mighty-otters-march.md
@@ -1,0 +1,30 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+'@opensaas/stack-storage': minor
+---
+
+Add non-destructive multi-column mode to `image()` / `file()` for adopting an existing Keystone database without dropping columns (ADR-0006).
+
+Keystone stores an image across seven per-part columns (`_url`, `_width`, `_height`, `_filesize`, `_contentType`, `_contentDisposition`, `_pathname`) and a file across three (`_filename`, `_filesize`, `_url`). By default `image()`/`file()` still back a single `Json?` column (greenfield unchanged). Set `db.columns: 'keystone'` to map the field onto the existing per-part columns in place — assembled into an `ImageMetadata`/`FileMetadata` on read and split back on write — so a migrating project reaches a clean schema diff with no data migration and no re-upload of existing assets.
+
+```typescript
+import { image, file } from '@opensaas/stack-storage/fields'
+
+fields: {
+  // Maps onto image_url, image_width, … image_pathname in place.
+  avatar: image({ storage: 'images', db: { columns: 'keystone' } }),
+
+  // Per-part @map names are configurable for non-default column names.
+  cover: image({
+    storage: 'images',
+    db: { columns: { mode: 'keystone', map: { url: 'cover_link' } } },
+  }),
+
+  resume: file({ storage: 'documents', db: { columns: 'keystone' } }),
+}
+```
+
+No-re-upload guarantee (both modes): an already-shaped metadata value — or, in multi-column mode, populated columns — is authoritative and never triggers a storage upload; only a `File`-like input uploads.
+
+Adds a multi-column field-emission contract (`getPrismaColumns`) plus `getColumnNames`/`assembleColumns`/`splitColumns` to the field-authoring surface so any field can map onto several physical columns. The generator emits one `@map`-ped Prisma line per column; reads assemble the logical value from the raw columns and strip them from the result; writes split the logical value back across the columns.

--- a/.changeset/multi-column-write-access.md
+++ b/.changeset/multi-column-write-access.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix field-level write-access bypass for multi-column `image()`/`file()` fields. The per-part column split now respects the field's own `create`/`update` access (denied fields write none of their columns), matching single-column behaviour.
+
+Note the known lossy multi-column round-trip when assembling legacy Keystone columns: `originalFilename` collapses to `filename`, `uploadedAt` is `''`, and a NULL `contentType` reads back as `application/octet-stream`.

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { generatePrismaSchema, resolveListTimestamps } from './prisma.js'
-import type { OpenSaasConfig, ListConfig, DatabaseConfig } from '@opensaas/stack-core'
+import type { OpenSaasConfig, ListConfig, DatabaseConfig, FieldConfig } from '@opensaas/stack-core'
 import type { TypeInfo } from '@opensaas/stack-core/extend'
 import {
   text,
@@ -2429,5 +2429,122 @@ describe('resolveListTimestamps', () => {
       createdAt: false,
       updatedAt: false,
     })
+  })
+})
+
+describe('Multi-column field emission', () => {
+  // A field that emits several physical columns through getPrismaColumns (the
+  // contract storage image()/file() use in Keystone-parity mode — see
+  // ADR-0006). Built inline so the generator test stays self-contained.
+  function multiColumnField(
+    columns: Array<{ name: string; type: string; modifiers?: string; map?: string }>,
+  ): FieldConfig {
+    return {
+      type: 'multiColumn',
+      getPrismaColumns: () => columns,
+      // A multi-column field still reports a logical TS type; the generator does
+      // not call getPrismaType when getPrismaColumns returns columns.
+      getTypeScriptType: () => ({ type: 'unknown', optional: true }),
+    } as unknown as FieldConfig
+  }
+
+  it('emits one Prisma line per column with @map names', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: {
+        Teacher: {
+          fields: {
+            name: text(),
+            image: multiColumnField([
+              { name: 'image_url', type: 'String', modifiers: '?', map: 'image_url' },
+              { name: 'image_width', type: 'Int', modifiers: '?', map: 'image_width' },
+              { name: 'image_height', type: 'Int', modifiers: '?', map: 'image_height' },
+              { name: 'image_filesize', type: 'Int', modifiers: '?', map: 'image_filesize' },
+              {
+                name: 'image_contentType',
+                type: 'String',
+                modifiers: '?',
+                map: 'image_contentType',
+              },
+              {
+                name: 'image_contentDisposition',
+                type: 'String',
+                modifiers: '?',
+                map: 'image_contentDisposition',
+              },
+              { name: 'image_pathname', type: 'String', modifiers: '?', map: 'image_pathname' },
+            ]),
+          },
+        },
+      },
+    }
+
+    const schema = generatePrismaSchema(config)
+
+    // The single logical field never appears as its own column.
+    expect(schema).not.toMatch(/^\s*image\s+Json/m)
+    // Seven per-part columns are emitted, each nullable and @map-ped onto its
+    // physical Keystone column.
+    expect(schema).toContain('image_url    String? @map("image_url")')
+    expect(schema).toContain('image_width  Int? @map("image_width")')
+    expect(schema).toContain('image_height Int? @map("image_height")')
+    expect(schema).toContain('image_filesize Int? @map("image_filesize")')
+    expect(schema).toContain('image_contentType String? @map("image_contentType")')
+    expect(schema).toContain('image_contentDisposition String? @map("image_contentDisposition")')
+    expect(schema).toContain('image_pathname String? @map("image_pathname")')
+  })
+
+  it('honours a custom physical column name via the descriptor map', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: {
+        Teacher: {
+          fields: {
+            avatar: multiColumnField([
+              { name: 'avatarUrl', type: 'String', modifiers: '?', map: 'avatar_url' },
+            ]),
+          },
+        },
+      },
+    }
+
+    const schema = generatePrismaSchema(config)
+    expect(schema).toContain('avatarUrl    String? @map("avatar_url")')
+  })
+
+  it('emits a plain column line when no map is supplied', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: {
+        Doc: {
+          fields: {
+            fileUrl: multiColumnField([{ name: 'fileUrl', type: 'String', modifiers: '?' }]),
+          },
+        },
+      },
+    }
+
+    const schema = generatePrismaSchema(config)
+    expect(schema).toContain('fileUrl      String?')
+    expect(schema).not.toContain('@map')
+  })
+
+  it('falls back to single-column getPrismaType when getPrismaColumns returns nothing', () => {
+    // A field exposing getPrismaColumns that returns undefined must behave
+    // exactly like a normal single-column field.
+    const field = {
+      type: 'maybeMulti',
+      getPrismaColumns: () => undefined,
+      getPrismaType: () => ({ type: 'String', modifiers: '?' }),
+      getTypeScriptType: () => ({ type: 'string', optional: true }),
+    } as unknown as FieldConfig
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: { Thing: { fields: { value: field } } },
+    }
+
+    const schema = generatePrismaSchema(config)
+    expect(schema).toContain('value        String?')
   })
 })

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -215,6 +215,32 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
         continue
       }
 
+      // Multi-column fields (e.g. storage image()/file() in Keystone-parity
+      // mode) emit several physical columns instead of one. The generator stays
+      // neutral: it places whatever lines the field returns, the same way it
+      // delegates to relationship fields via getPrismaRelation. See ADR-0006.
+      if (fieldConfig.getPrismaColumns) {
+        const columns = fieldConfig.getPrismaColumns(fieldName)
+        if (columns && columns.length > 0) {
+          for (const column of columns) {
+            const colMods = (column.modifiers ?? '').trimStart()
+            const colNull = colMods.startsWith('?') ? '?' : ''
+            let colAttrs = colMods.startsWith('?') ? colMods.slice(1).trimStart() : colMods
+            // Append @map to bind the column to its physical name (the live
+            // Keystone column). Emitted whenever a `map` is supplied so the
+            // mapping is explicit and configurable.
+            if (column.map) {
+              colAttrs = `${colAttrs ? colAttrs + ' ' : ''}@map("${column.map}")`
+            }
+            const paddedColName = column.name.padEnd(12)
+            lines.push(
+              `  ${paddedColName} ${column.type}${colNull}${colAttrs ? ' ' + colAttrs : ''}`,
+            )
+          }
+          continue
+        }
+      }
+
       const prismaType = mapFieldTypeToPrisma(
         fieldName,
         fieldConfig,

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -477,6 +477,14 @@ function generateGetPayloadType(listName: string, fields: Record<string, FieldCo
     .filter(([_, config]) => config.resultExtension)
     .map(([name, _]) => name)
 
+  // Multi-column fields (e.g. storage image()/file() in Keystone-parity mode)
+  // back several raw Prisma columns that must be stripped from the public
+  // payload: only the assembled logical field (added back via TransformedFields)
+  // is exposed. Collect those raw column names for omission. See ADR-0006.
+  const multiColumnRawNames = Object.entries(fields).flatMap(([name, config]) =>
+    config.getColumnNames ? config.getColumnNames(name) : [],
+  )
+
   // Get relationship fields to override with custom GetPayload types
   const relationshipFields = Object.entries(fields)
     .filter(([_, config]) => config.type === 'relationship')
@@ -519,7 +527,11 @@ function generateGetPayloadType(listName: string, fields: Record<string, FieldCo
   // Build the base type (Prisma's GetPayload minus relationship and transformed fields)
   // When virtual fields exist, strip them from T before passing to Prisma so Prisma never
   // tries to resolve a virtual field name (which would produce `never` in its payload type).
-  const fieldsToOmit = [...transformedFieldNames, ...relationshipFields.map((r) => r.name)]
+  const fieldsToOmit = [
+    ...transformedFieldNames,
+    ...relationshipFields.map((r) => r.name),
+    ...multiColumnRawNames,
+  ]
   const prismaT =
     virtualFields.length > 0 ? `StripVirtualFromArgs<T, keyof ${listName}VirtualFields>` : 'T'
   if (fieldsToOmit.length > 0) {

--- a/packages/core/src/access/field-visibility.ts
+++ b/packages/core/src/access/field-visibility.ts
@@ -118,8 +118,30 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
   const filtered: Record<string, unknown> = {}
   const MAX_DEPTH = 5 // Prevent infinite recursion
 
+  // Multi-column fields (e.g. storage image()/file() in Keystone-parity mode)
+  // back several physical columns rather than one. Before the per-field pass,
+  // assemble each such field's logical value from its raw columns and remove the
+  // raw columns from the working row, so only the assembled value is exposed
+  // (the raw per-part columns never leak). The assembled value then flows
+  // through the normal read-access + resolveOutput path under the field's own
+  // key. See ADR-0006.
+  const workingItem: Record<string, unknown> = { ...item }
+  for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
+    if (!fieldConfig.assembleColumns || !fieldConfig.getColumnNames) continue
+    const columnNames = fieldConfig.getColumnNames(fieldName)
+    // Only assemble when the raw columns are present in the row (i.e. they were
+    // selected); otherwise leave the field absent from the result.
+    const hasAnyColumn = columnNames.some((name) => name in workingItem)
+    if (!hasAnyColumn) continue
+    const assembled = fieldConfig.assembleColumns(fieldName, workingItem)
+    for (const name of columnNames) {
+      delete workingItem[name]
+    }
+    workingItem[fieldName] = assembled
+  }
+
   // Process existing fields from the database result
-  for (const [fieldName, value] of Object.entries(item)) {
+  for (const [fieldName, value] of Object.entries(workingItem)) {
     const fieldConfig = fieldConfigs[fieldName]
 
     // Always include id, createdAt, updatedAt
@@ -143,7 +165,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       // Gate the relationship on read access before recursing.
       const canRead = await checkFieldAccess(fieldConfig?.access, 'read', {
         ...args,
-        item,
+        item: workingItem,
       })
 
       if (!canRead) {
@@ -194,8 +216,8 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       fieldConfig,
       fieldName,
       value,
-      accessItem: item,
-      hookItem: item,
+      accessItem: workingItem,
+      hookItem: workingItem,
       listKey,
       args,
     })
@@ -222,7 +244,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
     // without one there is nothing to add to the result.
     if (!(fieldConfig.hooks?.resolveOutput && listKey)) {
       // Still evaluate read access to preserve any access-fn side effects.
-      await checkFieldAccess(fieldConfig.access, 'read', { ...args, item })
+      await checkFieldAccess(fieldConfig.access, 'read', { ...args, item: workingItem })
       continue
     }
 
@@ -232,7 +254,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       fieldConfig,
       fieldName,
       value: undefined, // Virtual fields don't have a database value
-      accessItem: item,
+      accessItem: workingItem,
       hookItem: filtered,
       listKey,
       args,

--- a/packages/core/src/access/multi-column-read-write.test.ts
+++ b/packages/core/src/access/multi-column-read-write.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { filterReadableFields } from './field-visibility.js'
+import { executeFieldResolveInputHooks } from '../hooks/index.js'
+import type { FieldConfig } from '../config/types.js'
+import type { AccessContext } from './types.js'
+
+/**
+ * Generic core wiring for multi-column fields (the contract storage
+ * image()/file() use in Keystone-parity mode — see ADR-0006). These tests are
+ * field-agnostic: they assert that ANY field implementing
+ * getColumnNames/assembleColumns/splitColumns is assembled on read (raw columns
+ * stripped) and split on write.
+ */
+
+// A minimal multi-column field: two physical columns `m_url` and `m_size`
+// assembled into `{ url, size }` and split back.
+function multiColumnField(): FieldConfig {
+  const COLUMNS = ['m_url', 'm_size']
+  return {
+    type: 'multiColumn',
+    getColumnNames: () => COLUMNS,
+    assembleColumns: (_fieldName: string, row: Record<string, unknown>) => {
+      const url = row.m_url
+      if (url === null || url === undefined || url === '') return null
+      return { url, size: row.m_size ?? 0 }
+    },
+    splitColumns: (_fieldName: string, value: unknown) => {
+      if (value === null || value === undefined) {
+        return { m_url: null, m_size: null }
+      }
+      const v = value as { url?: unknown; size?: unknown }
+      return { m_url: v.url ?? null, m_size: v.size ?? null }
+    },
+    // Field's own resolveInput is identity here (the value is authoritative).
+    hooks: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic test hook
+      resolveInput: async ({ resolvedData, fieldKey }: any) => resolvedData?.[fieldKey],
+    },
+  } as unknown as FieldConfig
+}
+
+function makeContext(): AccessContext {
+  return {
+    session: null,
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
+  } as any
+}
+
+describe('multi-column read assembly (filterReadableFields)', () => {
+  const fields = { media: multiColumnField() }
+
+  it('assembles the per-part columns into the logical field and strips the raw columns', async () => {
+    const row = { id: 'a', m_url: 'https://x/y.jpg', m_size: 99, title: 'hi' }
+    const result = await filterReadableFields(
+      row,
+      // title is a plain field
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- inline field configs
+      { ...fields, title: { type: 'text' } as any },
+      { session: null, context: makeContext() },
+      undefined,
+      0,
+      'Post',
+    )
+    expect(result).toEqual({ id: 'a', title: 'hi', media: { url: 'https://x/y.jpg', size: 99 } })
+    // Raw columns must NOT leak.
+    expect('m_url' in result).toBe(false)
+    expect('m_size' in result).toBe(false)
+  })
+
+  it('assembles a partially-populated row (only m_url present)', async () => {
+    const row = { id: 'b', m_url: 'https://x/only.jpg' }
+    const result = await filterReadableFields(
+      row,
+      fields,
+      { session: null, context: makeContext() },
+      undefined,
+      0,
+      'Post',
+    )
+    expect(result).toEqual({ id: 'b', media: { url: 'https://x/only.jpg', size: 0 } })
+  })
+
+  it('yields a null logical value when the columns are empty', async () => {
+    const row = { id: 'c', m_url: null, m_size: null }
+    const result = await filterReadableFields(
+      row,
+      fields,
+      { session: null, context: makeContext() },
+      undefined,
+      0,
+      'Post',
+    )
+    expect(result).toEqual({ id: 'c', media: null })
+  })
+
+  it('leaves the field absent when its columns were not selected', async () => {
+    const row = { id: 'd', title: 'no media columns' }
+    const result = await filterReadableFields(
+      row,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- inline field configs
+      { ...fields, title: { type: 'text' } as any },
+      { session: null, context: makeContext() },
+      undefined,
+      0,
+      'Post',
+    )
+    expect(result).toEqual({ id: 'd', title: 'no media columns' })
+    expect('media' in result).toBe(false)
+  })
+})
+
+describe('multi-column write split (executeFieldResolveInputHooks)', () => {
+  const fields = { media: multiColumnField() }
+
+  it('splits the logical value into per-part columns and removes the logical key', async () => {
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'create',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: 'https://x/y.jpg', m_size: 99 })
+    expect('media' in result).toBe(false)
+  })
+
+  it('splitting null clears all per-part columns', async () => {
+    const inputData = { media: null }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'update',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: null, m_size: null })
+  })
+
+  it('does not touch the columns when the logical field is absent from the write', async () => {
+    const inputData = { title: 'no media in payload' }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- inline field configs
+      { ...fields, title: { type: 'text' } as any },
+      'update',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ title: 'no media in payload' })
+    expect('m_url' in result).toBe(false)
+  })
+})

--- a/packages/core/src/access/multi-column-read-write.test.ts
+++ b/packages/core/src/access/multi-column-read-write.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { filterReadableFields } from './field-visibility.js'
 import { executeFieldResolveInputHooks } from '../hooks/index.js'
 import type { FieldConfig } from '../config/types.js'
-import type { AccessContext } from './types.js'
+import type { AccessContext, FieldAccess } from './types.js'
 
 /**
  * Generic core wiring for multi-column fields (the contract storage
@@ -13,11 +13,13 @@ import type { AccessContext } from './types.js'
  */
 
 // A minimal multi-column field: two physical columns `m_url` and `m_size`
-// assembled into `{ url, size }` and split back.
-function multiColumnField(): FieldConfig {
+// assembled into `{ url, size }` and split back. Optionally carries field-level
+// access so we can lock the write-access gate around the split.
+function multiColumnField(access?: FieldAccess): FieldConfig {
   const COLUMNS = ['m_url', 'm_size']
   return {
     type: 'multiColumn',
+    access,
     getColumnNames: () => COLUMNS,
     assembleColumns: (_fieldName: string, row: Record<string, unknown>) => {
       const url = row.m_url
@@ -39,10 +41,10 @@ function multiColumnField(): FieldConfig {
   } as unknown as FieldConfig
 }
 
-function makeContext(): AccessContext {
+function makeContext(overrides: { isSudo?: boolean } = {}): AccessContext {
   return {
     session: null,
-    _isSudo: false,
+    _isSudo: overrides.isSudo ?? false,
     _resolveOutputCounter: { depth: 0 },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
   } as any
@@ -154,5 +156,100 @@ describe('multi-column write split (executeFieldResolveInputHooks)', () => {
     )
     expect(result).toEqual({ title: 'no media in payload' })
     expect('m_url' in result).toBe(false)
+  })
+})
+
+describe('multi-column write split respects field-level write access', () => {
+  it('does NOT write any per-part columns when update access is denied', async () => {
+    const fields = { media: multiColumnField({ update: () => false }) }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'update',
+      makeContext(),
+      'Post',
+    )
+    // The logical key is dropped (it is not a real column) AND none of its
+    // per-part columns are written — identical to how filterWritableFields
+    // drops a denied single-column field.
+    expect(result).toEqual({})
+    expect('media' in result).toBe(false)
+    expect('m_url' in result).toBe(false)
+    expect('m_size' in result).toBe(false)
+  })
+
+  it('does NOT write any per-part columns when create access is denied', async () => {
+    const fields = { media: multiColumnField({ create: () => false }) }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'create',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({})
+    expect('m_url' in result).toBe(false)
+  })
+
+  it('still splits/writes the columns when write access is granted', async () => {
+    const fields = { media: multiColumnField({ update: () => true, create: () => true }) }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'update',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: 'https://x/y.jpg', m_size: 99 })
+    expect('media' in result).toBe(false)
+  })
+
+  it('denying the OTHER operation does not block the write (update field, create op)', async () => {
+    // A field that denies `update` must still be writable on `create`.
+    const fields = { media: multiColumnField({ update: () => false }) }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'create',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: 'https://x/y.jpg', m_size: 99 })
+  })
+
+  it('sudo bypasses the field-access gate and still splits', async () => {
+    const fields = { media: multiColumnField({ update: () => false }) }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'update',
+      makeContext({ isSudo: true }),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: 'https://x/y.jpg', m_size: 99 })
+  })
+
+  it('a multi-column field WITHOUT field-level access splits exactly as before', async () => {
+    const fields = { media: multiColumnField() }
+    const inputData = { media: { url: 'https://x/y.jpg', size: 99 } }
+    const result = await executeFieldResolveInputHooks(
+      inputData,
+      { ...inputData },
+      fields,
+      'update',
+      makeContext(),
+      'Post',
+    )
+    expect(result).toEqual({ m_url: 'https://x/y.jpg', m_size: 99 })
   })
 })

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -136,6 +136,7 @@ export type {
   SelectField,
   RelationshipField,
   PrismaRelationResult,
+  MultiColumnPrismaResult,
   JsonField,
   VirtualField,
   TypeDescriptor,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -510,6 +510,72 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
      */
     typeOnly?: boolean
   }>
+  /**
+   * Multi-column Prisma emission.
+   *
+   * Most scalar fields back a single Prisma column via {@link getPrismaType}.
+   * A field that maps onto SEVERAL physical columns (e.g. the storage
+   * `image()`/`file()` fields in multi-column / Keystone-parity mode — see
+   * ADR-0006) implements this instead: it returns one descriptor per column,
+   * each becoming its own line in the generated model. When present, the
+   * generator emits these lines and skips the single-column `getPrismaType`
+   * path. The field itself owns the column layout — the generator stays a
+   * neutral coordinator (no field-type switches), mirroring how relationship
+   * fields emit FK + relation lines through `getPrismaRelation`.
+   *
+   * @param fieldName - The field's config key (used to derive default column names)
+   * @returns One descriptor per physical column, or `undefined` to fall back to
+   *   the single-column `getPrismaType` path.
+   */
+  getPrismaColumns?: (fieldName: string) => MultiColumnPrismaResult[] | undefined
+  /**
+   * The physical Prisma column names this field owns when it spans multiple
+   * columns (see {@link getPrismaColumns}). The read path uses this to strip the
+   * raw per-part columns from query results so only the assembled logical value
+   * (produced by {@link assembleColumns}) is exposed.
+   *
+   * @param fieldName - The field's config key
+   */
+  getColumnNames?: (fieldName: string) => string[]
+  /**
+   * Assemble the field's logical value from a database row's per-part columns
+   * (the read direction of a multi-column field). Pure transform — called by the
+   * read pipeline before field visibility. Receives the full row so it can read
+   * its sibling columns by name.
+   *
+   * @param fieldName - The field's config key
+   * @param row - The raw database row (contains the per-part columns)
+   */
+  assembleColumns?: (fieldName: string, row: Record<string, unknown>) => unknown
+  /**
+   * Split the field's logical value into per-part columns for writing (the write
+   * direction of a multi-column field). Pure transform — called by the write
+   * pipeline after `resolveInput`; the returned record is merged into the write
+   * payload in place of the single field key.
+   *
+   * @param fieldName - The field's config key
+   * @param value - The resolved logical value (metadata, or `null` to clear)
+   */
+  splitColumns?: (fieldName: string, value: unknown) => Record<string, unknown>
+}
+
+/**
+ * A single physical column contributed by a multi-column field
+ * (see {@link BaseFieldConfig.getPrismaColumns}).
+ */
+export type MultiColumnPrismaResult = {
+  /** The Prisma model field name (the property the column is declared as). */
+  name: string
+  /** The Prisma scalar type, e.g. `'String'` or `'Int'`. */
+  type: string
+  /**
+   * Field modifiers, e.g. `'?'` for nullable. A leading `'?'` attaches to the
+   * type; anything after it is treated as trailing attributes (matching the
+   * single-column `getPrismaType` modifier convention).
+   */
+  modifiers?: string
+  /** Physical column name for the `@map` attribute, when it differs from `name`. */
+  map?: string
 }
 
 export type TextField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<TTypeInfo> & {

--- a/packages/core/src/extend.ts
+++ b/packages/core/src/extend.ts
@@ -11,4 +11,9 @@
 export type { Plugin, PluginContext, GeneratedFiles } from './config/index.js'
 
 // Third-party field authoring (implement BaseFieldConfig; see custom-field docs)
-export type { BaseFieldConfig, TypeInfo, TypeDescriptor } from './config/index.js'
+export type {
+  BaseFieldConfig,
+  TypeInfo,
+  TypeDescriptor,
+  MultiColumnPrismaResult,
+} from './config/index.js'

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -34,6 +34,7 @@ export type {
   JsonField,
   VirtualField,
   PrismaRelationResult,
+  MultiColumnPrismaResult,
 } from '../config/types.js'
 
 /**

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -235,24 +235,42 @@ export async function executeFieldResolveInputHooks(
     // Skip if field not in data
     if (!(fieldKey in result)) continue
 
-    // Skip if no hooks defined
-    if (!fieldConfig.hooks?.resolveInput) continue
+    // A field's resolveInput produces its resolved value; for most fields that
+    // value is stored back under the same key. Multi-column fields additionally
+    // split that value across their physical columns below.
+    let resolvedValue: unknown = result[fieldKey]
 
-    // Execute field hook
-    // Type assertion is safe here because hooks are typed correctly in field definitions
-    // and we're working with runtime values that match those types
-    const transformedValue = await fieldConfig.hooks.resolveInput({
-      listKey,
-      fieldKey,
-      operation,
-      inputData,
-      item,
-      resolvedData: { ...result }, // Pass a copy to avoid mutation affecting recorded args
-      context,
-    } as Parameters<typeof fieldConfig.hooks.resolveInput>[0])
+    if (fieldConfig.hooks?.resolveInput) {
+      // Execute field hook
+      // Type assertion is safe here because hooks are typed correctly in field definitions
+      // and we're working with runtime values that match those types
+      resolvedValue = await fieldConfig.hooks.resolveInput({
+        listKey,
+        fieldKey,
+        operation,
+        inputData,
+        item,
+        resolvedData: { ...result }, // Pass a copy to avoid mutation affecting recorded args
+        context,
+      } as Parameters<typeof fieldConfig.hooks.resolveInput>[0])
+    } else if (!fieldConfig.splitColumns) {
+      // No resolveInput and not a multi-column field — nothing to do.
+      continue
+    }
 
-    // Create new object with updated field to avoid mutating the passed reference
-    result = { ...result, [fieldKey]: transformedValue }
+    if (fieldConfig.splitColumns) {
+      // Multi-column field (e.g. storage image()/file() in Keystone-parity
+      // mode): replace the single logical key with its per-part columns so the
+      // write payload targets the live columns instead of a single one.
+      const columns = fieldConfig.splitColumns(fieldKey, resolvedValue)
+      // Drop the logical key (it is not a real column) and merge the columns.
+      const next = { ...result, ...columns }
+      delete next[fieldKey]
+      result = next
+    } else {
+      // Create new object with updated field to avoid mutating the passed reference
+      result = { ...result, [fieldKey]: resolvedValue }
+    }
   }
 
   return result

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -2,6 +2,7 @@ import type { Hooks } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
 import type { FieldConfig } from '../config/types.js'
 import { validateWithZod } from '../validation/schema.js'
+import { checkFieldAccess } from '../access/field-access.js'
 
 /**
  * Validation error collection
@@ -262,6 +263,30 @@ export async function executeFieldResolveInputHooks(
       // Multi-column field (e.g. storage image()/file() in Keystone-parity
       // mode): replace the single logical key with its per-part columns so the
       // write payload targets the live columns instead of a single one.
+      //
+      // The split removes the logical key from the payload BEFORE the
+      // canonical writable-field filter (`filterWritableFields`) runs, and the
+      // raw per-part column keys are not in `fieldConfigs` — so that later
+      // filter cannot enforce this field's own write access. Enforce it HERE,
+      // using the canonical field-access evaluator with the SAME arguments the
+      // write pipeline uses. A single-column field denied by `update`/`create`
+      // is simply omitted from the write; a denied multi-column field must
+      // likewise contribute NONE of its per-part columns. (sudo bypasses via
+      // `checkFieldAccess`.)
+      const canWrite = await checkFieldAccess(fieldConfig.access, operation, {
+        session: context.session,
+        item,
+        context,
+        inputData,
+      })
+      if (!canWrite) {
+        // Denied: drop the logical key and write none of its columns — exactly
+        // as filterWritableFields drops a denied single-column field.
+        const next = { ...result }
+        delete next[fieldKey]
+        result = next
+        continue
+      }
       const columns = fieldConfig.splitColumns(fieldKey, resolvedValue)
       // Drop the logical key (it is not a real column) and merge the columns.
       const next = { ...result, ...columns }

--- a/packages/storage/src/fields/index.ts
+++ b/packages/storage/src/fields/index.ts
@@ -1,8 +1,99 @@
-import type { BaseFieldConfig, TypeInfo } from '@opensaas/stack-core/extend'
+import type {
+  BaseFieldConfig,
+  TypeInfo,
+  MultiColumnPrismaResult,
+} from '@opensaas/stack-core/extend'
 import { z } from 'zod'
 import type { ComponentType } from 'react'
 import type { FileMetadata, ImageMetadata, ImageTransformationConfig } from '../config/types.js'
 import type { FileValidationOptions } from '../utils/upload.js'
+import {
+  assembleFileMetadata,
+  assembleImageMetadata,
+  fileColumnDescriptors,
+  fileColumnNames,
+  imageColumnDescriptors,
+  imageColumnNames,
+  resolveFileColumnMap,
+  resolveImageColumnMap,
+  splitFileMetadata,
+  splitImageMetadata,
+  type FileColumnMap,
+  type ImageColumnMap,
+} from '../utils/multi-column.js'
+
+/**
+ * Multi-column (Keystone-parity) database mode for image()/file() fields.
+ *
+ * The default backing for image()/file() is a single `Json?` column. A
+ * migrating project that already has a Keystone database can instead set
+ * `columns: 'keystone'` to map the field onto the existing per-part columns in
+ * place — no destructive migration, no re-upload of existing assets. The
+ * per-part column names (used in `@map`) follow Keystone's `<field>_<part>`
+ * convention and can be overridden individually. See ADR-0006.
+ */
+export interface ImageDbConfig {
+  /** Custom database column name for single-Json? mode (unused in multi-column mode). */
+  map?: string
+  /** Override DB-level nullability for single-Json? mode. */
+  isNullable?: boolean
+  /** Override the native database type for single-Json? mode. */
+  nativeType?: string
+  /**
+   * Enable multi-column mode by setting `'keystone'`. Per-part column-name
+   * overrides may be supplied; any omitted part falls back to the Keystone
+   * default `<field>_<part>`.
+   */
+  columns?: 'keystone' | { mode: 'keystone'; map?: Partial<ImageColumnMap> }
+}
+
+/**
+ * Multi-column (Keystone-parity) database mode for file() fields.
+ */
+export interface FileDbConfig {
+  /** Custom database column name for single-Json? mode (unused in multi-column mode). */
+  map?: string
+  /** Override DB-level nullability for single-Json? mode. */
+  isNullable?: boolean
+  /** Override the native database type for single-Json? mode. */
+  nativeType?: string
+  /**
+   * Enable multi-column mode by setting `'keystone'`. Per-part column-name
+   * overrides may be supplied; any omitted part falls back to the Keystone
+   * default `<field>_<part>`.
+   */
+  columns?: 'keystone' | { mode: 'keystone'; map?: Partial<FileColumnMap> }
+}
+
+/** Whether a field-level `db.columns` option requests multi-column mode. */
+function isMultiColumn(columns: ImageDbConfig['columns'] | FileDbConfig['columns']): boolean {
+  return columns === 'keystone' || (typeof columns === 'object' && columns?.mode === 'keystone')
+}
+
+/** Extract any per-part `@map` overrides from a `db.columns` option. */
+function imageColumnOverrides(
+  columns: ImageDbConfig['columns'],
+): Partial<ImageColumnMap> | undefined {
+  return typeof columns === 'object' ? columns.map : undefined
+}
+
+function fileColumnOverrides(columns: FileDbConfig['columns']): Partial<FileColumnMap> | undefined {
+  return typeof columns === 'object' ? columns.map : undefined
+}
+
+/**
+ * Detect a File-like input (something we should upload). An already-shaped
+ * metadata value or populated multi-column row is authoritative and must never
+ * trigger an upload (the no-re-upload guarantee — see ADR-0006).
+ */
+function isFileLike(value: unknown): value is File {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'arrayBuffer' in value &&
+    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === 'function'
+  )
+}
 
 /**
  * File field configuration
@@ -19,6 +110,12 @@ export interface FileFieldConfig<
   cleanupOnDelete?: boolean
   /** Automatically delete old file from storage when replaced with new file */
   cleanupOnReplace?: boolean
+  /**
+   * Database configuration. By default a file is backed by a single `Json?`
+   * column; set `db.columns: 'keystone'` to map onto existing Keystone per-part
+   * columns in place (non-destructive migration). See ADR-0006.
+   */
+  db?: FileDbConfig
   /** UI options */
   ui?: {
     /** Custom component to use for rendering this field */
@@ -53,6 +150,12 @@ export interface ImageFieldConfig<
   cleanupOnDelete?: boolean
   /** Automatically delete old file from storage when replaced with new file */
   cleanupOnReplace?: boolean
+  /**
+   * Database configuration. By default an image is backed by a single `Json?`
+   * column; set `db.columns: 'keystone'` to map onto existing Keystone per-part
+   * columns in place (non-destructive migration). See ADR-0006.
+   */
+  db?: ImageDbConfig
   /** UI options */
   ui?: {
     /** Custom component to use for rendering this field */
@@ -97,37 +200,47 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
 ): FileFieldConfig<TTypeInfo> {
   const { hooks: userHooks, ...restOptions } = options
 
+  // Multi-column (Keystone-parity) mode maps onto existing per-part columns
+  // instead of a single Json? column. The column map is resolved lazily per
+  // field name so default `<field>_<part>` names line up with the live columns.
+  const multiColumn = isMultiColumn(options.db?.columns)
+  const columnMapFor = (fieldName: string): FileColumnMap =>
+    resolveFileColumnMap(fieldName, fileColumnOverrides(options.db?.columns))
+
   const fieldConfig: FileFieldConfig<TTypeInfo> = {
     type: 'file',
     ...restOptions,
 
-    // Override Prisma's Json type with FileMetadata | null in context.db types
+    // Override Prisma's Json type with FileMetadata | null in context.db types.
+    // Multi-column mode adds the same logical field back via TransformedFields
+    // while the raw per-part columns are stripped from the payload.
     resultExtension: {
       outputType: "import('@opensaas/stack-storage').FileMetadata | null",
     },
 
     hooks: {
+      // Keystone-compliant field resolveInput args: the field value lives at
+      // `resolvedData[fieldKey]`. See FieldResolveInputHookArgs in core.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
-      resolveInput: async ({ inputValue, context, item, fieldName }: any) => {
+      resolveInput: async ({ resolvedData, fieldKey, context, item }: any) => {
+        const inputValue = resolvedData?.[fieldKey]
+
         // If null/undefined, return as-is (deletion or no change)
         if (inputValue === null || inputValue === undefined) {
           return inputValue
         }
 
-        // If already FileMetadata, keep existing (edit mode - no new file uploaded)
+        // If already FileMetadata, keep existing (edit mode - no new file
+        // uploaded). An existing metadata value is AUTHORITATIVE and must never
+        // re-upload. See ADR-0006.
         if (typeof inputValue === 'object' && 'filename' in inputValue && 'url' in inputValue) {
           return inputValue as FileMetadata
         }
 
-        // If File object, upload it
-        // Check if it's a File-like object (has arrayBuffer method)
-        if (
-          typeof inputValue === 'object' &&
-          'arrayBuffer' in inputValue &&
-          typeof (inputValue as { arrayBuffer?: unknown }).arrayBuffer === 'function'
-        ) {
+        // Only a File-like input triggers an upload.
+        if (isFileLike(inputValue)) {
           // Convert File to buffer
-          const fileObj = inputValue as File
+          const fileObj = inputValue
           const arrayBuffer = await fileObj.arrayBuffer()
           const buffer = Buffer.from(arrayBuffer)
 
@@ -137,8 +250,8 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
           })) as FileMetadata
 
           // If cleanupOnReplace is enabled and there was an old file, delete it
-          if (fieldConfig.cleanupOnReplace && item && fieldName) {
-            const oldMetadata = item[fieldName] as FileMetadata | null
+          if (fieldConfig.cleanupOnReplace && item && fieldKey) {
+            const oldMetadata = item[fieldKey] as FileMetadata | null
             if (oldMetadata && oldMetadata.filename) {
               try {
                 await context.storage.deleteFile(oldMetadata.storageProvider, oldMetadata.filename)
@@ -157,12 +270,12 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
       },
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
-      afterOperation: async ({ operation, item, fieldName, context }: any) => {
-        // Only cleanup on delete if enabled
+      afterOperation: async ({ operation, originalItem, fieldKey, context }: any) => {
+        // Only cleanup on delete if enabled. The deleted row is `originalItem`.
         if (operation === 'delete' && fieldConfig.cleanupOnDelete) {
-          const fileMetadata = item[fieldName] as FileMetadata | null
+          const fileMetadata = originalItem?.[fieldKey] as FileMetadata | null
 
-          if (fileMetadata && fileMetadata.filename) {
+          if (fileMetadata && typeof fileMetadata === 'object' && fileMetadata.filename) {
             try {
               await context.storage.deleteFile(fileMetadata.storageProvider, fileMetadata.filename)
             } catch (error) {
@@ -194,7 +307,7 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
     },
 
     getPrismaType: (_fieldName: string) => {
-      // Store as JSON in database
+      // Store as JSON in database (single-column default mode).
       return { type: 'Json', modifiers: '?' }
     },
 
@@ -215,6 +328,26 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
         },
       ]
     },
+  }
+
+  // Multi-column emission + assemble/split. Only attached in multi-column mode
+  // so the single-Json? default is completely unaffected.
+  if (multiColumn) {
+    fieldConfig.getPrismaColumns = (fieldName: string): MultiColumnPrismaResult[] => {
+      const map = columnMapFor(fieldName)
+      return fileColumnDescriptors(map).map((col) => ({
+        name: col.name,
+        type: col.type,
+        modifiers: '?',
+        map: col.map,
+      }))
+    }
+    fieldConfig.getColumnNames = (fieldName: string): string[] =>
+      fileColumnNames(columnMapFor(fieldName))
+    fieldConfig.assembleColumns = (fieldName: string, row: Record<string, unknown>): unknown =>
+      assembleFileMetadata(row, columnMapFor(fieldName), fieldConfig.storage)
+    fieldConfig.splitColumns = (fieldName: string, value: unknown): Record<string, unknown> =>
+      splitFileMetadata((value ?? null) as FileMetadata | null, columnMapFor(fieldName))
   }
 
   return fieldConfig
@@ -247,24 +380,38 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
 ): ImageFieldConfig<TTypeInfo> {
   const { hooks: userHooks, ...restOptions } = options
 
+  // Multi-column (Keystone-parity) mode maps onto existing per-part columns
+  // instead of a single Json? column. See ADR-0006.
+  const multiColumn = isMultiColumn(options.db?.columns)
+  const columnMapFor = (fieldName: string): ImageColumnMap =>
+    resolveImageColumnMap(fieldName, imageColumnOverrides(options.db?.columns))
+
   const fieldConfig: ImageFieldConfig<TTypeInfo> = {
     type: 'image',
     ...restOptions,
 
-    // Override Prisma's Json type with ImageMetadata | null in context.db types
+    // Override Prisma's Json type with ImageMetadata | null in context.db types.
+    // Multi-column mode adds the same logical field back via TransformedFields
+    // while the raw per-part columns are stripped from the payload.
     resultExtension: {
       outputType: "import('@opensaas/stack-storage').ImageMetadata | null",
     },
 
     hooks: {
+      // Keystone-compliant field resolveInput args: the field value lives at
+      // `resolvedData[fieldKey]`. See FieldResolveInputHookArgs in core.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
-      resolveInput: async ({ inputValue, context, item, fieldName }: any) => {
+      resolveInput: async ({ resolvedData, fieldKey, context, item }: any) => {
+        const inputValue = resolvedData?.[fieldKey]
+
         // If null/undefined, return as-is (deletion or no change)
         if (inputValue === null || inputValue === undefined) {
           return inputValue
         }
 
-        // If already ImageMetadata, keep existing (edit mode - no new file uploaded)
+        // If already ImageMetadata, keep existing (edit mode - no new file
+        // uploaded). An existing metadata value is AUTHORITATIVE and must never
+        // re-upload. See ADR-0006.
         if (
           typeof inputValue === 'object' &&
           'filename' in inputValue &&
@@ -275,15 +422,10 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
           return inputValue as ImageMetadata
         }
 
-        // If File object, upload it
-        // Check if it's a File-like object (has arrayBuffer method)
-        if (
-          typeof inputValue === 'object' &&
-          'arrayBuffer' in inputValue &&
-          typeof (inputValue as { arrayBuffer?: unknown }).arrayBuffer === 'function'
-        ) {
+        // Only a File-like input triggers an upload.
+        if (isFileLike(inputValue)) {
           // Convert File to buffer
-          const fileObj = inputValue as File
+          const fileObj = inputValue
           const arrayBuffer = await fileObj.arrayBuffer()
           const buffer = Buffer.from(arrayBuffer)
 
@@ -299,8 +441,8 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
           )) as ImageMetadata
 
           // If cleanupOnReplace is enabled and there was an old file, delete it
-          if (fieldConfig.cleanupOnReplace && item && fieldName) {
-            const oldMetadata = item[fieldName] as ImageMetadata | null
+          if (fieldConfig.cleanupOnReplace && item && fieldKey) {
+            const oldMetadata = item[fieldKey] as ImageMetadata | null
             if (oldMetadata && oldMetadata.filename) {
               try {
                 await context.storage.deleteImage(oldMetadata)
@@ -319,12 +461,12 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
       },
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
-      afterOperation: async ({ operation, item, fieldName, context }: any) => {
-        // Only cleanup on delete if enabled
+      afterOperation: async ({ operation, originalItem, fieldKey, context }: any) => {
+        // Only cleanup on delete if enabled. The deleted row is `originalItem`.
         if (operation === 'delete' && fieldConfig.cleanupOnDelete) {
-          const imageMetadata = item[fieldName] as ImageMetadata | null
+          const imageMetadata = originalItem?.[fieldKey] as ImageMetadata | null
 
-          if (imageMetadata && imageMetadata.filename) {
+          if (imageMetadata && typeof imageMetadata === 'object' && imageMetadata.filename) {
             try {
               await context.storage.deleteImage(imageMetadata)
             } catch (error) {
@@ -390,6 +532,26 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
         },
       ]
     },
+  }
+
+  // Multi-column emission + assemble/split. Only attached in multi-column mode
+  // so the single-Json? default is completely unaffected.
+  if (multiColumn) {
+    fieldConfig.getPrismaColumns = (fieldName: string): MultiColumnPrismaResult[] => {
+      const map = columnMapFor(fieldName)
+      return imageColumnDescriptors(map).map((col) => ({
+        name: col.name,
+        type: col.type,
+        modifiers: '?',
+        map: col.map,
+      }))
+    }
+    fieldConfig.getColumnNames = (fieldName: string): string[] =>
+      imageColumnNames(columnMapFor(fieldName))
+    fieldConfig.assembleColumns = (fieldName: string, row: Record<string, unknown>): unknown =>
+      assembleImageMetadata(row, columnMapFor(fieldName), fieldConfig.storage)
+    fieldConfig.splitColumns = (fieldName: string, value: unknown): Record<string, unknown> =>
+      splitImageMetadata((value ?? null) as ImageMetadata | null, columnMapFor(fieldName))
   }
 
   return fieldConfig

--- a/packages/storage/src/utils/index.ts
+++ b/packages/storage/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './image.js'
 export * from './upload.js'
+export * from './multi-column.js'

--- a/packages/storage/src/utils/multi-column.ts
+++ b/packages/storage/src/utils/multi-column.ts
@@ -1,0 +1,346 @@
+/**
+ * Pure `metadata ↔ columns` mapper for the multi-column (Keystone-parity) mode
+ * of the `image()` / `file()` fields.
+ *
+ * Keystone stores an image across seven per-part columns and a file across
+ * three. To adopt a live Keystone database without a destructive migration (see
+ * ADR-0006), the storage fields can map onto those existing columns in place,
+ * assembling them into an {@link ImageMetadata} / {@link FileMetadata} on read
+ * and splitting a metadata value back into columns on write.
+ *
+ * This module is intentionally pure: no I/O, no storage-provider calls, no
+ * dependency on the field builders. It is unit-tested in isolation
+ * (`multi-column.test.ts`) and the read/write hooks call it.
+ */
+import type { FileMetadata, ImageMetadata } from '../config/types.js'
+
+/**
+ * The logical "parts" of a Keystone image field. Each maps to one physical
+ * column (whose physical name is configurable via `@map`).
+ */
+export type ImageColumnPart =
+  | 'url'
+  | 'width'
+  | 'height'
+  | 'filesize'
+  | 'contentType'
+  | 'contentDisposition'
+  | 'pathname'
+
+/**
+ * The logical "parts" of a Keystone file field.
+ */
+export type FileColumnPart = 'filename' | 'filesize' | 'url'
+
+/** Ordered list of image parts, matching Keystone's column layout. */
+export const IMAGE_COLUMN_PARTS: readonly ImageColumnPart[] = [
+  'url',
+  'width',
+  'height',
+  'filesize',
+  'contentType',
+  'contentDisposition',
+  'pathname',
+] as const
+
+/** Ordered list of file parts, matching Keystone's column layout. */
+export const FILE_COLUMN_PARTS: readonly FileColumnPart[] = ['filename', 'filesize', 'url'] as const
+
+/** The Prisma scalar type each image part is stored as. */
+const IMAGE_PART_PRISMA_TYPE: Record<ImageColumnPart, 'String' | 'Int'> = {
+  url: 'String',
+  width: 'Int',
+  height: 'Int',
+  filesize: 'Int',
+  contentType: 'String',
+  contentDisposition: 'String',
+  pathname: 'String',
+}
+
+/** The Prisma scalar type each file part is stored as. */
+const FILE_PART_PRISMA_TYPE: Record<FileColumnPart, 'String' | 'Int'> = {
+  filename: 'String',
+  filesize: 'Int',
+  url: 'String',
+}
+
+/**
+ * Map of image part → physical column name (the value used in `@map`).
+ * Defaults follow Keystone's `<field>_<part>` naming.
+ */
+export type ImageColumnMap = Record<ImageColumnPart, string>
+
+/** Map of file part → physical column name. */
+export type FileColumnMap = Record<FileColumnPart, string>
+
+/** A single physical column to emit for a multi-column field. */
+export interface MultiColumnDescriptor {
+  /** The Prisma model field name (the property carrying `@map`). */
+  name: string
+  /** The Prisma scalar type. */
+  type: 'String' | 'Int'
+  /** The physical column name used in `@map`. */
+  map: string
+}
+
+/**
+ * Build the default per-part column-name map for an image field, following
+ * Keystone's `<field>_<part>` convention.
+ *
+ * @example
+ * keystoneImageColumnMap('image') // { url: 'image_url', width: 'image_width', ... }
+ */
+export function keystoneImageColumnMap(fieldName: string): ImageColumnMap {
+  return {
+    url: `${fieldName}_url`,
+    width: `${fieldName}_width`,
+    height: `${fieldName}_height`,
+    filesize: `${fieldName}_filesize`,
+    contentType: `${fieldName}_contentType`,
+    contentDisposition: `${fieldName}_contentDisposition`,
+    pathname: `${fieldName}_pathname`,
+  }
+}
+
+/**
+ * Build the default per-part column-name map for a file field.
+ *
+ * @example
+ * keystoneFileColumnMap('file') // { filename: 'file_filename', filesize: 'file_filesize', url: 'file_url' }
+ */
+export function keystoneFileColumnMap(fieldName: string): FileColumnMap {
+  return {
+    filename: `${fieldName}_filename`,
+    filesize: `${fieldName}_filesize`,
+    url: `${fieldName}_url`,
+  }
+}
+
+/**
+ * Resolve the effective image column map: defaults from {@link keystoneImageColumnMap},
+ * with any caller-supplied per-part overrides applied on top.
+ */
+export function resolveImageColumnMap(
+  fieldName: string,
+  overrides?: Partial<ImageColumnMap>,
+): ImageColumnMap {
+  return { ...keystoneImageColumnMap(fieldName), ...overrides }
+}
+
+/**
+ * Resolve the effective file column map.
+ */
+export function resolveFileColumnMap(
+  fieldName: string,
+  overrides?: Partial<FileColumnMap>,
+): FileColumnMap {
+  return { ...keystoneFileColumnMap(fieldName), ...overrides }
+}
+
+/**
+ * The Prisma model field name carrying a given image part's column. We name the
+ * model field after the physical column itself (i.e. `<field>_url`) so the
+ * generated property and its `@map` line up with the live Keystone column.
+ */
+function imagePartFieldName(map: ImageColumnMap, part: ImageColumnPart): string {
+  return map[part]
+}
+
+function filePartFieldName(map: FileColumnMap, part: FileColumnPart): string {
+  return map[part]
+}
+
+/**
+ * Describe the physical columns an image field emits in multi-column mode.
+ * Each descriptor's `name` is the Prisma model field name and `map` is the
+ * physical column it maps to (here they are identical so the schema reads
+ * naturally over the live columns).
+ */
+export function imageColumnDescriptors(map: ImageColumnMap): MultiColumnDescriptor[] {
+  return IMAGE_COLUMN_PARTS.map((part) => ({
+    name: imagePartFieldName(map, part),
+    type: IMAGE_PART_PRISMA_TYPE[part],
+    map: map[part],
+  }))
+}
+
+/**
+ * Describe the physical columns a file field emits in multi-column mode.
+ */
+export function fileColumnDescriptors(map: FileColumnMap): MultiColumnDescriptor[] {
+  return FILE_COLUMN_PARTS.map((part) => ({
+    name: filePartFieldName(map, part),
+    type: FILE_PART_PRISMA_TYPE[part],
+    map: map[part],
+  }))
+}
+
+/** The physical column field names an image field owns (for read stripping). */
+export function imageColumnNames(map: ImageColumnMap): string[] {
+  return IMAGE_COLUMN_PARTS.map((part) => imagePartFieldName(map, part))
+}
+
+/** The physical column field names a file field owns (for read stripping). */
+export function fileColumnNames(map: FileColumnMap): string[] {
+  return FILE_COLUMN_PARTS.map((part) => filePartFieldName(map, part))
+}
+
+/** Coerce an unknown column value to a string, or `null` when absent/empty. */
+function asString(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string') return value
+  return String(value)
+}
+
+/** Coerce an unknown column value to a number, or `null` when absent/invalid. */
+function asNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : null
+  }
+  if (typeof value === 'bigint') return Number(value)
+  return null
+}
+
+/**
+ * Assemble the per-part image columns from a database row into an
+ * {@link ImageMetadata}.
+ *
+ * Returns `null` when the row carries no image at all (the `url` column is the
+ * authoritative presence signal — Keystone leaves every part NULL for an empty
+ * image). Partially-populated rows (e.g. only `image_url`) still assemble into a
+ * valid object, with missing scalar parts defaulted (width/height/size → 0).
+ *
+ * `storageProvider` is supplied by the caller (the field knows which provider it
+ * is bound to); legacy columns do not carry it.
+ */
+export function assembleImageMetadata(
+  row: Record<string, unknown>,
+  map: ImageColumnMap,
+  storageProvider: string,
+): ImageMetadata | null {
+  const url = asString(row[map.url])
+  if (url === null || url === '') {
+    return null
+  }
+
+  const pathname = asString(row[map.pathname])
+  const contentType = asString(row[map.contentType])
+  const contentDisposition = asString(row[map.contentDisposition])
+
+  // Keystone stores the storage key in `pathname`; fall back to the URL when
+  // absent so `filename` is always populated.
+  const filename = pathname ?? url
+
+  const metadata: ImageMetadata = {
+    filename,
+    originalFilename: filename,
+    url,
+    mimeType: contentType ?? 'application/octet-stream',
+    size: asNumber(row[map.filesize]) ?? 0,
+    width: asNumber(row[map.width]) ?? 0,
+    height: asNumber(row[map.height]) ?? 0,
+    uploadedAt: '',
+    storageProvider,
+  }
+
+  // Preserve the Keystone-only content disposition (no first-class metadata
+  // field) so a round-trip back to columns does not lose it.
+  if (contentDisposition !== null) {
+    metadata.metadata = { contentDisposition }
+  }
+
+  return metadata
+}
+
+/**
+ * Split an {@link ImageMetadata} (or `null`) back into the per-part image
+ * columns for writing. A `null`/`undefined` metadata clears every column.
+ */
+export function splitImageMetadata(
+  metadata: ImageMetadata | null | undefined,
+  map: ImageColumnMap,
+): Record<string, string | number | null> {
+  if (metadata === null || metadata === undefined) {
+    return {
+      [map.url]: null,
+      [map.width]: null,
+      [map.height]: null,
+      [map.filesize]: null,
+      [map.contentType]: null,
+      [map.contentDisposition]: null,
+      [map.pathname]: null,
+    }
+  }
+
+  const contentDisposition =
+    metadata.metadata && typeof metadata.metadata.contentDisposition === 'string'
+      ? metadata.metadata.contentDisposition
+      : null
+
+  return {
+    [map.url]: metadata.url,
+    [map.width]: metadata.width ?? null,
+    [map.height]: metadata.height ?? null,
+    [map.filesize]: metadata.size ?? null,
+    [map.contentType]: metadata.mimeType ?? null,
+    [map.contentDisposition]: contentDisposition,
+    // Keystone's pathname holds the storage key (our `filename`).
+    [map.pathname]: metadata.filename ?? null,
+  }
+}
+
+/**
+ * Assemble the per-part file columns from a database row into a
+ * {@link FileMetadata}. Returns `null` when no file is present.
+ */
+export function assembleFileMetadata(
+  row: Record<string, unknown>,
+  map: FileColumnMap,
+  storageProvider: string,
+): FileMetadata | null {
+  const url = asString(row[map.url])
+  const filename = asString(row[map.filename])
+
+  // Either a URL or a filename signals a present file.
+  if ((url === null || url === '') && (filename === null || filename === '')) {
+    return null
+  }
+
+  const resolvedFilename = filename ?? url ?? ''
+
+  return {
+    filename: resolvedFilename,
+    originalFilename: resolvedFilename,
+    url: url ?? '',
+    mimeType: 'application/octet-stream',
+    size: asNumber(row[map.filesize]) ?? 0,
+    uploadedAt: '',
+    storageProvider,
+  }
+}
+
+/**
+ * Split a {@link FileMetadata} (or `null`) back into the per-part file columns
+ * for writing. A `null`/`undefined` metadata clears every column.
+ */
+export function splitFileMetadata(
+  metadata: FileMetadata | null | undefined,
+  map: FileColumnMap,
+): Record<string, string | number | null> {
+  if (metadata === null || metadata === undefined) {
+    return {
+      [map.filename]: null,
+      [map.filesize]: null,
+      [map.url]: null,
+    }
+  }
+
+  return {
+    [map.filename]: metadata.filename ?? null,
+    [map.filesize]: metadata.size ?? null,
+    [map.url]: metadata.url ?? null,
+  }
+}

--- a/packages/storage/tests/multi-column-fields.test.ts
+++ b/packages/storage/tests/multi-column-fields.test.ts
@@ -162,6 +162,44 @@ describe('image() / file() multi-column mode', () => {
     })
   })
 
+  describe('field-level write access is preserved alongside the column split', () => {
+    // The core write pipeline gates the multi-column split on the field's own
+    // write access (so a denied multi-column field writes NONE of its per-part
+    // columns — see packages/core/.../multi-column-read-write.test.ts). For that
+    // gate to fire, the field builder must surface the user-provided `access` on
+    // the config (the same object key the single-column path reads). These tests
+    // lock that wiring for the real image()/file() fields. See ADR-0006 / #477.
+    it('image() in multi-column mode carries user access AND splitColumns together', () => {
+      const denyUpdate = () => false
+      const field = image({
+        storage: 'images',
+        db: { columns: 'keystone' },
+        access: { update: denyUpdate },
+      })
+      expect(field.access?.update).toBe(denyUpdate)
+      // The gate has both inputs it needs: the access object and the splitter.
+      expect(typeof field.splitColumns).toBe('function')
+    })
+
+    it('file() in multi-column mode carries user access AND splitColumns together', () => {
+      const denyCreate = () => false
+      const field = file({
+        storage: 'documents',
+        db: { columns: 'keystone' },
+        access: { create: denyCreate },
+      })
+      expect(field.access?.create).toBe(denyCreate)
+      expect(typeof field.splitColumns).toBe('function')
+    })
+
+    it('single-column image() still carries access and has no splitColumns', () => {
+      const denyUpdate = () => false
+      const field = image({ storage: 'images', access: { update: denyUpdate } })
+      expect(field.access?.update).toBe(denyUpdate)
+      expect(field.splitColumns).toBeUndefined()
+    })
+  })
+
   describe('no-re-upload guarantee', () => {
     it('image() does NOT upload when given an existing ImageMetadata (single-Json mode)', async () => {
       const field = image({ storage: 'images' })

--- a/packages/storage/tests/multi-column-fields.test.ts
+++ b/packages/storage/tests/multi-column-fields.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi } from 'vitest'
+import { image, file } from '../src/fields/index.js'
+import type { ImageMetadata, FileMetadata } from '../src/config/types.js'
+
+/**
+ * Field-level behaviour of image()/file() in multi-column (Keystone-parity)
+ * mode, plus the no-re-upload guarantee in BOTH modes. See ADR-0006 / issue #477.
+ */
+
+/** A File-like stub with an arrayBuffer() method (triggers an upload). */
+function fakeFile(bytes = [1, 2, 3]): File {
+  return {
+    name: 'photo.png',
+    type: 'image/png',
+    arrayBuffer: async () => new Uint8Array(bytes).buffer,
+  } as unknown as File
+}
+
+/** A context whose storage records every upload call so we can assert on it. */
+function makeContext() {
+  const uploadImage = vi.fn(
+    async (): Promise<ImageMetadata> => ({
+      filename: 'new.png',
+      originalFilename: 'photo.png',
+      url: '/uploads/new.png',
+      mimeType: 'image/png',
+      size: 3,
+      width: 10,
+      height: 10,
+      uploadedAt: new Date().toISOString(),
+      storageProvider: 'images',
+    }),
+  )
+  const uploadFile = vi.fn(
+    async (): Promise<FileMetadata> => ({
+      filename: 'new.pdf',
+      originalFilename: 'doc.pdf',
+      url: '/uploads/new.pdf',
+      mimeType: 'application/pdf',
+      size: 3,
+      uploadedAt: new Date().toISOString(),
+      storageProvider: 'documents',
+    }),
+  )
+  return {
+    context: { storage: { uploadImage, uploadFile, deleteImage: vi.fn(), deleteFile: vi.fn() } },
+    uploadImage,
+    uploadFile,
+  }
+}
+
+describe('image() / file() multi-column mode', () => {
+  describe('single-Json? default is unchanged', () => {
+    it('image() default has no multi-column methods and emits Json?', () => {
+      const field = image({ storage: 'images' })
+      expect(field.getPrismaColumns).toBeUndefined()
+      expect(field.getColumnNames).toBeUndefined()
+      expect(field.assembleColumns).toBeUndefined()
+      expect(field.splitColumns).toBeUndefined()
+      expect(field.getPrismaType?.('image')).toEqual({ type: 'Json', modifiers: '?' })
+    })
+
+    it('file() default has no multi-column methods and emits Json?', () => {
+      const field = file({ storage: 'documents' })
+      expect(field.getPrismaColumns).toBeUndefined()
+      expect(field.getPrismaType?.('doc')).toEqual({ type: 'Json', modifiers: '?' })
+    })
+  })
+
+  describe('multi-column emission', () => {
+    it('image() in keystone mode emits seven @map-ped nullable columns', () => {
+      const field = image({ storage: 'images', db: { columns: 'keystone' } })
+      const columns = field.getPrismaColumns?.('image')
+      expect(columns).toHaveLength(7)
+      expect(columns?.every((c) => c.modifiers === '?')).toBe(true)
+      expect(columns?.map((c) => c.map)).toEqual([
+        'image_url',
+        'image_width',
+        'image_height',
+        'image_filesize',
+        'image_contentType',
+        'image_contentDisposition',
+        'image_pathname',
+      ])
+      expect(field.getColumnNames?.('image')).toHaveLength(7)
+    })
+
+    it('file() in keystone mode emits three @map-ped columns', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      const columns = field.getPrismaColumns?.('doc')
+      expect(columns?.map((c) => c.map)).toEqual(['doc_filename', 'doc_filesize', 'doc_url'])
+    })
+
+    it('per-part @map names are configurable', () => {
+      const field = image({
+        storage: 'images',
+        db: { columns: { mode: 'keystone', map: { url: 'image_link', pathname: 'image_key' } } },
+      })
+      const columns = field.getPrismaColumns?.('image')
+      const maps = columns?.map((c) => c.map)
+      expect(maps).toContain('image_link')
+      expect(maps).toContain('image_key')
+      // Un-overridden parts keep Keystone defaults.
+      expect(maps).toContain('image_width')
+      expect(field.getColumnNames?.('image')).toContain('image_link')
+    })
+  })
+
+  describe('assemble (read) and split (write)', () => {
+    it('image() assembles its columns and a url-only row yields a valid value', () => {
+      const field = image({ storage: 'images', db: { columns: 'keystone' } })
+      const full = field.assembleColumns?.('image', {
+        image_url: '/u/a.jpg',
+        image_width: 100,
+        image_height: 50,
+        image_filesize: 1024,
+        image_contentType: 'image/jpeg',
+        image_pathname: 'a.jpg',
+      }) as ImageMetadata
+      expect(full.url).toBe('/u/a.jpg')
+      expect(full.width).toBe(100)
+      expect(full.storageProvider).toBe('images')
+
+      const partial = field.assembleColumns?.('image', {
+        image_url: '/u/only.jpg',
+      }) as ImageMetadata
+      expect(partial.url).toBe('/u/only.jpg')
+      expect(partial.width).toBe(0)
+    })
+
+    it('image() split writes back into the per-part columns', () => {
+      const field = image({ storage: 'images', db: { columns: 'keystone' } })
+      const meta: ImageMetadata = {
+        filename: 'a.jpg',
+        originalFilename: 'a.jpg',
+        url: '/u/a.jpg',
+        mimeType: 'image/jpeg',
+        size: 1024,
+        width: 100,
+        height: 50,
+        uploadedAt: '',
+        storageProvider: 'images',
+      }
+      const columns = field.splitColumns?.('image', meta)
+      expect(columns).toMatchObject({
+        image_url: '/u/a.jpg',
+        image_width: 100,
+        image_height: 50,
+        image_filesize: 1024,
+        image_contentType: 'image/jpeg',
+        image_pathname: 'a.jpg',
+      })
+    })
+
+    it('file() split of null clears all columns', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      expect(field.splitColumns?.('doc', null)).toEqual({
+        doc_filename: null,
+        doc_filesize: null,
+        doc_url: null,
+      })
+    })
+  })
+
+  describe('no-re-upload guarantee', () => {
+    it('image() does NOT upload when given an existing ImageMetadata (single-Json mode)', async () => {
+      const field = image({ storage: 'images' })
+      const { context, uploadImage } = makeContext()
+      const existing: ImageMetadata = {
+        filename: 'a.jpg',
+        originalFilename: 'a.jpg',
+        url: '/u/a.jpg',
+        mimeType: 'image/jpeg',
+        size: 1,
+        width: 1,
+        height: 1,
+        uploadedAt: '',
+        storageProvider: 'images',
+      }
+      const result = await field.hooks?.resolveInput?.({
+        listKey: 'Post',
+        fieldKey: 'image',
+        operation: 'update',
+        inputData: { image: existing },
+        item: { image: existing },
+        resolvedData: { image: existing },
+        context,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      expect(uploadImage).not.toHaveBeenCalled()
+      expect(result).toBe(existing)
+    })
+
+    it('image() does NOT upload when given an existing ImageMetadata (multi-column mode)', async () => {
+      const field = image({ storage: 'images', db: { columns: 'keystone' } })
+      const { context, uploadImage } = makeContext()
+      const existing: ImageMetadata = {
+        filename: 'a.jpg',
+        originalFilename: 'a.jpg',
+        url: '/u/a.jpg',
+        mimeType: 'image/jpeg',
+        size: 1,
+        width: 1,
+        height: 1,
+        uploadedAt: '',
+        storageProvider: 'images',
+      }
+      const result = await field.hooks?.resolveInput?.({
+        listKey: 'Post',
+        fieldKey: 'image',
+        operation: 'create',
+        inputData: { image: existing },
+        item: undefined,
+        resolvedData: { image: existing },
+        context,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      expect(uploadImage).not.toHaveBeenCalled()
+      expect(result).toBe(existing)
+    })
+
+    it('image() DOES upload when given a File-like input', async () => {
+      const field = image({ storage: 'images', db: { columns: 'keystone' } })
+      const { context, uploadImage } = makeContext()
+      const result = await field.hooks?.resolveInput?.({
+        listKey: 'Post',
+        fieldKey: 'image',
+        operation: 'create',
+        inputData: { image: fakeFile() },
+        item: undefined,
+        resolvedData: { image: fakeFile() },
+        context,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      expect(uploadImage).toHaveBeenCalledTimes(1)
+      expect((result as ImageMetadata).url).toBe('/uploads/new.png')
+    })
+
+    it('file() does NOT upload existing metadata but DOES upload a File-like input', async () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      const { context, uploadFile } = makeContext()
+      const existing: FileMetadata = {
+        filename: 'd.pdf',
+        originalFilename: 'd.pdf',
+        url: '/u/d.pdf',
+        mimeType: 'application/pdf',
+        size: 1,
+        uploadedAt: '',
+        storageProvider: 'documents',
+      }
+      const kept = await field.hooks?.resolveInput?.({
+        listKey: 'Post',
+        fieldKey: 'doc',
+        operation: 'update',
+        inputData: { doc: existing },
+        item: { doc: existing },
+        resolvedData: { doc: existing },
+        context,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      expect(uploadFile).not.toHaveBeenCalled()
+      expect(kept).toBe(existing)
+
+      await field.hooks?.resolveInput?.({
+        listKey: 'Post',
+        fieldKey: 'doc',
+        operation: 'create',
+        inputData: { doc: fakeFile() },
+        item: undefined,
+        resolvedData: { doc: fakeFile() },
+        context,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      expect(uploadFile).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/storage/tests/multi-column.test.ts
+++ b/packages/storage/tests/multi-column.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IMAGE_COLUMN_PARTS,
+  FILE_COLUMN_PARTS,
+  keystoneImageColumnMap,
+  keystoneFileColumnMap,
+  resolveImageColumnMap,
+  resolveFileColumnMap,
+  imageColumnDescriptors,
+  fileColumnDescriptors,
+  imageColumnNames,
+  fileColumnNames,
+  assembleImageMetadata,
+  splitImageMetadata,
+  assembleFileMetadata,
+  splitFileMetadata,
+} from '../src/utils/multi-column.js'
+import type { ImageMetadata, FileMetadata } from '../src/config/types.js'
+
+describe('multi-column mapper', () => {
+  describe('column-name maps', () => {
+    it('builds Keystone default image column names', () => {
+      expect(keystoneImageColumnMap('image')).toEqual({
+        url: 'image_url',
+        width: 'image_width',
+        height: 'image_height',
+        filesize: 'image_filesize',
+        contentType: 'image_contentType',
+        contentDisposition: 'image_contentDisposition',
+        pathname: 'image_pathname',
+      })
+    })
+
+    it('builds Keystone default file column names', () => {
+      expect(keystoneFileColumnMap('doc')).toEqual({
+        filename: 'doc_filename',
+        filesize: 'doc_filesize',
+        url: 'doc_url',
+      })
+    })
+
+    it('applies per-part image overrides on top of defaults', () => {
+      const map = resolveImageColumnMap('avatar', { url: 'avatar_link', width: 'avatar_w' })
+      expect(map.url).toBe('avatar_link')
+      expect(map.width).toBe('avatar_w')
+      // Un-overridden parts keep the Keystone default.
+      expect(map.height).toBe('avatar_height')
+      expect(map.pathname).toBe('avatar_pathname')
+    })
+
+    it('applies per-part file overrides on top of defaults', () => {
+      const map = resolveFileColumnMap('resume', { url: 'resume_href' })
+      expect(map.url).toBe('resume_href')
+      expect(map.filename).toBe('resume_filename')
+    })
+  })
+
+  describe('descriptors / column names', () => {
+    it('emits seven image columns with @map names', () => {
+      const map = keystoneImageColumnMap('image')
+      const descriptors = imageColumnDescriptors(map)
+      expect(descriptors).toHaveLength(7)
+      expect(descriptors.map((d) => d.map)).toEqual([
+        'image_url',
+        'image_width',
+        'image_height',
+        'image_filesize',
+        'image_contentType',
+        'image_contentDisposition',
+        'image_pathname',
+      ])
+      // width/height/filesize are Int, the rest String.
+      const byName = Object.fromEntries(descriptors.map((d) => [d.map, d.type]))
+      expect(byName.image_width).toBe('Int')
+      expect(byName.image_height).toBe('Int')
+      expect(byName.image_filesize).toBe('Int')
+      expect(byName.image_url).toBe('String')
+      expect(byName.image_contentType).toBe('String')
+    })
+
+    it('emits three file columns with @map names', () => {
+      const descriptors = fileColumnDescriptors(keystoneFileColumnMap('doc'))
+      expect(descriptors.map((d) => d.map)).toEqual(['doc_filename', 'doc_filesize', 'doc_url'])
+    })
+
+    it('lists column names for read stripping', () => {
+      expect(imageColumnNames(keystoneImageColumnMap('image'))).toHaveLength(7)
+      expect(fileColumnNames(keystoneFileColumnMap('doc'))).toEqual([
+        'doc_filename',
+        'doc_filesize',
+        'doc_url',
+      ])
+      expect(IMAGE_COLUMN_PARTS).toHaveLength(7)
+      expect(FILE_COLUMN_PARTS).toHaveLength(3)
+    })
+  })
+
+  describe('image assemble/split round-trip', () => {
+    const map = keystoneImageColumnMap('image')
+
+    it('assembles a fully-populated row into ImageMetadata', () => {
+      const row = {
+        image_url: 'https://cdn.example.com/photo.jpg',
+        image_width: 800,
+        image_height: 600,
+        image_filesize: 12345,
+        image_contentType: 'image/jpeg',
+        image_contentDisposition: 'inline',
+        image_pathname: 'photo.jpg',
+      }
+      const meta = assembleImageMetadata(row, map, 'images')
+      expect(meta).toEqual({
+        filename: 'photo.jpg',
+        originalFilename: 'photo.jpg',
+        url: 'https://cdn.example.com/photo.jpg',
+        mimeType: 'image/jpeg',
+        size: 12345,
+        width: 800,
+        height: 600,
+        uploadedAt: '',
+        storageProvider: 'images',
+        metadata: { contentDisposition: 'inline' },
+      })
+    })
+
+    it('round-trips columns → metadata → columns', () => {
+      const row = {
+        image_url: 'https://cdn.example.com/photo.jpg',
+        image_width: 800,
+        image_height: 600,
+        image_filesize: 12345,
+        image_contentType: 'image/jpeg',
+        image_contentDisposition: 'inline',
+        image_pathname: 'photo.jpg',
+      }
+      const meta = assembleImageMetadata(row, map, 'images')
+      const columns = splitImageMetadata(meta, map)
+      expect(columns).toEqual(row)
+    })
+
+    it('assembles a partially-populated row (only image_url) into a valid value', () => {
+      const meta = assembleImageMetadata(
+        { image_url: 'https://cdn.example.com/only.png' },
+        map,
+        'images',
+      )
+      expect(meta).not.toBeNull()
+      expect(meta?.url).toBe('https://cdn.example.com/only.png')
+      // Missing pathname falls back to the URL for filename.
+      expect(meta?.filename).toBe('https://cdn.example.com/only.png')
+      // Missing scalar parts default to 0.
+      expect(meta?.width).toBe(0)
+      expect(meta?.height).toBe(0)
+      expect(meta?.size).toBe(0)
+      // Missing contentType defaults to octet-stream; no contentDisposition metadata.
+      expect(meta?.mimeType).toBe('application/octet-stream')
+      expect(meta?.metadata).toBeUndefined()
+    })
+
+    it('returns null for a row with no url (empty image)', () => {
+      expect(assembleImageMetadata({}, map, 'images')).toBeNull()
+      expect(
+        assembleImageMetadata(
+          { image_url: null, image_width: null, image_pathname: null },
+          map,
+          'images',
+        ),
+      ).toBeNull()
+    })
+
+    it('coerces string-typed numeric columns (e.g. from raw SQL) to numbers', () => {
+      const meta = assembleImageMetadata(
+        { image_url: 'u', image_width: '640', image_height: '480', image_filesize: '999' },
+        map,
+        'images',
+      )
+      expect(meta?.width).toBe(640)
+      expect(meta?.height).toBe(480)
+      expect(meta?.size).toBe(999)
+    })
+
+    it('splits null metadata into all-null columns (clears the field)', () => {
+      expect(splitImageMetadata(null, map)).toEqual({
+        image_url: null,
+        image_width: null,
+        image_height: null,
+        image_filesize: null,
+        image_contentType: null,
+        image_contentDisposition: null,
+        image_pathname: null,
+      })
+    })
+
+    it('honours per-part @map overrides on round-trip', () => {
+      const custom = resolveImageColumnMap('image', { url: 'image_link' })
+      const row = { image_link: 'https://x/y.jpg', image_pathname: 'y.jpg' }
+      const meta = assembleImageMetadata(row, custom, 'images')
+      expect(meta?.url).toBe('https://x/y.jpg')
+      const split = splitImageMetadata(meta, custom)
+      expect(split.image_link).toBe('https://x/y.jpg')
+    })
+  })
+
+  describe('file assemble/split round-trip', () => {
+    const map = keystoneFileColumnMap('doc')
+
+    it('assembles a populated row into FileMetadata', () => {
+      const meta = assembleFileMetadata(
+        { doc_filename: 'report.pdf', doc_filesize: 4096, doc_url: 'https://cdn/report.pdf' },
+        map,
+        'documents',
+      )
+      expect(meta).toEqual({
+        filename: 'report.pdf',
+        originalFilename: 'report.pdf',
+        url: 'https://cdn/report.pdf',
+        mimeType: 'application/octet-stream',
+        size: 4096,
+        uploadedAt: '',
+        storageProvider: 'documents',
+      })
+    })
+
+    it('round-trips file columns → metadata → columns', () => {
+      const row = {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+      }
+      const meta = assembleFileMetadata(row, map, 'documents')
+      expect(splitFileMetadata(meta, map)).toEqual(row)
+    })
+
+    it('assembles a partial row (only url) into a valid value', () => {
+      const meta = assembleFileMetadata({ doc_url: 'https://cdn/only.pdf' }, map, 'documents')
+      expect(meta).not.toBeNull()
+      expect(meta?.url).toBe('https://cdn/only.pdf')
+      expect(meta?.filename).toBe('https://cdn/only.pdf')
+      expect(meta?.size).toBe(0)
+    })
+
+    it('assembles a partial row (only filename) into a valid value', () => {
+      const meta = assembleFileMetadata({ doc_filename: 'legacy.bin' }, map, 'documents')
+      expect(meta).not.toBeNull()
+      expect(meta?.filename).toBe('legacy.bin')
+      expect(meta?.url).toBe('')
+    })
+
+    it('returns null for an empty file row', () => {
+      expect(assembleFileMetadata({}, map, 'documents')).toBeNull()
+      expect(
+        assembleFileMetadata({ doc_url: null, doc_filename: null }, map, 'documents'),
+      ).toBeNull()
+    })
+
+    it('splits null metadata into all-null columns', () => {
+      expect(splitFileMetadata(null, map)).toEqual({
+        doc_filename: null,
+        doc_filesize: null,
+        doc_url: null,
+      })
+    })
+  })
+
+  describe('typed round-trips with real metadata objects', () => {
+    it('image: a freshly-uploaded ImageMetadata splits and re-assembles consistently', () => {
+      const map = keystoneImageColumnMap('hero')
+      const uploaded: ImageMetadata = {
+        filename: 'abc123.webp',
+        originalFilename: 'hero.webp',
+        url: '/uploads/abc123.webp',
+        mimeType: 'image/webp',
+        size: 2048,
+        width: 1200,
+        height: 630,
+        uploadedAt: new Date().toISOString(),
+        storageProvider: 'images',
+      }
+      const cols = splitImageMetadata(uploaded, map)
+      const back = assembleImageMetadata(cols, map, 'images')
+      expect(back?.url).toBe(uploaded.url)
+      expect(back?.width).toBe(uploaded.width)
+      expect(back?.height).toBe(uploaded.height)
+      expect(back?.size).toBe(uploaded.size)
+      expect(back?.mimeType).toBe(uploaded.mimeType)
+      // pathname stores the storage key (our filename).
+      expect(back?.filename).toBe(uploaded.filename)
+    })
+
+    it('file: a freshly-uploaded FileMetadata splits and re-assembles consistently', () => {
+      const map = keystoneFileColumnMap('attachment')
+      const uploaded: FileMetadata = {
+        filename: 'xyz.pdf',
+        originalFilename: 'invoice.pdf',
+        url: '/uploads/xyz.pdf',
+        mimeType: 'application/pdf',
+        size: 9999,
+        uploadedAt: new Date().toISOString(),
+        storageProvider: 'documents',
+      }
+      const cols = splitFileMetadata(uploaded, map)
+      const back = assembleFileMetadata(cols, map, 'documents')
+      expect(back?.url).toBe(uploaded.url)
+      expect(back?.size).toBe(uploaded.size)
+      expect(back?.filename).toBe(uploaded.filename)
+    })
+  })
+})


### PR DESCRIPTION
Implements #477
Part of #476

## What this does

Adds a **non-destructive multi-column mode** to `image()` / `file()` so a project can adopt a pre-existing Keystone database without dropping columns (ADR-0006). The single-`Json?` column stays the greenfield default; multi-column mode is an opt-in per-field `db.columns: 'keystone'`.

```ts
import { image, file } from '@opensaas/stack-storage/fields'

fields: {
  // Maps onto the live image_url … image_pathname columns in place.
  avatar: image({ storage: 'images', db: { columns: 'keystone' } }),
  // Per-part @map names are configurable.
  cover: image({ storage: 'images', db: { columns: { mode: 'keystone', map: { url: 'cover_link' } } } }),
  resume: file({ storage: 'documents', db: { columns: 'keystone' } }),
}
```

## How it works

- **Multi-column emission** — new field-emission contract `getPrismaColumns` on `BaseFieldConfig` (mirrors how relationship fields emit FK + relation lines). The generator stays neutral: it places one `@map`-ped Prisma line per column it returns. No field-type switches in core/cli.
- **Pure `metadata ↔ columns` mapper** (`packages/storage/src/utils/multi-column.ts`) — `assemble*`/`split*` for image (7 cols) and file (3 cols), handling partial/NULL rows. Pure and unit-tested in isolation.
- **Assemble on read** — the read pipeline (`filterReadableFields`) assembles the per-part columns into the logical `ImageMetadata`/`FileMetadata` and **strips the raw columns** so they never leak. A row with only `image_url` still yields a valid value.
- **Split on write** — the write pipeline splits the logical value back across the per-part columns in place of the single key.
- **No-re-upload guarantee (both modes)** — an already-shaped metadata value / populated columns is authoritative and never triggers a storage upload; only a `File`-like input uploads. Locked by tests.

## Scope note / decision resolved

While wiring the runtime I found the storage fields' `resolveInput`/`afterOperation` hooks read non-existent `inputValue`/`fieldName` args instead of the Keystone-compliant `resolvedData[fieldKey]` / `originalItem`. That latent mismatch had to be corrected for the split/assemble (and the no-re-upload guarantee) to function through the real pipeline; it is now aligned to the documented field-hook contract.

The PRD's documentation/skill rewrite (`migrate-image-fields`, `specs/keystone-image-migration.md`) is a **separate slice of #476** and is intentionally out of scope here — this PR is the code slice (#477).

## Verification

- `pnpm build` — all packages + examples build.
- Tests: core 576, cli 275, storage 105 — all pass. New tests: pure mapper round-trip + partial/NULL; generator multi-column emission + single-column fallback; field-level no-re-upload (both modes) + emission; core generic read-assemble/write-split.
- `pnpm lint` (0 errors), `pnpm manypkg check` (valid), `pnpm format:check` (clean), `pnpm turbo run test` (32/32 tasks, examples unaffected).
- Changeset added (minor; core + cli + storage).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_