### PR TITLE
fix(cli): emit @@schema on native enum blocks in multi-schema mode

### DIFF
--- a/.changeset/quiet-enums-settle.md
+++ b/.changeset/quiet-enums-settle.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix multi-schema mode (db.schemas): emit @@schema on generated native enum blocks so an enum-backed select() no longer produces an invalid schema (P1012). Enums inherit their owning model's schema, defaulting to public; greenfield output is unchanged.

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -2062,6 +2062,107 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toContain('enum PostStatus {')
     })
 
+    it('should declare @@schema on generated enum blocks in multi-schema mode (P1012 fix)', () => {
+      // Multi-schema mode (db.schemas) requires every model AND every enum to
+      // declare an @@schema, or Prisma rejects the schema with P1012. Before this
+      // fix only models carried @@schema, so a db.schemas + enum-select config
+      // produced an invalid schema.
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+          schemas: ['public', 'auth'],
+        },
+        lists: {
+          Post: {
+            fields: {
+              title: text(),
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                db: { type: 'enum' },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Datasource is multi-schema
+      expect(schema).toContain('previewFeatures = ["multiSchema"]')
+      expect(schema).toContain('schemas  = ["public", "auth"]')
+
+      // The enum block exists and carries @@schema (default public — the list
+      // declares no schema of its own). This is the fix: previously the enum had
+      // no @@schema, which Prisma rejects with P1012 in multi-schema mode.
+      const enumBlock = schema.slice(
+        schema.indexOf('enum PostStatus {'),
+        schema.indexOf('}', schema.indexOf('enum PostStatus {')) + 1,
+      )
+      expect(enumBlock).toContain('@@schema("public")')
+    })
+
+    it('should place an enum in its owning model schema (enum inherits list db.schema)', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+          schemas: ['public', 'auth'],
+        },
+        lists: {
+          AuthUser: {
+            fields: {
+              name: text(),
+              role: select({
+                options: [
+                  { label: 'Admin', value: 'admin' },
+                  { label: 'Member', value: 'member' },
+                ],
+                db: { type: 'enum' },
+              }),
+            },
+            db: { schema: 'auth' },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // The enum follows its owning model into the `auth` schema, not `public`.
+      const enumBlock = schema.slice(
+        schema.indexOf('enum AuthUserRole {'),
+        schema.indexOf('}', schema.indexOf('enum AuthUserRole {')) + 1,
+      )
+      expect(enumBlock).toContain('@@schema("auth")')
+    })
+
+    it('should NOT add @@schema to enum blocks in greenfield mode (no db.schemas)', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'postgresql' },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [
+                  { label: 'Draft', value: 'draft' },
+                  { label: 'Published', value: 'published' },
+                ],
+                db: { type: 'enum' },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Enum block is generated...
+      expect(schema).toContain('enum PostStatus {')
+      // ...but greenfield output is unchanged — no @@schema anywhere.
+      expect(schema).not.toContain('@@schema')
+    })
+
     it('should match snapshot for enum select field', () => {
       const config: OpenSaasConfig = {
         db: { provider: 'sqlite' },

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -125,8 +125,13 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
   lines.push('}')
   lines.push('')
 
-  // Collect enum definitions from all fields (first pass)
-  const enumDefinitions: Map<string, string[]> = new Map()
+  // Collect enum definitions from all fields (first pass). In multi-schema mode
+  // we also record the schema each enum belongs to: Prisma requires every enum
+  // (like every model) to declare an `@@schema(...)`, or it errors with P1012.
+  // An enum inherits the schema of its owning list (the model carrying the
+  // field), falling back to `public`.
+  type EnumDefinition = { values: string[]; schema: string }
+  const enumDefinitions: Map<string, EnumDefinition> = new Map()
   for (const [listName, listConfig] of Object.entries(config.lists)) {
     for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
       if (fieldConfig.type === 'relationship' || fieldConfig.virtual) continue
@@ -138,17 +143,28 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
           keystoneCompat,
         )
         if (result.enumValues && result.enumValues.length > 0) {
-          enumDefinitions.set(result.type, result.enumValues)
+          // The enum lives in the owning model's schema (so an enum used by an
+          // `auth`-schema model lands in `auth`, not `public`). Default to
+          // `public` when the list declares no schema.
+          enumDefinitions.set(result.type, {
+            values: result.enumValues,
+            schema: listConfig.db?.schema ?? 'public',
+          })
         }
       }
     }
   }
 
   // Generate enum blocks
-  for (const [enumName, values] of enumDefinitions) {
+  for (const [enumName, { values, schema: enumSchema }] of enumDefinitions) {
     lines.push(`enum ${enumName} {`)
     for (const value of values) {
       lines.push(`  ${value}`)
+    }
+    // In multi-schema mode every enum must declare an `@@schema(...)` or Prisma
+    // rejects the schema (P1012). Greenfield (single schema) output is unchanged.
+    if (multiSchema) {
+      lines.push(`  @@schema("${enumSchema}")`)
     }
     lines.push('}')
     lines.push('')


### PR DESCRIPTION
Implements #504

Part of #480

## Problem

In multi-schema mode (`db.schemas` set), Prisma requires every model **and** every enum to declare an `@@schema(...)`, or it errors with `P1012`. The generator only emitted `@@schema` on models, so a config combining `db.schemas` with a `select({ db: { type: 'enum' } })` field produced an invalid Prisma schema.

## Fix

`packages/cli/src/generator/prisma.ts` now emits `@@schema(...)` on each generated native `enum` block when multi-schema mode is active. Each enum inherits the schema of its owning model (the list's `db.schema`), defaulting to `"public"`. Greenfield output (no `db.schemas`) is unchanged — no `@@schema` is emitted on enums.

## Tests

Added to `packages/cli/src/generator/prisma.test.ts`:
- A `db.schemas` + enum-backed `select` config emits a valid multi-schema schema where the enum block carries `@@schema("public")`.
- An enum inherits its owning model's `db.schema` (an `auth`-schema model's enum lands in `auth`).
- Greenfield (no `db.schemas`) emits no `@@schema` on enums.

## Verification

- `pnpm build` — pass
- `packages/cli` tests — 274 pass
- `packages/core` tests — 569 pass
- `pnpm lint` — 0 errors
- `pnpm manypkg check` — pass
- `pnpm format:check` — pass
- `pnpm turbo run test` (incl. example builds) — 32/32 pass

Changeset: `.changeset/quiet-enums-settle.md` (patch, `@opensaas/stack-cli`).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_