### PR TITLE
Remove leftover debug console.log in packages/core/src/fields/index.ts

### DIFF
--- a/.changeset/quiet-otters-clap.md
+++ b/.changeset/quiet-otters-clap.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Remove leftover debug console.log statements from runtime code (password field resolveInput and MCP tool call handler)

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -708,7 +708,6 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
       resolveInput: async ({ inputData, fieldKey }: { inputData: any; fieldKey: string }) => {
         // Skip if undefined or null (allows partial updates)
         const inputValue = inputData[fieldKey]
-        console.log('Password resolveInput called with value:', inputValue)
         if (inputValue === undefined || inputValue === null) {
           return inputValue
         }

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -410,8 +410,6 @@ async function handleToolsCall(
   const toolName = params?.name
   const toolArgs = params?.arguments || {}
 
-  console.log('Handling tool call:', toolName, toolArgs)
-
   if (!toolName) {
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
Fixes #517

## What changed

Removed two genuine stray debug `console.log` statements from `@opensaas/stack-core` runtime code:

- `packages/core/src/fields/index.ts:711` — `console.log('Password resolveInput called with value:', inputValue)` inside the password field `resolveInput` hook (the leftover named in the issue, ~line 710).
- `packages/core/src/mcp/handler.ts:413` — `console.log('Handling tool call:', toolName, toolArgs)` in the MCP `tools/call` handler (found during the quick scan of the rest of `packages/core/src`).

## What was intentionally left alone

The other `console.log` matches in `packages/core/src` are all inside JSDoc comment examples (prefixed with `*`) and are intentional documentation, so they were kept:

- `packages/core/src/config/types.ts:251` and `:272`
- `packages/core/src/fields/index.ts:1295`

No `console.warn`/`console.error` or user-facing warnings were touched. No behaviour change beyond removing debug output.

## Verification

- `pnpm build` — pass (11/11 tasks)
- `cd packages/core && pnpm test` — pass (582 tests)
- `pnpm lint` — 0 errors (4 pre-existing unrelated warnings)
- `pnpm manypkg check` — pass
- `pnpm format:check` — pass

Changeset added: `@opensaas/stack-core` patch.

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_