### PR TITLE
test(storage): file() multi-column field-builder coverage (#478)

### DIFF
--- a/.changeset/file-multi-column-tests.md
+++ b/.changeset/file-multi-column-tests.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage': patch
+---
+
+Add `file()` field-builder-level tests for multi-column (Keystone-parity) mode (issue #478): assemble/split of `FileMetadata` across the three Keystone columns through the `file()` builder, including only-`file_url` partial rows, empty-row → null, custom `@map` round-trip, and nullable/`Int`-typed column emission. Test-only; no behaviour change.

--- a/packages/storage/tests/multi-column-fields.test.ts
+++ b/packages/storage/tests/multi-column-fields.test.ts
@@ -85,10 +85,31 @@ describe('image() / file() multi-column mode', () => {
       expect(field.getColumnNames?.('image')).toHaveLength(7)
     })
 
-    it('file() in keystone mode emits three @map-ped columns', () => {
+    it('file() in keystone mode emits three @map-ped nullable columns', () => {
       const field = file({ storage: 'documents', db: { columns: 'keystone' } })
       const columns = field.getPrismaColumns?.('doc')
+      expect(columns).toHaveLength(3)
+      expect(columns?.every((c) => c.modifiers === '?')).toBe(true)
       expect(columns?.map((c) => c.map)).toEqual(['doc_filename', 'doc_filesize', 'doc_url'])
+      // filesize is Int; filename/url are String.
+      const byMap = Object.fromEntries((columns ?? []).map((c) => [c.map, c.type]))
+      expect(byMap.doc_filesize).toBe('Int')
+      expect(byMap.doc_filename).toBe('String')
+      expect(byMap.doc_url).toBe('String')
+      expect(field.getColumnNames?.('doc')).toEqual(['doc_filename', 'doc_filesize', 'doc_url'])
+    })
+
+    it('file() per-part @map names are configurable', () => {
+      const field = file({
+        storage: 'documents',
+        db: { columns: { mode: 'keystone', map: { url: 'doc_href' } } },
+      })
+      const maps = field.getPrismaColumns?.('doc')?.map((c) => c.map)
+      expect(maps).toContain('doc_href')
+      // Un-overridden parts keep Keystone defaults.
+      expect(maps).toContain('doc_filename')
+      expect(maps).not.toContain('doc_url')
+      expect(field.getColumnNames?.('doc')).toContain('doc_href')
     })
 
     it('per-part @map names are configurable', () => {
@@ -150,6 +171,67 @@ describe('image() / file() multi-column mode', () => {
         image_contentType: 'image/jpeg',
         image_pathname: 'a.jpg',
       })
+    })
+
+    it('file() assembles a fully-populated row into FileMetadata', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      const meta = field.assembleColumns?.('doc', {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+      }) as FileMetadata
+      expect(meta.url).toBe('https://cdn/report.pdf')
+      expect(meta.filename).toBe('report.pdf')
+      expect(meta.size).toBe(4096)
+      expect(meta.storageProvider).toBe('documents')
+    })
+
+    it('file() assembles a partial row (only doc_url) into a valid value', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      const meta = field.assembleColumns?.('doc', {
+        doc_url: 'https://cdn/only.pdf',
+      }) as FileMetadata
+      expect(meta.url).toBe('https://cdn/only.pdf')
+      // Missing filename falls back to the URL; missing filesize defaults to 0.
+      expect(meta.filename).toBe('https://cdn/only.pdf')
+      expect(meta.size).toBe(0)
+    })
+
+    it('file() assembles an empty (all-NULL) row to null', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      expect(
+        field.assembleColumns?.('doc', { doc_url: null, doc_filename: null, doc_filesize: null }),
+      ).toBeNull()
+    })
+
+    it('file() split writes back into the per-part columns', () => {
+      const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+      const meta: FileMetadata = {
+        filename: 'report.pdf',
+        originalFilename: 'report.pdf',
+        url: 'https://cdn/report.pdf',
+        mimeType: 'application/pdf',
+        size: 4096,
+        uploadedAt: '',
+        storageProvider: 'documents',
+      }
+      expect(field.splitColumns?.('doc', meta)).toEqual({
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+      })
+    })
+
+    it('file() round-trips a row through assemble → split with custom @map names', () => {
+      const field = file({
+        storage: 'documents',
+        db: { columns: { mode: 'keystone', map: { url: 'doc_href' } } },
+      })
+      const row = { doc_filename: 'a.bin', doc_filesize: 12, doc_href: 'https://cdn/a.bin' }
+      const meta = field.assembleColumns?.('doc', row)
+      expect((meta as FileMetadata).url).toBe('https://cdn/a.bin')
+      // Split back lands on the overridden physical column, not doc_url.
+      expect(field.splitColumns?.('doc', meta)).toEqual(row)
     })
 
     it('file() split of null clears all columns', () => {


### PR DESCRIPTION
Implements #478

Part of #476

## Scope note (read first)

Issue #478 (C2) asks to apply the multi-column field-emission contract and the `metadata ↔ columns` mapper from #477 to the `file()` field (mapping onto Keystone's `_filename`/`_filesize`/`_url` layout) and to generalise the mapper to handle `FileMetadata` (3 columns) alongside `ImageMetadata` (7 columns).

On investigation, **all of #478's runtime work shipped together with `image()` in PR #511 (the merged C1 work)**, not just the image side. On `main` today:

- `file()` in `db.columns: 'keystone'` mode already emits the three `@map`-ped scalar columns via `getPrismaColumns` (single-`Json?` stays the greenfield default).
- The mapper (`packages/storage/src/utils/multi-column.ts`) already handles `FileMetadata` round-trip and partial/NULL rows (e.g. only `file_url`) via `assembleFileMetadata` / `splitFileMetadata`.
- Per-part `@map` names are configurable (`db: { columns: { mode: 'keystone', map: { … } } }`).
- The no-re-upload guarantee holds for `file()` (existing metadata / populated columns never re-upload; a `File` input does), locked by tests in `multi-column-fields.test.ts`.
- A changeset for the feature already exists (`.changeset/mighty-otters-march.md`).

So the faithful remaining slice for #478 is to **lock the `file()` acceptance criteria at the field-builder boundary**, bringing `file()` coverage to parity with the `image()` coverage that already existed. I deliberately did **not** expand into the `migrate-image-fields` skill / `specs/keystone-image-migration.md` rewrite — that is PRD user-story #9 / a separate slice and is out of scope for #478's (code-only) acceptance criteria.

## What changed

Test-only, in `packages/storage/tests/multi-column-fields.test.ts`:

- `file().assembleColumns` through the builder: fully-populated row, only-`file_url` partial row, and an all-NULL row → `null`.
- `file().splitColumns` through the builder: `FileMetadata` → the three columns, plus a custom-`@map` (`doc_href`) assemble→split round-trip.
- Generator emission for `file()` now asserts three nullable columns with correct scalar types (`filesize` → `Int`; `filename`/`url` → `String`) and `getColumnNames`, plus a configurable per-part `@map` case.

Added `.changeset/file-multi-column-tests.md` (patch, `@opensaas/stack-storage`).

## Acceptance criteria (#478) — status on this branch

- [x] `file()` multi-column emits three `@map`-ped scalar columns; single-JSON unchanged
- [x] Per-part column `@map` names configurable
- [x] Mapper handles `FileMetadata` round-trip + partial/NULL (e.g. only `file_url`)
- [x] No-re-upload guarantee holds for `file()`
- [x] Changeset added

## Verification

- `pnpm build` — pass (11/11)
- `pnpm --filter stack-storage test` — 114 pass (was 108; +6 new `file()` tests)
- `pnpm --filter stack-core test` — 582 pass; `pnpm --filter stack-cli test` — 278 pass
- `pnpm lint` — 0 errors (4 pre-existing warnings in untouched files)
- `pnpm format:check` — clean; `pnpm manypkg check` — valid

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_