### PR TITLE
docs: fix stale read-operation hook order in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,14 @@ The hooks system provides data transformation and side effects during database o
 1. List-level `resolveInput` - Transform input data at list level
 2. Field-level `resolveInput` - Transform individual field values (e.g., hash passwords)
 3. List-level `validate` - Custom validation logic
-4. Field validation - Built-in rules (isRequired, length, min/max)
-5. Field-level access control - Filter writable fields
-6. Field-level `beforeOperation` - Side effects for individual fields
-7. List-level `beforeOperation` - Side effects at list level
-8. **Database operation**
-9. List-level `afterOperation` - Side effects at list level
-10. Field-level `afterOperation` - Side effects for individual fields
+4. Field-level `validate` - Custom validation logic for individual fields
+5. Field validation - Built-in rules (isRequired, length, min/max)
+6. Field-level access control - Filter writable fields
+7. Field-level `beforeOperation` - Side effects for individual fields
+8. List-level `beforeOperation` - Side effects at list level
+9. **Database operation**
+10. List-level `afterOperation` - Side effects at list level
+11. Field-level `afterOperation` - Side effects for individual fields
 
 **Hook execution order (read operations - query):**
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -173,21 +173,23 @@ const prismaType = field.getPrismaType(fieldName)
 
 1. List `resolveInput`
 2. Field `resolveInput` (e.g., hash password)
-3. List `validateInput`
-4. Field validation (isRequired, length, min/max)
-5. Field-level access control (filter writable fields)
-6. Field `beforeOperation`
-7. List `beforeOperation`
-8. **Database operation**
-9. List `afterOperation`
-10. Field `afterOperation`
+3. List `validate`
+4. Field `validate`
+5. Field validation (isRequired, length, min/max)
+6. Field-level access control (filter writable fields)
+7. Field `beforeOperation`
+8. List `beforeOperation`
+9. **Database operation**
+10. List `afterOperation`
+11. Field `afterOperation`
 
 ### Hook Execution Order (Read)
+
+Reads run no `afterOperation` (list or field):
 
 1. **Database operation**
 2. Field-level access control (filter readable fields)
 3. Field `resolveOutput`
-4. Field `afterOperation`
 
 ### Context Type Safety
 


### PR DESCRIPTION
## Summary

Fixes the stale **read (query) operation hook order** documented in the project's `CLAUDE.md` guidance. The docs listed a field-level `afterOperation` step on reads, but the actual runtime read path runs **no** `afterOperation` (list or field).

The real read pipeline (per `packages/core/src/access/field-visibility.ts` and the Field Visibility phase in `packages/core/src/context/write-pipeline.ts`) is three steps:

1. Database operation
2. Field-level access control (filter readable fields)
3. Field-level `resolveOutput`

The #522 migration guide already documented this correctly; the `CLAUDE.md` guidance was the stale copy.

## Changes

- **`packages/core/CLAUDE.md`** — "Hook Execution Order (Read)": removed the bogus `4. Field afterOperation` step and added a one-line note that reads run no `afterOperation`. This is the section that actually carried the stale 4-step read order.
- **Write-order sanity check (both files)** — while here, corrected the write (create/update) hook order to include the field-level `validate` step that the runtime actually runs (`packages/core/src/context/hook-pipeline.ts`: list `validate` → field `validate` → built-in field rules). The docs previously skipped straight from list `validate` to built-in rules.
  - `packages/core/CLAUDE.md` also renamed the deprecated `validateInput` to `validate`.
  - Root `CLAUDE.md` read section was already correct (3 steps); only its write order needed the field-`validate` insertion.

## Grounding

- Read path / no `afterOperation` on reads: `packages/core/src/access/field-visibility.ts` and the Field Visibility phase in `packages/core/src/context/write-pipeline.ts` (Phase 11 = `filterReadableFields`; no after-hooks on the read return path).
- Write order: `packages/core/src/context/hook-pipeline.ts` (list `resolveInput` → field `resolveInput` → list `validate` → field `validate` → built-in field rules) and `packages/core/src/context/write-pipeline.ts` (filter writable → nested ops → field/list `beforeOperation` → DB → list/field `afterOperation` → Field Visibility).

## Notes

Docs-only change; no package source or behaviour change. `CLAUDE.md` is repo/agent guidance (not in `packages/*/src` and not bundled into the published package), so no changeset is required and no plugin version bump applies.

## Verification

- `pnpm install --prefer-offline` — ok
- `pnpm format:check` — "All matched files use Prettier code style!"
- `pnpm lint` — 0 errors (4 pre-existing warnings in untouched `.ts` files)

Fixes #523

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_