### PR TITLE
fix(cli): map introspected Float columns to decimal() not float()

### DIFF
--- a/.changeset/lazy-foxes-march.md
+++ b/.changeset/lazy-foxes-march.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix migration introspectors mapping Prisma/Keystone Float columns to the non-existent `float()` builder; they now map to `decimal()` and warn about the Float→Decimal type change.

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -530,6 +530,13 @@ The auth plugin automatically provides User, Session, Account, and Verification 
       )
     }
 
+    // Float maps to decimal() - flag the type change (double -> decimal.js Decimal)
+    if (field.type === 'Float') {
+      warnings.push(
+        `Field "${field.name}" uses type "Float" - mapped to decimal() (a decimal.js Decimal, not a JS number). Review precision/rounding.`,
+      )
+    }
+
     const optionsStr = options.length > 0 ? `{ ${options.join(', ')} }` : ''
     return `${mapping.type}(${optionsStr})`
   }

--- a/packages/cli/src/migration/introspectors/keystone-introspector.ts
+++ b/packages/cli/src/migration/introspectors/keystone-introspector.ts
@@ -245,7 +245,7 @@ export class KeystoneIntrospector {
     const mappings: Record<string, { type: string; import: string }> = {
       text: { type: 'text', import: 'text' },
       integer: { type: 'integer', import: 'integer' },
-      float: { type: 'float', import: 'float' },
+      float: { type: 'decimal', import: 'decimal' }, // No native float - mapped to decimal()
       checkbox: { type: 'checkbox', import: 'checkbox' },
       timestamp: { type: 'timestamp', import: 'timestamp' },
       select: { type: 'select', import: 'select' },
@@ -276,6 +276,9 @@ export class KeystoneIntrospector {
     const hasVirtualFields = schema.models.some((model) =>
       model.fields.some((field) => field.type.toLowerCase() === 'virtual'),
     )
+    const hasFloatFields = schema.models.some((model) =>
+      model.fields.some((field) => field.type.toLowerCase() === 'float'),
+    )
 
     // Add storage configuration reminder if file/image fields are present
     if (hasFileOrImageFields) {
@@ -288,6 +291,13 @@ export class KeystoneIntrospector {
     if (hasVirtualFields) {
       warnings.push(
         "Your schema uses virtual() fields — you'll need to manually migrate these. OpenSaaS Stack has no GraphQL: replace graphql.field({ resolve }) with hooks: { resolveOutput } and declare the field type. See the migration guide or invoke the migrate-virtual-fields skill.",
+      )
+    }
+
+    // Add float field migration reminder
+    if (hasFloatFields) {
+      warnings.push(
+        'Your schema uses float() fields - these will be mapped to decimal() (a decimal.js Decimal, not a JS number). Review precision/rounding.',
       )
     }
 

--- a/packages/cli/src/migration/introspectors/prisma-introspector.ts
+++ b/packages/cli/src/migration/introspectors/prisma-introspector.ts
@@ -196,7 +196,7 @@ export class PrismaIntrospector {
     const mappings: Record<string, { type: string; import: string }> = {
       String: { type: 'text', import: 'text' },
       Int: { type: 'integer', import: 'integer' },
-      Float: { type: 'float', import: 'float' },
+      Float: { type: 'decimal', import: 'decimal' }, // No native float - mapped to decimal()
       Boolean: { type: 'checkbox', import: 'checkbox' },
       DateTime: { type: 'timestamp', import: 'timestamp' },
       Json: { type: 'json', import: 'json' },
@@ -220,6 +220,11 @@ export class PrismaIntrospector {
         if (['BigInt', 'Decimal', 'Bytes'].includes(field.type)) {
           warnings.push(
             `Field "${model.name}.${field.name}" uses unsupported type "${field.type}" - will be mapped to text()`,
+          )
+        }
+        if (field.type === 'Float') {
+          warnings.push(
+            `Field "${model.name}.${field.name}" uses type "Float" - will be mapped to decimal() (a decimal.js Decimal, not a JS number). Review precision/rounding.`,
           )
         }
       }

--- a/packages/cli/tests/introspectors/keystone-introspector.test.ts
+++ b/packages/cli/tests/introspectors/keystone-introspector.test.ts
@@ -93,6 +93,13 @@ export default {
     })
   })
 
+  it('should map float to decimal() (not the non-existent float())', () => {
+    expect(introspector.mapKeystoneTypeToOpenSaas('float')).toEqual({
+      type: 'decimal',
+      import: 'decimal',
+    })
+  })
+
   it('should handle file and image fields', () => {
     expect(introspector.mapKeystoneTypeToOpenSaas('image')).toEqual({
       type: 'image',
@@ -141,6 +148,31 @@ export default {
     expect(warnings.some((w) => w.includes('storage'))).toBe(true)
     // Should remind about manual migration for virtual field hooks
     expect(warnings.some((w) => w.includes('virtual') && w.includes('manually migrate'))).toBe(true)
+  })
+
+  it('should warn when a float field is mapped to decimal()', async () => {
+    const config = `
+export default {
+  db: {
+    provider: 'postgresql',
+  },
+  lists: {
+    Product: {
+      fields: {
+        price: {
+          type: 'float',
+        },
+      },
+    },
+  },
+}
+`
+    await fs.writeFile(path.join(tempDir, 'keystone.config.js'), config)
+
+    const result = await introspector.introspect(tempDir, 'keystone.config.js')
+    const warnings = introspector.getWarnings(result)
+
+    expect(warnings.some((w) => w.includes('float') && w.includes('decimal()'))).toBe(true)
   })
 
   it('should throw for missing config', async () => {

--- a/packages/cli/tests/introspectors/prisma-introspector.test.ts
+++ b/packages/cli/tests/introspectors/prisma-introspector.test.ts
@@ -185,6 +185,35 @@ model User {
     expect(introspector.mapPrismaTypeToOpenSaas('Json')).toEqual({ type: 'json', import: 'json' })
   })
 
+  it('should map Float to decimal() (not the non-existent float())', () => {
+    expect(introspector.mapPrismaTypeToOpenSaas('Float')).toEqual({
+      type: 'decimal',
+      import: 'decimal',
+    })
+  })
+
+  it('should warn when a Float column is mapped to decimal()', async () => {
+    const schema = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id    String @id
+  price Float
+}
+`
+    await fs.writeFile(path.join(tempDir, 'prisma', 'schema.prisma'), schema)
+
+    const result = await introspector.introspect(tempDir)
+    const warnings = introspector.getWarnings(result)
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('Float')
+    expect(warnings[0]).toContain('decimal()')
+  })
+
   it('should generate warnings for unsupported types', async () => {
     const schema = `
 datasource db {

--- a/packages/cli/tests/migration-generator.test.ts
+++ b/packages/cli/tests/migration-generator.test.ts
@@ -2,7 +2,10 @@
  * Migration Generator Tests
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs-extra'
+import path from 'path'
+import os from 'os'
 import { MigrationGenerator } from '../src/migration/generators/migration-generator.js'
 import type { MigrationSession } from '../src/migration/types.js'
 
@@ -587,6 +590,63 @@ describe('MigrationGenerator', () => {
       const output = await generator.generate(session)
 
       expect(output.configContent).not.toContain('AccessControl')
+    })
+  })
+
+  describe('Float Field Mapping', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'migration-float-'))
+      await fs.ensureDir(path.join(tempDir, 'prisma'))
+    })
+
+    afterEach(async () => {
+      await fs.remove(tempDir)
+    })
+
+    it('should generate decimal() (not float()) for a Float column and warn', async () => {
+      const schema = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id    String @id @default(cuid())
+  price Float
+}
+`
+      await fs.writeFile(path.join(tempDir, 'prisma', 'schema.prisma'), schema)
+
+      const session: MigrationSession = {
+        id: 'test',
+        projectType: 'prisma',
+        analysis: {
+          projectTypes: ['prisma'],
+          cwd: tempDir,
+          provider: 'postgresql',
+        },
+        currentQuestionIndex: 0,
+        answers: {
+          db_provider: 'postgresql',
+          enable_auth: false,
+          default_access: 'public-read-auth-write',
+        },
+        isComplete: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const output = await generator.generate(session)
+
+      // References the real decimal() builder, not the non-existent float()
+      expect(output.configContent).toContain('price: decimal(')
+      expect(output.configContent).not.toContain('float(')
+      // decimal is imported from the fields entry point
+      expect(output.configContent).toContain('decimal')
+      // Warns about the Float -> Decimal type change
+      expect(output.warnings.some((w) => w.includes('Float') && w.includes('decimal()'))).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

The auto-migration introspector mapped a Prisma `Float` column to a non-existent `float()` field builder, so a config generated from a database with `Float` columns wouldn't compile. This maps `Float` → `decimal()` (a real builder, defaults precision 18 / scale 4) instead, mirroring the existing `BigInt` → `text()` handling.

The same broken `float` reference existed in **two** introspectors, so both were fixed.

## Changes

- **`packages/cli/src/migration/introspectors/prisma-introspector.ts`** — map Prisma `Float` → `decimal()` (was `float()`); add a `Float`→`Decimal` warning in `getWarnings()` flagging the type change (double → `decimal.js` `Decimal`) so users review precision/rounding.
- **`packages/cli/src/migration/introspectors/keystone-introspector.ts`** — map Keystone `float` → `decimal()` (was `float()`); add a matching `float`→`decimal()` warning in `getWarnings()`.
- **`packages/cli/src/migration/generators/migration-generator.ts`** — add a `Float`→`Decimal` warning alongside the existing `BigInt`/`Decimal`/`Bytes` warning, following the same precedent.

No `float()` builder was introduced (out of scope). `decimal` is exported from `@opensaas/stack-core/fields` and flows through the existing `usedFieldTypes` import collection, so the generated config imports a real builder.

## Tests

Added/extended tests asserting the `Float`→`decimal()` mapping and the warning (all green):

- `prisma-introspector.test.ts`: "should map Float to decimal() (not the non-existent float())" and "should warn when a Float column is mapped to decimal()"
- `keystone-introspector.test.ts`: "should map float to decimal() (not the non-existent float())" and "should warn when a float field is mapped to decimal()"
- `migration-generator.test.ts`: "should generate decimal() (not float()) for a Float column and warn" (end-to-end: writes a schema with a `Float` column, asserts `decimal(` appears in config, `float(` does not, and the warning is emitted)

Full CLI suite: 285 passed.

## Changeset

`.changeset/lazy-foxes-march.md` (patch, `@opensaas/stack-cli`).

Fixes #524

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_