### PR TITLE
docs(ui): fix non-existent getAdminContext references in stack-ui docs

### DIFF
--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -50,7 +50,14 @@ Composable CRUD components:
 
 ### Server (`/server`)
 
-- `getAdminContext(headers)` - Get context with session from request headers
+Type-only re-exports for wiring the admin's server action (no runtime exports):
+
+- `ServerActionInput` - Props passed to the generic server action (re-exported from stack-core)
+- `ActionResult<T>` - Result shape returned by a server action
+
+The host app builds the access-scoped `context` itself (from the generated
+`.opensaas/context`) and passes it to `AdminUI`. There is no `getAdminContext`
+helper in this package.
 
 ## Architecture Patterns
 
@@ -154,7 +161,7 @@ export function RichTextField({ placeholder, minHeight, customOption, ...basePro
 
 ### Server/Client Boundaries
 
-- `AdminUI` is server component (uses `getAdminContext`)
+- `AdminUI` is a server component (the host builds and passes `context`)
 - Forms and interactive components are client components
 - Data serialization via props (no functions, only JSON-serializable data)
 
@@ -168,7 +175,7 @@ export function RichTextField({ placeholder, minHeight, customOption, ...basePro
 
 ### With @opensaas/stack-auth
 
-- `getAdminContext` uses Better-auth to get session
+- The host resolves the Better-auth session and passes it to `getContext(session)`
 - Session flows through context to access control
 - Auth UI components imported separately from `@opensaas/stack-auth/ui`
 
@@ -191,17 +198,47 @@ import '../../../lib/register-fields' // Side-effect import
 
 ### Basic Admin Setup
 
+The host builds the access-scoped `context` (and `config`) from the generated
+`.opensaas/context` and wires a `'use server'` action that forwards to
+`context.serverAction`:
+
 ```typescript
 // app/admin/[[...admin]]/page.tsx
 import { AdminUI } from '@opensaas/stack-ui'
-import { getAdminContext } from '@opensaas/stack-ui/server'
-import config from '@/opensaas.config'
+import type { ServerActionInput } from '@opensaas/stack-ui/server'
+import { getContext, config } from '@/.opensaas/context'
 
-export default async function AdminPage() {
-  const context = await getAdminContext()
-  return <AdminUI context={context} config={config} />
+// User-defined wrapper that runs the server action with an access-scoped context
+async function serverAction(props: ServerActionInput) {
+  'use server'
+  const context = await getContext()
+  return await context.serverAction(props)
+}
+
+interface AdminPageProps {
+  params: Promise<{ admin?: string[] }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export default async function AdminPage({ params, searchParams }: AdminPageProps) {
+  const resolvedParams = await params
+  const resolvedSearchParams = await searchParams
+  return (
+    <AdminUI
+      context={await getContext()}
+      config={await config}
+      params={resolvedParams.admin}
+      searchParams={resolvedSearchParams}
+      basePath="/admin"
+      serverAction={serverAction}
+    />
+  )
 }
 ```
+
+With auth, resolve the session and pass it to `getContext(session)` (in both the
+page and the wrapper). See `examples/starter`, `examples/starter-auth`, and
+`examples/auth-demo`.
 
 ### Custom Field Component (Global Registration)
 
@@ -305,7 +342,7 @@ Avoid `any` types - all props are strongly typed for type safety.
 
 ## Performance
 
-- Server components by default (AdminUI, getAdminContext)
+- Server components by default (AdminUI renders on the server)
 - Client components marked with `'use client'`
 - Minimal client-side JS for interactive features only
 - Data fetching on server reduces client bundle size

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -32,8 +32,8 @@ import { ItemCreateForm, ListTable, SearchBar } from '@opensaas/stack-ui/standal
 // Full components (page-level)
 import { Dashboard, ListView, ItemForm, AdminUI } from '@opensaas/stack-ui'
 
-// Server utilities
-import { getAdminContext } from '@opensaas/stack-ui/server'
+// Server utility types
+import type { ServerActionInput, ActionResult } from '@opensaas/stack-ui/server'
 
 // Utility functions
 import { cn, formatListName, formatFieldName } from '@opensaas/stack-ui/lib/utils'
@@ -175,18 +175,49 @@ import { DeleteButton } from '@opensaas/stack-ui/standalone'
 
 ### Level 4: Full Admin UI (`@opensaas/stack-ui`)
 
-Complete admin interface with routing and navigation.
+Complete admin interface with routing and navigation. The host app builds the
+access-scoped `context` (and `config`) from the generated `.opensaas/context`
+and passes them in, along with a `'use server'` wrapper that forwards form
+submissions to `context.serverAction`:
 
 ```tsx
+// app/admin/[[...admin]]/page.tsx
 import { AdminUI } from '@opensaas/stack-ui'
-;<AdminUI
-  context={context}
-  params={params?.admin}
-  searchParams={searchParams}
-  basePath="/admin"
-  serverAction={handleServerAction}
-/>
+import type { ServerActionInput } from '@opensaas/stack-ui/server'
+import { getContext, config } from '@/.opensaas/context'
+
+// User-defined wrapper that runs the server action with an access-scoped context
+async function serverAction(props: ServerActionInput) {
+  'use server'
+  const context = await getContext()
+  return await context.serverAction(props)
+}
+
+interface AdminPageProps {
+  params: Promise<{ admin?: string[] }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export default async function AdminPage({ params, searchParams }: AdminPageProps) {
+  const resolvedParams = await params
+  const resolvedSearchParams = await searchParams
+  return (
+    <AdminUI
+      context={await getContext()}
+      config={await config}
+      params={resolvedParams.admin}
+      searchParams={resolvedSearchParams}
+      basePath="/admin"
+      serverAction={serverAction}
+    />
+  )
+}
 ```
+
+> With `@opensaas/stack-auth`, resolve the session first and pass it to
+> `getContext(session)` (in both the page and the `serverAction` wrapper) so
+> access control runs as the signed-in user. See `examples/starter-auth` and
+> `examples/auth-demo`.
 
 ## Component Registry
 


### PR DESCRIPTION
## Summary

Fixes #533 (SF-13). The `@opensaas/stack-ui` README and CLAUDE.md quick-starts imported a non-existent `getAdminContext` runtime export from `@opensaas/stack-ui/server`, so the documented setup did not compile against the shipped package. `packages/ui/src/server/index.ts` re-exports **types only** (`ServerActionInput`, `ActionResult`) — there is no `getAdminContext`.

Per the design decision in the issue, this is the **docs-fix** option (option 2). No new helper is shipped.

## What changed

The docs now show the **actual shipped pattern**: the host app builds the access-scoped `context` (and `config`) from the generated `.opensaas/context` and passes them to `<AdminUI>`, along with a `'use server'` wrapper that forwards form submissions to `context.serverAction`. This matches the real working examples `examples/starter`, `examples/starter-auth`, and `examples/auth-demo`.

### References replaced / removed

`packages/ui/README.md`:
- Package Exports: replaced `import { getAdminContext } from '@opensaas/stack-ui/server'` with `import type { ServerActionInput, ActionResult } from '@opensaas/stack-ui/server'`.
- "Level 4: Full Admin UI": expanded the snippet to the full shipped page pattern (builds `context`, wires `serverAction`, passes `config`/`params`/`searchParams`/`basePath`), plus an auth note.

`packages/ui/CLAUDE.md`:
- "Server (`/server`)" export bullet: replaced the `getAdminContext(headers)` description with the type-only exports and a note that the host supplies `context` (no `getAdminContext` exists).
- "Server/Client Boundaries": removed "uses `getAdminContext`".
- "With @opensaas/stack-auth": replaced `getAdminContext uses Better-auth...` with host resolving the session and passing it to `getContext(session)`.
- "Basic Admin Setup": replaced the `getAdminContext()` snippet with the real `getContext()` + `serverAction` page pattern.
- "Performance": removed `getAdminContext` from the server-components bullet.

The only remaining mention of `getAdminContext` is an explicit statement that no such helper exists.

## Grounded in

`examples/starter/app/admin/[[...admin]]/page.tsx` (and identically `examples/starter-auth`, `examples/auth-demo`) — the documented imports/props all match `AdminUIProps` in `packages/ui/src/components/AdminUI.tsx`.

## Verification

- Docs-only change (`packages/ui/README.md`, `packages/ui/CLAUDE.md`) — **no changeset** needed.
- `pnpm format:check` — all files pass.
- `pnpm lint` — 0 errors (4 pre-existing warnings in unrelated `.ts` source files).

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_