### PR TITLE
fix(core): make ignored `select` on context.db reads a visible no-op (SF-11)

### DIFF
--- a/.changeset/quiet-otters-warn.md
+++ b/.changeset/quiet-otters-warn.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+context.db findUnique/findMany now warn (once per list+op) when passed an ignored `select` — narrow reads via `include` or a fragment `query`.

--- a/docs/content/api-reference/fields.md
+++ b/docs/content/api-reference/fields.md
@@ -1434,11 +1434,8 @@ User: list({
 })
 
 // Usage
-const user = await context.db.user.findUnique({
-  where: { id },
-  select: { firstName: true, lastName: true, fullName: true },
-})
-console.log(user.fullName) // "John Doe"
+const user = await context.db.user.findUnique({ where: { id } })
+console.log(user.fullName) // "John Doe" — computed via resolveOutput on every read
 ```
 
 ##### Complex Computed Value
@@ -1487,21 +1484,12 @@ Post: list({
 #### Important Notes
 
 {% callout type="warning" %}
-Virtual fields must be explicitly selected in queries. They are not included by default.
+`context.db` reads do not honour Prisma's `select` argument — passing `select` logs a runtime warning and is otherwise a no-op. Narrow a read with `include` (relationships) or a fragment `query`. Virtual fields are always computed via `resolveOutput` on every read.
 {% /callout %}
 
 ```typescript
-// ❌ Virtual field NOT computed
-const user = await context.db.user.findUnique({
-  where: { id },
-})
-// user.fullName is undefined
-
-// ✅ Virtual field IS computed
-const user = await context.db.user.findUnique({
-  where: { id },
-  select: { firstName: true, lastName: true, fullName: true },
-})
+// Virtual field is computed on every read — no select needed
+const user = await context.db.user.findUnique({ where: { id } })
 // user.fullName is "John Doe"
 ```
 

--- a/docs/content/core-concepts/field-types.md
+++ b/docs/content/core-concepts/field-types.md
@@ -580,7 +580,7 @@ The TypeScript type generator automatically collects and generates the necessary
 **Key Features:**
 
 - Does not create a database column
-- Only computed when explicitly selected/included in queries
+- Computed via `resolveOutput` on every read
 - Can combine data from multiple fields
 - Useful for derived values, computed properties, and external sync
 - Supports custom scalar types for financial precision
@@ -589,20 +589,13 @@ The TypeScript type generator automatically collects and generates the necessary
 
 ```typescript
 // Query with virtual field
-const user = await context.db.user.findUnique({
-  where: { id },
-  select: {
-    firstName: true,
-    lastName: true,
-    fullName: true, // Virtual field is computed on demand
-  },
-})
+const user = await context.db.user.findUnique({ where: { id } })
 
 console.log(user.fullName) // "John Doe"
 ```
 
-{% callout type="info" %}
-Virtual fields are only computed when explicitly included in `select` or `include` clauses. They are not computed by default to optimize performance.
+{% callout type="warning" %}
+`context.db` reads do not honour Prisma's `select` argument — passing `select` logs a runtime warning and is otherwise a no-op. Narrow a read with `include` (relationships) or a fragment `query`. Virtual fields are computed via `resolveOutput` on every read regardless.
 {% /callout %}
 
 ### JSON Field

--- a/docs/content/core-concepts/queries.md
+++ b/docs/content/core-concepts/queries.md
@@ -93,6 +93,10 @@ if (!post) return notFound()
 // post: PostData
 ```
 
+{% callout type="warning" %}
+`context.db` reads do **not** honour Prisma's `select` argument. Narrow a read with `include` (for relationships) or a fragment `query` instead. Passing `select` to `findUnique`/`findMany` is a no-op: it logs a runtime warning and the full, access-filtered record is still returned (field-level visibility is always enforced by [access control](/docs/core-concepts/access-control), regardless of `select`).
+{% /callout %}
+
 ### Via `runQuery` / `runQueryOne` (standalone helpers)
 
 When you don't have direct access to `context.db` (for example inside a hook or a shared utility), use the standalone helpers. They take the `context`, the PascalCase list key, the fragment, and query args:

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -191,6 +191,10 @@ Reads run no `afterOperation` (list or field):
 2. Field-level access control (filter readable fields)
 3. Field `resolveOutput`
 
+### Narrowing Reads (`select` is not honoured)
+
+`context.db` reads (`findUnique`, `findMany`) do **not** apply Prisma's `select` semantics. Narrow a read with `include` (for relationships) or a fragment `query` instead. Passing `select` is a visible no-op: the op logs a one-time `console.warn` and still returns the full, access-filtered record. Field-level visibility is always enforced by access control regardless of `select`, so there is no leak — only a correctness/perf footgun the warning surfaces.
+
 ### Context Type Safety
 
 Context uses generic typing to preserve Prisma types:
@@ -341,17 +345,14 @@ User: list({
 })
 
 // Usage
-const user = await context.db.user.findUnique({
-  where: { id },
-  select: { firstName: true, lastName: true, fullName: true }, // fullName computed on demand
-})
-console.log(user.fullName) // "John Doe"
+const user = await context.db.user.findUnique({ where: { id } })
+console.log(user.fullName) // "John Doe" — computed via resolveOutput on every read
 ```
 
 **Key characteristics:**
 
 - Not stored in database (no Prisma column created)
-- Only computed when explicitly selected/included in queries
+- Computed via `resolveOutput` on every read (`select` is not honoured — narrow with `include`/fragment `query`)
 - Must provide `type` (TypeScript type string) and `resolveOutput` hook
 - Can optionally provide `resolveInput` for write side effects
 - Useful for derived values, computed properties, and external API sync

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -23,6 +23,41 @@ export type ServerActionProps =
   | { listKey: string; action: 'delete'; id: string }
 
 /**
+ * Tracks which (listName, operation) pairs have already warned about an ignored
+ * `select` argument, so a misused read op warns once rather than on every call.
+ */
+const selectWarnings = new Set<string>()
+
+/**
+ * Warn (once per list+operation) when a caller passes a `select` argument to a
+ * read op that does not honour it.
+ *
+ * `context.db` reads never apply Prisma `select` semantics — narrowing is done
+ * via `include` or a fragment `query`. The op still runs and returns the full,
+ * access-filtered result, so this is a visible no-op rather than an error.
+ *
+ * Centralised here so every affected read op shares one implementation.
+ */
+function warnIfSelectIgnored(
+  args: { select?: unknown } | undefined,
+  listName: string,
+  operation: string,
+): void {
+  if (!args || args.select === undefined) return
+
+  const key = `${listName}.${operation}`
+  if (selectWarnings.has(key)) return
+  selectWarnings.add(key)
+
+  console.warn(
+    `[@opensaas/stack-core] \`select\` is ignored by context.db.${getDbKey(listName)}.${operation}() ` +
+      `and the full (access-filtered) record is returned. ` +
+      `Narrow a read with \`include\` or a fragment \`query\` instead. ` +
+      `See https://stack.opensaas.au/docs/core-concepts/queries`,
+  )
+}
+
+/**
  * Check if a list is configured as a singleton
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -373,7 +408,12 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
     include?: Record<string, unknown>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query?: any
+    // `select` is not honoured — accepted only so the no-op can be made visible.
+    select?: Record<string, unknown>
   }) => {
+    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
+    warnIfSelectIgnored(args, listName, 'findUnique')
+
     // Check query access (skip if sudo mode)
     let where: Record<string, unknown> = args.where
     if (!context._isSudo) {
@@ -471,7 +511,12 @@ function createFindMany<TPrisma extends PrismaClientLike>(
     include?: Record<string, unknown>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query?: any
+    // `select` is not honoured — accepted only so the no-op can be made visible.
+    select?: Record<string, unknown>
   }) => {
+    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
+    warnIfSelectIgnored(args, listName, 'findMany')
+
     // Check singleton constraint (throw error instead of silently returning empty)
     if (isSingletonList(listConfig)) {
       throw new ValidationError(

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getContext } from '../src/context/index.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 
@@ -423,6 +423,85 @@ describe('getContext', () => {
 
       // Hook should be called twice (once for each item)
       expect(configWithHook.lists.User.hooks?.resolveInput).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // `select` is not honoured by context.db reads — it is a visible no-op: the
+  // op warns (once per list+operation) and still returns the full, access-
+  // filtered result. Each test re-imports getContext via vi.resetModules() so
+  // the module-level warn-once cache starts empty.
+  describe('select no-op warning', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+    let freshGetContext: typeof getContext
+
+    beforeEach(async () => {
+      vi.resetModules()
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await import('../src/context/index.js')
+      freshGetContext = mod.getContext
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('warns AND still returns the row when findUnique is passed a select', async () => {
+      const mockUser = { id: '1', name: 'John', email: 'john@example.com' }
+      mockPrisma.user.findFirst.mockResolvedValue(mockUser)
+
+      const context = await freshGetContext(config, mockPrisma, null)
+      const result = await context.db.user.findUnique({
+        where: { id: '1' },
+        select: { name: true },
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('`select` is ignored')
+      expect(warnSpy.mock.calls[0][0]).toContain('findUnique')
+      // Behaviour unchanged: the op still runs and returns the full row.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalled()
+      expect(result).toEqual(mockUser)
+    })
+
+    it('warns AND still returns the rows when findMany is passed a select', async () => {
+      const mockUsers = [
+        { id: '1', name: 'John' },
+        { id: '2', name: 'Jane' },
+      ]
+      mockPrisma.user.findMany.mockResolvedValue(mockUsers)
+
+      const context = await freshGetContext(config, mockPrisma, null)
+      const result = await context.db.user.findMany({ select: { name: true } })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('`select` is ignored')
+      expect(warnSpy.mock.calls[0][0]).toContain('findMany')
+      expect(mockPrisma.user.findMany).toHaveBeenCalled()
+      expect(result).toEqual(mockUsers)
+    })
+
+    it('warns only once per list+operation across repeated calls', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([])
+
+      const context = await freshGetContext(config, mockPrisma, null)
+      await context.db.user.findMany({ select: { name: true } })
+      await context.db.user.findMany({ select: { name: true } })
+      await context.db.user.findMany({ select: { email: true } })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT warn for findUnique/findMany using only include or query', async () => {
+      const mockUser = { id: '1', name: 'John' }
+      mockPrisma.user.findFirst.mockResolvedValue(mockUser)
+      mockPrisma.user.findMany.mockResolvedValue([mockUser])
+
+      const context = await freshGetContext(config, mockPrisma, null)
+      await context.db.user.findUnique({ where: { id: '1' }, include: { posts: true } })
+      await context.db.user.findMany({ include: { posts: true } })
+      await context.db.user.findMany()
+
+      expect(warnSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

`context.db.<list>.findUnique` / `findMany` silently dropped a `select` argument and returned the full (access-filtered) row — a correctness/perf footgun (SF-11). Per the chosen design (option 2: **make the no-op visible + document**, not honour `select`), this PR makes the no-op visible at runtime and documents the only narrowing mechanisms (`include` / fragment `query`).

This is **not** a security change — field-level visibility was, and remains, enforced by the access layer (`filterReadableFields`) regardless of `select`.

## Changes

- **Runtime warning (centralised):** new `warnIfSelectIgnored()` helper in `packages/core/src/context/index.ts`. It emits a single `console.warn` (**warn-once, keyed per `listName.operation`**) only when `select` is actually present, then proceeds unchanged. Wired into `createFindUnique` and `createFindMany` — the two read ops that accept a caller args object where `select` would be dropped. (`get()` takes no args and there is no `db.findFirst`, so neither needed changes.)
- **Behaviour otherwise unchanged:** the op still runs and returns the full, access-filtered result.
- **Types:** `select?` was added to the two read-op arg types purely so the warning has a typed surface to read from. No change to `include`/`query` typing (no breaking change).
- **Docs:** `docs/content/core-concepts/queries.md`, `docs/content/core-concepts/field-types.md`, `docs/content/api-reference/fields.md`, and `packages/core/CLAUDE.md` now state `select` is not honoured and that reads are narrowed via `include` or a fragment `query`. The misleading virtual-field examples that used `select` were corrected (virtuals are computed via `resolveOutput` on every read).

## Tests

Added a `select no-op warning` describe block to `packages/core/tests/context.test.ts` (uses `vi.resetModules()` so the module-level warn-once cache starts empty per test):

- `warns AND still returns the row when findUnique is passed a select`
- `warns AND still returns the rows when findMany is passed a select`
- `warns only once per list+operation across repeated calls`
- `does NOT warn for findUnique/findMany using only include or query`

## Verification

- `pnpm --filter @opensaas/stack-core build` — clean
- `pnpm --filter @opensaas/stack-core test` — 586 passed (incl. 4 new)
- `pnpm lint` — 0 errors (4 pre-existing unrelated warnings)
- `pnpm format:check` — all files match Prettier style
- Changeset: `.changeset/quiet-otters-warn.md` (patch, `@opensaas/stack-core`)

Fixes #531

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_