### PR TITLE
feat(ui): autoCreate:false create-on-save + access-denied handling in SingletonView

### DIFF
--- a/.changeset/singleton-autocreate-access.md
+++ b/.changeset/singleton-autocreate-access.md
@@ -1,0 +1,13 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Handle `autoCreate: false` singletons and access-denied reads in the AdminUI singleton editor.
+
+When a singleton's `get()` returns no record, `SingletonView` now disambiguates the two reasons a singleton can be empty and renders the safe affordance:
+
+- **`autoCreate: false` with no row yet** (query + create allowed): renders a create-on-first-save form (reuses `ItemFormClient` in `mode="create"`). Core assigns the singleton `id` and enforces the single-record constraint on save, so the form sends only the user-entered field data.
+- **`query` access denied**: renders a friendly "no access" message — never an editable or create form.
+- **create denied (autoCreate: false, no row)**: renders a friendly "no record yet" message instead of an unusable form.
+
+An update-denied singleton still renders the edit form, but the save fails gracefully via the server action's denied envelope. The happy path (a record exists → edit form) and non-singleton lists are unchanged.

--- a/packages/ui/src/components/SingletonView.tsx
+++ b/packages/ui/src/components/SingletonView.tsx
@@ -5,6 +5,7 @@ import { formatListName } from '../lib/utils.js'
 import type { ServerActionInput } from '../server/types.js'
 import { type AccessContext, getDbKey, getUrlKey, OpenSaasConfig } from '@opensaas/stack-core'
 import { prepareItemForm } from '../lib/prepareItemForm.js'
+import { isOperationPotentiallyAllowed } from '../lib/operationAccess.js'
 
 export interface SingletonViewProps {
   context: AccessContext<unknown>
@@ -23,6 +24,21 @@ export interface SingletonViewProps {
  * the row with field defaults when absent, unless `autoCreate: false`), then
  * reuses the same `ItemFormClient` + serialization path as `ItemForm` so the
  * existing field rendering, validation, and `serverAction` save flow apply.
+ *
+ * A `null` from `get()` is ambiguous at the boundary — it means EITHER an
+ * `autoCreate: false` singleton with no row yet, OR that `query` access is
+ * denied (access-controlled reads return null/[] silently). We disambiguate
+ * using the list's operation-level access:
+ *
+ * - `query` denied  → friendly "no access" message (never an editable form).
+ * - `query` allowed + `create` allowed → a create-on-first-save form
+ *   (`ItemFormClient` in `mode="create"`); core assigns the singleton `id` and
+ *   enforces the single-record constraint on create.
+ * - `query` allowed + `create` denied → friendly "no record yet" message.
+ *
+ * An update-denied singleton still renders the edit form (the happy path), but
+ * the save fails gracefully: the server action's `update` access check returns
+ * a denied envelope, which `ItemFormClient` surfaces as an error.
  *
  * Server Component that fetches data and sets up actions.
  */
@@ -48,8 +64,9 @@ export async function SingletonView({
   }
 
   // Resolve the singleton record. `get()` auto-creates with field defaults when
-  // absent (the default). It returns null only when `autoCreate: false` — the
-  // create-on-save path for that case is slice 3 (#540), so guard for now.
+  // absent (the default), so a record is the common case. It returns null when
+  // either `autoCreate: false` with no row yet, OR `query` access is denied —
+  // these are indistinguishable here, so we disambiguate via access below.
   let record: Record<string, unknown> | null = null
   try {
     const delegate = context.db[getDbKey(listKey)]
@@ -61,13 +78,98 @@ export async function SingletonView({
   }
 
   if (!record) {
+    // A null `get()` is ambiguous (autoCreate:false-empty vs query-denied).
+    // Evaluate operation access to choose the safe affordance.
+    const accessArgs = { session: context.session, context }
+    const canQuery = await isOperationPotentiallyAllowed(
+      listConfig.access?.operation,
+      'query',
+      accessArgs,
+    )
+
+    // Query denied → the session cannot read this singleton at all. Show a
+    // friendly message; never an editable/create form.
+    if (!canQuery) {
+      return (
+        <div className="p-8 max-w-4xl">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold">{formatListName(listKey)}</h1>
+          </div>
+          <div className="bg-muted/50 border border-border rounded-lg p-6">
+            <p className="text-muted-foreground">
+              You don&apos;t have access to {formatListName(listKey)}.
+            </p>
+          </div>
+        </div>
+      )
+    }
+
+    // Query allowed but no row → an `autoCreate: false` singleton. Offer a
+    // create-on-first-save form only when `create` is actually permitted.
+    const canCreate = await isOperationPotentiallyAllowed(
+      listConfig.access?.operation,
+      'create',
+      accessArgs,
+    )
+
+    if (!canCreate) {
+      return (
+        <div className="p-8 max-w-4xl">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold">{formatListName(listKey)}</h1>
+          </div>
+          <div className="bg-muted/50 border border-border rounded-lg p-6">
+            <p className="text-muted-foreground">
+              There is no {formatListName(listKey)} record yet.
+            </p>
+          </div>
+        </div>
+      )
+    }
+
+    // Create-on-first-save: render the form in create mode with an empty record.
+    // The save goes through the existing `serverAction` create path; core
+    // assigns the singleton `id` (always `1`) and enforces the single-record
+    // constraint, so the form sends only the user-entered field data.
+    const {
+      serializableFields: createFields,
+      initialData: createInitialData,
+      relationshipData: createRelationshipData,
+    } = await prepareItemForm(context, config, listConfig, {})
+
     return (
       <div className="p-8 max-w-4xl">
+        {/* Header — a singleton has no list view, so link back to the dashboard. */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold">{formatListName(listKey)}</h1>
+          <Link
+            href={basePath}
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+          >
+            <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            Back to dashboard
+          </Link>
+          <h1 className="text-3xl font-bold">Create {formatListName(listKey)}</h1>
         </div>
-        <div className="bg-muted/50 border border-border rounded-lg p-6">
-          <p className="text-muted-foreground">There is no {formatListName(listKey)} record yet.</p>
+
+        {/* Create-on-first-save form */}
+        <div className="bg-card border border-border rounded-lg p-6">
+          <ItemFormClient
+            listKey={listKey}
+            urlKey={urlKey}
+            mode="create"
+            fields={createFields}
+            initialData={createInitialData}
+            basePath={basePath}
+            serverAction={serverAction}
+            relationshipData={createRelationshipData}
+          />
         </div>
       </div>
     )

--- a/packages/ui/src/lib/operationAccess.ts
+++ b/packages/ui/src/lib/operationAccess.ts
@@ -1,0 +1,53 @@
+import type { AccessContext, OperationAccess, Session } from '@opensaas/stack-core'
+
+/**
+ * The names of the operation-level access checks we evaluate in the UI.
+ */
+export type OperationAccessName = 'query' | 'create' | 'update' | 'delete'
+
+/**
+ * Evaluate a list's operation-level access control for the current session,
+ * coercing the result to a single "is this operation potentially permitted?"
+ * boolean.
+ *
+ * This mirrors how the core access engine treats a result:
+ * - `false`            → denied
+ * - `true`             → permitted
+ * - a filter object    → permitted, but scoped to matching rows
+ *
+ * Because the UI cannot know whether a returned filter would match the
+ * (possibly not-yet-created) singleton row, a filter is treated as "potentially
+ * permitted" — the actual operation still runs through the access engine, which
+ * re-applies the filter. This helper only decides which affordance to render.
+ *
+ * Access functions are user-defined and may throw (e.g. they assume a session
+ * shape that anonymous requests don't have). A throw is treated as **denied** —
+ * the safest outcome, so a misbehaving access function never exposes an
+ * editable/create form to a session that might not be allowed.
+ *
+ * No access function configured for the operation is also treated as denied,
+ * matching the core engine's deny-by-default (`checkAccess` returns `false`
+ * when `accessControl` is undefined).
+ */
+export async function isOperationPotentiallyAllowed(
+  access: OperationAccess | undefined,
+  operation: OperationAccessName,
+  args: { session: Session | null; context: AccessContext<unknown> },
+): Promise<boolean> {
+  const accessControl = access?.[operation]
+  // Deny by default — no rule means no access (matches the core engine).
+  if (!accessControl) return false
+
+  try {
+    const result = await accessControl({
+      session: args.session,
+      // The access engine passes the same context through to the function.
+      context: args.context,
+    })
+    // `false` denies; `true` or a filter object both mean "potentially allowed".
+    return result !== false
+  } catch {
+    // A throwing access function is treated as denied — never widen access on error.
+    return false
+  }
+}

--- a/packages/ui/tests/components/AdminUISingleton.test.tsx
+++ b/packages/ui/tests/components/AdminUISingleton.test.tsx
@@ -142,6 +142,129 @@ describe('AdminUI singleton routing', () => {
     expect(screen.queryByText('Create Settings')).not.toBeInTheDocument()
   })
 
+  it('renders a create-on-save form for an autoCreate:false singleton with no row', async () => {
+    // autoCreate:false + no row → get() returns null. query+create are allowed,
+    // so the editor must offer a create-on-first-save form (mode="create").
+    const autoCreateFalseConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Settings: list({
+          isSingleton: { autoCreate: false },
+          access: {
+            operation: {
+              query: () => true,
+              create: () => true,
+              update: () => true,
+              delete: () => true,
+            },
+          },
+          fields: { siteName: text() },
+        }),
+      },
+    }
+
+    const singletonGet = vi.fn(async () => null)
+    const context = makeContext({ settings: { get: singletonGet } })
+
+    const element = await SingletonView({
+      context,
+      config: autoCreateFalseConfig,
+      listKey: 'Settings',
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    render(element)
+
+    expect(singletonGet).toHaveBeenCalledTimes(1)
+
+    // Create header + the create affordance ("Create" submit button), not an edit form.
+    expect(screen.getByText('Create Settings')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    // An empty field input is rendered (no display value yet).
+    expect(screen.getByText('Site Name')).toBeInTheDocument()
+  })
+
+  it('renders a friendly message (not an editable form) for a read-denied singleton', async () => {
+    // query denied → get() returns null. A null is indistinguishable from an
+    // empty autoCreate:false singleton, so the editor disambiguates via access
+    // and must NOT show an editable/create form.
+    const readDeniedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Settings: list({
+          isSingleton: true,
+          access: {
+            operation: {
+              query: () => false,
+              create: () => true,
+              update: () => true,
+              delete: () => false,
+            },
+          },
+          fields: { siteName: text() },
+        }),
+      },
+    }
+
+    const singletonGet = vi.fn(async () => null)
+    const context = makeContext({ settings: { get: singletonGet } })
+
+    const element = await SingletonView({
+      context,
+      config: readDeniedConfig,
+      listKey: 'Settings',
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    render(element)
+
+    // Friendly no-access message, no form affordances at all.
+    expect(screen.getByText("You don't have access to Settings.")).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Create Settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('Edit Settings')).not.toBeInTheDocument()
+  })
+
+  it('renders a "no record yet" message when create is denied (no editable form)', async () => {
+    // autoCreate:false + no row, query allowed but create denied → cannot offer
+    // a create form; show a friendly "no record yet" message instead.
+    const createDeniedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Settings: list({
+          isSingleton: { autoCreate: false },
+          access: {
+            operation: {
+              query: () => true,
+              create: () => false,
+              update: () => true,
+              delete: () => false,
+            },
+          },
+          fields: { siteName: text() },
+        }),
+      },
+    }
+
+    const singletonGet = vi.fn(async () => null)
+    const context = makeContext({ settings: { get: singletonGet } })
+
+    const element = await SingletonView({
+      context,
+      config: createDeniedConfig,
+      listKey: 'Settings',
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    render(element)
+
+    expect(screen.getByText('There is no Settings record yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+  })
+
   it('renders the list table for a non-singleton list (ListView)', async () => {
     const findMany = vi.fn(async () => [
       { id: '1', title: 'First Post' },


### PR DESCRIPTION
## Summary

Slice 3/4 of the singleton-admin PRD (#532). Replaces the slice-1 placeholder shown when a singleton `get()` returns `null` with real create-on-save + access-denied handling in `@opensaas/stack-ui`'s `SingletonView`.

A `null` from the singleton `get()` is ambiguous at the boundary: it means EITHER an `autoCreate: false` singleton with no row yet, OR that `query` access is denied (access-controlled reads return `null`/`[]` silently). `SingletonView` now disambiguates using the list's operation-level access and renders the safe affordance:

- **`query` allowed + `create` allowed (autoCreate:false, no row)** → a create-on-first-save form, reusing `ItemFormClient` in `mode="create"` (via `prepareItemForm` with an empty record). On save, core assigns the singleton `id` (always `1`) and enforces the single-record constraint, so the form sends only the user-entered field data.
- **`query` denied** → a friendly "no access" message; never an editable/create form.
- **`create` denied (autoCreate:false, no row)** → a friendly "no record yet" message instead of an unusable form.

An update-denied singleton still renders the edit form (the slice-1 happy path), but the save fails gracefully via the server action's denied envelope, which `ItemFormClient` surfaces as an error.

The happy path (record exists → edit form) and non-singleton lists are unchanged.

## Design notes

- **Singleton id on create:** core injects `id: 1` itself in `createWriteStrategy.persist` (`const createData = singleton ? { id: 1, ...data } : data`). The form must NOT pass an id — it sends only the user's field data through the existing `serverAction` create path.
- **Disambiguation:** access functions are evaluated via a new local helper `isOperationPotentiallyAllowed` (`packages/ui/src/lib/operationAccess.ts`), strongly typed against the public `OperationAccess`/`AccessControl` types. It mirrors the core engine: `false` → denied; `true` or a filter object → potentially permitted; a missing rule → denied (deny-by-default); a throwing access function → denied (safest — never widens access on error).

## Tests

New cases in `packages/ui/tests/components/AdminUISingleton.test.tsx`:
- autoCreate:false singleton with no row renders a create form (mode="create", "Create" button, not "Save")
- read-denied singleton renders the friendly "no access" message (no editable/create form)
- create-denied singleton renders the "no record yet" message (no form)
- slice-1 happy path (edit form) and non-singleton ListView still pass (no regression)

All 170 `@opensaas/stack-ui` tests pass. `pnpm lint` (0 errors), `pnpm format:check`, and the stack-core + stack-ui builds are green.

Fixes #540
Part of #532

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_