### PR TITLE
feat(ui): singleton "Settings" nav group + dashboard "Configure" affordance

### DIFF
--- a/.changeset/singleton-nav-settings-group.md
+++ b/.changeset/singleton-nav-settings-group.md
@@ -1,0 +1,18 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Add first-class singleton presentation to the admin Navigation and Dashboard
+
+Singleton lists (`isSingleton`) are now visually distinguished from ordinary lists:
+
+- **Navigation:** singletons render under a dedicated "Settings" group with a gear
+  icon, separate from the standard "Lists" group. Each still links to its
+  single-record editor (`/<basePath>/<url>`). The "Settings" group is omitted when
+  there are no singletons (and the "Lists" group is omitted when there are only
+  singletons).
+- **Dashboard:** singletons appear in their own "Settings" section with a
+  "Configure" affordance instead of the misleading "N items" count (a singleton's
+  count is always 0 or 1). The Dashboard no longer calls `count()` for singletons.
+
+Non-singleton lists are unchanged.

--- a/packages/ui/src/components/Dashboard.tsx
+++ b/packages/ui/src/components/Dashboard.tsx
@@ -16,9 +16,16 @@ export interface DashboardProps {
 export async function Dashboard({ context, config, basePath = '/admin' }: DashboardProps) {
   const lists = Object.keys(config.lists || {})
 
-  // Get counts for each list
+  // Split lists into standard lists (shown in the counted grid) and singletons
+  // (shown in their own "Settings" section). A singleton's count is always 0/1,
+  // so the "N items" label is misleading — show a "Configure" affordance instead.
+  const standardLists = lists.filter((listKey) => !config.lists[listKey]?.isSingleton)
+  const singletonLists = lists.filter((listKey) => config.lists[listKey]?.isSingleton)
+
+  // Get counts for the standard lists only. Singletons don't show a count, so
+  // there's no need to call count() for them here.
   const listCounts = await Promise.all(
-    lists.map(async (listKey) => {
+    standardLists.map(async (listKey) => {
       try {
         const delegate = context.db[getDbKey(listKey)]
         const count = delegate?.count ? await delegate.count() : 0
@@ -51,7 +58,7 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
             Add lists to your opensaas.config.ts to get started.
           </p>
         </Card>
-      ) : (
+      ) : standardLists.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {listCounts.map(({ listKey, count }) => {
             const urlKey = getUrlKey(listKey)
@@ -96,6 +103,97 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
               </Link>
             )
           })}
+        </div>
+      ) : null}
+
+      {/* Settings section — singletons present a "Configure" affordance instead
+          of a misleading "N items" count. */}
+      {singletonLists.length > 0 && (
+        <div className={standardLists.length > 0 ? 'mt-12' : ''}>
+          <div className="mb-4 flex items-center gap-2">
+            <svg
+              className="w-5 h-5 text-muted-foreground"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            <h2 className="text-xl font-semibold text-foreground">Settings</h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {singletonLists.map((listKey) => {
+              const urlKey = getUrlKey(listKey)
+              return (
+                <Link key={listKey} href={`${basePath}/${urlKey}`}>
+                  <Card className="group hover:border-primary hover:shadow-lg hover:shadow-primary/20 transition-all duration-200 cursor-pointer h-full relative overflow-hidden">
+                    <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <CardHeader className="relative">
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <CardTitle className="text-xl group-hover:text-primary transition-colors">
+                            {formatListName(listKey)}
+                          </CardTitle>
+                        </div>
+                        <div className="text-muted-foreground opacity-60 group-hover:opacity-100 transition-opacity">
+                          <svg
+                            className="w-7 h-7"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                            />
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="relative">
+                      <div className="flex items-center text-sm font-medium text-primary">
+                        <span>Configure</span>
+                        <svg
+                          className="ml-1 w-4 h-4 group-hover:translate-x-1 transition-transform"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 5l7 7-7 7"
+                          />
+                        </svg>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              )
+            })}
+          </div>
         </div>
       )}
 

--- a/packages/ui/src/components/Navigation.tsx
+++ b/packages/ui/src/components/Navigation.tsx
@@ -22,7 +22,12 @@ export function Navigation({
   currentPath = '',
   onSignOut,
 }: NavigationProps) {
-  const lists = Object.keys(config.lists || {})
+  const allLists = Object.keys(config.lists || {})
+  // Split lists into standard lists (under "Lists") and singletons (under
+  // "Settings"). A singleton edits a single record, so it belongs in a distinct
+  // Settings group rather than the standard list grid.
+  const lists = allLists.filter((listKey) => !config.lists[listKey]?.isSingleton)
+  const singletons = allLists.filter((listKey) => config.lists[listKey]?.isSingleton)
 
   return (
     <nav className="w-64 border-r border-border bg-card h-screen sticky top-0 flex flex-col">
@@ -83,6 +88,58 @@ export function Navigation({
                       <span className="opacity-60 group-hover:opacity-100 transition-opacity">
                         📁
                       </span>
+                      {formatListName(listKey)}
+                    </span>
+                  </Link>
+                )
+              })}
+            </>
+          )}
+
+          {singletons.length > 0 && (
+            <>
+              <div className="pt-4 pb-2 px-3">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                  Settings
+                </p>
+              </div>
+              {singletons.map((listKey) => {
+                const urlKey = getUrlKey(listKey)
+                const isActive = currentPath.startsWith(`/${urlKey}`)
+                return (
+                  <Link
+                    key={listKey}
+                    href={`${basePath}/${urlKey}`}
+                    className={`block px-3 py-2.5 rounded-lg text-sm font-medium transition-all relative overflow-hidden group ${
+                      isActive
+                        ? 'bg-gradient-to-r from-primary to-accent text-primary-foreground shadow-lg shadow-primary/25'
+                        : 'text-foreground hover:bg-accent/50 hover:text-accent-foreground'
+                    }`}
+                  >
+                    {isActive && (
+                      <div className="absolute inset-0 bg-gradient-to-r from-primary/20 to-accent/20 animate-pulse" />
+                    )}
+                    <span className="relative flex items-center gap-2">
+                      <svg
+                        className="w-4 h-4 opacity-60 group-hover:opacity-100 transition-opacity"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                      </svg>
                       {formatListName(listKey)}
                     </span>
                   </Link>

--- a/packages/ui/tests/components/SingletonNavDashboard.test.tsx
+++ b/packages/ui/tests/components/SingletonNavDashboard.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { Navigation } from '../../src/components/Navigation.js'
+import { Dashboard } from '../../src/components/Dashboard.js'
+
+// next/link renders an anchor; happy-dom can render it directly.
+vi.mock('next/link.js', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+/**
+ * A config with one singleton list (SiteConfig) and one ordinary list (Post).
+ * Built with the real `list()` + field builders so the components see the same
+ * field shapes they would in a real app. The singleton is deliberately NOT
+ * named "Settings" so its link label can't be confused with the "Settings"
+ * group heading.
+ */
+const config: OpenSaasConfig = {
+  db: { provider: 'sqlite', url: 'file:./test.db' },
+  lists: {
+    SiteConfig: list({
+      isSingleton: true,
+      fields: {
+        siteName: text(),
+      },
+    }),
+    Post: list({
+      fields: {
+        title: text(),
+      },
+    }),
+  },
+}
+
+interface DelegateStub {
+  count?: (args?: unknown) => Promise<number>
+}
+
+/**
+ * Build a minimal AccessContext whose db delegates return canned data. Only the
+ * methods the views call are implemented.
+ */
+function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  // Cast: this is a stub for rendering tests, not a full Prisma-backed context.
+  return context as unknown as AccessContext<unknown>
+}
+
+describe('Navigation singleton grouping', () => {
+  it('renders singletons under a "Settings" group and non-singletons under "Lists"', () => {
+    const context = makeContext({})
+
+    render(<Navigation context={context} config={config} basePath="/admin" />)
+
+    // Both group headings are present.
+    expect(screen.getByText('Lists')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+
+    // The non-singleton Post links to its editor under the "Lists" group, and the
+    // singleton SiteConfig links to its editor under the "Settings" group. Both
+    // point at the bare [list] route (the editor).
+    const postLink = screen.getByRole('link', { name: /Post/ })
+    expect(postLink).toHaveAttribute('href', '/admin/post')
+
+    const siteConfigLink = screen.getByRole('link', { name: /Site Config/ })
+    expect(siteConfigLink).toHaveAttribute('href', '/admin/site-config')
+  })
+
+  it('does not render a "Settings" group when there are no singletons', () => {
+    const noSingletons: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({ fields: { title: text() } }),
+      },
+    }
+    const context = makeContext({})
+
+    render(<Navigation context={context} config={noSingletons} basePath="/admin" />)
+
+    expect(screen.getByText('Lists')).toBeInTheDocument()
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+  })
+
+  it('does not render a "Lists" group when there are only singletons', () => {
+    const onlySingletons: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        SiteConfig: list({ isSingleton: true, fields: { siteName: text() } }),
+      },
+    }
+    const context = makeContext({})
+
+    render(<Navigation context={context} config={onlySingletons} basePath="/admin" />)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.queryByText('Lists')).not.toBeInTheDocument()
+  })
+})
+
+describe('Dashboard singleton affordance', () => {
+  it('shows "Configure" for a singleton (no count) and a count for a non-singleton', async () => {
+    const siteConfigCount = vi.fn(async () => 1)
+    const postCount = vi.fn(async () => 2)
+    const context = makeContext({
+      siteConfig: { count: siteConfigCount },
+      post: { count: postCount },
+    })
+
+    const element = await Dashboard({ context, config, basePath: '/admin' })
+    render(element)
+
+    // Non-singleton Post card shows the normal "N items" count.
+    expect(screen.getByText('2 items')).toBeInTheDocument()
+
+    // The singleton card shows a "Configure" affordance and links to the editor.
+    const configureLink = screen.getByRole('link', { name: /Configure/ })
+    expect(configureLink).toHaveAttribute('href', '/admin/site-config')
+    expect(within(configureLink).getByText('Site Config')).toBeInTheDocument()
+
+    // The singleton's count() is never called — its count is misleading, so the
+    // dashboard does not query or render it.
+    expect(siteConfigCount).not.toHaveBeenCalled()
+    expect(postCount).toHaveBeenCalledTimes(1)
+
+    // No "N items" label appears for the singleton.
+    expect(screen.queryByText('1 item')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Slice 4/4 of the singleton-admin PRD (#532) — the full-polish presentation for `isSingleton` lists in `@opensaas/stack-ui`. This is presentation only; the singleton runtime and the single-record editor (slice 1, #538) are already on `main`.

### Navigation (`packages/ui/src/components/Navigation.tsx`)
- Splits the sidebar into two groups: standard lists stay under **"Lists"**, singletons render under a distinct **"Settings"** group with an inline gear SVG icon (matching the existing icon style).
- Both still link to `/<basePath>/<url>` (the editor).
- The "Settings" group is omitted when there are no singletons, and the "Lists" group is omitted when there are only singletons.

### Dashboard (`packages/ui/src/components/Dashboard.tsx`)
- Singletons now render in their own **"Settings"** section with a **"Configure"** affordance and a gear icon, instead of being mixed into the lists grid with a misleading "N items" count (a singleton's count is always 0/1).
- `count()` is no longer called for singletons (only for standard lists).
- Standard-list cards and their counts are unchanged.
- The "Quick Actions" / "Create {list}" block is intentionally left iterating over all lists — suppressing singletons there is slice 2 (#539), a separate PR.

Non-singleton nav/dashboard rendering is unchanged.

## Tests

New file `packages/ui/tests/components/SingletonNavDashboard.test.tsx` (4 tests, all passing):
- Navigation renders singletons under a "Settings" group and non-singletons under "Lists" (both linking to the editor).
- Navigation omits the "Settings" group when there are no singletons.
- Navigation omits the "Lists" group when there are only singletons.
- Dashboard shows a "Configure" affordance for a singleton (no "N items" count, `count()` not called) and the normal count for a non-singleton.

Full `@opensaas/stack-ui` suite: **171 passed (11 files)**.

## Verification
- `pnpm --filter @opensaas/stack-core build` ✅
- `pnpm --filter @opensaas/stack-ui build` ✅
- `pnpm --filter @opensaas/stack-ui test` ✅ (171 passed)
- `pnpm lint` ✅ (0 errors)
- `pnpm format:check` ✅
- `pnpm manypkg fix` ✅ (no changes)

Changeset: `.changeset/singleton-nav-settings-group.md` (minor, `@opensaas/stack-ui`).

Fixes #541
Part of #532

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_