### PR TITLE
feat(ui): suppress create/delete + redirect singleton sub-routes (2/4)

### DIFF
--- a/.changeset/singleton-suppress-redirect.md
+++ b/.changeset/singleton-suppress-redirect.md
@@ -1,0 +1,13 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Suppress create/delete affordances and redirect sub-routes for singleton lists in the admin UI.
+
+Singleton lists (`isSingleton: true`) have a single record edited at their bare `[list]` route, so the create and delete affordances no longer apply:
+
+- The Dashboard "Quick Actions" no longer renders a "Create {list}" link for singletons (only standard lists). The Quick Actions card is hidden entirely in a singleton-only admin.
+- The singleton editor (`SingletonView`) no longer renders a Delete control. A new optional `canDelete` prop (default `true`) on `ItemFormClient` controls this; non-singleton edit forms keep their Delete button.
+- The singleton sub-routes `/admin/<list>/create` and `/admin/<list>/<id>` now server-side `redirect()` to the bare editor `/admin/<list>`, so old links keep working.
+
+Non-singleton create/delete affordances and routing are unchanged.

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react'
+import { redirect } from 'next/navigation.js'
 import { Navigation } from './Navigation.js'
 import { Dashboard } from './Dashboard.js'
 import { ListView } from './ListView.js'
 import { ItemForm } from './ItemForm.js'
 import { SingletonView } from './SingletonView.js'
 import type { ServerActionInput } from '../server/types.js'
-import { type AccessContext, getListKeyFromUrl, OpenSaasConfig } from '@opensaas/stack-core'
+import {
+  type AccessContext,
+  getListKeyFromUrl,
+  getUrlKey,
+  OpenSaasConfig,
+} from '@opensaas/stack-core'
 import { generateThemeCSS } from '../lib/theme.js'
 
 export interface AdminUIProps {
@@ -53,6 +59,13 @@ export function AdminUI({
   if (!listKey) {
     // Dashboard
     content = <Dashboard context={context} config={config} basePath={basePath} />
+  } else if (config.lists[listKey]?.isSingleton && action) {
+    // A singleton has a single record edited at its bare [list] route, so the
+    // create/id sub-routes (`[list, 'create']` / `[list, id]`) don't apply.
+    // Redirect them to the bare editor so old links keep working. This runs
+    // before the create/edit ItemForm branches; non-singleton routing below is
+    // unchanged.
+    redirect(`${basePath}/${getUrlKey(listKey)}`)
   } else if (action === 'create') {
     // Create form
     content = (

--- a/packages/ui/src/components/Dashboard.tsx
+++ b/packages/ui/src/components/Dashboard.tsx
@@ -197,7 +197,10 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
         </div>
       )}
 
-      {lists.length > 0 && (
+      {/* Quick Actions only contains "Create {list}" links for standard lists,
+          so hide the whole card when there are no standard lists (e.g. a
+          singleton-only admin). */}
+      {standardLists.length > 0 && (
         <Card className="mt-12 bg-gradient-to-br from-accent/10 to-primary/10 border-accent/20">
           <CardHeader>
             <CardTitle className="text-lg flex items-center gap-2">
@@ -207,7 +210,9 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
           </CardHeader>
           <CardContent>
             <div className="flex flex-wrap gap-3">
-              {lists.map((listKey) => {
+              {/* Singletons have a single record (no create), so they're
+                  excluded here — only standard lists get a "Create" quick-action. */}
+              {standardLists.map((listKey) => {
                 const urlKey = getUrlKey(listKey)
                 return (
                   <Link

--- a/packages/ui/src/components/ItemFormClient.tsx
+++ b/packages/ui/src/components/ItemFormClient.tsx
@@ -21,6 +21,13 @@ export interface ItemFormClientProps {
   basePath: string
   serverAction: (input: ServerActionInput) => Promise<unknown>
   relationshipData?: Record<string, Array<{ id: string; label: string }>>
+  /**
+   * Whether to render the delete affordance in edit mode. Defaults to `true`.
+   * Singletons set this to `false` — a singleton has exactly one record that
+   * can't be deleted (core blocks `delete` even in sudo), so the control is
+   * suppressed for UX hygiene.
+   */
+  canDelete?: boolean
 }
 
 /**
@@ -58,6 +65,7 @@ export function ItemFormClient({
   basePath,
   serverAction,
   relationshipData = {},
+  canDelete = true,
 }: ItemFormClientProps) {
   const router = useRouter()
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -162,8 +170,8 @@ export function ItemFormClient({
           </Button>
         </div>
 
-        {/* Delete Button (Edit Mode Only) */}
-        {mode === 'edit' && itemId && (
+        {/* Delete Button (Edit Mode Only; suppressed for singletons) */}
+        {mode === 'edit' && itemId && canDelete && (
           <Button
             type="button"
             variant="destructive"

--- a/packages/ui/src/components/SingletonView.tsx
+++ b/packages/ui/src/components/SingletonView.tsx
@@ -169,6 +169,7 @@ export async function SingletonView({
             basePath={basePath}
             serverAction={serverAction}
             relationshipData={createRelationshipData}
+            canDelete={false}
           />
         </div>
       </div>
@@ -219,6 +220,7 @@ export async function SingletonView({
           basePath={basePath}
           serverAction={serverAction}
           relationshipData={relationshipData}
+          canDelete={false}
         />
       </div>
     </div>

--- a/packages/ui/tests/components/AdminUISingletonSuppress.test.tsx
+++ b/packages/ui/tests/components/AdminUISingletonSuppress.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { AdminUI } from '../../src/components/AdminUI.js'
+import { ItemForm } from '../../src/components/ItemForm.js'
+import { SingletonView } from '../../src/components/SingletonView.js'
+import { Dashboard } from '../../src/components/Dashboard.js'
+
+// Mock Next.js navigation — AdminUI calls redirect() (server-side) for singleton
+// sub-routes, and the form/table client components call useRouter().
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+const mockRedirect = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  redirect: (url: string) => mockRedirect(url),
+}))
+
+// next/link renders an anchor; happy-dom can render it directly.
+vi.mock('next/link.js', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+/**
+ * A config with one singleton list (Settings) and one ordinary list (Post).
+ * Built with the real `list()` + field builders so the components see the same
+ * field shapes they would in a real app.
+ */
+const config: OpenSaasConfig = {
+  db: { provider: 'sqlite', url: 'file:./test.db' },
+  lists: {
+    Settings: list({
+      isSingleton: true,
+      fields: {
+        siteName: text(),
+      },
+    }),
+    Post: list({
+      fields: {
+        title: text(),
+      },
+    }),
+  },
+}
+
+interface DelegateStub {
+  get?: () => Promise<Record<string, unknown> | null>
+  findUnique?: (args: unknown) => Promise<Record<string, unknown> | null>
+  findMany?: (args: unknown) => Promise<Array<Record<string, unknown>>>
+  count?: (args?: unknown) => Promise<number>
+}
+
+/**
+ * Build a minimal AccessContext whose db delegates return canned data. Only the
+ * methods the views call are implemented.
+ */
+function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  // Cast: this is a stub for rendering tests, not a full Prisma-backed context.
+  return context as unknown as AccessContext<unknown>
+}
+
+const noopServerAction = vi.fn(async () => ({ success: true }))
+
+beforeEach(() => {
+  mockRedirect.mockClear()
+  mockPush.mockClear()
+  mockRefresh.mockClear()
+})
+
+describe('AdminUI singleton sub-route redirects', () => {
+  it('redirects a singleton [list, "create"] to the bare editor route', async () => {
+    const context = makeContext({
+      settings: { get: vi.fn(async () => ({ id: '1', siteName: 'My Site' })) },
+    })
+
+    await AdminUI({
+      context,
+      config,
+      params: ['settings', 'create'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    expect(mockRedirect).toHaveBeenCalledTimes(1)
+    expect(mockRedirect).toHaveBeenCalledWith('/admin/settings')
+  })
+
+  it('redirects a singleton [list, id] to the bare editor route', async () => {
+    const context = makeContext({
+      settings: { get: vi.fn(async () => ({ id: '1', siteName: 'My Site' })) },
+    })
+
+    await AdminUI({
+      context,
+      config,
+      params: ['settings', '1'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    expect(mockRedirect).toHaveBeenCalledTimes(1)
+    expect(mockRedirect).toHaveBeenCalledWith('/admin/settings')
+  })
+
+  it('honours a custom basePath in the redirect target', async () => {
+    const context = makeContext({
+      settings: { get: vi.fn(async () => ({ id: '1', siteName: 'My Site' })) },
+    })
+
+    await AdminUI({
+      context,
+      config,
+      params: ['settings', 'create'],
+      basePath: '/dashboard',
+      serverAction: noopServerAction,
+    })
+
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard/settings')
+  })
+
+  it('does NOT redirect a singleton bare [list] route (renders the editor)', async () => {
+    const context = makeContext({
+      settings: { get: vi.fn(async () => ({ id: '1', siteName: 'My Site' })) },
+    })
+
+    await AdminUI({
+      context,
+      config,
+      params: ['settings'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('does NOT redirect non-singleton create/edit routes (routing unchanged)', async () => {
+    const context = makeContext({
+      post: {
+        findMany: vi.fn(async () => []),
+        count: vi.fn(async () => 0),
+        findUnique: vi.fn(async () => ({ id: '1', title: 'First Post' })),
+      },
+    })
+
+    // Non-singleton create
+    await AdminUI({
+      context,
+      config,
+      params: ['post', 'create'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    expect(mockRedirect).not.toHaveBeenCalled()
+
+    // Non-singleton edit
+    await AdminUI({
+      context,
+      config,
+      params: ['post', '1'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+})
+
+describe('Dashboard create suppression for singletons', () => {
+  it('does not render a "Create {singleton}" quick-action but does for a non-singleton', async () => {
+    const context = makeContext({
+      settings: { count: vi.fn(async () => 1) },
+      post: { count: vi.fn(async () => 2) },
+    })
+
+    const element = await Dashboard({ context, config, basePath: '/admin' })
+    render(element)
+
+    // The Quick Actions block offers "Create" only for the standard list.
+    expect(screen.getByText('Create Post')).toBeInTheDocument()
+    expect(screen.queryByText('Create Settings')).not.toBeInTheDocument()
+
+    // There is no create link pointing at the singleton anywhere on the dashboard.
+    const createLinks = screen.getAllByRole('link', { name: /Create/ })
+    for (const link of createLinks) {
+      expect(link).not.toHaveAttribute('href', '/admin/settings/create')
+    }
+  })
+
+  it('hides the Quick Actions card entirely in a singleton-only admin', async () => {
+    const singletonOnly: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Settings: list({ isSingleton: true, fields: { siteName: text() } }),
+      },
+    }
+    const context = makeContext({ settings: { count: vi.fn(async () => 1) } })
+
+    const element = await Dashboard({ context, config: singletonOnly, basePath: '/admin' })
+    render(element)
+
+    expect(screen.queryByText('Quick Actions')).not.toBeInTheDocument()
+    expect(screen.queryByText('Create Settings')).not.toBeInTheDocument()
+  })
+})
+
+describe('Delete suppression in the singleton editor', () => {
+  it('renders no delete control in the singleton editor (SingletonView)', async () => {
+    const context = makeContext({
+      settings: { get: vi.fn(async () => ({ id: '1', siteName: 'My Site' })) },
+    })
+
+    const element = await SingletonView({
+      context,
+      config,
+      listKey: 'Settings',
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    render(element)
+
+    // The edit form renders (Save present) but the Delete affordance is gone.
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('still renders the delete control for a non-singleton edit form (ItemForm)', async () => {
+    const context = makeContext({
+      post: { findUnique: vi.fn(async () => ({ id: '1', title: 'First Post' })) },
+    })
+
+    const element = await ItemForm({
+      context,
+      config,
+      listKey: 'Post',
+      mode: 'edit',
+      itemId: '1',
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+    render(element)
+
+    // Non-singleton edit forms keep the delete affordance.
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Slice 2/4 of the singleton-admin PRD (#532). Suppresses the affordances that don't apply to a singleton and redirects its sub-routes.

## What changed (`packages/ui`)

1. **Redirect singleton sub-routes** (`AdminUI.tsx`): when `config.lists[listKey]?.isSingleton` and there is an `action` (i.e. `[list,'create']` or `[list,id]`), AdminUI calls Next's server-side `redirect()` to the bare editor route `${basePath}/${getUrlKey(listKey)}`. The check runs before the create/edit `ItemForm` branches; non-singleton routing is unchanged.

2. **Create suppression** (`Dashboard.tsx`): the "Quick Actions" / "Create {list}" block now iterates `standardLists` instead of all `lists`, so singletons get no Create quick-action. The Quick Actions card is hidden entirely when there are no standard lists (singleton-only admin).

3. **Delete suppression** (`ItemFormClient.tsx` + `SingletonView.tsx`): the delete affordance in `ItemFormClient` (edit mode) lived in the form-actions footer. Added a new optional `canDelete` prop (default `true`) gating that Delete button; `SingletonView` now passes `canDelete={false}` into both its create-on-save and edit forms. Non-singleton edit forms keep delete (default `true`). Core already blocks `delete` on singletons even in sudo — this is UX hygiene so the control isn't shown.

## Tests (`packages/ui/tests/components/AdminUISingletonSuppress.test.tsx`)

- AdminUI redirects singleton `[list,'create']` and `[list,id]` to the bare editor route (mocks `next/navigation`, asserts `redirect` called with the right path, including a custom `basePath`); singleton bare `[list]` and non-singleton create/edit routes do NOT redirect.
- Dashboard does NOT render "Create {singleton}" but DOES for a non-singleton; Quick Actions card hidden in a singleton-only admin.
- The singleton editor (`SingletonView`) renders no Delete control; a non-singleton `ItemForm` edit still renders Delete.

All 183 `@opensaas/stack-ui` tests pass (9 new). Build, lint (0 errors), and `format:check` all green. Changeset: `.changeset/singleton-suppress-redirect.md` (minor).

Fixes #539
Part of #532

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_