### PR TITLE
test(cli): add generous timeout to flaky generate overwrite test (#536)

### DIFF
--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -115,6 +115,11 @@ describe('Generate Command Integration', () => {
       expect(fs.existsSync(prismaPath)).toBe(true)
     })
 
+    // Generous timeout: this otherwise-fast synchronous test occasionally
+    // stalls past the 5s default on cold/loaded CI runners (the `test` task runs
+    // cache-bypassed on every PR, so a transient I/O stall here can fail an
+    // unrelated change). The headroom absorbs that contention without masking a
+    // real regression — the assertions are unchanged.
     it('should overwrite existing files', () => {
       const config1: OpenSaasConfig = {
         db: {
@@ -157,7 +162,7 @@ describe('Generate Command Integration', () => {
       writePrismaSchema(config2, prismaPath)
       schema = fs.readFileSync(prismaPath, 'utf-8')
       expect(schema).toMatchSnapshot('overwrite-after')
-    })
+    }, 30000)
 
     it('should handle custom opensaasPath', () => {
       const config: OpenSaasConfig = {


### PR DESCRIPTION
Fixes #536.

The synchronous `generate.test.ts > "should overwrite existing files"` test is normally fast (siblings run at 1–23ms; locally the whole file runs in ~300ms) but intermittently stalled past the default 5000ms on a CI runner, failing the `test` job on an unrelated docs PR (#534's first run). Because the `test` task runs cache-bypassed on every PR, that transient stall can fail changes that touch nothing related to the CLI.

This adds a generous 30s timeout to that one test plus an explanatory comment. The assertions are unchanged; the headroom just absorbs occasional CI I/O contention.

Test-only change — no changeset (the published artifact is unaffected).

Verified locally: `generate.test.ts` 18/18 pass; prettier + eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_