### PR TITLE
feat(storage): add storage provider registration hook (SF-15)

### DIFF
--- a/.changeset/storage-provider-registry.md
+++ b/.changeset/storage-provider-registry.md
@@ -1,0 +1,29 @@
+---
+'@opensaas/stack-storage': minor
+---
+
+Add a storage provider registration API so non-`local` and custom providers are constructable.
+
+`createStorageProvider` now resolves a provider `type` through a registry instead of a hardcoded `switch`, which previously only built `'local'` and threw for everything else. `'local'` is registered as a built-in default, so existing behaviour is unchanged. The host opts into the optional provider packages (`@opensaas/stack-storage-s3`, `@opensaas/stack-storage-vercel`) or a custom provider by registering it — `@opensaas/stack-storage` does not depend on the provider packages, keeping the AWS/Vercel SDKs off every storage user. Reads are unaffected: assembling existing asset metadata only stamps the provider name and never constructs a provider.
+
+```typescript
+// lib/register-storage.ts (server-only, imported at app startup)
+import { registerStorageProvider } from '@opensaas/stack-storage/runtime'
+import { S3StorageProvider, type S3StorageConfig } from '@opensaas/stack-storage-s3'
+
+registerStorageProvider<S3StorageConfig>('s3', (config) => new S3StorageProvider(config))
+```
+
+```typescript
+// opensaas.config.ts — reference the registered provider by type
+import { s3Storage } from '@opensaas/stack-storage-s3'
+
+export default config({
+  storage: {
+    avatars: s3Storage({ bucket: 'user-avatars', region: 'us-east-1' }),
+  },
+  // ...
+})
+```
+
+Custom providers register the same way: implement `StorageProvider`, give it a `type`, then call `registerStorageProvider(type, (config) => new MyProvider(config))`. An unregistered type throws a clear error pointing at `registerStorageProvider`.

--- a/packages/storage/CLAUDE.md
+++ b/packages/storage/CLAUDE.md
@@ -50,7 +50,10 @@ packages/storage-vercel/  # Separate Vercel Blob provider package
 - `uploadImage(config, provider, data, options)` - Upload image with transformations
 - `deleteFile(config, provider, filename)` - Delete file
 - `deleteImage(config, metadata)` - Delete image and all transformations
-- `createStorageProvider(config, providerName)` - Create provider instance
+- `createStorageProvider(config, providerName)` - Create provider instance (resolves the provider `type` through the registry)
+- `registerStorageProvider(type, factory)` - Register a provider `type` → constructor (host opts in to optional/custom providers)
+- `getStorageProviderFactory(type)` / `hasStorageProvider(type)` - Inspect the registry
+- `resetStorageProviderRegistry()` - Reset to built-in defaults (mainly for tests)
 
 ### Utils (`src/utils/`)
 
@@ -352,39 +355,138 @@ avatar: image({
 })
 ```
 
-### Custom Storage Provider
+### Storage Provider Registry
+
+`createStorageProvider` resolves a provider `type` through a **registry** rather
+than a hardcoded `switch`. `'local'` is registered as a built-in default, so it
+works with no setup. Every other provider — the optional packages
+(`@opensaas/stack-storage-s3`, `@opensaas/stack-storage-vercel`) and your own
+custom providers — must be **registered by the host** before
+`createStorageProvider` can build them.
+
+`@opensaas/stack-storage` deliberately does **not** depend on `-s3`/`-vercel`:
+wiring them into the factory directly would force the AWS/Vercel SDKs onto every
+storage user. The host opts in by registering only the provider(s) it uses.
+
+#### Registering an optional provider package
+
+Register once at app startup (e.g. in a server-only module imported by your app
+entry, the upload route, or `instrumentation.ts`):
+
+```typescript
+// lib/register-storage.ts (server-only)
+import { registerStorageProvider } from '@opensaas/stack-storage/runtime'
+import { S3StorageProvider, type S3StorageConfig } from '@opensaas/stack-storage-s3'
+
+registerStorageProvider<S3StorageConfig>('s3', (config) => new S3StorageProvider(config))
+```
+
+Then reference the provider by `type` in config (via the package's config
+builder, which sets `type: 's3'`):
+
+```typescript
+import { s3Storage } from '@opensaas/stack-storage-s3'
+
+export default config({
+  storage: {
+    avatars: s3Storage({ bucket: 'user-avatars', region: 'us-east-1' }),
+  },
+  // ...
+})
+```
+
+The Vercel Blob provider follows the same shape:
+
+```typescript
+import { registerStorageProvider } from '@opensaas/stack-storage/runtime'
+import {
+  VercelBlobStorageProvider,
+  type VercelBlobStorageConfig,
+} from '@opensaas/stack-storage-vercel'
+
+registerStorageProvider<VercelBlobStorageConfig>(
+  'vercel-blob',
+  (config) => new VercelBlobStorageProvider(config),
+)
+```
+
+#### Registering a custom provider
+
+Implement `StorageProvider`, give it a `type` discriminator, then register it:
 
 ```typescript
 // lib/cloudflare-r2-storage.ts
-import type { StorageProvider } from '@opensaas/stack-storage'
+import type {
+  StorageProvider,
+  UploadOptions,
+  UploadResult,
+  BaseStorageConfig,
+} from '@opensaas/stack-storage'
 
-export class CloudflareR2StorageProvider implements StorageProvider {
-  async upload(file: Buffer, filename: string, options?) {
-    // Upload to Cloudflare R2
-    // ...
-    return { filename, url, size, contentType }
-  }
-
-  async download(filename: string) {
-    // Download from R2
-    // ...
-  }
-
-  async delete(filename: string) {
-    // Delete from R2
-    // ...
-  }
-
-  getUrl(filename: string) {
-    return `https://r2.example.com/${filename}`
-  }
+export interface CloudflareR2Config extends BaseStorageConfig {
+  type: 'cloudflare-r2'
+  bucket: string
+  accountId: string
 }
 
-// Register in runtime
-import { createStorageProvider } from '@opensaas/stack-storage/runtime'
+export class CloudflareR2StorageProvider implements StorageProvider {
+  constructor(private config: CloudflareR2Config) {}
 
-// Extend createStorageProvider to support 'cloudflare-r2' type
+  async upload(
+    file: Buffer | Uint8Array,
+    filename: string,
+    options?: UploadOptions,
+  ): Promise<UploadResult> {
+    // Upload to Cloudflare R2 ...
+    return {
+      filename,
+      url: this.getUrl(filename),
+      size: file.length,
+      contentType: options?.contentType ?? 'application/octet-stream',
+    }
+  }
+
+  async download(filename: string): Promise<Buffer> {
+    // Download from R2 ...
+    return Buffer.from('')
+  }
+
+  async delete(filename: string): Promise<void> {
+    // Delete from R2 ...
+  }
+
+  getUrl(filename: string): string {
+    return `https://r2.example.com/${this.config.bucket}/${filename}`
+  }
+}
 ```
+
+```typescript
+// lib/register-storage.ts (server-only)
+import { registerStorageProvider } from '@opensaas/stack-storage/runtime'
+import { CloudflareR2StorageProvider, type CloudflareR2Config } from './cloudflare-r2-storage'
+
+registerStorageProvider<CloudflareR2Config>(
+  'cloudflare-r2',
+  (config) => new CloudflareR2StorageProvider(config),
+)
+```
+
+```typescript
+// opensaas.config.ts
+export default config({
+  storage: {
+    media: { type: 'cloudflare-r2', bucket: 'media', accountId: process.env.CF_ACCOUNT_ID! },
+  },
+  // ...
+})
+```
+
+If a field references a provider whose `type` has not been registered,
+`createStorageProvider` throws a clear error
+(`Unknown storage provider type: <type>. Register it with registerStorageProvider(...)`).
+Reads are unaffected — assembling existing asset metadata only stamps the
+provider **name** and never constructs a provider.
 
 ## Type Safety
 

--- a/packages/storage/src/runtime/index.ts
+++ b/packages/storage/src/runtime/index.ts
@@ -1,17 +1,26 @@
 import type { OpenSaasConfig } from '@opensaas/stack-core'
 import type {
   StorageProvider,
-  LocalStorageConfig,
   FileMetadata,
   ImageMetadata,
   ImageTransformationConfig,
 } from '../config/types.js'
-import { LocalStorageProvider } from '../providers/local.js'
 import { validateFile, getMimeType, type FileValidationOptions } from '../utils/upload.js'
 import { getImageDimensions, processImageTransformations } from '../utils/image.js'
+import { getStorageProviderFactory } from './registry.js'
 
 /**
- * Creates a storage provider instance from config
+ * Creates a storage provider instance from config.
+ *
+ * The provider `type` is resolved through the provider registry (see
+ * {@link registerStorageProvider}) rather than a closed `switch`. `'local'` is
+ * registered as a built-in default, so it works with no registration step.
+ * Optional providers (`@opensaas/stack-storage-s3`,
+ * `@opensaas/stack-storage-vercel`) and custom providers must be registered by
+ * the host before they can be constructed.
+ *
+ * @throws If the named provider is not present in `config.storage`.
+ * @throws If no provider factory has been registered for the config's `type`.
  */
 export function createStorageProvider(
   config: OpenSaasConfig,
@@ -23,12 +32,16 @@ export function createStorageProvider(
 
   const providerConfig = config.storage[providerName]
 
-  switch (providerConfig.type) {
-    case 'local':
-      return new LocalStorageProvider(providerConfig as unknown as LocalStorageConfig)
-    default:
-      throw new Error(`Unknown storage provider type: ${providerConfig.type}`)
+  const factory = getStorageProviderFactory(providerConfig.type)
+  if (!factory) {
+    throw new Error(
+      `Unknown storage provider type: ${providerConfig.type}. ` +
+        `Register it with registerStorageProvider('${providerConfig.type}', ...) from ` +
+        `'@opensaas/stack-storage/runtime' before use.`,
+    )
   }
+
+  return factory(providerConfig)
 }
 
 /**
@@ -241,3 +254,13 @@ export async function deleteImage(config: OpenSaasConfig, metadata: ImageMetadat
 }
 
 export { parseFileFromFormData } from '../utils/upload.js'
+
+// Provider registration API: hosts register optional/custom providers so
+// createStorageProvider can construct them (see registry.ts).
+export {
+  registerStorageProvider,
+  getStorageProviderFactory,
+  hasStorageProvider,
+  resetStorageProviderRegistry,
+  type StorageProviderFactory,
+} from './registry.js'

--- a/packages/storage/src/runtime/registry.ts
+++ b/packages/storage/src/runtime/registry.ts
@@ -1,0 +1,106 @@
+import type { StorageProvider, BaseStorageConfig, LocalStorageConfig } from '../config/types.js'
+import { LocalStorageProvider } from '../providers/local.js'
+
+/**
+ * A factory that constructs a {@link StorageProvider} from its provider config.
+ *
+ * The factory is generic over the concrete config shape so a provider package
+ * can register with full type safety (e.g. `S3StorageConfig`), while the
+ * registry stores factories against the {@link BaseStorageConfig} contract that
+ * every provider config satisfies.
+ *
+ * @typeParam TConfig - The provider-specific config type (must extend
+ * {@link BaseStorageConfig}).
+ */
+export type StorageProviderFactory<TConfig extends BaseStorageConfig = BaseStorageConfig> = (
+  config: TConfig,
+) => StorageProvider
+
+/**
+ * Internal registry mapping a provider `type` to its factory.
+ *
+ * Factories are stored against {@link BaseStorageConfig} because every provider
+ * config extends it. `registerStorageProvider` narrows the public input to the
+ * concrete config type, then widens it for storage — this conversion happens
+ * once, internally, so the public API stays free of `any`/casts.
+ */
+const registry = new Map<string, StorageProviderFactory>()
+
+/**
+ * Registers a storage provider factory for a given provider `type`.
+ *
+ * The host application calls this to opt in to a provider it uses — either one
+ * of the optional provider packages (`@opensaas/stack-storage-s3`,
+ * `@opensaas/stack-storage-vercel`) or a custom provider. Once registered,
+ * {@link createStorageProvider} can construct that provider when a field is
+ * bound to it.
+ *
+ * Registering an already-registered `type` overwrites the previous factory,
+ * allowing a host to replace a built-in (e.g. swap the default `'local'`
+ * provider) if needed.
+ *
+ * @typeParam TConfig - The provider-specific config type.
+ * @param type - The provider `type` discriminator used in storage config
+ * (e.g. `'s3'`, `'vercel-blob'`, `'cloudflare-r2'`).
+ * @param factory - A function that builds the provider from its config.
+ *
+ * @example
+ * ```typescript
+ * import { registerStorageProvider } from '@opensaas/stack-storage/runtime'
+ * import { S3StorageProvider, type S3StorageConfig } from '@opensaas/stack-storage-s3'
+ *
+ * registerStorageProvider<S3StorageConfig>('s3', (config) => new S3StorageProvider(config))
+ * ```
+ */
+export function registerStorageProvider<TConfig extends BaseStorageConfig>(
+  type: string,
+  factory: StorageProviderFactory<TConfig>,
+): void {
+  // `factory` accepts a narrower `TConfig`; the registry stores it against the
+  // wider `BaseStorageConfig`. This widening wrapper is safe because
+  // `createStorageProvider` only ever invokes a factory with the config whose
+  // `type` selected it, so the runtime config always matches `TConfig`.
+  const widened: StorageProviderFactory = (config) => factory(config as TConfig)
+  registry.set(type, widened)
+}
+
+/**
+ * Returns the factory registered for a provider `type`, or `undefined` when no
+ * provider has been registered under that `type`.
+ */
+export function getStorageProviderFactory(type: string): StorageProviderFactory | undefined {
+  return registry.get(type)
+}
+
+/**
+ * Returns `true` when a provider factory is registered for the given `type`.
+ */
+export function hasStorageProvider(type: string): boolean {
+  return registry.has(type)
+}
+
+/**
+ * Resets the registry to only the built-in defaults.
+ *
+ * Primarily useful in tests to guarantee isolation between cases that register
+ * custom providers.
+ */
+export function resetStorageProviderRegistry(): void {
+  registry.clear()
+  registerBuiltinProviders()
+}
+
+/**
+ * Registers the providers that ship with `@opensaas/stack-storage` itself.
+ *
+ * Currently only `'local'`, which keeps existing behaviour unchanged: hosts get
+ * local filesystem storage with no registration step. Optional providers
+ * (`s3`, `vercel-blob`) are NOT registered here — the host opts into those to
+ * avoid forcing the AWS/Vercel SDKs onto every storage user.
+ */
+function registerBuiltinProviders(): void {
+  registerStorageProvider<LocalStorageConfig>('local', (config) => new LocalStorageProvider(config))
+}
+
+// Register built-in providers on module load so `'local'` works by default.
+registerBuiltinProviders()

--- a/packages/storage/tests/provider-registry.test.ts
+++ b/packages/storage/tests/provider-registry.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { OpenSaasConfig } from '@opensaas/stack-core'
+import {
+  createStorageProvider,
+  registerStorageProvider,
+  getStorageProviderFactory,
+  hasStorageProvider,
+  resetStorageProviderRegistry,
+} from '../src/runtime/index.js'
+import { LocalStorageProvider } from '../src/providers/local.js'
+import { assembleImageMetadata, keystoneImageColumnMap } from '../src/utils/multi-column.js'
+import type {
+  StorageProvider,
+  UploadOptions,
+  UploadResult,
+  BaseStorageConfig,
+} from '../src/config/types.js'
+
+/**
+ * A minimal custom provider config + implementation used to prove that a
+ * non-`local`, host-registered provider can be constructed via the registry —
+ * without `@opensaas/stack-storage` depending on `-s3`/`-vercel`.
+ */
+interface FakeStorageConfig extends BaseStorageConfig {
+  type: 'fake'
+  baseUrl: string
+}
+
+class FakeStorageProvider implements StorageProvider {
+  constructor(public readonly config: FakeStorageConfig) {}
+
+  async upload(
+    _file: Buffer | Uint8Array,
+    filename: string,
+    options?: UploadOptions,
+  ): Promise<UploadResult> {
+    return {
+      filename,
+      url: `${this.config.baseUrl}/${filename}`,
+      size: 0,
+      contentType: options?.contentType ?? 'application/octet-stream',
+    }
+  }
+
+  async download(): Promise<Buffer> {
+    return Buffer.from('')
+  }
+
+  async delete(): Promise<void> {}
+
+  getUrl(filename: string): string {
+    return `${this.config.baseUrl}/${filename}`
+  }
+}
+
+/** Builds a minimal, strongly-typed config carrying a single storage provider. */
+function configWith(name: string, providerConfig: BaseStorageConfig): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite' },
+    lists: {},
+    storage: { [name]: providerConfig },
+  }
+}
+
+describe('storage provider registry', () => {
+  beforeEach(() => {
+    // Restore registry to built-in defaults so registrations don't leak.
+    resetStorageProviderRegistry()
+  })
+
+  describe('built-in defaults', () => {
+    it("registers 'local' by default so createStorageProvider builds it", () => {
+      const config = configWith('files', {
+        type: 'local',
+        uploadDir: './uploads',
+        serveUrl: '/uploads',
+      })
+
+      const provider = createStorageProvider(config, 'files')
+
+      expect(provider).toBeInstanceOf(LocalStorageProvider)
+    })
+
+    it("reports 'local' as registered", () => {
+      expect(hasStorageProvider('local')).toBe(true)
+      expect(getStorageProviderFactory('local')).toBeTypeOf('function')
+    })
+  })
+
+  describe('registering a custom provider', () => {
+    it('lets createStorageProvider construct a registered non-local provider', () => {
+      registerStorageProvider<FakeStorageConfig>(
+        'fake',
+        (providerConfig) => new FakeStorageProvider(providerConfig),
+      )
+
+      const config = configWith('cdn', {
+        type: 'fake',
+        baseUrl: 'https://cdn.example.com',
+      })
+
+      const provider = createStorageProvider(config, 'cdn')
+
+      expect(provider).toBeInstanceOf(FakeStorageProvider)
+      expect(provider.getUrl('photo.jpg')).toBe('https://cdn.example.com/photo.jpg')
+    })
+
+    it('passes the provider config through to the factory', () => {
+      let received: FakeStorageConfig | undefined
+      registerStorageProvider<FakeStorageConfig>('fake', (providerConfig) => {
+        received = providerConfig
+        return new FakeStorageProvider(providerConfig)
+      })
+
+      const providerConfig: FakeStorageConfig = {
+        type: 'fake',
+        baseUrl: 'https://assets.example.com',
+      }
+
+      createStorageProvider(configWith('assets', providerConfig), 'assets')
+
+      expect(received).toEqual(providerConfig)
+    })
+
+    it('reflects registration via hasStorageProvider/getStorageProviderFactory', () => {
+      expect(hasStorageProvider('fake')).toBe(false)
+
+      registerStorageProvider<FakeStorageConfig>(
+        'fake',
+        (providerConfig) => new FakeStorageProvider(providerConfig),
+      )
+
+      expect(hasStorageProvider('fake')).toBe(true)
+      expect(getStorageProviderFactory('fake')).toBeTypeOf('function')
+    })
+
+    it('overwrites a previous registration for the same type', () => {
+      registerStorageProvider<FakeStorageConfig>(
+        'fake',
+        (providerConfig) => new FakeStorageProvider({ ...providerConfig, baseUrl: 'first' }),
+      )
+      registerStorageProvider<FakeStorageConfig>(
+        'fake',
+        (providerConfig) => new FakeStorageProvider({ ...providerConfig, baseUrl: 'second' }),
+      )
+
+      const provider = createStorageProvider(
+        configWith('cdn', { type: 'fake', baseUrl: 'ignored' }),
+        'cdn',
+      )
+
+      expect(provider.getUrl('x')).toBe('second/x')
+    })
+  })
+
+  describe('unregistered providers', () => {
+    it('throws a clear error for an unregistered type', () => {
+      const config = configWith('cdn', { type: 's3', bucket: 'my-bucket' })
+
+      expect(() => createStorageProvider(config, 'cdn')).toThrow(
+        /Unknown storage provider type: s3/,
+      )
+      expect(() => createStorageProvider(config, 'cdn')).toThrow(/registerStorageProvider/)
+    })
+
+    it('still throws when the named provider is absent from config', () => {
+      const config = configWith('files', {
+        type: 'local',
+        uploadDir: './uploads',
+        serveUrl: '/uploads',
+      })
+
+      expect(() => createStorageProvider(config, 'missing')).toThrow(
+        /Storage provider 'missing' not found in config/,
+      )
+    })
+  })
+
+  describe('read path is unaffected by the registry', () => {
+    it('assembleImageMetadata stamps the provider name without constructing a provider', () => {
+      // No provider registered for 'remote'; the read path must not care.
+      expect(hasStorageProvider('remote')).toBe(false)
+
+      const map = keystoneImageColumnMap('image')
+      const row = {
+        image_url: 'https://cdn.example.com/pic.jpg',
+        image_width: 800,
+        image_height: 600,
+        image_filesize: 1234,
+        image_contentType: 'image/jpeg',
+        image_pathname: 'pic.jpg',
+      }
+
+      const meta = assembleImageMetadata(row, map, 'remote')
+
+      expect(meta).not.toBeNull()
+      expect(meta?.storageProvider).toBe('remote')
+      expect(meta?.url).toBe('https://cdn.example.com/pic.jpg')
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds a **provider-registration hook** to the storage runtime so non-`local` and custom providers are constructable. Implements ADR-0009.

`createStorageProvider` (`packages/storage/src/runtime/index.ts`) previously used a hardcoded `switch` that only built `'local'` and threw `Unknown storage provider type: …` for everything else — so the published `@opensaas/stack-storage-s3` / `-vercel` providers (and any custom provider) could not be constructed for uploads.

It now resolves a provider `type` through a **registry**:

- **`registerStorageProvider(type, factory)`** — exported from `@opensaas/stack-storage/runtime`. The host registers the optional provider it uses (or a custom one).
- `createStorageProvider` looks the `type` up in the registry instead of a closed `switch`.
- **`'local'` is registered as a built-in default** (on module load), so existing behaviour is unchanged with no registration step.
- An **unregistered** type still throws a clear error that points at `registerStorageProvider`.
- Also exported: `getStorageProviderFactory`, `hasStorageProvider`, `resetStorageProviderRegistry` (test isolation), and the `StorageProviderFactory<TConfig>` type.

## No new runtime dependency

`@opensaas/stack-storage` does **not** depend on `@opensaas/stack-storage-s3` / `-vercel` — `package.json` is unchanged. The host opts into the optional provider it uses, avoiding the eager-dep problem (ADR-0008) of forcing the AWS/Vercel SDKs onto every storage user. Tests register a local fake/custom provider rather than pulling in a provider package.

## Read path unchanged

`assembleImageMetadata` (`packages/storage/src/utils/multi-column.ts`) still stamps only the provider **name** and never constructs a provider — left untouched and covered by a test.

## Type safety

The public API is strongly typed (`registerStorageProvider<TConfig extends BaseStorageConfig>`, `StorageProviderFactory<TConfig>`) with no `any`/casts exposed. The single internal config-widening cast lives inside the package with an explanatory comment. The old `as unknown as LocalStorageConfig` cast was removed.

## Docs

Completed the storage `CLAUDE.md` "Custom Storage Provider" section (which dead-ended at "Extend `createStorageProvider` to support…") with the real registration recipe: registering an optional provider package (`s3`, `vercel-blob`), registering a custom provider, and referencing it by `type` in config.

## Tests

New `packages/storage/tests/provider-registry.test.ts` (9 tests):
- `'local'` builds by default via the registry
- registering a custom provider lets `createStorageProvider` build it
- config is passed through to the factory; re-registration overwrites
- `hasStorageProvider` / `getStorageProviderFactory` reflect registration
- unregistered type throws a clear error; missing-name still throws
- `assembleImageMetadata` (read path) stamps the provider name without constructing a provider

All 123 storage tests pass. `pnpm lint` (0 errors), `pnpm format:check`, and `pnpm --filter @opensaas/stack-storage build` all pass. Changeset included (`minor`).

Fixes #549

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_