### PR TITLE
feat(ui): add list-level ui.listView config (initialColumns + initialSort)

### DIFF
--- a/.changeset/wise-otters-listview.md
+++ b/.changeset/wise-otters-listview.md
@@ -1,0 +1,33 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add list-level `ui.listView` config (mirroring Keystone) for default columns and sort
+
+Lists now support a `ui.listView` block in `opensaas.config.ts` that sets the
+admin list table's default column selection/order and default sort. Naming
+mirrors Keystone's `ui.listView` so migrators can map defaults directly.
+
+```typescript
+lists: {
+  Post: list({
+    fields: {
+      title: text(),
+      status: text(),
+      createdAt: timestamp(),
+    },
+    ui: {
+      listView: {
+        // Column selection AND order
+        initialColumns: ['title', 'status'],
+        // Default sort
+        initialSort: { field: 'createdAt', direction: 'desc' },
+      },
+    },
+  }),
+}
+```
+
+When `ui.listView` is absent, behaviour is unchanged: the table shows all
+non-system fields and applies no default sort.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -148,6 +148,8 @@ export type {
   DatabaseConfig,
   SessionConfig,
   UIConfig,
+  ListUIConfig,
+  ListViewUIConfig,
   ThemeConfig,
   ThemePreset,
   ThemeColors,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1402,6 +1402,68 @@ export type ListConfig<TTypeInfo extends TypeInfo> = {
          */
         autoCreate?: boolean
       }
+  /**
+   * UI configuration for this list (admin interface).
+   *
+   * Mirrors Keystone's list-level `ui` block. Currently only `listView`
+   * defaults (columns + sort) are supported.
+   */
+  ui?: ListUIConfig
+}
+
+/**
+ * List-level UI configuration for the admin interface.
+ *
+ * Mirrors Keystone's `ui` block on a list. Only the list-view defaults
+ * (column selection/order and default sort) are supported today; other
+ * Keystone concerns (`label`, `labelField`, `description`) are intentionally
+ * deferred as they cover different concerns (navigation text and
+ * relationship-picker labels rather than list-view defaults).
+ */
+export type ListUIConfig = {
+  /**
+   * Default list-view (table) configuration for this list, mirroring
+   * Keystone's `ui.listView`.
+   */
+  listView?: ListViewUIConfig
+}
+
+/**
+ * Default list-view (table) configuration for a list, mirroring Keystone's
+ * `ui.listView`.
+ *
+ * When omitted, the admin UI falls back to its existing defaults: every
+ * non-system field is shown as a column and no default sort is applied.
+ */
+export type ListViewUIConfig = {
+  /**
+   * The fields to show as columns in the list table, in order.
+   *
+   * Drives both the column **selection** and their **order**. When omitted,
+   * all non-system fields are shown (current default behaviour).
+   *
+   * @example
+   * ```typescript
+   * ui: { listView: { initialColumns: ['title', 'status', 'author'] } }
+   * ```
+   */
+  initialColumns?: string[]
+  /**
+   * The default sort applied to the list table.
+   *
+   * When omitted, no default sort is applied (current default behaviour).
+   *
+   * @example
+   * ```typescript
+   * ui: { listView: { initialSort: { field: 'createdAt', direction: 'desc' } } }
+   * ```
+   */
+  initialSort?: {
+    /** The field to sort by. Must be a field defined on the list. */
+    field: string
+    /** The sort direction. */
+    direction: 'asc' | 'desc'
+  }
 }
 
 /**

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -208,5 +208,35 @@ describe('config helpers', () => {
       expect(testList.hooks).toBeDefined()
       expect(testList.hooks?.resolveInput).toBeDefined()
     })
+
+    it('should accept ui.listView config (initialColumns + initialSort)', () => {
+      const testList = list({
+        fields: {
+          title: { type: 'text' },
+          status: { type: 'text' },
+          createdAt: { type: 'timestamp' },
+        },
+        ui: {
+          listView: {
+            initialColumns: ['title', 'status'],
+            initialSort: { field: 'createdAt', direction: 'desc' },
+          },
+        },
+      })
+
+      expect(testList.ui?.listView?.initialColumns).toEqual(['title', 'status'])
+      expect(testList.ui?.listView?.initialSort).toEqual({
+        field: 'createdAt',
+        direction: 'desc',
+      })
+    })
+
+    it('should leave ui undefined when not configured', () => {
+      const testList = list({
+        fields: { title: { type: 'text' } },
+      })
+
+      expect(testList.ui).toBeUndefined()
+    })
   })
 })

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -108,6 +108,12 @@ export function AdminUI({
     const search = typeof searchParams.search === 'string' ? searchParams.search : undefined
     const page = typeof searchParams.page === 'string' ? parseInt(searchParams.page, 10) : 1
 
+    // Read list-view defaults (column selection/order + default sort) from the
+    // list-level `ui.listView` config (mirrors Keystone). When absent, the
+    // ListView falls back to its existing defaults (all non-system fields,
+    // no default sort).
+    const listView = config.lists[listKey]?.ui?.listView
+
     content = (
       <ListView
         context={context}
@@ -116,6 +122,8 @@ export function AdminUI({
         basePath={basePath}
         search={search}
         page={page}
+        columns={listView?.initialColumns}
+        initialSort={listView?.initialSort}
       />
     )
   }

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -3,6 +3,15 @@ import { ListViewClient } from './ListViewClient.js'
 import { formatListName } from '../lib/utils.js'
 import { type AccessContext, getDbKey, getUrlKey, OpenSaasConfig } from '@opensaas/stack-core'
 
+/**
+ * Default sort for the list table, mirroring Keystone's `ui.listView.initialSort`.
+ * Plain serializable data so it can cross the server/client boundary.
+ */
+export interface ListViewSort {
+  field: string
+  direction: 'asc' | 'desc'
+}
+
 export interface ListViewProps {
   context: AccessContext<unknown>
   config: OpenSaasConfig
@@ -12,6 +21,11 @@ export interface ListViewProps {
   page?: number
   pageSize?: number
   search?: string
+  /**
+   * Default sort applied to the table (from the list's `ui.listView.initialSort`).
+   * When omitted, no default sort is applied.
+   */
+  initialSort?: ListViewSort
 }
 
 /**
@@ -27,6 +41,7 @@ export async function ListView({
   page = 1,
   pageSize = 50,
   search,
+  initialSort,
 }: ListViewProps) {
   const key = getDbKey(listKey)
   const urlKey = getUrlKey(listKey)
@@ -142,6 +157,7 @@ export async function ListView({
         )}
         relationshipRefs={relationshipRefs}
         columns={columns}
+        initialSort={initialSort}
         listKey={listKey}
         urlKey={urlKey}
         basePath={basePath}

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -23,6 +23,12 @@ export interface ListViewClientProps {
   fieldTypes: Record<string, string>
   relationshipRefs: Record<string, string>
   columns?: string[]
+  /**
+   * Default sort for the table (from the list's `ui.listView.initialSort`).
+   * Seeds the initial sort column/direction. When omitted, the table starts
+   * unsorted (current default behaviour).
+   */
+  initialSort?: { field: string; direction: 'asc' | 'desc' }
   listKey: string
   urlKey: string
   basePath: string
@@ -41,6 +47,7 @@ export function ListViewClient({
   fieldTypes,
   relationshipRefs,
   columns,
+  initialSort,
   urlKey,
   basePath,
   page,
@@ -49,8 +56,8 @@ export function ListViewClient({
   search: initialSearch,
 }: ListViewClientProps) {
   const router = useRouter()
-  const [sortBy, setSortBy] = useState<string | null>(null)
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+  const [sortBy, setSortBy] = useState<string | null>(initialSort?.field ?? null)
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(initialSort?.direction ?? 'asc')
   const [searchInput, setSearchInput] = useState(initialSearch || '')
 
   // Determine which columns to show

--- a/packages/ui/tests/components/AdminUIListView.test.tsx
+++ b/packages/ui/tests/components/AdminUIListView.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as React from 'react'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text, timestamp } from '@opensaas/stack-core/fields'
+import { AdminUI } from '../../src/components/AdminUI.js'
+import { ListView } from '../../src/components/ListView.js'
+
+// Mock Next.js navigation — client components call useRouter().
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}))
+
+vi.mock('next/link.js', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+interface DelegateStub {
+  findMany?: (args: unknown) => Promise<Array<Record<string, unknown>>>
+  count?: (args: unknown) => Promise<number>
+}
+
+function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  return context as unknown as AccessContext<unknown>
+}
+
+const noopServerAction = vi.fn(async () => ({ success: true }))
+
+/**
+ * AdminUI returns <> {style?} <div><Navigation/><main>{content}</main></div> </>.
+ * Drill into <main> to recover the routed content element (the <ListView /> the
+ * router chose for the bare [list] route) so we can inspect the props AdminUI
+ * passed to it.
+ */
+function routedContent(tree: React.ReactNode): React.ReactElement {
+  const fragment = tree as React.ReactElement<{ children: React.ReactNode }>
+  const children = React.Children.toArray(fragment.props.children)
+  const wrapper = children.find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'div',
+  )
+  if (!wrapper) throw new Error('AdminUI layout wrapper not found')
+  const main = React.Children.toArray(wrapper.props.children).find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'main',
+  )
+  if (!main) throw new Error('AdminUI <main> not found')
+  return main.props.children as React.ReactElement
+}
+
+describe('AdminUI ui.listView wiring', () => {
+  it('passes initialColumns + initialSort from ui.listView to ListView', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: {
+            title: text(),
+            status: text(),
+            createdAt: timestamp(),
+          },
+          ui: {
+            listView: {
+              initialColumns: ['title', 'status'],
+              initialSort: { field: 'createdAt', direction: 'desc' },
+            },
+          },
+        }),
+      },
+    }
+
+    const context = makeContext({
+      post: { findMany: vi.fn(async () => []), count: vi.fn(async () => 0) },
+    })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['post'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ListView)
+    // initialColumns drives the `columns` prop (selection + order).
+    expect(content.props.columns).toEqual(['title', 'status'])
+    // initialSort flows through as the default sort.
+    expect(content.props.initialSort).toEqual({ field: 'createdAt', direction: 'desc' })
+  })
+
+  it('passes undefined columns + initialSort when ui.listView is absent', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: {
+            title: text(),
+          },
+        }),
+      },
+    }
+
+    const context = makeContext({
+      post: { findMany: vi.fn(async () => []), count: vi.fn(async () => 0) },
+    })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['post'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ListView)
+    // Absent config → current behaviour unchanged (no column override, no default sort).
+    expect(content.props.columns).toBeUndefined()
+    expect(content.props.initialSort).toBeUndefined()
+  })
+})

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -73,6 +73,66 @@ describe('ListViewClient', () => {
       expect(screen.getByText('Status')).toBeInTheDocument()
       expect(screen.queryByText('Views')).not.toBeInTheDocument()
     })
+
+    it('should render columns in the provided order (initialColumns)', () => {
+      // initialColumns flows through AdminUI as the `columns` prop and drives
+      // both selection AND order.
+      render(<ListViewClient {...defaultProps} columns={['views', 'title']} />)
+
+      const headers = screen.getAllByRole('columnheader')
+      // First two headers should follow the provided order, then Actions.
+      expect(headers[0]).toHaveTextContent('Views')
+      expect(headers[1]).toHaveTextContent('Title')
+      expect(headers[2]).toHaveTextContent('Actions')
+      // Unlisted column is excluded.
+      expect(screen.queryByText('Status')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('initialSort', () => {
+    it('should apply default sort from initialSort without any click', () => {
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'asc' }} />,
+      )
+
+      const rows = screen.getAllByRole('row')
+      // Sorted ascending by title: First, Second, Third
+      expect(rows[1]).toHaveTextContent('First Post')
+      expect(rows[2]).toHaveTextContent('Second Post')
+      expect(rows[3]).toHaveTextContent('Third Post')
+    })
+
+    it('should respect descending direction from initialSort', () => {
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'desc' }} />,
+      )
+
+      const rows = screen.getAllByRole('row')
+      // Sorted descending by title: Third, Second, First
+      expect(rows[1]).toHaveTextContent('Third Post')
+      expect(rows[2]).toHaveTextContent('Second Post')
+      expect(rows[3]).toHaveTextContent('First Post')
+    })
+
+    it('should show sort indicator on the initialSort column', () => {
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'desc' }} />,
+      )
+
+      expect(screen.getByText('↓')).toBeInTheDocument()
+    })
+
+    it('should not apply any default sort when initialSort is absent', () => {
+      render(<ListViewClient {...defaultProps} />)
+
+      const rows = screen.getAllByRole('row')
+      // Unchanged: items render in their original (input) order, no indicator.
+      expect(rows[1]).toHaveTextContent('First Post')
+      expect(rows[2]).toHaveTextContent('Second Post')
+      expect(rows[3]).toHaveTextContent('Third Post')
+      expect(screen.queryByText('↑')).not.toBeInTheDocument()
+      expect(screen.queryByText('↓')).not.toBeInTheDocument()
+    })
   })
 
   describe('sorting', () => {


### PR DESCRIPTION
## Summary

Adds a list-level `ui.listView` config to core's `ListConfig`, mirroring Keystone 1:1 so migrators can map per-list defaults directly. Wires it through `AdminUI` → `ListView` → `ListViewClient`.

- `initialColumns: string[]` — drives the list table's default column **selection and order**.
- `initialSort: { field, direction }` — sets the **default sort**.
- `label` / `labelField` / `description` are intentionally **deferred** (different concerns).

```typescript
lists: {
  Post: list({
    fields: { title: text(), status: text(), createdAt: timestamp() },
    ui: {
      listView: {
        initialColumns: ['title', 'status'],
        initialSort: { field: 'createdAt', direction: 'desc' },
      },
    },
  }),
}
```

When `ui.listView` is absent, behaviour is unchanged: all non-system fields are shown and no default sort is applied.

## How it's consumed

- **core** (`packages/core/src/config/types.ts`): new `ListUIConfig` / `ListViewUIConfig` types, exposed on `ListConfig.ui`; exported from `@opensaas/stack-core` config entry. `list()` passes `ui` through unchanged.
- **AdminUI** (`packages/ui/src/components/AdminUI.tsx`): the ListView branch reads `config.lists[listKey].ui?.listView` and passes `initialColumns` as the `columns` prop and `initialSort` as a new prop.
- **ListView** (`packages/ui/src/components/ListView.tsx`): accepts `initialSort` and threads it to the client component (plain serializable data across the server/client boundary).
- **ListViewClient** (`packages/ui/src/components/ListViewClient.tsx`): seeds `sortBy`/`sortOrder` state from `initialSort`; existing `columns` already drives selection/order.

## Tests

- `packages/core/tests/config.test.ts`: `ui.listView` (initialColumns + initialSort) is accepted; `ui` stays `undefined` when not configured.
- `packages/ui/tests/components/ListViewClient.test.tsx`: column order from `initialColumns`; default sort + direction from `initialSort`; sort indicator on the seeded column; no default sort when `initialSort` absent.
- `packages/ui/tests/components/AdminUIListView.test.tsx`: AdminUI passes `initialColumns`/`initialSort` from config to ListView; passes `undefined` when `ui.listView` absent.

All green: stack-core 588 tests, stack-ui 190 tests. Lint (0 errors), `format:check` pass.

Fixes #550

https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULd2HCT8dUve9aa9gKi6sX)_