### PR TITLE
fix(core): fail loud on non-sudo writes in filterWritableFields (#564, #568)

### DIFF
--- a/.changeset/loud-foxes-write.md
+++ b/.changeset/loud-foxes-write.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Make non-sudo writes fail loud in `filterWritableFields` (Keystone parity).
+
+Undeclared `data` keys on create/update now throw instead of passing through unchecked (#564), and fields denied by field-level access now throw instead of being silently stripped (#568). `sudo` remains the single trusted bypass; system fields, relationship foreign keys, and multi-column split columns still pass through.

--- a/.changeset/loud-foxes-write.md
+++ b/.changeset/loud-foxes-write.md
@@ -4,4 +4,6 @@
 
 Make non-sudo writes fail loud in `filterWritableFields` (Keystone parity).
 
-Undeclared `data` keys on create/update now throw instead of passing through unchecked (#564), and fields denied by field-level access now throw instead of being silently stripped (#568). `sudo` remains the single trusted bypass; system fields, relationship foreign keys, and multi-column split columns still pass through.
+Undeclared `data` keys on create/update now throw instead of passing through unchecked (#564), and fields denied by field-level access now throw instead of being silently stripped (#568). `sudo` remains the single trusted bypass; system fields and relationship foreign keys still pass through. Raw multi-column split columns (e.g. `media_url`/`media_size` from an `image()`/`file()` field) are now gated by their owning field's write access — supplying them directly under non-sudo when that field denies the write throws, instead of bypassing the field's `access.create`/`access.update`.
+
+Behavioural narrowing: a list-level `resolveInput` hook that adds keys to `resolvedData` which are not declared fields will now be rejected by the undeclared-key throw. No production hook does this today.

--- a/packages/core/src/access/field-access.test.ts
+++ b/packages/core/src/access/field-access.test.ts
@@ -254,9 +254,10 @@ describe('filterWritableFields', () => {
     expect(filtered).toHaveProperty('title', 'Test')
   })
 
-  it('passes through raw per-part columns from a multi-column field (non-sudo)', async () => {
+  it('passes through raw per-part columns from a multi-column field whose write access ALLOWS (non-sudo)', async () => {
     // Multi-column fields inject raw columns (e.g. m_url/m_size) that are not
     // declared in fieldConfigs; they must not trip the undeclared-key reject.
+    // With no field-level access (allow), they pass through.
     const fieldConfigs = {
       media: {
         type: 'image',
@@ -271,6 +272,66 @@ describe('filterWritableFields', () => {
     const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
       session: null,
       context: nonSudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).toHaveProperty('media_url', 'https://x/y.jpg')
+    expect(filtered).toHaveProperty('media_size', 99)
+  })
+
+  it('THROWS when raw split columns are supplied for a field whose write access is DENIED (non-sudo)', async () => {
+    // Security (#568): a non-sudo caller who supplies the raw per-part columns
+    // DIRECTLY must not bypass the owning field's write-access gate. The
+    // logical-key gate in the hooks layer never fires here (no `media` key), so
+    // this filter is the only enforcement point — it must throw.
+    const fieldConfigs = {
+      media: {
+        type: 'image',
+        access: { create: () => false, update: () => false },
+        getColumnNames: (fieldName: string) => [`${fieldName}_url`, `${fieldName}_size`],
+      },
+    }
+    const data = {
+      media_url: 'https://evil/x.jpg',
+      media_size: 1,
+    }
+
+    // Throws ValidationError, and the message names the owning field.
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'create', {
+        session: null,
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(ValidationError)
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'update', {
+        session: null,
+        item: { id: 'item-1' },
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(/media/)
+  })
+
+  it('passes raw split columns through under sudo regardless of denied owning-field access', async () => {
+    // sudo is the single trusted bypass; `checkFieldAccess` returns true under
+    // sudo, so even a would-be-denied multi-column field passes through.
+    const fieldConfigs = {
+      media: {
+        type: 'image',
+        access: { create: () => false, update: () => false },
+        getColumnNames: (fieldName: string) => [`${fieldName}_url`, `${fieldName}_size`],
+      },
+    }
+    const data = {
+      media_url: 'https://x/y.jpg',
+      media_size: 99,
+    }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
+      session: null,
+      context: sudoContext(),
       inputData: data,
     })
 

--- a/packages/core/src/access/field-access.test.ts
+++ b/packages/core/src/access/field-access.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from 'vitest'
 import { filterWritableFields } from './field-access.js'
+import { ValidationError } from '../hooks/index.js'
+
+// A non-sudo access context. The cast is localized to test setup (mirrors the
+// existing sudo-context casts in this file): the runtime AccessContext carries
+// Prisma plumbing the unit under test never touches.
+function nonSudoContext() {
+  return {
+    session: null,
+    _isSudo: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+function sudoContext() {
+  return {
+    session: null,
+    _isSudo: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
 
 describe('filterWritableFields', () => {
   it('should filter out foreign key fields when their corresponding relationship field exists', async () => {
@@ -145,5 +165,179 @@ describe('filterWritableFields', () => {
 
     // authorId is a foreign key for author relationship, so it should be filtered
     expect(filtered).not.toHaveProperty('authorId')
+  })
+
+  // ── #564: undeclared data keys must fail CLOSED (throw) for non-sudo writes ──
+
+  it('throws on an undeclared data key for a non-sudo create', async () => {
+    const fieldConfigs = { title: { type: 'text' } }
+    const data = {
+      title: 'Test',
+      // Not a declared field — e.g. a Prisma back-relation the config never
+      // exposed (`from_Enrolment_student`). Must be rejected, not passed through.
+      from_Enrolment_student: { disconnect: [{ id: 'e1' }] },
+    }
+
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'create', {
+        session: null,
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(ValidationError)
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'create', {
+        session: null,
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(/from_Enrolment_student/)
+  })
+
+  it('throws on an undeclared data key for a non-sudo update', async () => {
+    const fieldConfigs = { title: { type: 'text' } }
+    const data = {
+      title: 'Updated',
+      bogusKey: 'value',
+    }
+
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'update', {
+        session: null,
+        item: { id: 'post-1' },
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(/bogusKey/)
+  })
+
+  it('passes undeclared data keys through under sudo (the single trusted bypass)', async () => {
+    const fieldConfigs = { title: { type: 'text' } }
+    const data = {
+      title: 'Test',
+      from_Enrolment_student: { disconnect: [{ id: 'e1' }] },
+    }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
+      session: null,
+      context: sudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).toHaveProperty('title', 'Test')
+    expect(filtered).toHaveProperty('from_Enrolment_student')
+  })
+
+  it('still skips system fields and relationship FK fields cleanly for a non-sudo write', async () => {
+    const fieldConfigs = {
+      title: { type: 'text' },
+      author: { type: 'relationship', many: false },
+    }
+    const data = {
+      id: 'post-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: 'Test',
+      authorId: 'user-1', // FK skipped, not rejected
+    }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
+      session: null,
+      context: nonSudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).not.toHaveProperty('id')
+    expect(filtered).not.toHaveProperty('createdAt')
+    expect(filtered).not.toHaveProperty('updatedAt')
+    expect(filtered).not.toHaveProperty('authorId')
+    expect(filtered).toHaveProperty('title', 'Test')
+  })
+
+  it('passes through raw per-part columns from a multi-column field (non-sudo)', async () => {
+    // Multi-column fields inject raw columns (e.g. m_url/m_size) that are not
+    // declared in fieldConfigs; they must not trip the undeclared-key reject.
+    const fieldConfigs = {
+      media: {
+        type: 'image',
+        getColumnNames: (fieldName: string) => [`${fieldName}_url`, `${fieldName}_size`],
+      },
+    }
+    const data = {
+      media_url: 'https://x/y.jpg',
+      media_size: 99,
+    }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
+      session: null,
+      context: nonSudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).toHaveProperty('media_url', 'https://x/y.jpg')
+    expect(filtered).toHaveProperty('media_size', 99)
+  })
+
+  // ── #568: field-access-denied keys must THROW, not be silently stripped ──────
+
+  it('throws when a declared field is denied by field-level access (non-sudo)', async () => {
+    const fieldConfigs = {
+      title: { type: 'text' },
+      status: {
+        type: 'text',
+        access: { update: () => false, create: () => false },
+      },
+    }
+    const data = { title: 'Test', status: 'published' }
+
+    await expect(
+      filterWritableFields(data, fieldConfigs, 'update', {
+        session: null,
+        item: { id: 'post-1' },
+        context: nonSudoContext(),
+        inputData: data,
+      }),
+    ).rejects.toThrow(/status/)
+  })
+
+  it('does NOT throw on a would-be-denied field under sudo', async () => {
+    const fieldConfigs = {
+      title: { type: 'text' },
+      status: {
+        type: 'text',
+        access: { update: () => false, create: () => false },
+      },
+    }
+    const data = { title: 'Test', status: 'published' }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'update', {
+      session: null,
+      item: { id: 'post-1' },
+      context: sudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).toHaveProperty('title', 'Test')
+    expect(filtered).toHaveProperty('status', 'published')
+  })
+
+  it('passes a declared relationship field through to nested operations (non-sudo)', async () => {
+    const fieldConfigs = {
+      title: { type: 'text' },
+      author: { type: 'relationship', many: false },
+    }
+    const data = {
+      title: 'Test',
+      author: { connect: { id: 'user-1' } },
+    }
+
+    const filtered = await filterWritableFields(data, fieldConfigs, 'create', {
+      session: null,
+      context: nonSudoContext(),
+      inputData: data,
+    })
+
+    expect(filtered).toHaveProperty('author')
+    expect(filtered.author).toEqual({ connect: { id: 'user-1' } })
   })
 })

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -1,5 +1,9 @@
 import type { Session, AccessContext } from './types.js'
 import type { FieldAccess } from './types.js'
+// `ValidationError` is referenced only inside function bodies (call-time), never
+// at module-evaluation time, so the field-access ⇄ hooks import cycle is safe
+// under ESM live bindings.
+import { ValidationError } from '../hooks/index.js'
 
 /**
  * Shared field-level access evaluation.
@@ -100,7 +104,14 @@ function matchesFilter(item: Record<string, unknown>, filter: Record<string, unk
  */
 export async function filterWritableFields<T extends Record<string, unknown>>(
   data: T,
-  fieldConfigs: Record<string, { access?: FieldAccess; type?: string }>,
+  fieldConfigs: Record<
+    string,
+    {
+      access?: FieldAccess
+      type?: string
+      getColumnNames?: (fieldName: string) => string[]
+    }
+  >,
   operation: 'create' | 'update',
   args: {
     session: Session | null
@@ -114,6 +125,14 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
   // Build a set of foreign key field names to exclude
   // Foreign keys should not be in the data when using Prisma's relation syntax
   const foreignKeyFields = new Set<string>()
+  // Build a set of the raw per-part column names contributed by multi-column
+  // fields (e.g. storage image()/file() in Keystone-parity mode). These keys are
+  // injected into the write payload by the field's `splitColumns` AFTER
+  // resolveInput and are intentionally NOT declared in `fieldConfigs`, so they
+  // are legitimate undeclared keys that must NOT trip the #564 reject below.
+  // Their own write access was already enforced at split time (see
+  // `executeFieldResolveInputHooks`).
+  const splitColumnFields = new Set<string>()
   for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
     if (fieldConfig.type === 'relationship') {
       // For non-many relationships, Prisma creates a foreign key field named `${fieldName}Id`
@@ -122,7 +141,14 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
         foreignKeyFields.add(`${fieldName}Id`)
       }
     }
+    if (typeof fieldConfig.getColumnNames === 'function') {
+      for (const column of fieldConfig.getColumnNames(fieldName)) {
+        splitColumnFields.add(column)
+      }
+    }
   }
+
+  const isSudo = args.context._isSudo === true
 
   for (const [fieldName, value] of Object.entries(data)) {
     const fieldConfig = fieldConfigs[fieldName]
@@ -144,15 +170,49 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
       continue
     }
 
-    // Check field access (checkFieldAccess already handles sudo mode)
-    const canWrite = await checkFieldAccess(fieldConfig?.access, operation, {
+    // Pass through raw per-part columns produced by a multi-column field's
+    // `splitColumns`. They are undeclared by design; their write access was
+    // enforced when the logical field was split (see the #564 note above).
+    if (splitColumnFields.has(fieldName)) {
+      filtered[fieldName] = value
+      continue
+    }
+
+    // #564 — undeclared data keys must fail CLOSED.
+    // A key with no entry in `fieldConfigs` is not a field the list config
+    // exposes. The generated Prisma model has MORE fields than the config
+    // declares (e.g. back-relations like `from_Enrolment_student`), so allowing
+    // an undeclared key to pass through lets a non-sudo caller drive ungated
+    // nested writes on undeclared back-relations. Mirror Keystone's
+    // GraphQL-schema behaviour and reject it. `sudo` is the single trusted
+    // bypass, so undeclared keys still pass through under sudo.
+    if (!fieldConfig) {
+      if (isSudo) {
+        filtered[fieldName] = value
+        continue
+      }
+      throw new ValidationError([
+        `Cannot ${operation} "${fieldName}": it is not a field of this list. ` +
+          `Undeclared data keys are rejected (use sudo to bypass).`,
+      ])
+    }
+
+    // #568 — fields denied by field-level access must THROW, not be silently
+    // dropped. Keystone threw a GraphQL access error for the same situation;
+    // silently stripping the field lets a write "succeed" while doing less than
+    // asked (and skips any hook side effects gated on that field).
+    // `checkFieldAccess` already returns `true` under sudo, so sudo writes never
+    // reach the throw below — no parallel sudo path is needed here.
+    const canWrite = await checkFieldAccess(fieldConfig.access, operation, {
       ...args,
       inputData: args.inputData,
     })
 
-    if (canWrite) {
-      filtered[fieldName] = value
+    if (!canWrite) {
+      throw new ValidationError([`Cannot ${operation} "${fieldName}": field-level access denied.`])
     }
+
+    filtered[fieldName] = value
   }
 
   return filtered as Partial<T>

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -125,14 +125,23 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
   // Build a set of foreign key field names to exclude
   // Foreign keys should not be in the data when using Prisma's relation syntax
   const foreignKeyFields = new Set<string>()
-  // Build a set of the raw per-part column names contributed by multi-column
-  // fields (e.g. storage image()/file() in Keystone-parity mode). These keys are
-  // injected into the write payload by the field's `splitColumns` AFTER
-  // resolveInput and are intentionally NOT declared in `fieldConfigs`, so they
-  // are legitimate undeclared keys that must NOT trip the #564 reject below.
-  // Their own write access was already enforced at split time (see
-  // `executeFieldResolveInputHooks`).
-  const splitColumnFields = new Set<string>()
+  // Map each raw per-part column name contributed by a multi-column field
+  // (e.g. storage image()/file() in Keystone-parity mode) back to its OWNING
+  // declared field. These columns are injected into the write payload by the
+  // field's `splitColumns` AFTER resolveInput and are intentionally NOT declared
+  // as their own entries in `fieldConfigs`, so without this map they would trip
+  // the #564 undeclared-key reject below.
+  //
+  // SECURITY (#568): a raw column must NOT be blanket-passed through. The hooks
+  // layer (`executeFieldResolveInputHooks`) only gates the owning field when the
+  // LOGICAL key (e.g. `media`) is present, because it iterates declared fields,
+  // not data keys. A non-sudo caller who supplies the raw columns DIRECTLY
+  // (`data: { media_url, media_size }`) never produces that logical key, so that
+  // gate never fires. We therefore gate each raw column HERE by its owning
+  // field's write access — denied (non-sudo) throws, allowed (or sudo) passes
+  // through — so the legitimate multi-column write path is preserved while the
+  // direct-raw-column bypass is closed.
+  const splitColumnOwners = new Map<string, { fieldName: string; access?: FieldAccess }>()
   for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
     if (fieldConfig.type === 'relationship') {
       // For non-many relationships, Prisma creates a foreign key field named `${fieldName}Id`
@@ -143,7 +152,7 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
     }
     if (typeof fieldConfig.getColumnNames === 'function') {
       for (const column of fieldConfig.getColumnNames(fieldName)) {
-        splitColumnFields.add(column)
+        splitColumnOwners.set(column, { fieldName, access: fieldConfig.access })
       }
     }
   }
@@ -170,10 +179,27 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
       continue
     }
 
-    // Pass through raw per-part columns produced by a multi-column field's
-    // `splitColumns`. They are undeclared by design; their write access was
-    // enforced when the logical field was split (see the #564 note above).
-    if (splitColumnFields.has(fieldName)) {
+    // Raw per-part columns produced by a multi-column field's `splitColumns`.
+    // They are undeclared by design, so they must not trip the #564 reject — but
+    // they must NOT be blanket-passed through either: gate each one by its
+    // OWNING field's write access (see the SECURITY note where the map is built).
+    // This is the real gate for callers who supply the raw columns directly,
+    // because the logical-key gate in `executeFieldResolveInputHooks` never fires
+    // for them. Denied (non-sudo) throws — same fail-loud behaviour as a denied
+    // declared field (#568); allowed (or sudo, via `checkFieldAccess`) passes
+    // through, preserving the legitimate multi-column write path.
+    const splitColumnOwner = splitColumnOwners.get(fieldName)
+    if (splitColumnOwner) {
+      const canWrite = await checkFieldAccess(splitColumnOwner.access, operation, {
+        ...args,
+        inputData: args.inputData,
+      })
+      if (!canWrite) {
+        throw new ValidationError([
+          `Cannot ${operation} "${splitColumnOwner.fieldName}" (via column "${fieldName}"): ` +
+            `field-level access denied.`,
+        ])
+      }
       filtered[fieldName] = value
       continue
     }

--- a/packages/core/tests/access.test.ts
+++ b/packages/core/tests/access.test.ts
@@ -9,6 +9,7 @@ import {
   isPrismaFilter,
 } from '../src/access/index.js'
 import type { AccessControl, FieldAccess, AccessContext } from '../src/access/types.js'
+import { ValidationError } from '../src/hooks/index.js'
 
 describe('Access Control', () => {
   const mockContext: AccessContext = {
@@ -406,7 +407,9 @@ describe('Access Control', () => {
       expect(result.name).toBe('John')
     })
 
-    it('should filter out fields with denied write access', async () => {
+    // #568: a denied write field must THROW (Keystone fail-loud parity), rather
+    // than being silently stripped. Updated from the old silent-strip contract.
+    it('should throw when a field with denied write access is supplied', async () => {
       const data = {
         name: 'John',
         email: 'john@example.com',
@@ -424,16 +427,21 @@ describe('Access Control', () => {
         },
       }
 
-      const result = await filterWritableFields(data, fieldConfigs, 'create', {
-        session: null,
-        context: mockContext,
-      })
-
-      expect(result.name).toBe('John')
-      expect(result.email).toBe('john@example.com')
-      expect(result.role).toBeUndefined()
+      await expect(
+        filterWritableFields(data, fieldConfigs, 'create', {
+          session: null,
+          context: mockContext,
+        }),
+      ).rejects.toThrow(ValidationError)
+      await expect(
+        filterWritableFields(data, fieldConfigs, 'create', {
+          session: null,
+          context: mockContext,
+        }),
+      ).rejects.toThrow(/role/)
     })
 
+    // #568: create-allowed / update-denied — create passes, update THROWS.
     it('should respect different access for create vs update', async () => {
       const data = {
         email: 'john@example.com',
@@ -457,13 +465,13 @@ describe('Access Control', () => {
 
       expect(createResult.email).toBe('john@example.com')
 
-      // Deny on update
-      const updateResult = await filterWritableFields(data, fieldConfigs, 'update', {
-        session: null,
-        context: mockContext,
-      })
-
-      expect(updateResult.email).toBeUndefined()
+      // Deny on update — now throws instead of silently dropping the field.
+      await expect(
+        filterWritableFields(data, fieldConfigs, 'update', {
+          session: null,
+          context: mockContext,
+        }),
+      ).rejects.toThrow(/email/)
     })
 
     it('should pass item to field access on update', async () => {

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -266,31 +266,28 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       const context = getContext(await testConfig, mockPrisma, null)
 
-      await context.db.post.update({
-        where: { id: '1' },
-        data: {
-          title: 'Updated Title',
-          author: {
-            create: {
-              name: 'John',
-              email: 'john@example.com',
-              role: 'admin', // Should be filtered out
+      // #568: a nested-create field denied by field-level access now THROWS
+      // (Keystone fail-loud parity) instead of being silently stripped. Nested
+      // writes flow through the same `filterWritableFields` gate, so the denied
+      // `role` field rejects the whole write.
+      await expect(
+        context.db.post.update({
+          where: { id: '1' },
+          data: {
+            title: 'Updated Title',
+            author: {
+              create: {
+                name: 'John',
+                email: 'john@example.com',
+                role: 'admin', // Denied on create -> throws
+              },
             },
           },
-        },
-      })
+        }),
+      ).rejects.toThrow(/role/)
 
-      // Verify the update was called
-      expect(mockPrisma.post.update).toHaveBeenCalled()
-
-      // Get the actual data passed to Prisma
-      const callArgs = mockPrisma.post.update.mock.calls[0][0]
-      const authorCreateData = callArgs.data.author.create
-
-      // Role should be filtered out
-      expect(authorCreateData.role).toBeUndefined()
-      expect(authorCreateData.name).toBe('John')
-      expect(authorCreateData.email).toBe('john@example.com')
+      // The denied field must abort the write, not let it proceed.
+      expect(mockPrisma.post.update).not.toHaveBeenCalled()
     })
 
     it('should run field validation on nested create', async () => {


### PR DESCRIPTION
## Summary

Brings the write pipeline's field filter (`filterWritableFields`, Phase 5 of `write-pipeline.ts`) to **Keystone fail-loud parity**. Both fixes touch the same function, so they ship together to avoid collision.

Implements #564
Implements #568
Part of #581

### #564 — undeclared data keys fail CLOSED (throw)
Previously a `data` key with no entry in `fieldConfigs` resolved `fieldConfig === undefined`, `checkFieldAccess(undefined, …)` returned `true`, and the key passed through to Prisma unchecked. Because the generated Prisma model has more fields than the list config declares (back-relations like `from_Enrolment_student`), a non-sudo caller could drive ungated nested writes on undeclared back-relations.

Now: an undeclared key on create/update **throws** for non-sudo writes. Since the filter runs at Phase 5 (before `processNestedOperations` at Phase 5.5), this also closes the undeclared-back-relation nested-write hole — no change to `nested-operations.ts` required.

### #568 — field-access-denied keys throw instead of silent strip
Previously `if (canWrite) filtered[fieldName] = value` silently dropped denied fields, letting a write "succeed" while doing less than asked (and skipping hook side effects gated on that field).

Now: a caller-supplied declared field denied by field-level access **throws**.

### Preserved behaviour
- **`sudo` is the single trusted bypass** — undeclared keys pass through under sudo, and `checkFieldAccess` already returns `true` under sudo (no parallel sudo path added).
- System fields (`id`/`createdAt`/`updatedAt`), virtual fields, relationship foreign keys (`${field}Id`), and multi-column split columns (from `getColumnNames`) still pass through cleanly.
- Declared relationship fields still pass through to nested operations.

## How the throw is surfaced
Uses the project's existing `ValidationError` (from `hooks/index.js`) — the same type the write pipeline already throws for validation failures, so callers/tests have a single convention for non-silent write rejections. The field-access ⇄ hooks import is a cycle, but `ValidationError` is referenced only inside the function body (call-time), so it is safe under ESM live bindings.

## Tests
- New focused unit tests in `packages/core/src/access/field-access.test.ts`: undeclared key throws (non-sudo create + update); undeclared key passes under sudo; system/FK fields skip cleanly; multi-column split columns pass through; declared field denied throws; sudo would-be-denied field does NOT throw; declared relationship field passes through.
- Updated 3 existing tests that encoded the OLD silent-strip contract to the new fail-loud contract: 2 in `tests/access.test.ts` and 1 nested-create test in `tests/nested-access-and-hooks.test.ts`.

## Verification
- `pnpm lint`: pass (0 errors; only pre-existing warnings)
- `pnpm manypkg fix` / `pnpm format`: clean
- `pnpm -C packages/core build` (tsc typecheck): pass
- `pnpm -C packages/core test`: 596 passed
- Changeset added (`patch` for `@opensaas/stack-core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_