### PR TITLE
feat(core): add findFirst to access-controlled context.db delegates

### DIFF
--- a/.changeset/swift-otters-findfirst.md
+++ b/.changeset/swift-otters-findfirst.md
@@ -1,0 +1,31 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+Add `findFirst` to access-controlled `context.db.<list>` delegates
+
+`findFirst` is sugar over the existing access-filtered `findMany` (`take: 1`), so
+it introduces no new access surface: it applies the exact same query-access checks
+and access-controlled include building as `findMany`, then returns the first
+matching row or `null`. It honours the read-side silent-failure contract — an
+access-denied query yields `null` rather than throwing.
+
+```ts
+// Non-unique single-row lookup
+const account = await context.db.account.findFirst({
+  where: { userId: '123' },
+  orderBy: { createdAt: 'desc' },
+})
+
+// Narrow the single result with a query fragment
+const post = await context.db.post.findFirst({
+  where: { published: true },
+  query: postFragment,
+})
+// post: ResultOf<typeof postFragment> | null
+```
+
+The CLI type generator now emits a `findFirst` method (and `<List>FindFirstArgs`
+type) for each list in the generated `.opensaas/types.ts`, so migrated apps that
+reach for the familiar Prisma `findFirst` pattern get full type support.

--- a/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
@@ -281,6 +281,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -329,6 +337,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>

--- a/packages/cli/src/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/types.test.ts.snap
@@ -140,6 +140,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -188,6 +196,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -375,6 +386,14 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
+  select?: PostSelect | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select'> & {
@@ -423,6 +442,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   post: {
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
+    ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
     ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
@@ -690,6 +712,15 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support in nested relationships
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select' | 'include'> & {
+  select?: UserSelect | null
+  include?: UserInclude | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support in nested relationships
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include'> & {
@@ -913,6 +944,15 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support in nested relationships
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'include'> & {
+  select?: PostSelect | null
+  include?: PostInclude | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support in nested relationships
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
@@ -967,6 +1007,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
     ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
+    ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
     ) => Promise<Array<UserGetPayload<T>>>
@@ -990,6 +1033,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   post: {
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
+    ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
     ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
@@ -1210,6 +1256,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -1258,6 +1312,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -1445,6 +1502,14 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
+  select?: PostSelect | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select'> & {
@@ -1493,6 +1558,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   post: {
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
+    ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
     ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
@@ -1677,6 +1745,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -1725,6 +1801,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -1912,6 +1991,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -1960,6 +2047,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -2144,6 +2234,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -2297,6 +2395,14 @@ export type PostFindUniqueArgs = Omit<Prisma.PostFindUniqueArgs, 'select'> & {
  * Custom FindManyArgs for Post with virtual field support
  */
 export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select'> & {
+  select?: PostSelect | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
+ * Custom FindFirstArgs for Post with virtual field support
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
   select?: PostSelect | null
   query?: Fragment<PostOutput, FieldSelection<PostOutput>>
 }
@@ -2460,6 +2566,14 @@ export type CommentFindManyArgs = Omit<Prisma.CommentFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for Comment with virtual field support
+ */
+export type CommentFindFirstArgs = Omit<Prisma.CommentFindFirstArgs, 'select'> & {
+  select?: CommentSelect | null
+  query?: Fragment<CommentOutput, FieldSelection<CommentOutput>>
+}
+
+/**
  * Custom CreateArgs for Comment with virtual field support
  */
 export type CommentCreateArgs = Omit<Prisma.CommentCreateArgs, 'select'> & {
@@ -2509,6 +2623,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
     ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
+    ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
     ) => Promise<Array<UserGetPayload<T>>>
@@ -2533,6 +2650,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
     ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
+    ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
     ) => Promise<Array<PostGetPayload<T>>>
@@ -2556,6 +2676,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   comment: {
     findUnique: <T extends CommentFindUniqueArgs>(
       args: Prisma.SelectSubset<T, CommentFindUniqueArgs>
+    ) => Promise<CommentGetPayload<T> | null>
+    findFirst: <T extends CommentFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, CommentFindFirstArgs>
     ) => Promise<CommentGetPayload<T> | null>
     findMany: <T extends CommentFindManyArgs>(
       args?: Prisma.SelectSubset<T, CommentFindManyArgs>
@@ -2800,6 +2923,15 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support in nested relationships
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'include'> & {
+  select?: PostSelect | null
+  include?: PostInclude | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support in nested relationships
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
@@ -2963,6 +3095,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -3012,6 +3152,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
     ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
+    ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
     ) => Promise<Array<PostGetPayload<T>>>
@@ -3035,6 +3178,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -3279,6 +3425,15 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support in nested relationships
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'include'> & {
+  select?: PostSelect | null
+  include?: PostInclude | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support in nested relationships
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
@@ -3442,6 +3597,14 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select'> & {
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
+  select?: UserSelect | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
@@ -3491,6 +3654,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
     ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
+    ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
     ) => Promise<Array<PostGetPayload<T>>>
@@ -3514,6 +3680,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   user: {
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
+    ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
     ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
@@ -3757,6 +3926,15 @@ export type UserFindManyArgs = Omit<Prisma.UserFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for User with virtual field support in nested relationships
+ */
+export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select' | 'include'> & {
+  select?: UserSelect | null
+  include?: UserInclude | null
+  query?: Fragment<UserOutput, FieldSelection<UserOutput>>
+}
+
+/**
  * Custom CreateArgs for User with virtual field support in nested relationships
  */
 export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include'> & {
@@ -3980,6 +4158,15 @@ export type PostFindManyArgs = Omit<Prisma.PostFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for Post with virtual field support in nested relationships
+ */
+export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'include'> & {
+  select?: PostSelect | null
+  include?: PostInclude | null
+  query?: Fragment<PostOutput, FieldSelection<PostOutput>>
+}
+
+/**
  * Custom CreateArgs for Post with virtual field support in nested relationships
  */
 export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
@@ -4034,6 +4221,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends UserFindUniqueArgs>(
       args: Prisma.SelectSubset<T, UserFindUniqueArgs>
     ) => Promise<UserGetPayload<T> | null>
+    findFirst: <T extends UserFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, UserFindFirstArgs>
+    ) => Promise<UserGetPayload<T> | null>
     findMany: <T extends UserFindManyArgs>(
       args?: Prisma.SelectSubset<T, UserFindManyArgs>
     ) => Promise<Array<UserGetPayload<T>>>
@@ -4057,6 +4247,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   post: {
     findUnique: <T extends PostFindUniqueArgs>(
       args: Prisma.SelectSubset<T, PostFindUniqueArgs>
+    ) => Promise<PostGetPayload<T> | null>
+    findFirst: <T extends PostFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, PostFindFirstArgs>
     ) => Promise<PostGetPayload<T> | null>
     findMany: <T extends PostFindManyArgs>(
       args?: Prisma.SelectSubset<T, PostFindManyArgs>
@@ -4294,6 +4487,15 @@ export type AccountFindUniqueArgs = Omit<Prisma.AccountFindUniqueArgs, 'select' 
  * Custom FindManyArgs for Account with virtual field support in nested relationships
  */
 export type AccountFindManyArgs = Omit<Prisma.AccountFindManyArgs, 'select' | 'include'> & {
+  select?: AccountSelect | null
+  include?: AccountInclude | null
+  query?: Fragment<AccountOutput, FieldSelection<AccountOutput>>
+}
+
+/**
+ * Custom FindFirstArgs for Account with virtual field support in nested relationships
+ */
+export type AccountFindFirstArgs = Omit<Prisma.AccountFindFirstArgs, 'select' | 'include'> & {
   select?: AccountSelect | null
   include?: AccountInclude | null
   query?: Fragment<AccountOutput, FieldSelection<AccountOutput>>
@@ -4547,6 +4749,15 @@ export type BillFindManyArgs = Omit<Prisma.BillFindManyArgs, 'select' | 'include
 }
 
 /**
+ * Custom FindFirstArgs for Bill with virtual field support in nested relationships
+ */
+export type BillFindFirstArgs = Omit<Prisma.BillFindFirstArgs, 'select' | 'include'> & {
+  select?: BillSelect | null
+  include?: BillInclude | null
+  query?: Fragment<BillOutput, FieldSelection<BillOutput>>
+}
+
+/**
  * Custom CreateArgs for Bill with virtual field support in nested relationships
  */
 export type BillCreateArgs = Omit<Prisma.BillCreateArgs, 'select' | 'include'> & {
@@ -4601,6 +4812,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
     findUnique: <T extends AccountFindUniqueArgs>(
       args: Prisma.SelectSubset<T, AccountFindUniqueArgs>
     ) => Promise<AccountGetPayload<T> | null>
+    findFirst: <T extends AccountFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, AccountFindFirstArgs>
+    ) => Promise<AccountGetPayload<T> | null>
     findMany: <T extends AccountFindManyArgs>(
       args?: Prisma.SelectSubset<T, AccountFindManyArgs>
     ) => Promise<Array<AccountGetPayload<T>>>
@@ -4624,6 +4838,9 @@ export type CustomDB = Omit<AccessControlledDB<PrismaClient>,
   bill: {
     findUnique: <T extends BillFindUniqueArgs>(
       args: Prisma.SelectSubset<T, BillFindUniqueArgs>
+    ) => Promise<BillGetPayload<T> | null>
+    findFirst: <T extends BillFindFirstArgs>(
+      args?: Prisma.SelectSubset<T, BillFindFirstArgs>
     ) => Promise<BillGetPayload<T> | null>
     findMany: <T extends BillFindManyArgs>(
       args?: Prisma.SelectSubset<T, BillFindManyArgs>

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -701,6 +701,32 @@ export type ${listName}FindManyArgs = Omit<Prisma.${listName}FindManyArgs, 'sele
 }
 
 /**
+ * Generate custom FindFirstArgs type that uses our extended Select/Include
+ */
+function generateFindFirstArgsType(listName: string, fields: Record<string, FieldConfig>): string {
+  const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+
+  if (hasRelationships) {
+    return `/**
+ * Custom FindFirstArgs for ${listName} with virtual field support in nested relationships
+ */
+export type ${listName}FindFirstArgs = Omit<Prisma.${listName}FindFirstArgs, 'select' | 'include'> & {
+  select?: ${listName}Select | null
+  include?: ${listName}Include | null
+  query?: Fragment<${listName}Output, FieldSelection<${listName}Output>>
+}`
+  } else {
+    return `/**
+ * Custom FindFirstArgs for ${listName} with virtual field support
+ */
+export type ${listName}FindFirstArgs = Omit<Prisma.${listName}FindFirstArgs, 'select'> & {
+  select?: ${listName}Select | null
+  query?: Fragment<${listName}Output, FieldSelection<${listName}Output>>
+}`
+  }
+}
+
+/**
  * Generate custom CreateArgs type that uses our extended Select/Include
  */
 function generateCreateArgsType(listName: string, fields: Record<string, FieldConfig>): string {
@@ -863,6 +889,11 @@ function generateCustomDBType(config: OpenSaasConfig): string {
     // findUnique - generic to preserve Prisma's conditional return type with custom Args for virtual field support
     lines.push(`    findUnique: <T extends ${listName}FindUniqueArgs>(`)
     lines.push(`      args: Prisma.SelectSubset<T, ${listName}FindUniqueArgs>`)
+    lines.push(`    ) => Promise<${listName}GetPayload<T> | null>`)
+
+    // findFirst - generic to preserve Prisma's conditional return type with custom Args for virtual field support
+    lines.push(`    findFirst: <T extends ${listName}FindFirstArgs>(`)
+    lines.push(`      args?: Prisma.SelectSubset<T, ${listName}FindFirstArgs>`)
     lines.push(`    ) => Promise<${listName}GetPayload<T> | null>`)
 
     // findMany - generic to preserve Prisma's conditional return type with custom Args for virtual field support
@@ -1085,6 +1116,8 @@ export function generateTypes(config: OpenSaasConfig): string {
     lines.push(generateFindUniqueArgsType(listName, listConfig.fields))
     lines.push('')
     lines.push(generateFindManyArgsType(listName, listConfig.fields))
+    lines.push('')
+    lines.push(generateFindFirstArgsType(listName, listConfig.fields))
     lines.push('')
     lines.push(generateCreateArgsType(listName, listConfig.fields))
     lines.push('')

--- a/packages/core/src/access/types.ts
+++ b/packages/core/src/access/types.ts
@@ -111,6 +111,48 @@ export interface AugmentedFindMany<TOriginal extends (...args: any[]) => any> {
 }
 
 /**
+ * Extra query arguments accepted when a `query` Fragment is provided alongside
+ * `context.db.<list>.findFirst({ query: myFragment, ... })`.
+ */
+export type FindFirstQueryArgs = {
+  where?: Record<string, unknown>
+  orderBy?: Record<string, 'asc' | 'desc'> | Array<Record<string, 'asc' | 'desc'>>
+  skip?: number
+}
+
+/**
+ * Overloaded `findFirst` that accepts an optional `query` Fragment.
+ *
+ * `findFirst` is sugar over the access-controlled `findMany` (`take: 1`), so it
+ * applies the exact same query-access checks and access-controlled include
+ * building, then returns the first matching record or `null`.
+ *
+ * - **With `query`**: builds the Prisma `include` from the fragment, executes the
+ *   query, applies access control, and returns a record shaped to `ResultOf<fragment>`
+ *   or `null`.
+ * - **Without `query`**: behaves exactly like the original Prisma `findFirst`.
+ *
+ * @example
+ * ```ts
+ * const post = await context.db.post.findFirst({
+ *   where:   { published: true },
+ *   orderBy: { createdAt: 'desc' },
+ *   query:   postFragment,
+ * })
+ * // post: ResultOf<typeof postFragment> | null
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface AugmentedFindFirst<TOriginal extends (...args: any[]) => any> {
+  // Overload 1: with query fragment — return type narrows to ResultOf<fragment> | null
+  <TItem, TFields extends FieldSelection<TItem>>(
+    args: FindFirstQueryArgs & { query: Fragment<TItem, TFields> },
+  ): Promise<ResultOf<Fragment<TItem, TFields>> | null>
+  // Overload 2: original Prisma behaviour
+  (...args: Parameters<TOriginal>): ReturnType<TOriginal>
+}
+
+/**
  * Overloaded `findUnique` that accepts an optional `query` Fragment.
  *
  * - **With `query`**: builds the Prisma `include` from the fragment, executes the
@@ -149,6 +191,8 @@ export type AccessControlledDB<TPrisma extends PrismaClientLike> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     findUnique: any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    findFirst: any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     findMany: any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create: any
@@ -161,6 +205,7 @@ export type AccessControlledDB<TPrisma extends PrismaClientLike> = {
   }
     ? {
         findUnique: AugmentedFindUnique<TPrisma[K]['findUnique']>
+        findFirst: AugmentedFindFirst<TPrisma[K]['findFirst']>
         findMany: AugmentedFindMany<TPrisma[K]['findMany']>
         create: TPrisma[K]['create']
         update: TPrisma[K]['update']

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -247,6 +247,7 @@ export function getContext<
     const operations: Record<string, unknown> = {
       findUnique: createFindUnique(listName, listConfig, prisma, context, config),
       findMany: findManyOp,
+      findFirst: createFindFirst(findManyOp),
       create: createOp,
       update: updateOp,
       delete: createDelete(listName, listConfig, prisma, context, config),
@@ -600,6 +601,31 @@ function createFindMany<TPrisma extends PrismaClientLike>(
     }
 
     return filtered
+  }
+}
+
+/**
+ * Create findFirst operation with access control.
+ *
+ * findFirst is sugar over the access-controlled findMany: it runs the exact same
+ * query-access checks and access-controlled include building as findMany, then
+ * returns the first matching row (or null when nothing matches). This introduces
+ * no new access surface — it inherits findMany's silent-failure contract (an
+ * access-denied query yields `[]`, which becomes `null` here).
+ */
+function createFindFirst(findManyOp: ReturnType<typeof createFindMany>) {
+  return async (args?: {
+    where?: Record<string, unknown>
+    orderBy?: Record<string, 'asc' | 'desc'> | Array<Record<string, 'asc' | 'desc'>>
+    skip?: number
+    include?: Record<string, unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query?: any
+    // `select` is not honoured — accepted only so the no-op can be made visible.
+    select?: Record<string, unknown>
+  }) => {
+    const result = await findManyOp({ ...args, take: 1 })
+    return result[0] ?? null
   }
 }
 

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getContext } from '../src/context/index.js'
+import { defineFragment } from '../src/query/index.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 
 describe('getContext', () => {
@@ -224,6 +225,102 @@ describe('getContext', () => {
 
       expect(mockPrisma.user.findMany).toHaveBeenCalled()
       expect(result).toEqual(mockUsers)
+    })
+
+    describe('findFirst', () => {
+      it('should return the first matching row', async () => {
+        const mockUsers = [
+          { id: '1', name: 'John', email: 'john@example.com' },
+          { id: '2', name: 'Jane', email: 'jane@example.com' },
+        ]
+        mockPrisma.user.findMany.mockResolvedValue(mockUsers)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findFirst()
+
+        // Delegates to the access-controlled findMany with take: 1
+        expect(mockPrisma.user.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 1 }))
+        expect(result).toEqual(mockUsers[0])
+      })
+
+      it('should return null (not undefined, not throw) when nothing matches', async () => {
+        mockPrisma.user.findMany.mockResolvedValue([])
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findFirst({ where: { name: 'Nobody' } })
+
+        expect(result).toBeNull()
+        expect(result).not.toBeUndefined()
+      })
+
+      it('should respect where and orderBy', async () => {
+        const mockUser = { id: '2', name: 'Jane', email: 'jane@example.com' }
+        mockPrisma.user.findMany.mockResolvedValue([mockUser])
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findFirst({
+          where: { name: 'Jane' },
+          orderBy: { name: 'asc' },
+        })
+
+        expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ name: 'Jane' }),
+            orderBy: { name: 'asc' },
+            take: 1,
+          }),
+        )
+        expect(result).toEqual(mockUser)
+      })
+
+      it('should honour query-access denial the same as findMany (denied -> null)', async () => {
+        const deniedConfig: OpenSaasConfig = {
+          ...config,
+          lists: {
+            ...config.lists,
+            User: {
+              ...config.lists.User,
+              access: {
+                operation: {
+                  query: () => false,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+          },
+        }
+        mockPrisma.user.findMany.mockResolvedValue([
+          { id: '1', name: 'John', email: 'john@example.com' },
+        ])
+
+        const context = await getContext(deniedConfig, mockPrisma, null)
+        const result = await context.db.user.findFirst()
+
+        // Denied query short-circuits before hitting prisma — exactly like findMany
+        expect(result).toBeNull()
+        expect(mockPrisma.user.findMany).not.toHaveBeenCalled()
+      })
+
+      it('should respect a query fragment, narrowing the returned single result', async () => {
+        const mockUsers = [
+          { id: '1', name: 'John', email: 'john@example.com' },
+          { id: '2', name: 'Jane', email: 'jane@example.com' },
+        ]
+        mockPrisma.user.findMany.mockResolvedValue(mockUsers)
+
+        const fragment = defineFragment<{ id: string; name: string; email: string }>()({
+          id: true,
+          name: true,
+        } as const)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findFirst({ query: fragment })
+
+        // Fragment narrows the result to only the requested fields (email omitted)
+        expect(result).toEqual({ id: '1', name: 'John' })
+      })
     })
 
     it('should delegate create to prisma with access control and hooks', async () => {


### PR DESCRIPTION
Implements #565. Part of #581.

## What

Adds `findFirst(args)` to the access-controlled `context.db.<list>` delegates. Per the issue, this is **option 1: sugar over the existing access-filtered `findMany` with `take: 1`** — it introduces **no new access surface**. It applies exactly the same query-access checks and access-controlled include building as `findMany`, then returns the first row or `null`.

This honours the shared read-side policy from #581: reads keep the silent-failure contract (access-denied query → `null`, not a throw), and `sudo` remains the single bypass (inherited unchanged from `findMany`).

## How

- **`packages/core/src/context/index.ts`** — new `createFindFirst(findManyOp)` factory that delegates to the already-built `findManyOp` with `take: 1` and returns `result[0] ?? null`. Wired into the delegates `operations` object. Zero duplication of access logic — identical semantics by construction. Supports the same `where`/`orderBy`/`include`/`query`-fragment args as `findMany`.
- **`packages/core/src/access/types.ts`** — added `AugmentedFindFirst` interface (mirrors `AugmentedFindUnique`/`AugmentedFindMany`): a `query`-fragment overload returning `Promise<ResultOf<fragment> | null>` plus the original Prisma `findFirst` signature passthrough. Wired `findFirst` into the `AccessControlledDB` mapped type. The generic `PrismaModelDelegate` already declared `findFirst`.
- **`packages/cli/src/generator/types.ts`** — the generated `CustomDB` explicitly enumerates delegate methods (it is **not** purely derived from `AccessControlledDB`), so `findFirst` and a `<List>FindFirstArgs` type are now emitted for each list in `.opensaas/types.ts`, giving migrated apps full type support for the familiar Prisma `findFirst` pattern.

## Tests

Added to `packages/core/tests/context.test.ts` (the existing context/findMany suite):
- returns the first matching row (and delegates with `take: 1`)
- returns `null` (not `undefined`, not throw) when nothing matches
- respects `where` / `orderBy`
- honours query-access denial the same as `findMany` (denied → `null`, prisma not hit)
- respects a `query` fragment, narrowing the returned single result

## Verification

- `pnpm lint` — 0 errors (only pre-existing unrelated warnings)
- `pnpm manypkg fix` + `pnpm format` — clean
- `pnpm -C packages/core build` and `pnpm -C packages/cli build` — pass
- `pnpm -C packages/core test` — 593 passed (incl. 5 new)
- Regenerated the blog example to confirm `findFirst`/`FindFirstArgs` appear in generated types
- Changeset added (minor on `@opensaas/stack-core` and `@opensaas/stack-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_