### PR TITLE
fix(core): enforce unique-where for findUnique

### DIFF
--- a/.changeset/swift-foxes-cheer.md
+++ b/.changeset/swift-foxes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Enforce unique-`where` for `context.db.<list>.findUnique` — a non-unique `where` now throws a clear error instead of silently returning a nondeterministic row. Use `findFirst` for non-unique single-row lookups.

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -66,6 +66,72 @@ function isSingletonList(listConfig: ListConfig<any>): boolean {
 }
 
 /**
+ * Compute the set of single-field unique selectors a `findUnique` `where` may be
+ * keyed by, derived from what the list config exposes at runtime.
+ *
+ * The set is:
+ * - `id` — always a unique identifier on every list.
+ * - Any field declared `isIndexed: 'unique'` in the config (e.g. `text({ isIndexed: 'unique' })`).
+ * - For a `relationship` field declared `isIndexed: 'unique'`, the foreign-key
+ *   column name (`<field>Id`) — that is the column Prisma marks `@unique`, so the
+ *   unique `where` is keyed by `<field>Id`, not the relation field itself.
+ *
+ * Chosen rule (documented intentionally): the config does NOT expose compound
+ * (`@@unique`) keys at runtime — there is no list-level unique declaration in the
+ * config API — so we cannot validate compound `<Model>_<a>_<b>` selectors. We
+ * therefore enforce the tractable subset: `where` must contain EXACTLY ONE
+ * recognised single-field unique key and NO other keys. This rejects non-unique
+ * filters (the bug in #567) and rejects extra non-unique keys alongside a unique
+ * one, while never falsely rejecting a valid single-field unique lookup. If a
+ * project legitimately needs a compound-unique lookup, that path is not covered
+ * here and would need explicit config support; the safe escape hatch for any
+ * non-unique single-row lookup is `findFirst` (see #565).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function getUniqueWhereKeys(listConfig: ListConfig<any>): Set<string> {
+  const keys = new Set<string>(['id'])
+
+  for (const [fieldKey, fieldConfig] of Object.entries(listConfig.fields)) {
+    if (!fieldConfig || typeof fieldConfig !== 'object') continue
+    if (!('isIndexed' in fieldConfig) || fieldConfig.isIndexed !== 'unique') continue
+
+    if (fieldConfig.type === 'relationship') {
+      // A unique relationship's `@unique` lives on the FK column `<field>Id`.
+      keys.add(`${fieldKey}Id`)
+    } else {
+      keys.add(fieldKey)
+    }
+  }
+
+  return keys
+}
+
+/**
+ * Enforce Keystone `findOne` semantics for `findUnique`: the caller-supplied
+ * `where` must be a valid unique selector. A non-unique `where` is a caller-shape
+ * error (not an access denial), so this THROWS rather than silently returning
+ * `null` — consistent with the fail-loud-on-misuse stance of PRD #581. A
+ * non-unique single-row lookup should use `findFirst` instead (see #565).
+ */
+function assertUniqueWhere(
+  where: Record<string, unknown> | undefined,
+  uniqueKeys: Set<string>,
+  listName: string,
+): void {
+  const keys = where ? Object.keys(where) : []
+
+  const message =
+    `findUnique on "${listName}" requires a unique \`where\` (a single unique key such as ` +
+    `${Array.from(uniqueKeys).join(', ')}). ` +
+    `Received: ${keys.length === 0 ? '{}' : `{ ${keys.join(', ')} }`}. ` +
+    `Use \`findFirst\` for a non-unique single-row lookup.`
+
+  if (keys.length !== 1 || !uniqueKeys.has(keys[0])) {
+    throw new ValidationError([message], {})
+  }
+}
+
+/**
  * Check if auto-create is enabled for a singleton list
  * Defaults to true if not explicitly set to false
  */
@@ -405,7 +471,10 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
   config: OpenSaasConfig,
 ) {
   return async (args: {
-    where: { id: string }
+    // Accepts any unique selector at the delegate level (the generated
+    // `<List>FindUniqueArgs` type narrows `where` to Prisma's `WhereUniqueInput`).
+    // The runtime guard below rejects non-unique shapes.
+    where: Record<string, unknown>
     include?: Record<string, unknown>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query?: any
@@ -414,6 +483,15 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
   }) => {
     // `select` is a visible no-op: warn, then proceed with include/query narrowing.
     warnIfSelectIgnored(args, listName, 'findUnique')
+
+    // Enforce unique-`where` (Keystone `findOne` parity). This is a caller-shape
+    // check independent of access, so it runs first and THROWS on misuse — it is
+    // not an access denial and must not be masked as a silent `null`. The
+    // type-level constraint already lives on the generated delegate: the custom
+    // `<List>FindUniqueArgs` only Omits `select`/`include` from
+    // `Prisma.<List>FindUniqueArgs`, so its `where` stays Prisma's
+    // `<List>WhereUniqueInput` — this runtime guard backstops untyped callers.
+    assertUniqueWhere(args.where, getUniqueWhereKeys(listConfig), listName)
 
     // Check query access (skip if sudo mode)
     let where: Record<string, unknown> = args.where

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -213,6 +213,131 @@ describe('getContext', () => {
       expect(result).toEqual(mockUser)
     })
 
+    describe('findUnique unique-where enforcement (#567)', () => {
+      it('accepts a valid unique where (id) and keeps access + include intact', async () => {
+        const mockUser = { id: '1', name: 'John', email: 'john@example.com' }
+        mockPrisma.user.findFirst.mockResolvedValue(mockUser)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findUnique({
+          where: { id: '1' },
+          include: { posts: true },
+        })
+
+        // Access control still runs and the underlying delegate is invoked with
+        // the merged where + include (proving access + include path is intact).
+        expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ id: '1' }),
+            include: { posts: true },
+          }),
+        )
+        expect(result).toEqual(mockUser)
+      })
+
+      it('accepts a configured-unique field (email) as the unique where', async () => {
+        const mockUser = { id: '1', name: 'John', email: 'john@example.com' }
+        mockPrisma.user.findFirst.mockResolvedValue(mockUser)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findUnique({
+          where: { email: 'john@example.com' },
+        })
+
+        expect(mockPrisma.user.findFirst).toHaveBeenCalled()
+        expect(result).toEqual(mockUser)
+      })
+
+      it('narrows the result through a query fragment with a unique where', async () => {
+        const mockUser = { id: '1', name: 'John', email: 'john@example.com' }
+        mockPrisma.user.findFirst.mockResolvedValue(mockUser)
+
+        const fragment = defineFragment<{ id: string; name: string; email: string }>()({
+          id: true,
+          name: true,
+        } as const)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findUnique({ where: { id: '1' }, query: fragment })
+
+        // Fragment narrows the result to only the requested fields (email omitted)
+        expect(result).toEqual({ id: '1', name: 'John' })
+      })
+
+      it('THROWS on a non-unique where (caller-shape error, not a silent null)', async () => {
+        mockPrisma.user.findFirst.mockResolvedValue({ id: '1', name: 'John' })
+
+        const context = await getContext(config, mockPrisma, null)
+
+        // `name` is not a unique key — this is misuse and must throw, not return null.
+        await expect(context.db.user.findUnique({ where: { name: 'John' } })).rejects.toThrow(
+          /requires a unique `where`/,
+        )
+        // The error guides the caller toward findFirst (the non-unique escape hatch).
+        await expect(context.db.user.findUnique({ where: { name: 'John' } })).rejects.toThrow(
+          /findFirst/,
+        )
+        // Guard runs before any DB access.
+        expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      })
+
+      it('THROWS when a unique key is mixed with extra non-unique keys', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(
+          context.db.user.findUnique({ where: { id: '1', name: 'John' } }),
+        ).rejects.toThrow(/requires a unique `where`/)
+        expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      })
+
+      it('THROWS on an empty where', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(context.db.user.findUnique({ where: {} })).rejects.toThrow(
+          /requires a unique `where`/,
+        )
+        expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      })
+
+      it('returns null on access denial (silent-failure contract preserved)', async () => {
+        const deniedConfig: OpenSaasConfig = {
+          ...config,
+          lists: {
+            ...config.lists,
+            User: {
+              ...config.lists.User,
+              access: {
+                operation: {
+                  query: () => false,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+          },
+        }
+        mockPrisma.user.findFirst.mockResolvedValue({ id: '1', name: 'John' })
+
+        const context = await getContext(deniedConfig, mockPrisma, null)
+        const result = await context.db.user.findUnique({ where: { id: '1' } })
+
+        // Access denied -> null (not a throw), and the DB is never queried.
+        expect(result).toBeNull()
+        expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      })
+
+      it('returns null when no record matches a valid unique where', async () => {
+        mockPrisma.user.findFirst.mockResolvedValue(null)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findUnique({ where: { id: 'missing' } })
+
+        expect(result).toBeNull()
+        expect(mockPrisma.user.findFirst).toHaveBeenCalled()
+      })
+    })
+
     it('should delegate findMany to prisma with access control', async () => {
       const mockUsers = [
         { id: '1', name: 'John' },


### PR DESCRIPTION
Implements #567. Part of #581.

## Problem

`context.db.<list>.findUnique` executed Prisma `findFirst` under the hood and accepted **any** `where` shape. A non-unique filter was neither rejected nor deterministic (no `orderBy`), silently diverging from Keystone's `findOne` unique-where semantics. A migrated `findOne({ where: { someNonUniqueField } })` would type-check, run, and return an arbitrary matching row.

## Change

Added a runtime guard to `createFindUnique` (`packages/core/src/context/index.ts`) that enforces a unique `where`:

- The `where` must contain **exactly one** recognised unique key and no other keys.
- The unique-key set is derived from the list config **at runtime**: `id` (always) plus any field declared `isIndexed: 'unique'`. For a unique `relationship` field, the FK column `<field>Id` is the recognised key (that's where Prisma puts `@unique`).
- A non-unique `where` is a **caller-shape error**, so the guard **throws** a clear `ValidationError` (fail-loud-on-misuse, per the PRD) rather than masking it as a silent `null`. The message points callers to `findFirst` (#565) for non-unique single-row lookups.

**Documented rule (in code):** the config API exposes no list-level compound (`@@unique`) declaration at runtime, so compound selectors can't be validated. The guard therefore enforces the tractable subset — exactly one single-field unique key — which fixes the bug and rejects extra non-unique keys, without ever falsely rejecting a valid single-field unique lookup.

## Type level

No generator change needed. The generated `<List>FindUniqueArgs` already `Omit`s only `select`/`include` from `Prisma.<List>FindUniqueArgs`, so its `where` stays Prisma's `<List>WhereUniqueInput` — the type is already correctly constrained. The runtime guard backstops untyped callers. A code comment records this.

## Preserved behaviour

Query-access check, filter merge, access-controlled `include` / `query`-fragment narrowing, field visibility, `sudo` bypass, and `null` on access denial / no match are all unchanged.

## Fold-in (#565 review note)

The singleton "Cannot use findMany … Use get() instead" message reachable via `findFirst` was **skipped**: `createFindFirst` only receives `findManyOp` (no `listConfig`/`listName`), and the existing singleton test asserts the literal `'Cannot use findMany'`. Making it findFirst-accurate would require threading config + editing an unrelated test, exceeding the "clean 1-line" bar — left out to avoid scope creep.

## Tests

Added to the existing context/findUnique tests in `packages/core/tests/context.test.ts`:
- valid unique `where` (id) works as before — access + include intact
- configured-unique field (email) accepted
- query-fragment narrowing with a unique `where`
- non-unique `where` THROWS (and message references `findFirst`); guard runs before DB access
- unique key mixed with extra non-unique keys THROWS
- empty `where` THROWS
- access-denied findUnique still returns `null`
- no-match returns `null`

## Verification

- `pnpm lint` — 0 errors (only pre-existing warnings)
- `pnpm manypkg fix`, `pnpm format` — clean
- `pnpm build` — full repo typecheck/build passes
- Full test suite green: core (601), cli (289), auth (133), ui (190), rag (178), storage (123), storage-s3 (43), storage-vercel (30), create-opensaas-app (41)
- Changeset added (`@opensaas/stack-core`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_