### PR TITLE
Fix nested connect false denial: read access + DB reachability

### DIFF
--- a/.changeset/silent-otters-connect.md
+++ b/.changeset/silent-otters-connect.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix false denial of nested `connect` (and `connectOrCreate`'s connect branch): connect now requires read/query access on the target and evaluates filter results via DB reachability (`findFirst({ where: { AND: [connection, accessFilter] } })`), so nested-relation and `AND`/`OR`/`some`/`none`/`not` filters no longer always fail.

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -117,8 +117,76 @@ async function processNestedCreate(
 }
 
 /**
+ * Verify that a single connection target is reachable for the caller.
+ *
+ * Connecting an existing row references it; it does not modify the row's own
+ * data. Mirroring Keystone, this requires **read/query** access on the target
+ * list (not `update`). When query access returns a filter object, the filter is
+ * evaluated in the DATABASE (not in memory) via
+ * `findFirst({ where: { AND: [connection, accessFilter] } })`. The connect is
+ * allowed iff that query returns a row, which correctly handles arbitrary
+ * nested-relation predicates and boolean combinators (`AND`/`OR`/`some`/
+ * `none`/`not`). The existence check is folded into the reachability query so a
+ * non-existent id is still denied.
+ *
+ * Sudo bypasses the entire check (handled by the caller).
+ *
+ * TODO(#578): also gate connect by the owning relationship field's field-level
+ * access. `NestedOpHandlerArgs` does not currently carry the owning field's
+ * config/access, so threading it through is deferred; the read-access +
+ * DB-reachability change here is the must-have correctness fix.
+ */
+async function verifyConnectReachable(
+  connection: Record<string, unknown>,
+  relatedListName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  relatedListConfig: ListConfig<any>,
+  context: AccessContext,
+  prisma: unknown,
+): Promise<void> {
+  // Access Prisma model dynamically - required because model names are generated at runtime
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const model = (prisma as any)[getDbKey(relatedListName)]
+
+  // Connecting references an existing row; it requires READ (query) access on
+  // the target, not update access.
+  const queryAccess = relatedListConfig.access?.operation?.query
+  const accessResult = await checkAccess(queryAccess, {
+    session: context.session,
+    context,
+  })
+
+  // Explicit denial.
+  if (accessResult === false) {
+    throw new Error('Access denied: Cannot connect to this item')
+  }
+
+  // Full access: still verify the row exists (keep "Item not found" behaviour).
+  if (accessResult === true) {
+    const item = await model.findUnique({ where: connection })
+    if (!item) {
+      throw new Error(`Cannot connect: Item not found`)
+    }
+    return
+  }
+
+  // Filter result: confirm the row is reachable under the access filter by
+  // AND-combining the connection identifier with the filter and querying the DB.
+  // A non-existent id and an unreachable row both yield no row → denied. This
+  // correctly evaluates arbitrary nested-relation predicates and boolean
+  // combinators because the database does the matching, not an in-memory walk.
+  const reachable = await model.findFirst({
+    where: { AND: [connection, accessResult] },
+  })
+
+  if (!reachable) {
+    throw new Error('Access denied: Cannot connect to this item')
+  }
+}
+
+/**
  * Process nested connect operations
- * Verifies update access to the items being connected
+ * Verifies read (query) access to the items being connected via DB reachability
  */
 async function processNestedConnect(
   connections: Record<string, unknown> | Array<Record<string, unknown>>,
@@ -130,47 +198,10 @@ async function processNestedConnect(
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const connectionsArray = Array.isArray(connections) ? connections : [connections]
 
-  // Check update access for each item being connected (skip if sudo mode)
+  // Check read access for each item being connected (skip if sudo mode)
   if (!context._isSudo) {
     for (const connection of connectionsArray) {
-      // Access Prisma model dynamically - required because model names are generated at runtime
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const model = (prisma as any)[getDbKey(relatedListName)]
-
-      // Fetch the item to check access
-      const item = await model.findUnique({
-        where: connection,
-      })
-
-      if (!item) {
-        throw new Error(`Cannot connect: Item not found`)
-      }
-
-      // Check update access (connecting modifies the relationship)
-      const updateAccess = relatedListConfig.access?.operation?.update
-      const accessResult = await checkAccess(updateAccess, {
-        session: context.session,
-        item,
-        context,
-      })
-
-      if (accessResult === false) {
-        throw new Error('Access denied: Cannot connect to this item')
-      }
-
-      // If access returns a filter, check if item matches
-      if (typeof accessResult === 'object') {
-        // Simple field matching
-        for (const [key, value] of Object.entries(accessResult)) {
-          if (typeof value === 'object' && value !== null && 'equals' in value) {
-            if (item[key] !== (value as Record<string, unknown>).equals) {
-              throw new Error('Access denied: Cannot connect to this item')
-            }
-          } else if (item[key] !== value) {
-            throw new Error('Access denied: Cannot connect to this item')
-          }
-        }
-      }
+      await verifyConnectReachable(connection, relatedListName, relatedListConfig, context, prisma)
     }
   }
 
@@ -316,31 +347,47 @@ async function processNestedConnectOrCreate(
         config,
       )
 
-      // Check access for the connect portion (try to find existing item) (skip if sudo mode)
+      // Check access for the connect portion (skip if sudo mode).
+      //
+      // connectOrCreate connects an existing row when present, otherwise
+      // creates. So when the row exists we apply the same connect semantics as
+      // processNestedConnect — READ (query) access on the target, evaluated via
+      // DB reachability for filter results. When the row does not exist we fall
+      // through to create. We must NOT swallow an access-denied error: only the
+      // genuine "row absent" case may fall back to create.
       if (!context._isSudo) {
-        try {
-          // Access Prisma model dynamically - required because model names are generated at runtime
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const model = (prisma as any)[getDbKey(relatedListName)]
-          const existingItem = await model.findUnique({
-            where: opRecord.where,
+        // Access Prisma model dynamically - required because model names are generated at runtime
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const model = (prisma as any)[getDbKey(relatedListName)]
+        const where = opRecord.where as Record<string, unknown>
+
+        const existingItem = await model.findUnique({ where })
+
+        // Only enforce connect access when the row actually exists; otherwise
+        // the create branch (already processed) is used.
+        if (existingItem) {
+          const queryAccess = relatedListConfig.access?.operation?.query
+          const accessResult = await checkAccess(queryAccess, {
+            session: context.session,
+            item: existingItem,
+            context,
           })
 
-          if (existingItem) {
-            // Check update access for connection
-            const updateAccess = relatedListConfig.access?.operation?.update
-            const accessResult = await checkAccess(updateAccess, {
-              session: context.session,
-              item: existingItem,
-              context,
+          if (accessResult === false) {
+            throw new Error('Access denied: Cannot connect to existing item')
+          }
+
+          // Filter result: confirm the existing row is reachable under the
+          // access filter via DB reachability (handles nested/boolean filters).
+          if (accessResult !== true) {
+            const reachable = await model.findFirst({
+              where: { AND: [where, accessResult] },
             })
 
-            if (accessResult === false) {
+            if (!reachable) {
               throw new Error('Access denied: Cannot connect to existing item')
             }
           }
-        } catch {
-          // Item doesn't exist, will use create (already processed)
         }
       }
 

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -717,7 +717,7 @@ describe('Nested Operations - Access Control and Hooks', () => {
   })
 
   describe('Access Denial Scenarios', () => {
-    it('should deny nested connect when update access is denied on related item', async () => {
+    it('should deny nested connect when read (query) access scopes out the target row', async () => {
       const testConfig = config({
         db: {
           provider: 'postgresql',
@@ -730,11 +730,9 @@ describe('Nested Operations - Access Control and Hooks', () => {
             },
             access: {
               operation: {
-                query: () => true,
-                update: ({ session }) => {
-                  // Only allow updating own profile
-                  return { id: { equals: session?.userId } }
-                },
+                // Only allow reading own profile (a scalar filter)
+                query: ({ session }) => ({ id: { equals: session?.userId } }),
+                update: () => true,
               },
             },
           }),
@@ -758,11 +756,8 @@ describe('Nested Operations - Access Control and Hooks', () => {
         title: 'Original Title',
       })
 
-      // Mock finding the user to connect (different from session user)
-      mockPrisma.user.findUnique.mockResolvedValue({
-        id: '2',
-        name: 'Other User',
-      })
+      // User 2 is NOT reachable under { id: { equals: '1' } } → findFirst returns null.
+      mockPrisma.user.findFirst.mockResolvedValue(null)
 
       const context = getContext(await testConfig, mockPrisma, { userId: '1' })
 
@@ -771,14 +766,19 @@ describe('Nested Operations - Access Control and Hooks', () => {
           where: { id: '1' },
           data: {
             author: {
-              connect: { id: '2' }, // Connecting to user 2, but session is user 1
+              connect: { id: '2' }, // Connecting to user 2, but session can only read user 1
             },
           },
         }),
       ).rejects.toThrow('Access denied: Cannot connect to this item')
+
+      // Reachability must be evaluated in the DB, AND-combining connection + filter.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: { AND: [{ id: '2' }, { id: { equals: '1' } }] },
+      })
     })
 
-    it('should allow nested connect when update access is granted', async () => {
+    it('should allow nested connect when read (query) access is granted (boolean true)', async () => {
       const testConfig = config({
         db: {
           provider: 'postgresql',
@@ -791,8 +791,8 @@ describe('Nested Operations - Access Control and Hooks', () => {
             },
             access: {
               operation: {
-                query: () => true,
-                update: () => true, // Allow all updates
+                query: () => true, // Allow reading all users
+                update: () => true,
               },
             },
           }),
@@ -840,6 +840,500 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       expect(result).toBeDefined()
       expect(mockPrisma.post.update).toHaveBeenCalled()
+      // Boolean-true access must not run a reachability re-check.
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+    })
+
+    it('connect requires READ access, not target UPDATE (read-not-update repro)', async () => {
+      // Caller can READ the target (query=allowAll) but CANNOT update it
+      // (update=admin-only). Under the old behaviour this denied the connect;
+      // it must now succeed because connect only references the row.
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          LessonTerm: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true, // anyone can read
+                update: () => false, // nobody (non-admin) can update
+              },
+            },
+          }),
+          Enrolment: list({
+            fields: {
+              title: text(),
+              term: relationship({ ref: 'LessonTerm' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.enrolment = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ id: 'e1', title: 'Term 1 Enrolment' }),
+        create: vi.fn(),
+        update: vi.fn().mockResolvedValue({ id: 'e1', title: 'Term 1 Enrolment', termId: 't1' }),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.lessonTerm = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ id: 't1', name: 'Term 1' }),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'student-1' })
+
+      const result = await context.db.enrolment.update({
+        where: { id: 'e1' },
+        data: {
+          term: {
+            connect: { id: 't1' },
+          },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.enrolment.update).toHaveBeenCalled()
+      // query=true → existence check via findUnique, no reachability re-check.
+      expect(mockPrisma.lessonTerm.findUnique).toHaveBeenCalledWith({ where: { id: 't1' } })
+      expect(mockPrisma.lessonTerm.findFirst).not.toHaveBeenCalled()
+    })
+
+    it('allows nested connect when a NESTED-RELATION filter is reachable (account-holder self-connect)', async () => {
+      // Account's row filter is a nested-relation filter:
+      //   { user: { id: { equals: session.userId } } }
+      // The old in-memory matcher could not evaluate this and always denied.
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: ({ session }) => ({ user: { id: { equals: session?.userId } } }),
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({ ref: 'Account' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        findFirst: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn().mockResolvedValue({ id: 's1', name: 'Kid', accountId: 'acc-1' }),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      const result = await context.db.student.create({
+        data: {
+          name: 'Kid',
+          account: { connect: { id: 'acc-1' } },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.student.create).toHaveBeenCalled()
+      // Reachability check evaluated the nested-relation filter in the DB.
+      expect(mockPrisma.account.findFirst).toHaveBeenCalledWith({
+        where: {
+          AND: [{ id: 'acc-1' }, { user: { id: { equals: 'user-1' } } }],
+        },
+      })
+    })
+
+    it('denies nested connect when a NESTED-RELATION filter is NOT reachable', async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: ({ session }) => ({ user: { id: { equals: session?.userId } } }),
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({ ref: 'Account' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        // Not reachable for this caller → findFirst returns null.
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'attacker' })
+
+      await expect(
+        context.db.student.create({
+          data: {
+            name: 'Kid',
+            account: { connect: { id: 'someone-elses-account' } },
+          },
+        }),
+      ).rejects.toThrow('Access denied: Cannot connect to this item')
+      expect(mockPrisma.student.create).not.toHaveBeenCalled()
+    })
+
+    it('evaluates AND/OR/some/none/not boolean-combinator filters via DB reachability', async () => {
+      const complexFilter = {
+        OR: [
+          { AND: [{ status: { equals: 'active' } }, { NOT: { archived: { equals: true } } }] },
+          { members: { some: { userId: { equals: 'user-1' } } } },
+        ],
+      }
+
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Team: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => complexFilter,
+                update: () => true,
+              },
+            },
+          }),
+          Project: list({
+            fields: {
+              title: text(),
+              team: relationship({ ref: 'Team' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.team = {
+        findFirst: vi.fn().mockResolvedValue({ id: 'team-1', name: 'Team A' }),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.project = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn().mockResolvedValue({ id: 'p1', title: 'P1', teamId: 'team-1' }),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      const result = await context.db.project.create({
+        data: {
+          title: 'P1',
+          team: { connect: { id: 'team-1' } },
+        },
+      })
+
+      expect(result).toBeDefined()
+      // The full boolean-combinator filter is AND-combined with the connection
+      // and handed to the DB — no in-memory walk, no false denial.
+      expect(mockPrisma.team.findFirst).toHaveBeenCalledWith({
+        where: { AND: [{ id: 'team-1' }, complexFilter] },
+      })
+    })
+
+    it('sudo connect bypasses the access check entirely', async () => {
+      const queryAccess = vi.fn(() => false as const)
+
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: queryAccess, // would deny everything
+                update: () => false,
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              author: relationship({ ref: 'User.posts' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.post.findUnique.mockResolvedValue({ id: '1', title: 'Original Title' })
+      mockPrisma.post.update.mockResolvedValue({ id: '1', title: 'Original Title', authorId: '2' })
+
+      const context = getContext(await testConfig, mockPrisma, { userId: '1' }).sudo()
+
+      const result = await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          author: { connect: { id: '2' } },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.post.update).toHaveBeenCalled()
+      // Sudo skips access evaluation: neither the access fn nor reachability run.
+      expect(queryAccess).not.toHaveBeenCalled()
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled()
+    })
+
+    it("connectOrCreate's connect branch uses read-access + DB reachability and denies unreachable rows", async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: ({ session }) => ({ user: { id: { equals: session?.userId } } }),
+                create: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({ ref: 'Account' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        // Row exists ...
+        findUnique: vi.fn().mockResolvedValue({ id: 'acc-x', name: 'Other Account' }),
+        // ... but is NOT reachable under the access filter for this caller.
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      await expect(
+        context.db.student.create({
+          data: {
+            name: 'Kid',
+            account: {
+              connectOrCreate: {
+                where: { id: 'acc-x' },
+                create: { name: 'New Account' },
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow('Access denied: Cannot connect to existing item')
+
+      expect(mockPrisma.account.findFirst).toHaveBeenCalledWith({
+        where: { AND: [{ id: 'acc-x' }, { user: { id: { equals: 'user-1' } } }] },
+      })
+      expect(mockPrisma.student.create).not.toHaveBeenCalled()
+    })
+
+    it("connectOrCreate's connect branch allows a reachable existing row", async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: ({ session }) => ({ user: { id: { equals: session?.userId } } }),
+                create: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({ ref: 'Account' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        findUnique: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn().mockResolvedValue({ id: 's1', name: 'Kid', accountId: 'acc-1' }),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      const result = await context.db.student.create({
+        data: {
+          name: 'Kid',
+          account: {
+            connectOrCreate: {
+              where: { id: 'acc-1' },
+              create: { name: 'New Account' },
+            },
+          },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.student.create).toHaveBeenCalled()
     })
 
     it('should deny nested update when update access is denied on related item', async () => {


### PR DESCRIPTION
## Summary

Implements #578. Part of #581.

`processNestedConnect` (and the connect branch of `processNestedConnectOrCreate`) had two related bugs that falsely denied legitimate access-scoped nested `connect`s:

1. **Wrong access phase.** It checked the target list's `operation.update`. Connecting references an existing row; it does not modify it. Keystone required **read/query** access on the target. The check now uses `access.operation.query`.
2. **In-memory matcher could not evaluate nested filters.** When access returned a filter object, the old code walked it in memory and only compared flat scalar leaves. A nested-relation filter like `{ user: { id: { equals: session.userId } } }` (and `AND`/`OR`/`some`/`none`/`not`) fell through to a strict object `!==` and **always** failed → false denial.

## The fix

Connect now mirrors Keystone semantics and evaluates the access filter in the **database**, not in memory:

- `accessResult === false` → deny (throw)
- `accessResult === true` → allow, no re-check (still verifies the row exists via `findUnique`, preserving the "Item not found" behaviour)
- `accessResult` is a filter object → **DB-reachability check**: `model.findFirst({ where: { AND: [connection, accessFilter] } })`. Allowed iff a row is returned. A non-existent id or an unreachable row both yield no row → denied (security preserved).

The connection identifier and the access filter are AND-combined with an explicit `{ AND: [connection, accessResult] }`, which folds existence into the reachability query and correctly handles arbitrary nested-relation predicates and boolean combinators.

The same corrected logic is applied to `connectOrCreate`'s connect branch. That branch additionally no longer swallows access-denied errors in its existence fallback — only a genuinely absent row falls through to create.

**Sudo** bypasses the whole check, exactly as before (`if (!context._isSudo)`).

### Owning-side field-level access (deferred)

The brief mentions also applying the owning relationship field's field-level access on connect. `NestedOpHandlerArgs` does not currently carry the owning field's config/access, so threading it through would be significant new plumbing. This is deferred with a `// TODO(#578)` in the code. The read-access + DB-reachability change here is the must-have that fixes the reported false-denial.

## Tests

Added to `packages/core/tests/nested-access-and-hooks.test.ts`:

- Nested connect to a target whose query access returns a **nested-relation filter** succeeds when reachable, denied when not (account-holder self-connect repro).
- Connect requires **read** access not target **update** (read-not-update repro succeeds).
- **AND/OR/some/none/not** boolean-combinator filter evaluated via DB reachability (no false denial/allow).
- `connectOrCreate`'s connect branch denies an existing-but-unreachable row and allows a reachable one.
- Sudo connect bypasses the check entirely.

## Verification

- `pnpm -C packages/core test`: 610 passed
- `pnpm -C packages/cli test`: 289 passed
- `pnpm lint`: 0 errors (pre-existing warnings only)
- `pnpm manypkg fix` + `pnpm format`: clean
- core `tsc` build: passes
- Changeset: `@opensaas/stack-core` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_