### PR TITLE
fix(core): merge explicit include with access control on reads (#566)

### DIFF
--- a/.changeset/spotted-falcons-merge.md
+++ b/.changeset/spotted-falcons-merge.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix row-level access bypass when an explicit `include` is passed to non-sudo `findUnique`/`findMany`. The caller's `include` is now merged with (not replaced by) the access-controlled include: denied relations are dropped, each relation's access `where` is AND-combined with any caller nested `where`, and nested includes are filtered at every level. Sudo and query-fragment paths are unchanged.

--- a/.changeset/spotted-falcons-merge.md
+++ b/.changeset/spotted-falcons-merge.md
@@ -2,4 +2,4 @@
 '@opensaas/stack-core': patch
 ---
 
-Fix row-level access bypass when an explicit `include` is passed to non-sudo `findUnique`/`findMany`. The caller's `include` is now merged with (not replaced by) the access-controlled include: denied relations are dropped, each relation's access `where` is AND-combined with any caller nested `where`, and nested includes are filtered at every level. Sudo and query-fragment paths are unchanged.
+Fix row-level access bypass when an explicit `include` is passed to non-sudo `findUnique`/`findMany`. The caller's `include` is now merged with (not replaced by) the access-controlled include: denied relations are dropped, each relation's access `where` is AND-combined with any caller nested `where`, and nested includes are filtered at every level. Sudo and query-fragment paths are unchanged. When no access-controlled include is computed (inside a `resolveOutput`/virtual-field context, at max include depth, or for a list with no relationships), the caller's `include` is passed through unchanged rather than dropped — avoiding fail-closed data loss.

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -95,3 +95,140 @@ export async function buildIncludeWithAccessControl(
 
   return hasRelationships ? include : undefined
 }
+
+/**
+ * A single relation entry in a Prisma `include` object: either a bare `true`
+ * (fetch with no extra constraints) or an object that scopes the fetch with a
+ * `where` filter and/or a nested `include`.
+ */
+type IncludeEntry = boolean | { where?: PrismaFilter; include?: IncludeObject }
+type IncludeObject = Record<string, IncludeEntry>
+
+/** The structured (object) form of a relation include entry. */
+type IncludeEntryObject = { where?: PrismaFilter; include?: IncludeObject }
+
+/**
+ * Narrow an unknown include value to the structured object form (vs bare `true`
+ * or any other primitive). Caller-supplied includes arrive untyped at the
+ * runtime boundary, so we validate the shape here rather than casting.
+ */
+function asEntryObject(value: unknown): IncludeEntryObject | null {
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const where = obj.where
+    const include = obj.include
+    const entry: IncludeEntryObject = {}
+    if (where && typeof where === 'object') entry.where = where as PrismaFilter
+    if (include && typeof include === 'object') entry.include = include as IncludeObject
+    return entry
+  }
+  return null
+}
+
+/**
+ * AND-combine an access `where` with a caller-supplied nested `where`.
+ *
+ * The access filter is authoritative: the caller's filter may only NARROW the
+ * result further, never widen past what access permits. We therefore wrap both
+ * in a Prisma `AND` so neither can override the other. If only one side is
+ * present, it is returned as-is; if neither is present, the result is undefined.
+ */
+function andWhere(
+  accessWhere: PrismaFilter | undefined,
+  callerWhere: PrismaFilter | undefined,
+): PrismaFilter | undefined {
+  if (accessWhere && callerWhere) {
+    return { AND: [accessWhere, callerWhere] }
+  }
+  return accessWhere ?? callerWhere
+}
+
+/**
+ * Merge a caller-supplied `include` with the access-controlled include — phase-1
+ * row/relation scoping for explicit caller selections.
+ *
+ * The caller's `include` decides WHICH relations to fetch; access control decides
+ * WHETHER each relation may be fetched and WITH WHAT filter. Replacing the
+ * access-controlled include with the caller's wholesale (the bug in #566) drops
+ * every per-relation access `where` and denied-relation exclusion, silently
+ * bypassing row-level access on any non-sudo read that passes `include`.
+ *
+ * For each relation the caller asks to include:
+ * - If the relation is a config-declared relationship but is ABSENT from the
+ *   access-controlled include, its `query` access returned `false` → it is DROPPED
+ *   (not fetched).
+ * - If it is present (allowed, possibly with a filter), the access entry is used
+ *   as the base: the access `where` is AND-combined with any caller-supplied
+ *   nested `where`, and nested includes are recursively merged using the related
+ *   list's field configs (so deeply-nested selections are filtered at every
+ *   level). A bare caller `true` becomes the access-controlled shape (filter +
+ *   nested filtered include), never bare `true`.
+ * - If the caller names a key that is NOT a config-declared relationship, it is
+ *   passed through unchanged (access control does not govern it).
+ *
+ * The access-controlled include is recursive to `MAX_DEPTH` (see
+ * `buildIncludeWithAccessControl`); beyond that depth no auto-include exists, so
+ * deeper caller selections pass through unscoped — consistent with the existing
+ * auto-include behaviour.
+ */
+export function mergeIncludeWithAccessControl(
+  callerInclude: Record<string, unknown>,
+  accessControlledInclude: Record<string, unknown> | undefined,
+  fieldConfigs: Record<string, FieldConfig>,
+  config: OpenSaasConfig,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {}
+  const accessInclude = accessControlledInclude ?? {}
+
+  for (const [relationName, callerValue] of Object.entries(callerInclude)) {
+    const fieldConfig = fieldConfigs[relationName]
+    const isDeclaredRelationship =
+      fieldConfig?.type === 'relationship' && 'ref' in fieldConfig && !!fieldConfig.ref
+
+    // Not a config-declared relationship → access control does not govern it; pass through unchanged.
+    if (!isDeclaredRelationship) {
+      merged[relationName] = callerValue
+      continue
+    }
+
+    const accessValue = accessInclude[relationName]
+
+    // Declared relationship absent from the access include → query access denied → drop it.
+    if (accessValue === undefined) {
+      continue
+    }
+
+    const accessEntry = asEntryObject(accessValue)
+    const callerEntry = asEntryObject(callerValue)
+
+    // Resolve the related list's field configs so nested includes merge recursively.
+    const relatedConfig = getRelatedListConfig(fieldConfig.ref as string, config)
+    const relatedFields = relatedConfig?.listConfig.fields
+
+    const mergedWhere = andWhere(accessEntry?.where, callerEntry?.where)
+
+    let mergedNested: Record<string, unknown> | undefined
+    if (callerEntry?.include && relatedFields) {
+      // Recurse: scope the caller's nested selection against the nested access include.
+      mergedNested = mergeIncludeWithAccessControl(
+        callerEntry.include,
+        accessEntry?.include,
+        relatedFields,
+        config,
+      )
+    } else if (accessEntry?.include) {
+      // Caller selected the relation bare (no nested include); keep the
+      // access-controlled nested include so deeper relations stay filtered.
+      mergedNested = accessEntry.include
+    }
+
+    const entry: { where?: PrismaFilter; include?: Record<string, unknown> } = {}
+    if (mergedWhere) entry.where = mergedWhere
+    if (mergedNested && Object.keys(mergedNested).length > 0) entry.include = mergedNested
+
+    // A bare-`true` relation with no access filter and no nested include stays `true`.
+    merged[relationName] = Object.keys(entry).length > 0 ? entry : true
+  }
+
+  return merged
+}

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -170,6 +170,16 @@ function andWhere(
  * `buildIncludeWithAccessControl`); beyond that depth no auto-include exists, so
  * deeper caller selections pass through unscoped — consistent with the existing
  * auto-include behaviour.
+ *
+ * `accessControlledInclude` being `undefined` is NOT "every relation denied". It
+ * means no access-controlled include was computed at all — a non-denial outcome
+ * that `buildIncludeWithAccessControl` returns when inside a `resolveOutput`/
+ * virtual-field context, at `MAX_DEPTH`, or when the list has no relationships.
+ * In every one of those cases there is nothing to merge against, so the caller's
+ * `include` is passed through unchanged (matching the prior `args.include || …`
+ * fallback). This is distinct from an `undefined` ENTRY inside a defined access
+ * include, which DOES mean the relation was denied and must be dropped (see the
+ * per-relation loop below). Only the whole-object `undefined` is a passthrough.
  */
 export function mergeIncludeWithAccessControl(
   callerInclude: Record<string, unknown>,
@@ -177,8 +187,17 @@ export function mergeIncludeWithAccessControl(
   fieldConfigs: Record<string, FieldConfig>,
   config: OpenSaasConfig,
 ): Record<string, unknown> {
+  // No access-controlled include was computed (resolveOutput/virtual context,
+  // MAX_DEPTH, or a list with no relationships) → nothing to scope against, so
+  // pass the caller's include through unchanged. Dropping relations here would be
+  // fail-closed data loss, not a denial. Denied relations are dropped only when a
+  // defined access include OMITS them (handled per-relation below).
+  if (accessControlledInclude === undefined) {
+    return callerInclude
+  }
+
   const merged: Record<string, unknown> = {}
-  const accessInclude = accessControlledInclude ?? {}
+  const accessInclude = accessControlledInclude
 
   for (const [relationName, callerValue] of Object.entries(callerInclude)) {
     const fieldConfig = fieldConfigs[relationName]

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -22,6 +22,6 @@ export {
 // Canonical field-level access evaluation (shared by read and write paths).
 export { checkFieldAccess, filterWritableFields } from './field-access.js'
 // Phase 1 — Access Filter (pre-query row/relation scoping).
-export { buildIncludeWithAccessControl } from './access-filter.js'
+export { buildIncludeWithAccessControl, mergeIncludeWithAccessControl } from './access-filter.js'
 // Phase 2 — Field Visibility (post-query field stripping + resolveOutput).
 export { filterReadableFields } from './field-visibility.js'

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -5,6 +5,7 @@ import {
   mergeFilters,
   filterReadableFields,
   buildIncludeWithAccessControl,
+  mergeIncludeWithAccessControl,
 } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
@@ -522,6 +523,10 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
 
     if (fragment) {
       include = buildInclude(fragment._fields) ?? undefined
+    } else if (context._isSudo) {
+      // Sudo bypasses access control entirely — the caller's include is trusted
+      // and used as-is (matching the prior behaviour); no per-relation filtering.
+      include = args.include
     } else {
       // Build include with access control filters
       const accessControlledInclude = await buildIncludeWithAccessControl(
@@ -532,7 +537,18 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
         },
         config,
       )
-      include = args.include || accessControlledInclude
+      // MERGE (not replace) a caller-supplied include with the access-controlled
+      // include: the caller selects WHICH relations to fetch, access control
+      // decides WHETHER and WITH WHAT filter (#566). A bare auto-include (no
+      // caller include) still uses the access-controlled include directly.
+      include = args.include
+        ? mergeIncludeWithAccessControl(
+            args.include,
+            accessControlledInclude,
+            listConfig.fields,
+            config,
+          )
+        : accessControlledInclude
     }
 
     // Execute query with optimized includes
@@ -630,6 +646,10 @@ function createFindMany<TPrisma extends PrismaClientLike>(
     let include: Record<string, unknown> | undefined
     if (fragment) {
       include = buildInclude(fragment._fields) ?? undefined
+    } else if (context._isSudo) {
+      // Sudo bypasses access control entirely — the caller's include is trusted
+      // and used as-is (matching the prior behaviour); no per-relation filtering.
+      include = args?.include
     } else {
       // Build include with access control filters
       const accessControlledInclude = await buildIncludeWithAccessControl(
@@ -640,7 +660,18 @@ function createFindMany<TPrisma extends PrismaClientLike>(
         },
         config,
       )
-      include = args?.include || accessControlledInclude
+      // MERGE (not replace) a caller-supplied include with the access-controlled
+      // include: the caller selects WHICH relations to fetch, access control
+      // decides WHETHER and WITH WHAT filter (#566). A bare auto-include (no
+      // caller include) still uses the access-controlled include directly.
+      include = args?.include
+        ? mergeIncludeWithAccessControl(
+            args.include,
+            accessControlledInclude,
+            listConfig.fields,
+            config,
+          )
+        : accessControlledInclude
     }
 
     // Execute query with optimized includes

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -448,6 +448,179 @@ describe('getContext', () => {
       })
     })
 
+    describe('explicit include merges with access control (#566)', () => {
+      // Author has many Posts; Post.query access scopes to published posts only.
+      // A caller-supplied `include` must NOT bypass that per-relation filter.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let relPrisma: any
+      let relConfig: OpenSaasConfig
+
+      beforeEach(() => {
+        relPrisma = {
+          author: {
+            findFirst: vi.fn(),
+            findUnique: vi.fn(),
+            findMany: vi.fn(),
+          },
+          post: {
+            findFirst: vi.fn(),
+            findUnique: vi.fn(),
+            findMany: vi.fn(),
+          },
+          comment: {
+            findFirst: vi.fn(),
+            findMany: vi.fn(),
+          },
+        }
+
+        relConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            Author: {
+              fields: {
+                name: { type: 'text' },
+                posts: { type: 'relationship', ref: 'Post.author', many: true },
+              },
+              access: { operation: { query: () => true } },
+            },
+            Post: {
+              fields: {
+                title: { type: 'text' },
+                author: { type: 'relationship', ref: 'Author.posts' },
+                comments: { type: 'relationship', ref: 'Comment.post', many: true },
+              },
+              access: {
+                // Row filter: only published posts are visible.
+                operation: { query: () => ({ status: { equals: 'published' } }) },
+              },
+            },
+            Comment: {
+              fields: {
+                body: { type: 'text' },
+                post: { type: 'relationship', ref: 'Post.comments' },
+              },
+              access: {
+                operation: { query: () => ({ approved: { equals: true } }) },
+              },
+            },
+            Secret: {
+              fields: {
+                value: { type: 'text' },
+              },
+              // Fully denied list.
+              access: { operation: { query: () => false } },
+            },
+          },
+        }
+        // Add a denied relation onto Author for the "drop denied relation" test.
+        relConfig.lists.Author.fields.secrets = {
+          type: 'relationship',
+          ref: 'Secret',
+          many: true,
+        }
+      })
+
+      it('findMany: caller include {posts:true} applies the relation access where (not bare true)', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo', posts: [] }])
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findMany({ include: { posts: true } })
+
+        // The relation is fetched WITH the Post query-access where (NOT bare true),
+        // proving the row-level bypass is closed.
+        const call = relPrisma.author.findMany.mock.calls[0][0]
+        expect(call.include.posts).not.toBe(true)
+        expect(call.include.posts.where).toEqual({ status: { equals: 'published' } })
+      })
+
+      it('findUnique: caller include {posts:true} applies the relation access where', async () => {
+        relPrisma.author.findFirst.mockResolvedValue({ id: 'a1', name: 'Jo', posts: [] })
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findUnique({ where: { id: 'a1' }, include: { posts: true } })
+
+        const call = relPrisma.author.findFirst.mock.calls[0][0]
+        expect(call.where).toEqual(expect.objectContaining({ id: 'a1' }))
+        expect(call.include.posts).not.toBe(true)
+        expect(call.include.posts.where).toEqual({ status: { equals: 'published' } })
+      })
+
+      it('drops a relation whose query access is false when named in the caller include', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo' }])
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findMany({ include: { secrets: true, posts: true } })
+
+        const call = relPrisma.author.findMany.mock.calls[0][0]
+        // Denied `secrets` relation is dropped; allowed `posts` keeps its filter.
+        expect(call.include.secrets).toBeUndefined()
+        expect(call.include.posts.where).toEqual({ status: { equals: 'published' } })
+      })
+
+      it('AND-combines a caller nested where with the relation access where', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo', posts: [] }])
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findMany({
+          include: { posts: { where: { title: { contains: 'hello' } } } },
+        })
+
+        const call = relPrisma.author.findMany.mock.calls[0][0]
+        // Both the access where and the caller where are applied via AND.
+        expect(call.include.posts.where).toEqual({
+          AND: [{ status: { equals: 'published' } }, { title: { contains: 'hello' } }],
+        })
+      })
+
+      it('access-filters nested (2-level) caller includes at every level', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo', posts: [] }])
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findMany({
+          include: { posts: { include: { comments: true } } },
+        })
+
+        const call = relPrisma.author.findMany.mock.calls[0][0]
+        // Level 1 (posts) and level 2 (comments) both carry their access where.
+        expect(call.include.posts.where).toEqual({ status: { equals: 'published' } })
+        expect(call.include.posts.include.comments.where).toEqual({ approved: { equals: true } })
+      })
+
+      it('sudo with explicit include returns the include unfiltered (behaviour preserved)', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo' }])
+
+        const context = await getContext(relConfig, relPrisma, null).sudo()
+        await context.db.author.findMany({ include: { posts: true, secrets: true } })
+
+        // Under sudo the caller include is used as-is: no filter, nothing dropped.
+        expect(relPrisma.author.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({ include: { posts: true, secrets: true } }),
+        )
+      })
+
+      it('query fragment path is unaffected by the merge (fragment include used, unfiltered)', async () => {
+        relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo', posts: [] }])
+
+        const postsFragment = defineFragment<{ id: string; title: string }>()({
+          title: true,
+        } as const)
+        const fragment = defineFragment<{ id: string; name: string; posts: unknown }>()({
+          id: true,
+          name: true,
+          posts: postsFragment,
+        } as const)
+
+        const context = await getContext(relConfig, relPrisma, null)
+        await context.db.author.findMany({ query: fragment })
+
+        const call = relPrisma.author.findMany.mock.calls[0][0]
+        // Fragment-built include is used as-is; the merge helper is NOT applied to
+        // the fragment path, so the relation carries no access `where` here. (The
+        // fragment posts-selection contains only scalars, so it builds to `true`.)
+        expect(call.include).toEqual({ posts: true })
+      })
+    })
+
     it('should delegate create to prisma with access control and hooks', async () => {
       const mockUser = { id: '1', name: 'John', email: 'john@example.com' }
       mockPrisma.user.create.mockResolvedValue(mockUser)

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getContext } from '../src/context/index.js'
 import { defineFragment } from '../src/query/index.js'
+import { virtual } from '../src/fields/index.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 
 describe('getContext', () => {
@@ -618,6 +619,91 @@ describe('getContext', () => {
         // the fragment path, so the relation carries no access `where` here. (The
         // fragment posts-selection contains only scalars, so it builds to `true`.)
         expect(call.include).toEqual({ posts: true })
+      })
+
+      // Regression: when buildIncludeWithAccessControl returns `undefined` (a
+      // NON-denial outcome), the caller include must PASS THROUGH unchanged
+      // rather than every declared relation being silently dropped. The original
+      // #566 merge treated `undefined` as "all relations denied" (fail-closed
+      // data loss). `undefined` is returned in three non-denial cases:
+      //   1. inside a resolveOutput hook / virtual-field context,
+      //   2. at MAX_DEPTH,
+      //   3. when a list has no relationships.
+      describe('passes caller include through when no access include is computed', () => {
+        // Build an Author config with a virtual field whose resolveOutput issues a
+        // read WITH an explicit include. While that hook runs,
+        // _resolveOutputCounter.depth > 0, so buildIncludeWithAccessControl
+        // returns undefined for the inner read — exercising the
+        // `accessControlledInclude === undefined` passthrough path.
+        function configWithResolveOutputProbe(
+          callerInclude: Record<string, unknown>,
+          capture: (include: unknown) => void,
+        ): OpenSaasConfig {
+          return {
+            ...relConfig,
+            lists: {
+              ...relConfig.lists,
+              Author: {
+                ...relConfig.lists.Author,
+                fields: {
+                  ...relConfig.lists.Author.fields,
+                  commentSummary: virtual({
+                    type: 'string',
+                    hooks: {
+                      resolveOutput: async ({ context }) => {
+                        await context.db.comment.findMany({ include: callerInclude })
+                        capture(relPrisma.comment.findMany.mock.calls[0][0].include)
+                        return 'summary'
+                      },
+                    },
+                  }),
+                },
+              },
+            },
+          }
+        }
+
+        it('findUnique inside a resolveOutput hook keeps the caller include (not dropped)', async () => {
+          let innerIncludeSeen: unknown
+          const hookConfig = configWithResolveOutputProbe({ post: true }, (include) => {
+            innerIncludeSeen = include
+          })
+
+          relPrisma.author.findFirst.mockResolvedValue({ id: 'a1', name: 'Jo' })
+          relPrisma.comment.findMany.mockResolvedValue([{ id: 'c1', body: 'hi', post: null }])
+
+          const context = await getContext(hookConfig, relPrisma, null)
+          await context.db.author.findUnique({ where: { id: 'a1' } })
+
+          // The caller include `{ post: true }` survives: the declared `post`
+          // relation is NOT dropped despite the access include being undefined here.
+          expect(innerIncludeSeen).toEqual({ post: true })
+        })
+
+        it('findMany inside a resolveOutput hook passes a NESTED caller include through whole', async () => {
+          let innerIncludeSeen: unknown
+          const hookConfig = configWithResolveOutputProbe(
+            { post: { include: { author: true } } },
+            (include) => {
+              innerIncludeSeen = include
+            },
+          )
+
+          relPrisma.author.findMany.mockResolvedValue([{ id: 'a1', name: 'Jo' }])
+          relPrisma.comment.findMany.mockResolvedValue([{ id: 'c1', body: 'hi', post: null }])
+
+          const context = await getContext(hookConfig, relPrisma, null)
+          await context.db.author.findMany()
+
+          // The whole nested caller include passes through untouched (no access
+          // include exists to merge against in resolveOutput context).
+          expect(innerIncludeSeen).toEqual({ post: { include: { author: true } } })
+        })
+
+        // The MAX_DEPTH and no-relationships cases also make
+        // buildIncludeWithAccessControl return undefined; they flow through the
+        // identical `accessControlledInclude === undefined` branch verified above,
+        // so the resolveOutput probe covers all three non-denial cases.
       })
     })
 


### PR DESCRIPTION
Implements #566. Part of #581.

## Problem (HIGH — silent row-level access bypass)

On non-sudo `findUnique`/`findMany`, a caller-supplied `include` previously **replaced** the access-controlled include wholesale:

```js
include = args.include || accessControlledInclude
```

So any nested relation named in an explicit `include` was fetched with **no** per-relation access `where` filter and **no** denied-relation exclusion. The API was safest used naively (bare read → fully filtered auto-include) and unsafe used deliberately (explicit include → unfiltered relations).

## Fix — merge, not replace

New `mergeIncludeWithAccessControl` (in `packages/core/src/access/access-filter.ts`, exported from `access/index.ts`) intersects the caller's `include` with the access-controlled include. The caller's include selects WHICH relations to fetch; access control decides WHETHER and WITH WHAT filter.

For each relation the caller asks to include:
- **Denied relation** (query access `false`, so absent from the access-controlled include) → **dropped** (not fetched).
- **Allowed with a filter** → the relation's access `where` is applied, **AND-combined** with any caller-supplied nested `where` (caller can only narrow, never widen).
- **Bare `true`** → becomes the access-controlled shape (filter + nested filtered include), never bare `true`.
- **Nested includes** → recursively merged using the related list's field configs, so deeply-nested caller includes are access-filtered at every level (the access include is recursive to depth 5 via `buildIncludeWithAccessControl`; beyond that no auto-include exists and deeper caller keys pass through, matching existing behaviour).
- A key that is **not** a config-declared relationship is passed through unchanged (access control does not govern it — preserves existing behaviour).

### Behaviour preserved
- **Sudo**: caller `include` is used as-is (no filtering, nothing dropped) — sudo is never made more restrictive than before.
- **Query fragment path**: unchanged — the fragment-built include is still used directly; the merge only applies to the explicit `args.include` path.
- **`assertUniqueWhere` guard (#567)**: untouched — the merge is downstream of it.

## Tests

Added in `packages/core/tests/context.test.ts` (`#566` describe block), all red-before/green-after:
- `findMany`/`findUnique` with `include: { rel: true }` where `rel` query access returns a row filter → relation carries that access `where`, not bare `true`.
- A relation with query access `false` named in the caller include is dropped.
- A caller nested `where` is AND-combined with the access `where`.
- Nested (2-level) includes are access-filtered at each level.
- Sudo with explicit include returns the include unfiltered.
- The query-fragment path is unaffected.

## Verification
- `pnpm -C packages/core test` → 618 passed
- `pnpm -C packages/cli test` → 289 passed
- `pnpm build` (all 11 tasks), `pnpm lint` (0 errors), `pnpm manypkg fix`, `pnpm format` → clean
- Changeset: `@opensaas/stack-core` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_