### PR TITLE
fix(cli): derive keystone-mode storage `needs` from part columns

### DIFF
--- a/.changeset/wise-points-cheer.md
+++ b/.changeset/wise-points-cheer.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix `tsc` failure in generated `prisma-extensions.ts` for multi-column storage fields in `db: { columns: 'keystone' }` mode. The result extension's `needs` now references the physical part columns (e.g. `image_url`, `image_pathname`, …) derived from the field's `getColumnNames`, instead of the logical field name which has no scalar on the model (previously typed `true` against `never`). This removes the last error forcing `@ts-nocheck` on the generated bundle (#559).

--- a/packages/cli/src/generator/prisma-extensions.test.ts
+++ b/packages/cli/src/generator/prisma-extensions.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { generatePrismaExtensions } from './prisma-extensions.js'
+import type { OpenSaasConfig, FieldConfig } from '@opensaas/stack-core'
+import { text, virtual } from '@opensaas/stack-core/fields'
+
+/**
+ * Builds a synthetic multi-column storage field (the shape image()/file()
+ * produce in `db: { columns: 'keystone' }` mode). The CLI package does not
+ * depend on @opensaas/stack-storage, so we mimic the relevant surface directly:
+ * a field with a `resultExtension` (so it participates in the result extension)
+ * and a `getColumnNames` that returns the physical part columns. See #559.
+ */
+function multiColumnStorageField(columns: string[]): FieldConfig {
+  return {
+    type: 'image',
+    resultExtension: {
+      outputType: "import('@opensaas/stack-storage').ImageMetadata | null",
+    },
+    getColumnNames: (fieldName: string) => columns.map((part) => `${fieldName}_${part}`),
+  }
+}
+
+describe('Prisma Extensions Generator', () => {
+  it('derives `needs` from the part columns for keystone-mode image fields', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql' },
+      lists: {
+        Production: {
+          fields: {
+            image: multiColumnStorageField([
+              'url',
+              'width',
+              'height',
+              'filesize',
+              'contentType',
+              'contentDisposition',
+              'pathname',
+            ]),
+          },
+        },
+      },
+    }
+
+    const output = generatePrismaExtensions(config)
+
+    // needs references the physical part columns that actually exist on the
+    // model, NOT the logical `image` field (which has no scalar in this mode).
+    expect(output).toContain(
+      'needs: { image_url: true, image_width: true, image_height: true, image_filesize: true, image_contentType: true, image_contentDisposition: true, image_pathname: true },',
+    )
+    expect(output).not.toContain('needs: { image: true }')
+
+    // compute must not read a non-existent `image` scalar off the model.
+    expect(output).not.toContain('const value = production.image')
+  })
+
+  it('derives `needs` from the part columns for keystone-mode file fields', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql' },
+      lists: {
+        Production: {
+          fields: {
+            doc: multiColumnStorageField(['filename', 'filesize', 'url']),
+          },
+        },
+      },
+    }
+
+    const output = generatePrismaExtensions(config)
+
+    expect(output).toContain('needs: { doc_filename: true, doc_filesize: true, doc_url: true },')
+    expect(output).not.toContain('needs: { doc: true }')
+  })
+
+  it('honours custom/overridden column names returned by getColumnNames', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql' },
+      lists: {
+        Production: {
+          fields: {
+            // getColumnNames is the single source of truth for the physical
+            // names, so a custom map flows through without hardcoding suffixes.
+            banner: {
+              type: 'image',
+              resultExtension: {
+                outputType: "import('@opensaas/stack-storage').ImageMetadata | null",
+              },
+              getColumnNames: () => ['custom_name', 'banner_pathname'],
+            },
+          },
+        },
+      },
+    }
+
+    const output = generatePrismaExtensions(config)
+
+    expect(output).toContain('needs: { custom_name: true, banner_pathname: true },')
+  })
+
+  it('keeps single-column (non-keystone) fields on the logical field name', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql' },
+      lists: {
+        Post: {
+          fields: {
+            // A single-column field with a resultExtension and no getColumnNames
+            // must still emit `needs: { <fieldName>: true }`.
+            title: {
+              ...text(),
+              resultExtension: { outputType: 'string | null' },
+            },
+          },
+        },
+      },
+    }
+
+    const output = generatePrismaExtensions(config)
+
+    expect(output).toContain('needs: { title: true },')
+    expect(output).toContain('const value = post.title')
+  })
+
+  it('still emits empty `needs` for virtual fields', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql' },
+      lists: {
+        User: {
+          fields: {
+            firstName: text(),
+            fullName: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: ({ item }: { item: Record<string, unknown> }) =>
+                  String(item.firstName ?? ''),
+              },
+            }),
+          },
+        },
+      },
+    }
+
+    const output = generatePrismaExtensions(config)
+
+    expect(output).toContain('needs: {},')
+  })
+})

--- a/packages/cli/src/generator/prisma-extensions.ts
+++ b/packages/cli/src/generator/prisma-extensions.ts
@@ -83,18 +83,44 @@ export function generatePrismaExtensions(config: OpenSaasConfig, configImport?: 
 
     for (const [fieldName, fieldConfig] of fieldsWithExtensions) {
       const isVirtual = fieldConfig.virtual
+      // Multi-column storage fields (e.g. image()/file() in keystone-columns
+      // mode) spread across several part columns (image_url, image_pathname, …)
+      // and have no single logical scalar on the model. Their logical value is
+      // re-assembled by core's read pipeline (assembleColumns), not by this
+      // result extension, so the compute here must not reference a scalar that
+      // doesn't exist. See #559.
+      const isMultiColumn = !isVirtual && typeof fieldConfig.getColumnNames === 'function'
 
       lines.push(`      ${fieldName}: {`)
 
       if (isVirtual) {
         // Virtual fields don't need database fields - they compute from the full item
         lines.push(`        needs: {},`)
+      } else if (isMultiColumn && fieldConfig.getColumnNames) {
+        // Prisma types `needs` against the model's scalar fields. Referencing the
+        // logical field name here would type the literal `true` against `never`
+        // (no such scalar exists). Derive `needs` from the physical part columns
+        // instead. getColumnNames already returns the resolved/overridden names,
+        // so custom column maps Just Work. See #559.
+        const columnNames = fieldConfig.getColumnNames(fieldName)
+        const needsEntries = columnNames.map((column) => `${column}: true`).join(', ')
+        lines.push(`        needs: { ${needsEntries} },`)
       } else {
-        // Non-virtual fields need their database value
+        // Non-virtual single-column fields need their database value
         lines.push(`        needs: { ${fieldName}: true },`)
       }
 
       lines.push(`        compute: (${modelKey}) => {`)
+
+      if (isMultiColumn) {
+        // The logical value lives across part columns and is assembled elsewhere;
+        // there is no scalar to read or transform here. Returning undefined keeps
+        // the assembled value (re-added via TransformedFields) authoritative.
+        lines.push(`          return undefined`)
+        lines.push(`        },`)
+        lines.push(`      },`)
+        continue
+      }
 
       if (!isVirtual) {
         // For non-virtual fields, get the database value and check nullability


### PR DESCRIPTION
Implements #559. Part of #580.

## Problem

In `db: { columns: 'keystone' }` mode, storage `image()`/`file()` fields are stored as multiple part columns on the Prisma model (e.g. `image_url`, `image_filesize`, `image_pathname`, …) with **no** single `image` scalar. But the generated `.opensaas/prisma-extensions.ts` still emitted a result extension with `needs: { image: true }`. Prisma types `needs` against the model's scalar fields, so the literal `true` was typed against `never`:

```
prisma-extensions.ts(354,18): error TS2322: Type 'true' is not assignable to type 'never'.
```

These were the last errors forcing `@ts-nocheck` on the generated bundle.

## Fix

In `packages/cli/src/generator/prisma-extensions.ts`, when a field exposes `getColumnNames` (the multi-column contract that `image()`/`file()` implement in keystone-columns mode):

- `needs` is built from `getColumnNames(fieldName)` — each resolved part column → `true` — instead of `{ [fieldName]: true }`.
- `compute` no longer reads the non-existent logical scalar (`production.image`); it returns `undefined`. The logical value is re-assembled by core's read pipeline (`assembleColumns`) and re-added via `TransformedFields`, so runtime behaviour is unchanged (the scalar was already absent → `undefined`).

### How the part-column names are derived

`getColumnNames` is the single source of truth: it already returns the resolved/overridden physical names (honouring custom `db: { columns: { mode: 'keystone', map: { url: 'custom_name' } } }` maps). The fix derives `needs` directly from it and does **not** hardcode the `_url`/`_pathname`/… suffixes. This mirrors the existing pattern in `packages/cli/src/generator/types.ts`. The emitted `needs` keys exactly match the `@map`-ped columns the Prisma generator produces for the same field.

For an `image` field named `image`:
```
needs: { image_url: true, image_width: true, image_height: true, image_filesize: true, image_contentType: true, image_contentDisposition: true, image_pathname: true }
```
For a `file` field named `doc`:
```
needs: { doc_filename: true, doc_filesize: true, doc_url: true }
```

### Unchanged

- Single-column (non-keystone) storage fields and all other fields still emit `needs: { <fieldName>: true }`.
- Virtual fields still emit `needs: {}`.

## Tests

Added `packages/cli/src/generator/prisma-extensions.test.ts` covering: keystone-mode image and file fields (part columns), custom/overridden column names flowing through `getColumnNames`, single-column fields unchanged, and virtual fields unchanged. Full cli suite: 294 passing. `tsc` (build) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyPQQD4zvAiBFJJyKYhvCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyPQQD4zvAiBFJJyKYhvCH)_