### PR TITLE
feat(cli,core): default ts/esm prisma generator options + db.prismaGeneratorOptions passthrough

### DIFF
--- a/.changeset/prisma-generator-options.md
+++ b/.changeset/prisma-generator-options.md
@@ -1,0 +1,24 @@
+---
+'@opensaas/stack-cli': minor
+'@opensaas/stack-core': minor
+---
+
+Make the generated `.opensaas/prisma-client` subtree statically resolvable by default and add a `db.prismaGeneratorOptions` passthrough.
+
+The generated `generator client { ... }` block now emits `importFileExtension = "ts"` and `moduleFormat = "esm"` by default, so the prisma-client subtree uses explicit `.ts` import extensions and matches the extension style the rest of the `.opensaas` bundle already uses — the whole import graph is statically resolvable by a bundler out of the box, no post-generation surgery required.
+
+A new optional `db.prismaGeneratorOptions` lets you override these values when you need a different module/extension story (e.g. emitting `.js` extensions for a plain-Node consumer). Any value you supply wins; omitted keys fall back to the `ts`/`esm` defaults. The existing `previewFeatures = ["multiSchema"]` emission (when `db.schemas` is set) is preserved and coexists with the new options.
+
+```typescript
+export default config({
+  db: {
+    provider: 'postgresql',
+    prismaGeneratorOptions: {
+      importFileExtension: 'js',
+      moduleFormat: 'commonjs',
+    },
+    // ... rest of config
+  },
+  // ...
+})
+```

--- a/examples/auth-demo/prisma/schema.prisma
+++ b/examples/auth-demo/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/blog/prisma/schema.prisma
+++ b/examples/blog/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/composable-dashboard/prisma/schema.prisma
+++ b/examples/composable-dashboard/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/custom-field/prisma/schema.prisma
+++ b/examples/custom-field/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/file-upload-demo/prisma/schema.prisma
+++ b/examples/file-upload-demo/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/json-demo/prisma/schema.prisma
+++ b/examples/json-demo/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/rag-openai-chatbot/prisma/schema.prisma
+++ b/examples/rag-openai-chatbot/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/starter-auth/prisma/schema.prisma
+++ b/examples/starter-auth/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/starter/prisma/schema.prisma
+++ b/examples/starter/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/examples/tiptap-demo/prisma/schema.prisma
+++ b/examples/tiptap-demo/prisma/schema.prisma
@@ -1,6 +1,8 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
@@ -122,8 +122,10 @@ export const config = getConfig()
 
 exports[`Generate Command Integration > Generator Integration > should generate all files for a basic config > prisma-schema 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -386,8 +388,10 @@ export type Context<TSession extends OpensaasSession = OpensaasSession> = BaseCo
 
 exports[`Generate Command Integration > Generator Integration > should generate consistent output across multiple runs > consistent-output 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -403,8 +407,10 @@ model User {
 
 exports[`Generate Command Integration > Generator Integration > should handle different database providers > mysql-provider 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -415,8 +421,10 @@ datasource db {
 
 exports[`Generate Command Integration > Generator Integration > should handle different database providers > postgresql-provider 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -427,8 +435,10 @@ datasource db {
 
 exports[`Generate Command Integration > Generator Integration > should handle different database providers > sqlite-provider 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -439,8 +449,10 @@ datasource db {
 
 exports[`Generate Command Integration > Generator Integration > should handle empty lists config > empty-lists-schema 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -501,8 +513,10 @@ export type Context<TSession extends OpensaasSession = OpensaasSession> = BaseCo
 
 exports[`Generate Command Integration > Generator Integration > should overwrite existing files > overwrite-after 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -518,8 +532,10 @@ model Post {
 
 exports[`Generate Command Integration > Generator Integration > should overwrite existing files > overwrite-before 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -398,7 +398,7 @@ describe('Generate Command Integration', () => {
       const { paths, crossReferences } = generateWithResolvedPaths(config)
 
       const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
-      expect(schema).toContain(`output   = "${crossReferences.prismaClientOutput}"`)
+      expect(schema).toContain(`output              = "${crossReferences.prismaClientOutput}"`)
 
       // Resolved from the schema file's directory, the output lands inside the
       // configured bundle directory.
@@ -428,7 +428,7 @@ describe('Generate Command Integration', () => {
       expect(fs.existsSync(path.join(tempDir, '.opensaas', 'context.ts'))).toBe(true)
 
       const schema = fs.readFileSync(path.join(tempDir, 'prisma', 'schema.prisma'), 'utf-8')
-      expect(schema).toContain('output   = "../.opensaas/prisma-client"')
+      expect(schema).toContain('output              = "../.opensaas/prisma-client"')
 
       const context = fs.readFileSync(path.join(tempDir, '.opensaas', 'context.ts'), 'utf-8')
       // The default config import carries an explicit `.ts` extension (ADR-0008).
@@ -472,7 +472,7 @@ describe('Generate Command Integration', () => {
       // The prisma client output cross-reference follows opensaasPath, so the
       // emitted schema points at the relocated bundle (no longer a no-op).
       const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
-      expect(schema).toContain('output   = "../.custom/prisma-client"')
+      expect(schema).toContain('output              = "../.custom/prisma-client"')
     })
 
     it('lets output.opensaasDir override opensaasPath when both are set', () => {
@@ -496,7 +496,7 @@ describe('Generate Command Integration', () => {
       expect(fs.existsSync(path.join(tempDir, '.opensaas'))).toBe(false)
 
       const schema = fs.readFileSync(paths.prismaSchema, 'utf-8')
-      expect(schema).toContain('output   = "../generated/opensaas/prisma-client"')
+      expect(schema).toContain('output              = "../generated/opensaas/prisma-client"')
     })
   })
 

--- a/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/prisma.test.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`Prisma Schema Generator > Keystone-compat mode (db.keystoneCompat) > emits @default("") for non-null text without an explicit default (snapshot) 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -24,8 +26,10 @@ model Account {
 
 exports[`Prisma Schema Generator > field defaultValue → @default(...) > generates a representative multi-field model with mixed defaults 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -44,8 +48,10 @@ model Config {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate basic schema with datasource and generator 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -56,8 +62,10 @@ datasource db {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate many-to-one relationship 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -82,8 +90,10 @@ model Post {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate model with basic fields 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -101,8 +111,10 @@ model User {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate model with checkbox field 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -119,8 +131,10 @@ model Post {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate model with timestamp field 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -137,8 +151,10 @@ model Post {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate multiple models 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -164,8 +180,10 @@ model Comment {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should generate one-to-many relationship 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -187,8 +205,10 @@ model Post {
 
 exports[`Prisma Schema Generator > generatePrismaSchema > should use custom opensaasPath for generator output 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.custom-path/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.custom-path/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -199,8 +219,10 @@ datasource db {
 
 exports[`Prisma Schema Generator > select field with enum type > should generate singleton model with bare Int @id (no @default) 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {
@@ -217,8 +239,10 @@ model Settings {
 
 exports[`Prisma Schema Generator > select field with enum type > should match snapshot for enum select field 1`] = `
 "generator client {
-  provider = "prisma-client"
-  output   = "../.opensaas/prisma-client"
+  provider            = "prisma-client"
+  output              = "../.opensaas/prisma-client"
+  importFileExtension = "ts"
+  moduleFormat        = "esm"
 }
 
 datasource db {

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1076,7 +1076,104 @@ describe('Prisma Schema Generator', () => {
 
       const schema = generatePrismaSchema(config)
 
-      expect(schema).toContain('previewFeatures = ["multiSchema"]')
+      expect(schema).toContain('previewFeatures     = ["multiSchema"]')
+      expect(schema).toContain('schemas  = ["public", "auth"]')
+    })
+
+    it('should default importFileExtension="ts" and moduleFormat="esm" in the generator block', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // Defaults make the prisma-client subtree statically resolvable (ADR-0008)
+      expect(schema).toContain('importFileExtension = "ts"')
+      expect(schema).toContain('moduleFormat        = "esm"')
+    })
+
+    it('should honour db.prismaGeneratorOptions overrides for the generator block', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+          prismaGeneratorOptions: {
+            importFileExtension: 'js',
+            moduleFormat: 'commonjs',
+          },
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // User-supplied values win over the ts/esm defaults
+      expect(schema).toContain('importFileExtension = "js"')
+      expect(schema).toContain('moduleFormat        = "commonjs"')
+      expect(schema).not.toContain('importFileExtension = "ts"')
+      expect(schema).not.toContain('moduleFormat        = "esm"')
+    })
+
+    it('should fall back to defaults for any omitted prismaGeneratorOptions key', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+          // Only override the extension; moduleFormat falls back to the default
+          prismaGeneratorOptions: {
+            importFileExtension: 'js',
+          },
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('importFileExtension = "js"')
+      expect(schema).toContain('moduleFormat        = "esm"')
+    })
+
+    it('should emit multiSchema previewFeatures alongside the new generator options', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+          schemas: ['public', 'auth'],
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+            },
+            db: { schema: 'public' },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // The new options coexist with the preserved multiSchema preview feature
+      expect(schema).toContain('importFileExtension = "ts"')
+      expect(schema).toContain('moduleFormat        = "esm"')
+      expect(schema).toContain('previewFeatures     = ["multiSchema"]')
       expect(schema).toContain('schemas  = ["public", "auth"]')
     })
 
@@ -1237,7 +1334,7 @@ describe('Prisma Schema Generator', () => {
       const schema = generatePrismaSchema(config)
 
       // Multi-schema datasource is valid: preview feature + schemas array
-      expect(schema).toContain('previewFeatures = ["multiSchema"]')
+      expect(schema).toContain('previewFeatures     = ["multiSchema"]')
       expect(schema).toContain('schemas  = ["public", "auth"]')
 
       // Auth models pinned to their live table names, in the auth schema
@@ -2160,7 +2257,7 @@ describe('Prisma Schema Generator', () => {
       const schema = generatePrismaSchema(config)
 
       // Datasource is multi-schema
-      expect(schema).toContain('previewFeatures = ["multiSchema"]')
+      expect(schema).toContain('previewFeatures     = ["multiSchema"]')
       expect(schema).toContain('schemas  = ["public", "auth"]')
 
       // The enum block exists and carries @@schema (default public — the list

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -108,12 +108,25 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
   const schemas = config.db.schemas
   const multiSchema = Array.isArray(schemas) && schemas.length > 0
 
+  // Prisma generator options for the `.opensaas/prisma-client` subtree. By
+  // default we emit `importFileExtension = "ts"` and `moduleFormat = "esm"` so
+  // the generated client uses explicit `.ts` import extensions — matching the
+  // rest of the `.opensaas` bundle (ADR-0008) and keeping the whole import graph
+  // statically resolvable by a bundler. A project can override either value via
+  // `db.prismaGeneratorOptions`; any supplied value wins, omitted keys fall back
+  // to the `ts`/`esm` defaults.
+  const prismaGeneratorOptions = config.db.prismaGeneratorOptions
+  const importFileExtension = prismaGeneratorOptions?.importFileExtension ?? 'ts'
+  const moduleFormat = prismaGeneratorOptions?.moduleFormat ?? 'esm'
+
   // Generator and datasource
   lines.push('generator client {')
-  lines.push('  provider = "prisma-client"')
-  lines.push(`  output   = "${clientOutput}"`)
+  lines.push('  provider            = "prisma-client"')
+  lines.push(`  output              = "${clientOutput}"`)
+  lines.push(`  importFileExtension = "${importFileExtension}"`)
+  lines.push(`  moduleFormat        = "${moduleFormat}"`)
   if (multiSchema) {
-    lines.push('  previewFeatures = ["multiSchema"]')
+    lines.push('  previewFeatures     = ["multiSchema"]')
   }
   lines.push('}')
   lines.push('')

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1673,6 +1673,40 @@ export type DatabaseConfig = {
    * ```
    */
   extendPrismaSchema?: (schema: string) => string
+  /**
+   * Override the Prisma `generator client { ... }` options the CLI emits for the
+   * `.opensaas` prisma-client subtree.
+   *
+   * By default the generator emits `importFileExtension = "ts"` and
+   * `moduleFormat = "esm"` so the whole generated bundle is statically
+   * resolvable and matches the explicit `.ts` import-extension style the rest of
+   * the `.opensaas` bundle uses (see ADR-0008). Supply this option only when you
+   * need a different module/extension story (e.g. emitting `.js` extensions for a
+   * Node-only consumer). Any value you provide wins; omitted keys fall back to
+   * the `ts`/`esm` defaults.
+   *
+   * @example Emit `.js` extensions and CommonJS for a plain-Node consumer
+   * ```typescript
+   * db: {
+   *   provider: 'postgresql',
+   *   prismaGeneratorOptions: {
+   *     importFileExtension: 'js',
+   *     moduleFormat: 'commonjs',
+   *   },
+   *   // ... rest of config
+   * }
+   * ```
+   */
+  prismaGeneratorOptions?: {
+    /**
+     * Value for the generator's `importFileExtension` option. Defaults to `'ts'`.
+     */
+    importFileExtension?: 'ts' | 'js'
+    /**
+     * Value for the generator's `moduleFormat` option. Defaults to `'esm'`.
+     */
+    moduleFormat?: 'esm' | 'commonjs'
+  }
 }
 
 /**


### PR DESCRIPTION
Implements #560. Part of #580.

## What

The CLI generator emits the `.opensaas` Prisma client into `.opensaas/prisma-client/**`, but the generated `generator client { ... }` block previously set only `provider`, `output`, and (conditionally) `previewFeatures`. That left the prisma-client subtree using extensionless imports (`./enums`, `./internal/class`) that a bundler can't statically resolve — making the bundle extension-inconsistent out of the box (the rest of the bundle already emits explicit `.ts` import extensions per ADR-0008).

This PR does both halves of the issue's Ask:

1. **Default `importFileExtension = "ts"` and `moduleFormat = "esm"`** in the emitted generator block, so the whole graph is statically resolvable by default and matches the `.ts`-extension style the rest of the bundle uses.
2. **`db.prismaGeneratorOptions` passthrough** — a new optional, strongly-typed field on `DatabaseConfig`:
   ```ts
   prismaGeneratorOptions?: {
     importFileExtension?: 'ts' | 'js'
     moduleFormat?: 'esm' | 'commonjs'
   }
   ```
   threaded into the emission. When provided, the user's values win; when omitted, each falls back to the `ts`/`esm` default.

The existing `previewFeatures = ["multiSchema"]` emission (when `db.schemas` is set) is preserved and coexists with the new options.

```typescript
export default config({
  db: {
    provider: 'postgresql',
    prismaGeneratorOptions: {
      importFileExtension: 'js',
      moduleFormat: 'commonjs',
    },
    // ... rest of config
  },
})
```

## Changes

- `packages/cli/src/generator/prisma.ts` — compute effective `importFileExtension`/`moduleFormat` (override ?? default) and emit each line in the generator block. The block is `=`-aligned to match `prisma format` output.
- `packages/core/src/config/types.ts` — add the optional `prismaGeneratorOptions` field to `DatabaseConfig` with doc comment + example (literal-union typed, no `any`).
- Tests (`prisma.test.ts`): default emission, override honoured, partial-override fallback, and multiSchema previewFeatures coexisting. Updated snapshots and the existing `generate.test.ts`/`previewFeatures` assertions for the new aligned block.
- Regenerated the committed `generator client` block in all 10 example `prisma/schema.prisma` files to match the new generator output (generator block only — model bodies left untouched).
- Changeset (`@opensaas/stack-cli` + `@opensaas/stack-core`, minor).

## Verification

- `pnpm --filter @opensaas/stack-cli test` — 293 passed
- `pnpm --filter @opensaas/stack-core test` — 627 passed
- `pnpm --filter @opensaas/stack-core build` and cli `tsc --noEmit` — clean (the new type compiles)
- `pnpm lint` — 0 errors (pre-existing warnings only), `pnpm format`, `pnpm manypkg fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyPQQD4zvAiBFJJyKYhvCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyPQQD4zvAiBFJJyKYhvCH)_