### PR TITLE
fix(core): update validation no longer rejects omitted required fields under zod 4.4

### DIFF
--- a/.changeset/quiet-otters-fix.md
+++ b/.changeset/quiet-otters-fix.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix update validation rejecting omitted required fields under zod 4.4 by using key-optionality (`.optional()`) instead of `z.union([schema, z.undefined()])`. Partial updates that omit a required-on-create field now validate; present values still enforce their rules.

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -84,7 +84,7 @@ export function text<
           : withMin
 
       if (isRequired && operation === 'update') {
-        return z.union([withMax, z.undefined()])
+        return withMax.optional()
       }
 
       return !isRequired ? withMax.optional().nullable() : withMax
@@ -574,8 +574,8 @@ export function calendarDay<
       if (isRequired && operation === 'create') {
         return dateSchema
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: can be undefined for partial updates
-        return z.union([dateSchema, z.undefined()])
+        // Required in update mode: omitted keys pass; present values must be valid
+        return dateSchema.optional()
       } else {
         return dateSchema.optional().nullable()
       }
@@ -752,13 +752,13 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
             message: `${formatFieldName(fieldName)} is required`,
           })
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: if provided, reject empty strings
-        return z.union([
-          z.string().min(1, {
+        // Required in update mode: omitted keys pass; if provided, reject empty strings
+        return z
+          .string()
+          .min(1, {
             message: `${formatFieldName(fieldName)} is required`,
-          }),
-          z.undefined(),
-        ])
+          })
+          .optional()
       } else {
         // Not required: can be undefined or any string
         return z
@@ -1315,8 +1315,8 @@ export function json<
         // Required in create mode: value must be provided
         return baseSchema
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: can be undefined for partial updates
-        return z.union([baseSchema, z.undefined()])
+        // Required in update mode: omitted keys pass; present values must be valid
+        return baseSchema.optional()
       } else {
         // Not required: can be undefined or null
         return baseSchema.optional().nullable()

--- a/packages/core/src/validation/schema.test.ts
+++ b/packages/core/src/validation/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateZodSchema, validateWithZod } from './schema.js'
 import type { FieldConfig } from '../config/types.js'
-import { text, integer, select } from '../fields/index.js'
+import { text, integer, select, calendarDay, json, password } from '../fields/index.js'
 
 describe('Zod Schema Generation', () => {
   describe('generateZodSchema', () => {
@@ -217,6 +217,114 @@ describe('Zod Schema Generation', () => {
 
       const result = validateWithZod({}, fields, 'update')
       expect(result.success).toBe(true)
+    })
+  })
+
+  // Regression: issue #570
+  // Under zod 4.4, `z.union([schema, z.undefined()])` rejects a MISSING key,
+  // so partial updates that omit a required-on-create field used to throw a
+  // ValidationError before the DB write. Update-shapes must use key-optionality
+  // (`.optional()`) so validation only checks the keys actually present.
+  describe('omitted required field on update (issue #570)', () => {
+    it('passes when a required text field is omitted while another field is present', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+        bio: text(),
+      }
+
+      const result = validateWithZod({ bio: 'hello' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still enforces present-value rules for a required text field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+      }
+
+      // Empty string must still be rejected when the key IS present
+      const result = validateWithZod({ name: '' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('name')
+      }
+    })
+
+    it('still enforces length rules for a required text field present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        title: text({ validation: { isRequired: true, length: { min: 5 } } }),
+      }
+
+      const result = validateWithZod({ title: 'Hi' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors.title).toContain('at least 5 characters')
+      }
+    })
+
+    it('keeps required text fields required on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({}, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('name')
+      }
+    })
+
+    it('allows an omitted required calendarDay field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        startsOn: calendarDay({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still rejects an invalid calendarDay value when present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        startsOn: calendarDay({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ startsOn: 'not-a-date' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('startsOn')
+      }
+    })
+
+    it('allows an omitted required json field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('allows an omitted required password field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        secret: password({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still rejects an empty required password value when present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        secret: password({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ secret: '' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('secret')
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Implements #570. Part of #582.

The update-input validation layer generated the required-on-update field shape with `z.union([fieldSchema, z.undefined()])`. Under zod 4.4 (which the declared `zod ^4.3.6` resolves to in host apps) a union-with-`undefined` accepts an explicit `undefined` value but **rejects a missing key**. As a result, any `context.db.<list>.update({ where, data })` whose `data` omitted a required-on-create field threw a `ValidationError` before the DB write and before any hooks fired — breaking the normal partial-update idiom.

### Fix

Replaced the union-with-undefined update shape with key-optionality (`.optional()`) on the present-value schema, so update validation only checks keys that are actually present. The present-value rules (non-empty / length / format) are preserved; the field is **not** made nullable (omitting is allowed, but passing `null` to clear a required field is not newly introduced). The `create` branch and the non-required `.optional().nullable()` branch are unchanged.

Four built-in field builders in `packages/core/src/fields/index.ts` used this pattern and were all converted:

- `text` — `z.union([withMax, z.undefined()])` → `withMax.optional()`
- `calendarDay` — `z.union([dateSchema, z.undefined()])` → `dateSchema.optional()`
- `password` — multi-line `z.union([ z.string().min(1, …), z.undefined() ])` → `z.string().min(1, …).optional()`
- `json` — `z.union([baseSchema, z.undefined()])` → `baseSchema.optional()`

A grep confirms zero remaining `z.undefined()` occurrences in the file.

### Tests

Added a regression `describe` block in `packages/core/src/validation/schema.test.ts` that exercises the issue through the **real** validation path (`validateWithZod` → `generateZodSchema`, no mocks):

- Omitted required text field on update with another field present → passes.
- Required text field present-but-invalid on update (empty string / too short) → still rejected.
- Required text field on **create** still required (unchanged).
- Omitted required `calendarDay` / `json` / `password` on update → passes; invalid/empty present values still rejected.

### Verification

- `pnpm --filter @opensaas/stack-core build` — passes, no type errors.
- `pnpm --filter @opensaas/stack-core test run` — 650 passed (30 files), including the new regression tests.
- `pnpm lint` — 0 errors (4 pre-existing warnings in unrelated files); `pnpm manypkg fix`; `pnpm format` — clean.

A `patch` changeset for `@opensaas/stack-core` is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_