### PR TITLE
fix(core): make calendarDay a YYYY-MM-DD string end-to-end

### DIFF
--- a/.changeset/calm-otters-glide.md
+++ b/.changeset/calm-otters-glide.md
@@ -9,10 +9,10 @@ both directions, so its type, validation, and runtime value finally agree.
 Previously the field validated a `YYYY-MM-DD` string but its TypeScript type was
 `Date`, so a typed caller passing `new Date(...)` hit a runtime `ValidationError`.
 
-- The field type (entity, `CreateInput`, `UpdateInput`) is now `string`, so
-  passing a `Date` is a compile error.
-- Writes still accept only a `YYYY-MM-DD` string (malformed strings are rejected
-  with a clear message).
+- The field/read type and the generated `CreateInput`/`UpdateInput` input types
+  are now `string`.
+- Writes accept only a `YYYY-MM-DD` string; a malformed string or a `Date` is
+  rejected at runtime by validation (a `ValidationError`).
 - Storage is unchanged: `DateTime @db.Date` on Postgres/MySQL, the SQLite TEXT
   fallback as before.
 

--- a/.changeset/calm-otters-glide.md
+++ b/.changeset/calm-otters-glide.md
@@ -1,0 +1,31 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Make `calendarDay` a `YYYY-MM-DD` string end-to-end (Keystone's CalendarDay scalar)
+
+`calendarDay` is now a `YYYY-MM-DD` **string** at the `context.db` boundary in
+both directions, so its type, validation, and runtime value finally agree.
+Previously the field validated a `YYYY-MM-DD` string but its TypeScript type was
+`Date`, so a typed caller passing `new Date(...)` hit a runtime `ValidationError`.
+
+- The field type (entity, `CreateInput`, `UpdateInput`) is now `string`, so
+  passing a `Date` is a compile error.
+- Writes still accept only a `YYYY-MM-DD` string (malformed strings are rejected
+  with a clear message).
+- Storage is unchanged: `DateTime @db.Date` on Postgres/MySQL, the SQLite TEXT
+  fallback as before.
+
+**Behavioral change (reads):** reading a `calendarDay` now returns a
+`YYYY-MM-DD` string instead of a `Date`. A field `resolveOutput` transform
+normalises the value Prisma returns from the `@db.Date` column, using UTC
+components to avoid timezone off-by-one. Consumers that previously relied on a
+`Date` on read should update to the string form:
+
+```typescript
+const event = await context.db.event.findUnique({ where: { id } })
+event?.startDate // => '2025-01-15' (string, not Date)
+
+// Writes: pass YYYY-MM-DD strings, not Date objects
+await context.db.event.create({ data: { startDate: '2025-01-15' } })
+```

--- a/packages/core/src/fields/calendar-day.test.ts
+++ b/packages/core/src/fields/calendar-day.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { calendarDay } from './index.js'
+import { generateZodSchema, validateWithZod } from '../validation/schema.js'
+import type { FieldConfig } from '../config/types.js'
+
+/**
+ * calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
+ * scalar). Type, validation, and runtime read value must all agree on `string`.
+ * See issue #571.
+ */
+describe('calendarDay field (YYYY-MM-DD string end-to-end)', () => {
+  describe('getTypeScriptType', () => {
+    it('returns string (not Date), driving the entity + input types', () => {
+      const field = calendarDay()
+      expect(field.getTypeScriptType?.()).toEqual({ type: 'string', optional: true })
+    })
+
+    it('is non-optional when required and not nullable', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      expect(field.getTypeScriptType?.()).toEqual({ type: 'string', optional: false })
+    })
+
+    it('type-level: the declared type is the literal "string", so a Date is rejected', () => {
+      const field = calendarDay()
+      const tsType = field.getTypeScriptType?.()
+      // The generated entity/CreateInput/UpdateInput types are emitted from this
+      // literal. Asserting it is exactly 'string' is the type-level guarantee
+      // that a Date input is a compile error (the input field type is `string`).
+      expectTypeOf(tsType).toEqualTypeOf<{ type: string; optional: boolean } | undefined>()
+      if (tsType) {
+        expectTypeOf(tsType.type).toEqualTypeOf<string>()
+        expect(tsType.type).toBe('string')
+        // @ts-expect-error - the runtime type is 'string', never 'Date'
+        const _notDate: 'Date' = tsType.type
+        void _notDate
+      }
+    })
+  })
+
+  describe('getPrismaType (unchanged — stays DateTime @db.Date)', () => {
+    it('keeps DateTime storage with @db.Date on non-sqlite providers', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      const prisma = field.getPrismaType?.('startsOn', 'postgresql')
+      expect(prisma?.type).toBe('DateTime')
+      expect(prisma?.modifiers).toContain('@db.Date')
+    })
+
+    it('omits @db.Date on sqlite (TEXT fallback)', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      const prisma = field.getPrismaType?.('startsOn', 'sqlite')
+      expect(prisma?.type).toBe('DateTime')
+      expect(prisma?.modifiers ?? '').not.toContain('@db.Date')
+    })
+  })
+
+  describe('write validation (string-only)', () => {
+    const fields: Record<string, FieldConfig> = {
+      startsOn: calendarDay({ validation: { isRequired: true } }),
+    }
+
+    it('accepts a valid YYYY-MM-DD string on create', () => {
+      const result = validateWithZod({ startsOn: '2025-01-15' }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a malformed string with a clear message', () => {
+      const result = validateWithZod({ startsOn: '15/01/2025' }, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('startsOn')
+        expect(result.errors.startsOn).toMatch(/YYYY-MM-DD/)
+      }
+    })
+
+    it('rejects a Date instance at runtime (not a string)', () => {
+      // A typed caller cannot reach here (input type is `string`), but the
+      // validator is string-only as a runtime backstop.
+      const result = validateWithZod(
+        { startsOn: new Date('2025-01-15') } as unknown as Record<string, unknown>,
+        fields,
+        'create',
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('zod schema for the field validates the YYYY-MM-DD shape', () => {
+      const schema = generateZodSchema(fields, 'create')
+      expect(schema.safeParse({ startsOn: '2025-12-31' }).success).toBe(true)
+      expect(schema.safeParse({ startsOn: 'nope' }).success).toBe(false)
+    })
+  })
+
+  describe('read transform (resolveOutput returns a YYYY-MM-DD string)', () => {
+    // The read pipeline calls fieldConfig.hooks.resolveOutput({ value, ... }).
+    // We exercise that hook directly with the value shapes Prisma can return.
+    function readValue(value: unknown): unknown {
+      const field = calendarDay()
+      const hook = field.hooks?.resolveOutput
+      if (!hook) throw new Error('calendarDay must define a resolveOutput hook')
+      // Cast to the runtime call shape used by field-visibility.ts.
+      return (hook as unknown as (args: { value: unknown }) => unknown)({ value })
+    }
+
+    it('formats a Date (Postgres/MySQL @db.Date) to YYYY-MM-DD', () => {
+      expect(readValue(new Date('2025-01-15T00:00:00.000Z'))).toBe('2025-01-15')
+    })
+
+    it('is timezone-safe — a late-UTC Date does not drift a day', () => {
+      // 23:59:59Z is the same UTC calendar day; UTC-based formatting keeps it.
+      expect(readValue(new Date('2025-01-15T23:59:59.999Z'))).toBe('2025-01-15')
+    })
+
+    it('passes through an already-formatted string (SQLite TEXT)', () => {
+      expect(readValue('2025-01-15')).toBe('2025-01-15')
+    })
+
+    it('takes the date-only prefix of a full ISO string (SQLite TEXT)', () => {
+      expect(readValue('2025-01-15T00:00:00.000Z')).toBe('2025-01-15')
+    })
+
+    it('passes null/undefined through unchanged', () => {
+      expect(readValue(null)).toBeNull()
+      expect(readValue(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('user-provided hooks are preserved', () => {
+    it('merges a user resolveOutput over the default (last wins)', () => {
+      const field = calendarDay({
+        hooks: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test hook
+          resolveOutput: ({ value }: { value: any }) => `custom:${value}`,
+        },
+      })
+      const hook = field.hooks?.resolveOutput as unknown as (args: { value: unknown }) => unknown
+      expect(hook({ value: '2025-01-15' })).toBe('custom:2025-01-15')
+    })
+  })
+})

--- a/packages/core/src/fields/calendar-day.test.ts
+++ b/packages/core/src/fields/calendar-day.test.ts
@@ -20,12 +20,13 @@ describe('calendarDay field (YYYY-MM-DD string end-to-end)', () => {
       expect(field.getTypeScriptType?.()).toEqual({ type: 'string', optional: false })
     })
 
-    it('type-level: the declared type is the literal "string", so a Date is rejected', () => {
+    it('type-level: the declared type is the literal "string"', () => {
       const field = calendarDay()
       const tsType = field.getTypeScriptType?.()
-      // The generated entity/CreateInput/UpdateInput types are emitted from this
-      // literal. Asserting it is exactly 'string' is the type-level guarantee
-      // that a Date input is a compile error (the input field type is `string`).
+      // The entity/read type and the standalone generated CreateInput/UpdateInput
+      // types are emitted from this literal, so asserting it is exactly 'string'
+      // pins those types to `string`. (At the context.db write path a Date is
+      // rejected at runtime by validation, not at compile time — tracked in #599.)
       expectTypeOf(tsType).toEqualTypeOf<{ type: string; optional: boolean } | undefined>()
       if (tsType) {
         expectTypeOf(tsType.type).toEqualTypeOf<string>()

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -514,11 +514,23 @@ export function timestamp<
 /**
  * Calendar Day field - date only (no time) in ISO8601 format
  *
+ * Mirrors Keystone's `CalendarDay` scalar: the wire format through
+ * `context.db.*` is a `YYYY-MM-DD` **string** in both directions (read and
+ * write). The field's TypeScript type — entity, `CreateInput`, and
+ * `UpdateInput` — is `string`, so passing a `Date` is a compile-time error.
+ *
  * **Features:**
  * - Stores date values only (no time component)
  * - PostgreSQL/MySQL: Uses native DATE type via @db.Date
  * - SQLite: Uses String representation
- * - Accepts ISO8601 date strings (YYYY-MM-DD format)
+ * - **Writes:** accept only a `YYYY-MM-DD` string; a malformed string is
+ *   rejected with a clear message, and a `Date` fails to compile against the
+ *   generated input types.
+ * - **Reads:** always return a `YYYY-MM-DD` string. Even though the underlying
+ *   `@db.Date` column hands Prisma a `Date`, a `resolveOutput` transform
+ *   normalises it back to a `YYYY-MM-DD` string so the runtime value matches
+ *   the declared `string` type. UTC components are used to avoid timezone
+ *   off-by-one errors.
  * - Optional validation for required fields
  * - Database column mapping and nullability control
  * - Index support (boolean or 'unique')
@@ -539,13 +551,17 @@ export function timestamp<
  *   })
  * }
  *
- * // Creating with date values
+ * // Creating with date values — pass YYYY-MM-DD strings (NOT Date objects)
  * const event = await context.db.event.create({
  *   data: {
  *     startDate: '2025-01-15',
  *     endDate: '2025-01-20'
  *   }
  * })
+ *
+ * // Reading — values come back as YYYY-MM-DD strings
+ * const e = await context.db.event.findUnique({ where: { id } })
+ * e?.startDate // => '2025-01-15' (a string, not a Date)
  * ```
  *
  * @param options - Field configuration options
@@ -557,6 +573,19 @@ export function calendarDay<
   return {
     type: 'calendarDay',
     ...options,
+    // Reads: the underlying @db.Date column hands Prisma a Date (or a TEXT
+    // string under the SQLite fallback). Normalise to a YYYY-MM-DD string so the
+    // runtime value matches the declared `string` type. UTC components are used
+    // so the formatting never drifts a day in non-UTC timezones.
+    // Cast hooks to any since field builders are generic and can't know the
+    // specific TFieldKey (same pattern as password()).
+    hooks: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
+      resolveOutput: ({ value }: { value: any }) => formatCalendarDay(value),
+      // Merge with user-provided hooks if any
+      ...options?.hooks,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hook object needs type assertion for field builder
+    } as any,
     getZodSchema: (fieldName: string, operation: 'create' | 'update') => {
       const validation = options?.validation
       const isRequired = validation?.isRequired
@@ -628,12 +657,44 @@ export function calendarDay<
       const isRequired = validation?.isRequired
       const isNullable = db?.isNullable ?? !isRequired
 
+      // calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
+      // scalar). Returning 'string' here flips the entity type AND the generated
+      // CreateInput/UpdateInput types, so passing a Date is a compile error.
       return {
-        type: 'Date',
+        type: 'string',
         optional: isNullable,
       }
     },
   }
+}
+
+/**
+ * Format a stored calendar-day value to a `YYYY-MM-DD` string.
+ *
+ * Handles the value being a `Date` (Postgres/MySQL `@db.Date`), an already
+ * formatted string (SQLite TEXT fallback), or null/undefined. Dates are
+ * formatted from their UTC components so the result never drifts a day in
+ * non-UTC timezones.
+ */
+function formatCalendarDay(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) {
+    return value as null | undefined
+  }
+
+  if (value instanceof Date) {
+    // toISOString() is UTC; the YYYY-MM-DD prefix is timezone-safe.
+    return value.toISOString().slice(0, 10)
+  }
+
+  if (typeof value === 'string') {
+    // SQLite stores DateTime as TEXT. The value may already be YYYY-MM-DD or a
+    // full ISO timestamp — take the date-only prefix either way.
+    return value.slice(0, 10)
+  }
+
+  // Any other shape is unexpected for a @db.Date column; surface it untouched
+  // by returning undefined so callers see the field as absent rather than wrong.
+  return undefined
 }
 
 /**

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -523,9 +523,9 @@ export function timestamp<
  * - Stores date values only (no time component)
  * - PostgreSQL/MySQL: Uses native DATE type via @db.Date
  * - SQLite: Uses String representation
- * - **Writes:** accept only a `YYYY-MM-DD` string; a malformed string is
- *   rejected with a clear message, and a `Date` fails to compile against the
- *   generated input types.
+ * - **Writes:** accept only a `YYYY-MM-DD` string; a malformed string or a
+ *   `Date` is rejected at runtime by validation (a `ValidationError`). Genuine
+ *   compile-time rejection at the `context.db` call site is tracked in #599.
  * - **Reads:** always return a `YYYY-MM-DD` string. Even though the underlying
  *   `@db.Date` column hands Prisma a `Date`, a `resolveOutput` transform
  *   normalises it back to a `YYYY-MM-DD` string so the runtime value matches
@@ -658,8 +658,11 @@ export function calendarDay<
       const isNullable = db?.isNullable ?? !isRequired
 
       // calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
-      // scalar). Returning 'string' here flips the entity type AND the generated
-      // CreateInput/UpdateInput types, so passing a Date is a compile error.
+      // scalar). Returning 'string' here makes the entity/read type and the
+      // standalone generated CreateInput/UpdateInput types `string`. At the
+      // context.db write path a Date is still rejected at runtime by validation
+      // (the generated db method `data` type derives from Prisma's `Date | string`
+      // input — making it a compile-time error is tracked in #599).
       return {
         type: 'string',
         optional: isNullable,


### PR DESCRIPTION
Implements #571. Part of #582.

## Problem

`calendarDay()` was internally contradictory: its zod validation accepts only a `YYYY-MM-DD` string, it stores as `DateTime @db.Date`, but `getTypeScriptType()` returned `Date`. Since the generated `CreateInput`/`UpdateInput` types come from `getTypeScriptType()`, a typed caller passes `new Date(...)` and hits a runtime `ValidationError` before the write — type, validator, and storage boundary disagreed.

## Change

Make `calendarDay` a `YYYY-MM-DD` **string** end-to-end (Keystone's `CalendarDay` scalar) so type, validation, and runtime agree.

- `getTypeScriptType()` now returns `{ type: 'string', optional: isNullable }` (was `'Date'`). This makes the entity/read type **and** the standalone generated `CreateInput`/`UpdateInput` types `string`. At the `context.db` write path a `Date` is rejected at runtime by validation (a `ValidationError`); the generated db method `data` type still derives from Prisma's `Date | string` input, so a `Date` is not a compile-time error at the call site. Making it genuinely compile-time is a separate cross-cutting generator change, tracked in #599.
- `getZodSchema()` keeps the `YYYY-MM-DD` string validation (string + `^\d{4}-\d{2}-\d{2}$` regex with a clear message). The `.optional()` update branch from #570 is left intact.
- Added a field-level `resolveOutput` hook (merged with any user hooks, same pattern as `password()`) that normalises the stored date-only value to a `YYYY-MM-DD` string on read. It handles the value being a `Date` (Postgres/MySQL `@db.Date`), an already-formatted string (SQLite TEXT fallback), or null/undefined. Formatting is **UTC-safe** — a `Date` is formatted via `toISOString().slice(0, 10)` so it never drifts a day in non-UTC timezones; a string takes its date-only prefix.
- `getPrismaType()` unchanged: `DateTime`, with `@db.Date` for non-sqlite providers.
- Updated the JSDoc to document the `YYYY-MM-DD` string wire format in both directions.

## ⚠️ Behavioral change (reads)

Reading a `calendarDay` now returns a `YYYY-MM-DD` **string** instead of a `Date`. Flagged in the changeset (minor bump) with a usage note. Consumers relying on a `Date` on read should switch to the string form.

## Write-time Date rejection (runtime, not compile-time)

Writes accept only a `YYYY-MM-DD` string. A `Date` (or a malformed string) is rejected at runtime by validation (a `ValidationError`) — it is **not** a compile-time error at the `context.db.<list>.create()/update()` call site, because that method's `data` type derives from Prisma's `Date | string` input for a `@db.Date` column. The standalone generated `CreateInput`/`UpdateInput` types are now `string`. Genuine compile-time enforcement at the db call site is tracked in #599.

## Tests

New `packages/core/src/fields/calendar-day.test.ts` covers:
- `getTypeScriptType()` returns `string` (optional per nullability)
- type-level assertion: the declared type literal is exactly `string` (the standalone input/entity types are generated from it) plus a `@ts-expect-error` guard that the type is never `'Date'`
- `getPrismaType()` stays `DateTime @db.Date` (and omits `@db.Date` on sqlite)
- valid `YYYY-MM-DD` write succeeds; malformed string rejected with a `YYYY-MM-DD` message; a `Date` instance rejected at runtime
- read transform returns a `YYYY-MM-DD` string for `Date` and string inputs, is timezone-safe (late-UTC `Date` does not drift), and passes null/undefined through
- user-provided `resolveOutput` hooks are preserved (merge order)

## Verification

- `pnpm --filter @opensaas/stack-core build` — no type errors
- `pnpm --filter @opensaas/stack-core test run` — 665 pass
- `pnpm --filter @opensaas/stack-cli test run` — 308 pass (type/snapshot generator path unaffected; emitted input type for calendarDay is now `string`)
- `pnpm lint` — 0 errors (only pre-existing warnings), `pnpm manypkg fix`, `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_