### PR TITLE
feat(core): gate nested connect by owning relationship field access

### DIFF
--- a/.changeset/silver-foxes-gather.md
+++ b/.changeset/silver-foxes-gather.md
@@ -1,0 +1,24 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Gate nested `connect` by the owning relationship field's field-level access
+
+Nested `connect` (and the connect branch of `connectOrCreate`) is now gated by
+the owning relationship field's create/update field-level access, in addition to
+the target list's read/query access and DB-reachability check. This completes
+the Keystone-parity rule that a connect requires both read access on the target
+AND write access on the owning relationship field. `sudo` bypasses the check.
+
+```typescript
+Post: list({
+  fields: {
+    // A non-sudo caller can only connect an author when this field's
+    // update access permits it (and the target User is readable/reachable).
+    author: relationship({
+      ref: 'User.posts',
+      access: { update: ({ session }) => session?.role === 'editor' },
+    }),
+  },
+})
+```

--- a/docs/content/core-concepts/access-control.md
+++ b/docs/content/core-concepts/access-control.md
@@ -176,6 +176,53 @@ Fields `id`, `createdAt`, `updatedAt` are automatically:
 
 You cannot override access control for system fields.
 
+## Nested `connect` requires read/query access on the target
+
+When a write uses a nested `connect` (or the connect branch of `connectOrCreate`)
+to link an existing related row, the connect is gated by **read/query access on
+the target list**, evaluated against the database. The caller must be able to
+_read_ the row to connect it — a connect references an existing row but does not
+modify its data, so it requires read access on the target, not `update`. The
+owning relationship field's own create/update field-level access (e.g. the
+`access` on `Post.author`) must also permit the write, as with any field.
+
+```typescript
+lists: {
+  Author: list({
+    fields: { name: text() },
+    access: {
+      operation: {
+        // Without a `query` rule, read access is DENY-BY-DEFAULT...
+        update: () => true, // ...even though update is permissive.
+      },
+    },
+  }),
+  Post: list({
+    fields: {
+      title: text(),
+      author: relationship({ ref: 'Author' }),
+    },
+    access: { operation: { query: () => true, update: () => true } },
+  }),
+}
+
+// This nested connect is DENIED, because Author has no `query` rule
+// (deny-by-default), even though Author's `update` is permissive:
+await context.db.post.update({
+  where: { id },
+  data: { author: { connect: { id: authorId } } },
+})
+```
+
+> **Behaviour change / migration note.** Because the access engine is
+> **deny-by-default** for an undefined access rule, a related list that defines a
+> permissive `update` but leaves `query` **undefined** now **denies** nested
+> `connect` (previously such connects were allowed). This is the correct,
+> read-gated direction and is consistent with how normal reads of that list
+> already behave (they return empty). If you rely on connecting to such a list,
+> **define a `query` rule** that permits the connect (for example a permissive
+> `query: () => true` or a scoped filter). `sudo` bypasses the check entirely.
+
 ## Access Control Execution Order
 
 For **write operations** (create/update):

--- a/docs/content/core-concepts/access-control.md
+++ b/docs/content/core-concepts/access-control.md
@@ -176,15 +176,22 @@ Fields `id`, `createdAt`, `updatedAt` are automatically:
 
 You cannot override access control for system fields.
 
-## Nested `connect` requires read/query access on the target
+## Nested `connect` is gated by the owning relationship field's access
 
 When a write uses a nested `connect` (or the connect branch of `connectOrCreate`)
-to link an existing related row, the connect is gated by **read/query access on
-the target list**, evaluated against the database. The caller must be able to
-_read_ the row to connect it — a connect references an existing row but does not
-modify its data, so it requires read access on the target, not `update`. The
-owning relationship field's own create/update field-level access (e.g. the
-`access` on `Post.author`) must also permit the write, as with any field.
+to link an existing related row, the connect is gated by the **owning relationship
+field's create/update field-level access** (e.g. the `access` on `Post.author`),
+evaluated for the enclosing write's operation. If that field's field-level access
+denies the write, the connect is denied — exactly as for any other field on the
+write. This gate receives the same `item` (the row being updated) and `inputData`
+(the write payload) the parent write's field-access check uses, so a rule that
+depends on either evaluates identically wherever the field is enforced.
+
+For context, the connect is **also** gated by **read/query access on the target
+list** (evaluated against the database): the caller must be able to _read_ the row
+to connect it, because a connect references an existing row but does not modify its
+data, so it requires read access on the target, not `update`. Both checks must pass
+for a connect to succeed.
 
 ```typescript
 lists: {

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -1,6 +1,7 @@
 import type { OpenSaasConfig, ListConfig, FieldConfig } from '../config/types.js'
-import type { AccessContext } from '../access/types.js'
+import type { AccessContext, FieldAccess } from '../access/types.js'
 import { checkAccess, filterWritableFields, getRelatedListConfig } from '../access/index.js'
+import { checkFieldAccess } from '../access/field-access.js'
 import {
   executeResolveInput,
   executeValidate,
@@ -409,6 +410,14 @@ async function processNestedCreate(
  * `none`/`not`). The existence check is folded into the reachability query so a
  * non-existent id is still denied.
  *
+ * In ADDITION to the target read/reachability check (#578), the OWNING
+ * relationship field's field-level access (its `create`/`update` access on the
+ * list being written, e.g. `Post.author`) must permit the connect (#588). This
+ * is the other half Keystone required: a connect needs read access on the
+ * target AND write access on the owning relationship field. If the owning
+ * field's field-level access denies, the connect is denied even when the target
+ * row is readable/reachable.
+ *
  * Sudo bypasses the entire check (handled by the caller).
  */
 async function verifyConnectReachable(
@@ -418,10 +427,26 @@ async function verifyConnectReachable(
   relatedListConfig: ListConfig<any>,
   context: AccessContext,
   prisma: unknown,
+  owningFieldAccess: FieldAccess | undefined,
+  enclosingOperation: 'create' | 'update',
 ): Promise<void> {
   // Access Prisma model dynamically - required because model names are generated at runtime
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const model = (prisma as any)[getDbKey(relatedListName)]
+
+  // #588 — gate the connect by the OWNING relationship field's field-level
+  // access (evaluated for the enclosing write's operation). This runs in
+  // addition to the target read/reachability check below; a deny here denies
+  // the connect even if the target row is readable. `checkFieldAccess` returns
+  // `true` under sudo, but the caller already skips this whole function for
+  // sudo, so the gate never fires for trusted writes.
+  const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
+    session: context.session,
+    context,
+  })
+  if (!owningFieldAllowed) {
+    throw new Error('Access denied: Cannot connect to this item')
+  }
 
   // Connecting references an existing row; it requires READ (query) access on
   // the target, not update access.
@@ -461,7 +486,8 @@ async function verifyConnectReachable(
 
 /**
  * Process nested connect operations.
- * Verifies read (query) access to the items being connected via DB reachability.
+ * Verifies read (query) access to the items being connected via DB reachability
+ * AND the owning relationship field's field-level access (#588).
  */
 async function processNestedConnect(
   connections: Record<string, unknown> | Array<Record<string, unknown>>,
@@ -470,13 +496,23 @@ async function processNestedConnect(
   relatedListConfig: ListConfig<any>,
   context: AccessContext,
   prisma: unknown,
+  owningFieldAccess: FieldAccess | undefined,
+  enclosingOperation: 'create' | 'update',
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const connectionsArray = Array.isArray(connections) ? connections : [connections]
 
   // Check read access for each item being connected (skip if sudo mode)
   if (!context._isSudo) {
     for (const connection of connectionsArray) {
-      await verifyConnectReachable(connection, relatedListName, relatedListConfig, context, prisma)
+      await verifyConnectReachable(
+        connection,
+        relatedListName,
+        relatedListConfig,
+        context,
+        prisma,
+        owningFieldAccess,
+        enclosingOperation,
+      )
     }
   }
 
@@ -809,6 +845,8 @@ async function processNestedConnectOrCreate(
   prisma: unknown,
   afterTasks: AfterTask[],
   recovery: CreatedRowRecovery,
+  owningFieldAccess: FieldAccess | undefined,
+  enclosingOperation: 'create' | 'update',
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const operationsArray = Array.isArray(operations) ? operations : [operations]
 
@@ -821,9 +859,10 @@ async function processNestedConnectOrCreate(
       // connectOrCreate connects an existing row when present, otherwise
       // creates. So when the row exists we apply the same connect semantics as
       // processNestedConnect — READ (query) access on the target, evaluated via
-      // DB reachability for filter results. When the row does not exist we fall
-      // through to create. We must NOT swallow an access-denied error: only the
-      // genuine "row absent" case may fall back to create.
+      // DB reachability for filter results, PLUS the owning relationship field's
+      // field-level access (#588). When the row does not exist we fall through to
+      // create. We must NOT swallow an access-denied error: only the genuine
+      // "row absent" case may fall back to create.
       let rowExists = false
       if (!context._isSudo) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -836,6 +875,18 @@ async function processNestedConnectOrCreate(
         // the create branch is used.
         if (existingItem) {
           rowExists = true
+
+          // #588 — gate the connect branch by the OWNING relationship field's
+          // field-level access, identical to processNestedConnect. A deny here
+          // denies the connect even if the target row is readable/reachable.
+          const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
+            session: context.session,
+            context,
+          })
+          if (!owningFieldAllowed) {
+            throw new Error('Access denied: Cannot connect to existing item')
+          }
+
           const queryAccess = relatedListConfig.access?.operation?.query
           const accessResult = await checkAccess(queryAccess, {
             session: context.session,
@@ -902,6 +953,17 @@ interface NestedOpHandlerArgs {
   relatedListName: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   relatedListConfig: ListConfig<any>
+  /**
+   * Field-level `access` of the OWNING relationship field on the list being
+   * written (e.g. `Post.author`). Used by the connect/connectOrCreate handlers
+   * to gate connects by the owning field's create/update access (#588).
+   */
+  owningFieldAccess: FieldAccess | undefined
+  /**
+   * The enclosing write's operation (`create`/`update`), used as the field-access
+   * operation for the owning-field connect gate (#588).
+   */
+  enclosingOperation: 'create' | 'update'
   context: AccessContext
   config: OpenSaasConfig
   /** Prisma client used for dynamic model access during access checks. */
@@ -989,13 +1051,23 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
   },
   connect: {
     needsInclude: false,
-    execute: ({ value, relatedListName, relatedListConfig, context, prisma }) =>
+    execute: ({
+      value,
+      relatedListName,
+      relatedListConfig,
+      context,
+      prisma,
+      owningFieldAccess,
+      enclosingOperation,
+    }) =>
       processNestedConnect(
         value as Record<string, unknown> | Array<Record<string, unknown>>,
         relatedListName,
         relatedListConfig,
         context,
         prisma,
+        owningFieldAccess,
+        enclosingOperation,
       ),
   },
   connectOrCreate: {
@@ -1010,6 +1082,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
       prisma,
       afterTasks,
       recovery,
+      owningFieldAccess,
+      enclosingOperation,
     }) =>
       processNestedConnectOrCreate(
         value as Record<string, unknown> | Array<Record<string, unknown>>,
@@ -1021,6 +1095,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
         prisma,
         afterTasks,
         requireRecovery(recovery, 'connectOrCreate'),
+        owningFieldAccess,
+        enclosingOperation,
       ),
   },
   update: {
@@ -1186,12 +1262,20 @@ export async function processNestedOperations(
     // Sanity: ensure the resolved list name matches the config identity.
     const resolvedListName = relatedListName || findListName(relatedListConfig, config)
 
+    // #588 — the owning relationship field's field-level access (e.g. the
+    // `access` on `Post.author`). Threaded into the nested-op handlers so the
+    // connect/connectOrCreate handlers can gate connects by this field's
+    // create/update access, in addition to the target's read access.
+    const owningFieldAccess = fieldConfig.access
+
     processed[fieldName] = await processFieldNestedOps(
       fieldName,
       value as Record<string, unknown>,
       {
         relatedListName: resolvedListName,
         relatedListConfig,
+        owningFieldAccess,
+        enclosingOperation: operation,
         context,
         config,
         prisma: context.prisma,

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -322,6 +322,9 @@ async function processNestedCreate(
         'create',
         relatedListName,
         undefined,
+        // This nested row is being CREATED, so its enclosing inputData is its own
+        // create payload (passed to the connect-site owning-field gate, #588).
+        item,
       )
 
       // 8. Field-level beforeOperation (side effects) for this nested create
@@ -429,6 +432,8 @@ async function verifyConnectReachable(
   prisma: unknown,
   owningFieldAccess: FieldAccess | undefined,
   enclosingOperation: 'create' | 'update',
+  enclosingItem: Record<string, unknown> | undefined,
+  enclosingInputData: Record<string, unknown> | undefined,
 ): Promise<void> {
   // Access Prisma model dynamically - required because model names are generated at runtime
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -440,8 +445,16 @@ async function verifyConnectReachable(
   // the connect even if the target row is readable. `checkFieldAccess` returns
   // `true` under sudo, but the caller already skips this whole function for
   // sudo, so the gate never fires for trusted writes.
+  //
+  // `item`/`inputData` are the ENCLOSING write's `originalItem`/`inputData` —
+  // the SAME values the canonical Phase-5 `filterWritableFields` call passes for
+  // this field — so a field-access rule that depends on `item` or `inputData`
+  // (e.g. `({ item }) => item.status === 'draft'`) evaluates identically here and
+  // at Phase 5, and the two gates cannot diverge into a spurious connect denial.
   const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
     session: context.session,
+    item: enclosingItem,
+    inputData: enclosingInputData,
     context,
   })
   if (!owningFieldAllowed) {
@@ -498,6 +511,8 @@ async function processNestedConnect(
   prisma: unknown,
   owningFieldAccess: FieldAccess | undefined,
   enclosingOperation: 'create' | 'update',
+  enclosingItem: Record<string, unknown> | undefined,
+  enclosingInputData: Record<string, unknown> | undefined,
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const connectionsArray = Array.isArray(connections) ? connections : [connections]
 
@@ -512,6 +527,8 @@ async function processNestedConnect(
         prisma,
         owningFieldAccess,
         enclosingOperation,
+        enclosingItem,
+        enclosingInputData,
       )
     }
   }
@@ -644,6 +661,9 @@ async function processNestedUpdate(
         'update',
         relatedListName,
         originalItem,
+        // This nested row is being UPDATED, so its enclosing inputData is its own
+        // update payload (passed to the connect-site owning-field gate, #588).
+        updateData,
       )
 
       // Field-level beforeOperation (side effects)
@@ -847,6 +867,8 @@ async function processNestedConnectOrCreate(
   recovery: CreatedRowRecovery,
   owningFieldAccess: FieldAccess | undefined,
   enclosingOperation: 'create' | 'update',
+  enclosingItem: Record<string, unknown> | undefined,
+  enclosingInputData: Record<string, unknown> | undefined,
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const operationsArray = Array.isArray(operations) ? operations : [operations]
 
@@ -879,8 +901,14 @@ async function processNestedConnectOrCreate(
           // #588 — gate the connect branch by the OWNING relationship field's
           // field-level access, identical to processNestedConnect. A deny here
           // denies the connect even if the target row is readable/reachable.
+          // `item`/`inputData` are the ENCLOSING write's `originalItem`/
+          // `inputData` (the same values Phase-5 `filterWritableFields` passes),
+          // so item-/inputData-dependent field rules cannot diverge between the
+          // two gates.
           const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
             session: context.session,
+            item: enclosingItem,
+            inputData: enclosingInputData,
             context,
           })
           if (!owningFieldAllowed) {
@@ -964,6 +992,20 @@ interface NestedOpHandlerArgs {
    * operation for the owning-field connect gate (#588).
    */
   enclosingOperation: 'create' | 'update'
+  /**
+   * The enclosing write's existing row (the parent `originalItem`): present for an
+   * enclosing UPDATE, `undefined` for an enclosing CREATE. Threaded into the
+   * connect-site owning-field gate so it evaluates `item` exactly like the
+   * canonical Phase-5 `filterWritableFields` call and the two cannot diverge
+   * (#588 finding).
+   */
+  enclosingItem: Record<string, unknown> | undefined
+  /**
+   * The enclosing write's input data. Threaded into the connect-site owning-field
+   * gate so it evaluates `inputData` exactly like the canonical Phase-5
+   * `filterWritableFields` call (#588 finding).
+   */
+  enclosingInputData: Record<string, unknown> | undefined
   context: AccessContext
   config: OpenSaasConfig
   /** Prisma client used for dynamic model access during access checks. */
@@ -1059,6 +1101,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
       prisma,
       owningFieldAccess,
       enclosingOperation,
+      enclosingItem,
+      enclosingInputData,
     }) =>
       processNestedConnect(
         value as Record<string, unknown> | Array<Record<string, unknown>>,
@@ -1068,6 +1112,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
         prisma,
         owningFieldAccess,
         enclosingOperation,
+        enclosingItem,
+        enclosingInputData,
       ),
   },
   connectOrCreate: {
@@ -1084,6 +1130,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
       recovery,
       owningFieldAccess,
       enclosingOperation,
+      enclosingItem,
+      enclosingInputData,
     }) =>
       processNestedConnectOrCreate(
         value as Record<string, unknown> | Array<Record<string, unknown>>,
@@ -1097,6 +1145,8 @@ const nestedOpRegistry: Record<string, NestedOpHandler> = {
         requireRecovery(recovery, 'connectOrCreate'),
         owningFieldAccess,
         enclosingOperation,
+        enclosingItem,
+        enclosingInputData,
       ),
   },
   update: {
@@ -1228,6 +1278,11 @@ export async function processNestedOperations(
   operation: 'create' | 'update',
   parentListName: string,
   parentOriginalItem: Record<string, unknown> | undefined,
+  // The enclosing write's input data (the SAME value Phase-5 `filterWritableFields`
+  // passes as `inputData`). Threaded into the connect-site owning-field gate (#588
+  // finding) so item-/inputData-dependent field-access rules cannot diverge between
+  // Phase 5 and the connect site. `undefined` is tolerated (defaults to `{}`).
+  parentInputData: Record<string, unknown> | undefined = undefined,
   depth: number = 0,
 ): Promise<NestedOpsResult> {
   const MAX_DEPTH = 5
@@ -1276,6 +1331,12 @@ export async function processNestedOperations(
         relatedListConfig,
         owningFieldAccess,
         enclosingOperation: operation,
+        // The enclosing write's `originalItem`/`inputData` — the SAME values the
+        // canonical Phase-5 `filterWritableFields` call passes for this field — so
+        // the connect-site owning-field gate evaluates item-/inputData-dependent
+        // rules identically and cannot diverge into a spurious connect denial (#588).
+        enclosingItem: parentOriginalItem,
+        enclosingInputData: parentInputData ?? {},
         context,
         config,
         prisma: context.prisma,

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -344,6 +344,11 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
     writeOp,
     listName,
     originalItem,
+    // Pass the enclosing write's `inputData` (the SAME value the Phase-5
+    // `filterWritableFields` call above uses) so the connect-site owning-field
+    // gate evaluates item-/inputData-dependent field rules identically to Phase 5
+    // and the two cannot diverge into a spurious connect denial (#588 finding).
+    input,
   )
 
   // ── Phase 6: field-level beforeOperation (side effects only) ────────────────

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { getContext } from '../src/context/index.js'
 import { config, list } from '../src/config/index.js'
 import { text, relationship } from '../src/fields/index.js'
+import { checkFieldAccess } from '../src/access/field-access.js'
 
 /**
  * Mock Prisma Client for testing
@@ -1819,6 +1820,165 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       expect(result).toBeDefined()
       expect(mockPrisma.student.create).toHaveBeenCalled()
+    })
+
+    // #588 finding — the connect-site owning-field gate must receive the SAME
+    // `item`/`inputData` the canonical Phase-5 `filterWritableFields` call passes,
+    // so a field-access rule that depends on `item`/`inputData` cannot be ALLOWED
+    // by Phase 5 yet DENIED at the connect site (a spurious denial). With those
+    // values threaded, an item-/inputData-dependent rule that resolves to ALLOW at
+    // Phase 5 also resolves to ALLOW at the connect site, so the legitimate connect
+    // succeeds. (#568's Phase-5 gate is the first line of defense and evaluates the
+    // identical rule with the identical values; this test pins that the connect-site
+    // gate does not diverge from it.)
+    it('does not spuriously deny: owning-field access depending on item/inputData allows the connect (enclosing UPDATE)', async () => {
+      const owningUpdate = vi.fn(
+        ({ item, inputData }: { item?: { status?: string }; inputData?: { title?: string } }) =>
+          // Depends on BOTH the existing row (`item`) and the write payload
+          // (`inputData`). If the connect-site gate were called without these, it
+          // would throw on `item.status`/`inputData.title` and the legitimate
+          // connect would fail spuriously.
+          item?.status === 'draft' && inputData?.title === 'Updated',
+      )
+
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              author: relationship({
+                ref: 'User.posts',
+                access: {
+                  // Item-/inputData-dependent: allowed only when editing a draft
+                  // and setting title to 'Updated'.
+                  update: owningUpdate,
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      // Existing row is a draft → the item-dependent rule allows.
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: '1',
+        title: 'Original Title',
+        status: 'draft',
+      })
+      mockPrisma.user.findUnique.mockResolvedValue({ id: '2', name: 'John Doe' })
+      mockPrisma.post.update.mockResolvedValue({ id: '1', title: 'Updated', authorId: '2' })
+
+      const context = getContext(await testConfig, mockPrisma, { userId: '1' })
+
+      const result = await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          title: 'Updated',
+          author: { connect: { id: '2' } },
+        },
+      })
+
+      // No spurious denial: the connect succeeded.
+      expect(result).toBeDefined()
+      expect(mockPrisma.post.update).toHaveBeenCalled()
+      // Owning field allowed → fall through to the #578 target existence check.
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({ where: { id: '2' } })
+
+      // The gate was evaluated with the enclosing write's `item` (the draft
+      // originalItem) and `inputData` (the update payload) — the same values
+      // Phase-5 uses — proving the two evaluations cannot diverge.
+      const sawItemAndInput = owningUpdate.mock.calls.some(
+        ([arg]) => arg?.item?.status === 'draft' && arg?.inputData?.title === 'Updated',
+      )
+      expect(sawItemAndInput).toBe(true)
+    })
+  })
+
+  // Focused unit test of the connect-site gate's evaluator (#588 finding).
+  //
+  // The connect-site gate calls the SHARED `checkFieldAccess` evaluator with the
+  // enclosing write's `item`/`inputData`. #568 (Phase-5 `filterWritableFields`) is
+  // the first line of defense and calls the same evaluator with the same values,
+  // so an end-to-end sole-connect-site DENY is not separately constructible. This
+  // test therefore pins the evaluator directly: with `item`/`inputData` provided
+  // it honours an item-/inputData-dependent rule (DENY and ALLOW branches), which
+  // is exactly the contract the connect-site gate now relies on.
+  describe('Connect-site field gate evaluator honours item/inputData (#588)', () => {
+    it('DENIES when the item-/inputData-dependent rule resolves false', async () => {
+      const access = {
+        update: ({
+          item,
+          inputData,
+        }: {
+          item?: { status?: string }
+          inputData?: { title?: string }
+        }) => item?.status === 'draft' && inputData?.title === 'Updated',
+      }
+      const ctx = getContext(
+        await config({
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: { User: list({ fields: { name: text() } }) },
+        }),
+        mockPrisma,
+        { userId: '1' },
+      )
+
+      const allowed = await checkFieldAccess(access, 'update', {
+        session: ctx.session,
+        item: { status: 'published' }, // not a draft → rule is false
+        inputData: { title: 'Updated' },
+        context: ctx,
+      })
+      expect(allowed).toBe(false)
+    })
+
+    it('ALLOWS when the item-/inputData-dependent rule resolves true', async () => {
+      const access = {
+        update: ({
+          item,
+          inputData,
+        }: {
+          item?: { status?: string }
+          inputData?: { title?: string }
+        }) => item?.status === 'draft' && inputData?.title === 'Updated',
+      }
+      const ctx = getContext(
+        await config({
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: { User: list({ fields: { name: text() } }) },
+        }),
+        mockPrisma,
+        { userId: '1' },
+      )
+
+      const allowed = await checkFieldAccess(access, 'update', {
+        session: ctx.session,
+        item: { status: 'draft' },
+        inputData: { title: 'Updated' },
+        context: ctx,
+      })
+      expect(allowed).toBe(true)
     })
   })
 

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -1397,6 +1397,431 @@ describe('Nested Operations - Access Control and Hooks', () => {
     })
   })
 
+  // #588 — nested connect must ALSO be gated by the OWNING relationship field's
+  // field-level access (the `access` on the relationship field of the list being
+  // written, e.g. `Post.author`), in addition to the target read-access + DB
+  // reachability check from #578. A deny on the owning field denies the connect
+  // even when the target row is fully readable/reachable.
+  //
+  // NOTE: the owning relationship field's create/update access is enforced at two
+  // points for a write that names the relationship key: (1) the parent write's
+  // own `filterWritableFields` gate (#568), which fires FIRST and fail-louds with
+  // a "Cannot create/update <field>" ValidationError, and (2) the connect-site
+  // gate added here (#588), which fail-louds with "Access denied: Cannot
+  // connect…". For the standard nested-connect payload #568 short-circuits, so
+  // these deny tests assert the write is denied fail-loud (and never persisted)
+  // rather than pinning the exact layer. The ALLOW + sudo tests below exercise
+  // the connect-site gate's pass-through behaviour directly.
+  const OWNING_FIELD_DENIES = /field-level access denied|Cannot connect/
+
+  describe('Owning-field field-level access gate on nested connect (#588)', () => {
+    it('denies connect (enclosing UPDATE) when the owning field update access is denied, even though target is readable/reachable', async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true, // target fully readable
+                update: () => true,
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              // Owning relationship field denies update-time writes.
+              author: relationship({
+                ref: 'User.posts',
+                access: {
+                  update: () => false,
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.post.findUnique.mockResolvedValue({ id: '1', title: 'Original Title' })
+      // Target row is readable (query=true) and exists.
+      mockPrisma.user.findUnique.mockResolvedValue({ id: '2', name: 'John Doe' })
+
+      const context = getContext(await testConfig, mockPrisma, { userId: '1' })
+
+      await expect(
+        context.db.post.update({
+          where: { id: '1' },
+          data: {
+            author: { connect: { id: '2' } },
+          },
+        }),
+      ).rejects.toThrow(OWNING_FIELD_DENIES)
+
+      expect(mockPrisma.post.update).not.toHaveBeenCalled()
+      // Denied owning field short-circuits before the target row is touched.
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled()
+    })
+
+    it('denies connect (enclosing CREATE) when the owning field create access is denied, even though target is readable/reachable', async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true, // target fully readable
+                create: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              // Owning relationship field denies create-time writes.
+              account: relationship({
+                ref: 'Account',
+                access: {
+                  create: () => false,
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      await expect(
+        context.db.student.create({
+          data: {
+            name: 'Kid',
+            account: { connect: { id: 'acc-1' } },
+          },
+        }),
+      ).rejects.toThrow(OWNING_FIELD_DENIES)
+
+      expect(mockPrisma.student.create).not.toHaveBeenCalled()
+      expect(mockPrisma.account.findUnique).not.toHaveBeenCalled()
+    })
+
+    it('allows connect when the owning field access permits and the target row is reachable (enclosing UPDATE)', async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              author: relationship({
+                ref: 'User.posts',
+                access: {
+                  update: () => true, // owning field permits
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.post.findUnique.mockResolvedValue({ id: '1', title: 'Original Title' })
+      mockPrisma.user.findUnique.mockResolvedValue({ id: '2', name: 'John Doe' })
+      mockPrisma.post.update.mockResolvedValue({ id: '1', title: 'Original Title', authorId: '2' })
+
+      const context = getContext(await testConfig, mockPrisma, { userId: '1' })
+
+      const result = await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          author: { connect: { id: '2' } },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.post.update).toHaveBeenCalled()
+      // Owning field allowed → fall through to the #578 target existence check.
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({ where: { id: '2' } })
+    })
+
+    it('sudo bypasses the owning-field gate (denied owning field, connect still succeeds)', async () => {
+      const owningFieldUpdate = vi.fn(() => false as const)
+
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => false,
+                update: () => false,
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              author: relationship({
+                ref: 'User.posts',
+                access: {
+                  update: owningFieldUpdate, // would deny
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.post.findUnique.mockResolvedValue({ id: '1', title: 'Original Title' })
+      mockPrisma.post.update.mockResolvedValue({ id: '1', title: 'Original Title', authorId: '2' })
+
+      const context = getContext(await testConfig, mockPrisma, { userId: '1' }).sudo()
+
+      const result = await context.db.post.update({
+        where: { id: '1' },
+        data: {
+          author: { connect: { id: '2' } },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.post.update).toHaveBeenCalled()
+      // Sudo skips the whole connect check: neither the owning-field access fn
+      // nor the target reachability/existence read run.
+      expect(owningFieldUpdate).not.toHaveBeenCalled()
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled()
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled()
+    })
+
+    it("connectOrCreate's connect branch is gated by the owning field access (denied → throws, existing row)", async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true, // target readable
+                create: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({
+                ref: 'Account',
+                access: {
+                  create: () => false, // owning field denies on create
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        // Row exists and is reachable, but the owning field gate must still deny.
+        findUnique: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      await expect(
+        context.db.student.create({
+          data: {
+            name: 'Kid',
+            account: {
+              connectOrCreate: {
+                where: { id: 'acc-1' },
+                create: { name: 'New Account' },
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow(OWNING_FIELD_DENIES)
+
+      expect(mockPrisma.student.create).not.toHaveBeenCalled()
+      // Denied owning field short-circuits before the target reachability re-check.
+      expect(mockPrisma.account.findFirst).not.toHaveBeenCalled()
+    })
+
+    it("connectOrCreate's connect branch succeeds when the owning field access permits a reachable existing row", async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          Account: list({
+            fields: {
+              name: text(),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+                update: () => true,
+              },
+            },
+          }),
+          Student: list({
+            fields: {
+              name: text(),
+              account: relationship({
+                ref: 'Account',
+                access: {
+                  create: () => true, // owning field permits
+                },
+              }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                create: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.account = {
+        findUnique: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'acc-1', name: 'My Account' }),
+        findMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+      mockPrisma.student = {
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn().mockResolvedValue({ id: 's1', name: 'Kid', accountId: 'acc-1' }),
+        update: vi.fn(),
+        delete: vi.fn(),
+        count: vi.fn(),
+      }
+
+      const context = getContext(await testConfig, mockPrisma, { userId: 'user-1' })
+
+      const result = await context.db.student.create({
+        data: {
+          name: 'Kid',
+          account: {
+            connectOrCreate: {
+              where: { id: 'acc-1' },
+              create: { name: 'New Account' },
+            },
+          },
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(mockPrisma.student.create).toHaveBeenCalled()
+    })
+  })
+
   describe('Async resolveOutput Hooks', () => {
     it('should await async resolveOutput hooks for regular fields', async () => {
       const asyncResolveOutputHook = vi.fn(async ({ value }) => {


### PR DESCRIPTION
Implements #588. Part of #581. Follows #578.

## Summary

#578 made nested `connect` use the **target** list's read/query access plus a DB-reachability check. This PR adds the other half Keystone required: the **owning relationship field's field-level access** gate.

A nested `connect` (and the connect branch of `connectOrCreate`) is now denied unless **both**:
1. the target list's read/query access permits reading the row (existing #578 check, evaluated in the DB), **and**
2. the owning relationship field's create/update field-level access permits the write (new, #588) — evaluated for the enclosing write's operation (`create`/`update`) via the shared `checkFieldAccess` evaluator.

`sudo` bypasses the entire check, as before.

## How the owning field access is threaded

- `NestedOpHandlerArgs` now carries `owningFieldAccess: FieldAccess | undefined` and `enclosingOperation: 'create' | 'update'`.
- `processNestedOperations` already iterates `fieldConfigs` per relationship field, so it reads `fieldConfig.access` (the owning field's field-level access, e.g. `Post.author`) and passes it — together with its own `operation` — into the per-field `args` handed to `processFieldNestedOps`. Those flow through `...args` to the `connect` / `connectOrCreate` handlers unchanged.
- `verifyConnectReachable` (used by `processNestedConnect`) and the connect branch of `processNestedConnectOrCreate` call `checkFieldAccess(owningFieldAccess, enclosingOperation, { session, context })` first; a deny throws the existing connect-denied error. The #578 target read-access + DB-reachability behaviour is unchanged and still runs.

No `// TODO(#578)` breadcrumb existed in `verifyConnectReachable` (already removed on a prior PR), so no cleanup was needed there.

### Note on layering (finding)

The owning relationship field's field-level access is **also** enforced one step earlier by the parent write's `filterWritableFields` gate (#568), which fires before nested-op processing whenever the write names the relationship key. For the standard nested-connect payload that gate short-circuits first (with a `Cannot create/update <field>` error). The connect-site gate added here is the same check applied at the connect site (defense-in-depth and exactly what #588 asked to thread through the handler). The deny tests therefore assert the write is denied fail-loud and never persisted; the allow/sudo tests exercise the connect-site gate's pass-through directly.

## Docs

Added a "Nested `connect` requires read/query access on the target" section to `docs/content/core-concepts/access-control.md`, including the deny-by-default migration note: a related list with an undefined `query` but permissive `update` now denies nested connect and must define a `query` rule to permit it.

## Tests

New describe block in `packages/core/tests/nested-access-and-hooks.test.ts`:
- owning field DENIES connect for enclosing **update** and **create** (target readable/reachable) → write denied, not persisted;
- owning field ALLOWS → connect succeeds for a reachable row;
- **sudo** bypasses the gate;
- `connectOrCreate` connect branch gated identically (deny + allow);
- existing #578 nested-filter reachability tests still pass.

## Verification

- `pnpm lint`: 0 errors (4 pre-existing warnings, none in changed files).
- `pnpm manypkg fix`, `pnpm format`: clean.
- Build: all 11 packages.
- Full unit suites green: core 647, cli 308, auth 133, create-opensaas-app 41 (+2 skipped), rag 356, storage 123, storage-s3 43, storage-vercel 30, ui 190.
- Changeset: `@opensaas/stack-core` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016UunWbhcwnhaWUctwXJ8MJ)_