### PR TITLE
Release: Validation &amp; field-type input parity (zod 4.4 + calendarDay) — PRD #582

### DIFF
--- a/.changeset/calm-otters-glide.md
+++ b/.changeset/calm-otters-glide.md
@@ -1,0 +1,31 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Make `calendarDay` a `YYYY-MM-DD` string end-to-end (Keystone's CalendarDay scalar)
+
+`calendarDay` is now a `YYYY-MM-DD` **string** at the `context.db` boundary in
+both directions, so its type, validation, and runtime value finally agree.
+Previously the field validated a `YYYY-MM-DD` string but its TypeScript type was
+`Date`, so a typed caller passing `new Date(...)` hit a runtime `ValidationError`.
+
+- The field/read type and the generated `CreateInput`/`UpdateInput` input types
+  are now `string`.
+- Writes accept only a `YYYY-MM-DD` string; a malformed string or a `Date` is
+  rejected at runtime by validation (a `ValidationError`).
+- Storage is unchanged: `DateTime @db.Date` on Postgres/MySQL, the SQLite TEXT
+  fallback as before.
+
+**Behavioral change (reads):** reading a `calendarDay` now returns a
+`YYYY-MM-DD` string instead of a `Date`. A field `resolveOutput` transform
+normalises the value Prisma returns from the `@db.Date` column, using UTC
+components to avoid timezone off-by-one. Consumers that previously relied on a
+`Date` on read should update to the string form:
+
+```typescript
+const event = await context.db.event.findUnique({ where: { id } })
+event?.startDate // => '2025-01-15' (string, not Date)
+
+// Writes: pass YYYY-MM-DD strings, not Date objects
+await context.db.event.create({ data: { startDate: '2025-01-15' } })
+```

--- a/.changeset/quiet-otters-fix.md
+++ b/.changeset/quiet-otters-fix.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix update validation rejecting omitted required fields under zod 4.4 by using key-optionality (`.optional()`) instead of `z.union([schema, z.undefined()])`. Partial updates that omit a required-on-create field now validate; present values still enforce their rules.

--- a/packages/core/src/fields/calendar-day.test.ts
+++ b/packages/core/src/fields/calendar-day.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { calendarDay } from './index.js'
+import { generateZodSchema, validateWithZod } from '../validation/schema.js'
+import type { FieldConfig } from '../config/types.js'
+
+/**
+ * calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
+ * scalar). Type, validation, and runtime read value must all agree on `string`.
+ * See issue #571.
+ */
+describe('calendarDay field (YYYY-MM-DD string end-to-end)', () => {
+  describe('getTypeScriptType', () => {
+    it('returns string (not Date), driving the entity + input types', () => {
+      const field = calendarDay()
+      expect(field.getTypeScriptType?.()).toEqual({ type: 'string', optional: true })
+    })
+
+    it('is non-optional when required and not nullable', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      expect(field.getTypeScriptType?.()).toEqual({ type: 'string', optional: false })
+    })
+
+    it('type-level: the declared type is the literal "string"', () => {
+      const field = calendarDay()
+      const tsType = field.getTypeScriptType?.()
+      // The entity/read type and the standalone generated CreateInput/UpdateInput
+      // types are emitted from this literal, so asserting it is exactly 'string'
+      // pins those types to `string`. (At the context.db write path a Date is
+      // rejected at runtime by validation, not at compile time — tracked in #599.)
+      expectTypeOf(tsType).toEqualTypeOf<{ type: string; optional: boolean } | undefined>()
+      if (tsType) {
+        expectTypeOf(tsType.type).toEqualTypeOf<string>()
+        expect(tsType.type).toBe('string')
+        // @ts-expect-error - the runtime type is 'string', never 'Date'
+        const _notDate: 'Date' = tsType.type
+        void _notDate
+      }
+    })
+  })
+
+  describe('getPrismaType (unchanged — stays DateTime @db.Date)', () => {
+    it('keeps DateTime storage with @db.Date on non-sqlite providers', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      const prisma = field.getPrismaType?.('startsOn', 'postgresql')
+      expect(prisma?.type).toBe('DateTime')
+      expect(prisma?.modifiers).toContain('@db.Date')
+    })
+
+    it('omits @db.Date on sqlite (TEXT fallback)', () => {
+      const field = calendarDay({ validation: { isRequired: true } })
+      const prisma = field.getPrismaType?.('startsOn', 'sqlite')
+      expect(prisma?.type).toBe('DateTime')
+      expect(prisma?.modifiers ?? '').not.toContain('@db.Date')
+    })
+  })
+
+  describe('write validation (string-only)', () => {
+    const fields: Record<string, FieldConfig> = {
+      startsOn: calendarDay({ validation: { isRequired: true } }),
+    }
+
+    it('accepts a valid YYYY-MM-DD string on create', () => {
+      const result = validateWithZod({ startsOn: '2025-01-15' }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a malformed string with a clear message', () => {
+      const result = validateWithZod({ startsOn: '15/01/2025' }, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('startsOn')
+        expect(result.errors.startsOn).toMatch(/YYYY-MM-DD/)
+      }
+    })
+
+    it('rejects a Date instance at runtime (not a string)', () => {
+      // A typed caller cannot reach here (input type is `string`), but the
+      // validator is string-only as a runtime backstop.
+      const result = validateWithZod(
+        { startsOn: new Date('2025-01-15') } as unknown as Record<string, unknown>,
+        fields,
+        'create',
+      )
+      expect(result.success).toBe(false)
+    })
+
+    it('zod schema for the field validates the YYYY-MM-DD shape', () => {
+      const schema = generateZodSchema(fields, 'create')
+      expect(schema.safeParse({ startsOn: '2025-12-31' }).success).toBe(true)
+      expect(schema.safeParse({ startsOn: 'nope' }).success).toBe(false)
+    })
+  })
+
+  describe('read transform (resolveOutput returns a YYYY-MM-DD string)', () => {
+    // The read pipeline calls fieldConfig.hooks.resolveOutput({ value, ... }).
+    // We exercise that hook directly with the value shapes Prisma can return.
+    function readValue(value: unknown): unknown {
+      const field = calendarDay()
+      const hook = field.hooks?.resolveOutput
+      if (!hook) throw new Error('calendarDay must define a resolveOutput hook')
+      // Cast to the runtime call shape used by field-visibility.ts.
+      return (hook as unknown as (args: { value: unknown }) => unknown)({ value })
+    }
+
+    it('formats a Date (Postgres/MySQL @db.Date) to YYYY-MM-DD', () => {
+      expect(readValue(new Date('2025-01-15T00:00:00.000Z'))).toBe('2025-01-15')
+    })
+
+    it('is timezone-safe — a late-UTC Date does not drift a day', () => {
+      // 23:59:59Z is the same UTC calendar day; UTC-based formatting keeps it.
+      expect(readValue(new Date('2025-01-15T23:59:59.999Z'))).toBe('2025-01-15')
+    })
+
+    it('passes through an already-formatted string (SQLite TEXT)', () => {
+      expect(readValue('2025-01-15')).toBe('2025-01-15')
+    })
+
+    it('takes the date-only prefix of a full ISO string (SQLite TEXT)', () => {
+      expect(readValue('2025-01-15T00:00:00.000Z')).toBe('2025-01-15')
+    })
+
+    it('passes null/undefined through unchanged', () => {
+      expect(readValue(null)).toBeNull()
+      expect(readValue(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('user-provided hooks are preserved', () => {
+    it('merges a user resolveOutput over the default (last wins)', () => {
+      const field = calendarDay({
+        hooks: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test hook
+          resolveOutput: ({ value }: { value: any }) => `custom:${value}`,
+        },
+      })
+      const hook = field.hooks?.resolveOutput as unknown as (args: { value: unknown }) => unknown
+      expect(hook({ value: '2025-01-15' })).toBe('custom:2025-01-15')
+    })
+  })
+})

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -514,11 +514,23 @@ export function timestamp<
 /**
  * Calendar Day field - date only (no time) in ISO8601 format
  *
+ * Mirrors Keystone's `CalendarDay` scalar: the wire format through
+ * `context.db.*` is a `YYYY-MM-DD` **string** in both directions (read and
+ * write). The field's TypeScript type — entity, `CreateInput`, and
+ * `UpdateInput` — is `string`, so passing a `Date` is a compile-time error.
+ *
  * **Features:**
  * - Stores date values only (no time component)
  * - PostgreSQL/MySQL: Uses native DATE type via @db.Date
  * - SQLite: Uses String representation
- * - Accepts ISO8601 date strings (YYYY-MM-DD format)
+ * - **Writes:** accept only a `YYYY-MM-DD` string; a malformed string or a
+ *   `Date` is rejected at runtime by validation (a `ValidationError`). Genuine
+ *   compile-time rejection at the `context.db` call site is tracked in #599.
+ * - **Reads:** always return a `YYYY-MM-DD` string. Even though the underlying
+ *   `@db.Date` column hands Prisma a `Date`, a `resolveOutput` transform
+ *   normalises it back to a `YYYY-MM-DD` string so the runtime value matches
+ *   the declared `string` type. UTC components are used to avoid timezone
+ *   off-by-one errors.
  * - Optional validation for required fields
  * - Database column mapping and nullability control
  * - Index support (boolean or 'unique')
@@ -539,13 +551,17 @@ export function timestamp<
  *   })
  * }
  *
- * // Creating with date values
+ * // Creating with date values — pass YYYY-MM-DD strings (NOT Date objects)
  * const event = await context.db.event.create({
  *   data: {
  *     startDate: '2025-01-15',
  *     endDate: '2025-01-20'
  *   }
  * })
+ *
+ * // Reading — values come back as YYYY-MM-DD strings
+ * const e = await context.db.event.findUnique({ where: { id } })
+ * e?.startDate // => '2025-01-15' (a string, not a Date)
  * ```
  *
  * @param options - Field configuration options
@@ -557,6 +573,19 @@ export function calendarDay<
   return {
     type: 'calendarDay',
     ...options,
+    // Reads: the underlying @db.Date column hands Prisma a Date (or a TEXT
+    // string under the SQLite fallback). Normalise to a YYYY-MM-DD string so the
+    // runtime value matches the declared `string` type. UTC components are used
+    // so the formatting never drifts a day in non-UTC timezones.
+    // Cast hooks to any since field builders are generic and can't know the
+    // specific TFieldKey (same pattern as password()).
+    hooks: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
+      resolveOutput: ({ value }: { value: any }) => formatCalendarDay(value),
+      // Merge with user-provided hooks if any
+      ...options?.hooks,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hook object needs type assertion for field builder
+    } as any,
     getZodSchema: (fieldName: string, operation: 'create' | 'update') => {
       const validation = options?.validation
       const isRequired = validation?.isRequired
@@ -628,12 +657,47 @@ export function calendarDay<
       const isRequired = validation?.isRequired
       const isNullable = db?.isNullable ?? !isRequired
 
+      // calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
+      // scalar). Returning 'string' here makes the entity/read type and the
+      // standalone generated CreateInput/UpdateInput types `string`. At the
+      // context.db write path a Date is still rejected at runtime by validation
+      // (the generated db method `data` type derives from Prisma's `Date | string`
+      // input — making it a compile-time error is tracked in #599).
       return {
-        type: 'Date',
+        type: 'string',
         optional: isNullable,
       }
     },
   }
+}
+
+/**
+ * Format a stored calendar-day value to a `YYYY-MM-DD` string.
+ *
+ * Handles the value being a `Date` (Postgres/MySQL `@db.Date`), an already
+ * formatted string (SQLite TEXT fallback), or null/undefined. Dates are
+ * formatted from their UTC components so the result never drifts a day in
+ * non-UTC timezones.
+ */
+function formatCalendarDay(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) {
+    return value as null | undefined
+  }
+
+  if (value instanceof Date) {
+    // toISOString() is UTC; the YYYY-MM-DD prefix is timezone-safe.
+    return value.toISOString().slice(0, 10)
+  }
+
+  if (typeof value === 'string') {
+    // SQLite stores DateTime as TEXT. The value may already be YYYY-MM-DD or a
+    // full ISO timestamp — take the date-only prefix either way.
+    return value.slice(0, 10)
+  }
+
+  // Any other shape is unexpected for a @db.Date column; surface it untouched
+  // by returning undefined so callers see the field as absent rather than wrong.
+  return undefined
 }
 
 /**

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -84,7 +84,7 @@ export function text<
           : withMin
 
       if (isRequired && operation === 'update') {
-        return z.union([withMax, z.undefined()])
+        return withMax.optional()
       }
 
       return !isRequired ? withMax.optional().nullable() : withMax
@@ -574,8 +574,8 @@ export function calendarDay<
       if (isRequired && operation === 'create') {
         return dateSchema
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: can be undefined for partial updates
-        return z.union([dateSchema, z.undefined()])
+        // Required in update mode: omitted keys pass; present values must be valid
+        return dateSchema.optional()
       } else {
         return dateSchema.optional().nullable()
       }
@@ -752,13 +752,13 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
             message: `${formatFieldName(fieldName)} is required`,
           })
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: if provided, reject empty strings
-        return z.union([
-          z.string().min(1, {
+        // Required in update mode: omitted keys pass; if provided, reject empty strings
+        return z
+          .string()
+          .min(1, {
             message: `${formatFieldName(fieldName)} is required`,
-          }),
-          z.undefined(),
-        ])
+          })
+          .optional()
       } else {
         // Not required: can be undefined or any string
         return z
@@ -1315,8 +1315,8 @@ export function json<
         // Required in create mode: value must be provided
         return baseSchema
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: can be undefined for partial updates
-        return z.union([baseSchema, z.undefined()])
+        // Required in update mode: omitted keys pass; present values must be valid
+        return baseSchema.optional()
       } else {
         // Not required: can be undefined or null
         return baseSchema.optional().nullable()

--- a/packages/core/src/validation/schema.test.ts
+++ b/packages/core/src/validation/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateZodSchema, validateWithZod } from './schema.js'
 import type { FieldConfig } from '../config/types.js'
-import { text, integer, select } from '../fields/index.js'
+import { text, integer, select, calendarDay, json, password } from '../fields/index.js'
 
 describe('Zod Schema Generation', () => {
   describe('generateZodSchema', () => {
@@ -217,6 +217,114 @@ describe('Zod Schema Generation', () => {
 
       const result = validateWithZod({}, fields, 'update')
       expect(result.success).toBe(true)
+    })
+  })
+
+  // Regression: issue #570
+  // Under zod 4.4, `z.union([schema, z.undefined()])` rejects a MISSING key,
+  // so partial updates that omit a required-on-create field used to throw a
+  // ValidationError before the DB write. Update-shapes must use key-optionality
+  // (`.optional()`) so validation only checks the keys actually present.
+  describe('omitted required field on update (issue #570)', () => {
+    it('passes when a required text field is omitted while another field is present', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+        bio: text(),
+      }
+
+      const result = validateWithZod({ bio: 'hello' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still enforces present-value rules for a required text field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+      }
+
+      // Empty string must still be rejected when the key IS present
+      const result = validateWithZod({ name: '' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('name')
+      }
+    })
+
+    it('still enforces length rules for a required text field present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        title: text({ validation: { isRequired: true, length: { min: 5 } } }),
+      }
+
+      const result = validateWithZod({ title: 'Hi' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors.title).toContain('at least 5 characters')
+      }
+    })
+
+    it('keeps required text fields required on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        name: text({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({}, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('name')
+      }
+    })
+
+    it('allows an omitted required calendarDay field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        startsOn: calendarDay({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still rejects an invalid calendarDay value when present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        startsOn: calendarDay({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ startsOn: 'not-a-date' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('startsOn')
+      }
+    })
+
+    it('allows an omitted required json field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('allows an omitted required password field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        secret: password({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('still rejects an empty required password value when present on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        secret: password({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ secret: '' }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('secret')
+      }
     })
   })
 })


### PR DESCRIPTION
Delivers PRD #582 — makes field input validation and generated input types correct and consistent so normal partial-update idioms work and `calendarDay` no longer contradicts its own validation/storage.

## Included changes

- **#570** (`@opensaas/stack-core`, patch) — Update-input validation rejected omitted required fields under zod 4.4. Replaced the required-on-update `z.union([schema, z.undefined()])` shape with `.optional()` across the `text`, `calendarDay`, `password`, and `json` builders, so partial updates validate only the keys present. No new nullability introduced; create-time requiredness unchanged.
- **#571** (`@opensaas/stack-core`, minor) — `calendarDay` is now a `YYYY-MM-DD` string end-to-end: `getTypeScriptType()` returns `string`, string-only zod validation retained, and a timezone-safe `resolveOutput` normalises reads to `YYYY-MM-DD`. Storage stays `DateTime @db.Date`.

## ⚠️ Behavioral change (reads)

Reading a `calendarDay` now returns a `YYYY-MM-DD` **string** instead of a `Date`. Flagged in the `@opensaas/stack-core` minor changeset; consumers relying on a `Date` on read should switch to the string form.

## Verification

QA acceptance pass on the integration branch (HEAD `618ab09`): build clean, `@opensaas/stack-core` 665/665 tests, `@opensaas/stack-cli` 308/308 tests. Both changesets present (`quiet-otters-fix.md` patch, `calm-otters-glide.md` minor). QA sign-off: #582.

## Known limitation / follow-ups

- **#599** — At the `context.db.*.create()/update()` call site a `Date` is rejected at **runtime** (zod `ValidationError`), but not at compile time, because that `data` type derives from Prisma's `Date | string` for a `@db.Date` column. Genuine compile-time narrowing is a cross-cutting generator change tracked there.
- **#597** — `json()` required-on-create is not enforced (bare `z.unknown()`); pre-existing, surfaced during this delivery.

Closes #582 (already closed). Implements #570, #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_