### PR TITLE
fix(core): enforce required json fields on create (#597)

### DIFF
--- a/.changeset/clever-jars-shine.md
+++ b/.changeset/clever-jars-shine.md
@@ -1,0 +1,6 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Enforce required json fields on create: an omitted key is now rejected while any
+present value (object, array, primitive, or null) is still accepted.

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1376,8 +1376,14 @@ export function json<
       const baseSchema = z.unknown()
 
       if (isRequired && operation === 'create') {
-        // Required in create mode: value must be provided
-        return baseSchema
+        // Required in create mode: value must be provided (any present JSON
+        // value is accepted, including null). A bare z.unknown() is treated as
+        // optional inside z.object(), so an omitted key would silently pass;
+        // the refinement makes the key genuinely required by rejecting
+        // undefined (which also covers an absent key).
+        return baseSchema.refine((value) => value !== undefined, {
+          message: `${formatFieldName(fieldName)} is required`,
+        })
       } else if (isRequired && operation === 'update') {
         // Required in update mode: omitted keys pass; present values must be valid
         return baseSchema.optional()

--- a/packages/core/src/validation/schema.test.ts
+++ b/packages/core/src/validation/schema.test.ts
@@ -327,4 +327,83 @@ describe('Zod Schema Generation', () => {
       }
     })
   })
+
+  // Regression: issue #597
+  // A bare `z.unknown()` is treated as optional inside `z.object(...)`, so a
+  // required-on-create json field used to pass when the key was omitted. The
+  // create branch now refines the schema to reject undefined/absent keys while
+  // still accepting any present JSON value (object, array, primitive, null).
+  describe('required json on create (issue #597)', () => {
+    it('rejects an omitted required json field on create (key absent)', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('meta')
+        expect(result.errors.meta).toContain('is required')
+      }
+    })
+
+    it('rejects an explicit undefined required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: undefined }, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('meta')
+      }
+    })
+
+    it('accepts a present object value for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: { a: 1 } }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a present array value for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: [] }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a present null value for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: null }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a present primitive (0) value for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: 0 }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+
+    it('allows an omitted non-required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json(),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'create')
+      expect(result.success).toBe(true)
+    })
+  })
 })

--- a/packages/core/tests/field-types.test.ts
+++ b/packages/core/tests/field-types.test.ts
@@ -778,9 +778,13 @@ describe('Field Types', () => {
         const field = json({ validation: { isRequired: true } })
         const schema = field.getZodSchema('metadata', 'create')
 
+        // Any present JSON value is accepted, including null (issue #597)
         expect(schema.safeParse({ key: 'value' }).success).toBe(true)
-        // JSON field with isRequired still accepts undefined due to z.unknown() behavior
-        expect(schema.safeParse(undefined).success).toBe(true)
+        expect(schema.safeParse([1, 2, 3]).success).toBe(true)
+        expect(schema.safeParse(0).success).toBe(true)
+        expect(schema.safeParse(null).success).toBe(true)
+        // A required json field must reject undefined on create (issue #597)
+        expect(schema.safeParse(undefined).success).toBe(false)
       })
 
       test('allows undefined for required field in update mode', () => {


### PR DESCRIPTION
## Summary

Closes #597.

`json()`'s `getZodSchema` returned a bare `z.unknown()` for the required-on-**create** branch. Because `z.unknown()` is treated as optional inside a `z.object(...)`, a `json({ validation: { isRequired: true } })` field was **not** enforced on create — a create that omitted the key passed validation silently.

This PR refines the create-branch schema so a required json key is genuinely required, while still accepting any present JSON value.

## The fix

```ts
// required + create
return baseSchema.refine((value) => value !== undefined, {
  message: `${formatFieldName(fieldName)} is required`,
})
```

### Verified zod mechanism

Empirically tested against the project's zod (`^4.3.6`). In zod v4, wrapping `z.unknown()` with `.refine(...)` produces a schema that is **no longer treated as optional** inside `z.object(...)`, so an **absent key (`{}`)** is genuinely rejected — not just an explicit `undefined`. Confirmed through the real validation layer (`validateWithZod` → `generateZodSchema`):

- Required json, key **absent** (`{}`) → REJECTED with "Meta is required"
- Required json, explicit `undefined` → REJECTED
- Required json with `{ a: 1 }`, `[]`, `null`, `0` → ACCEPTED
- Non-required json omitted on create → ACCEPTED
- Required json **omitted on update** (#570 behavior) → still ACCEPTED (preserved, untouched)

The required-on-**update** branch from #570 (`.optional()`) is left unchanged.

## Tests

- Added a `required json on create (issue #597)` regression block in `packages/core/src/validation/schema.test.ts`, mirroring the #570 block and exercising the real validation path.
- Updated the field-level unit test in `tests/field-types.test.ts` that previously documented the buggy behaviour (`undefined` accepted) to assert the corrected semantics.

All 672 core tests pass; `tsc` build is clean; lint passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_