### PR TITLE
fix(core): required json fields reject present null in validation (#604)

### DIFF
--- a/.changeset/quiet-foxes-jump.md
+++ b/.changeset/quiet-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Required json fields now reject a present `null` during validation rather than failing later as a DB NOT NULL violation. Omitted keys on update are still allowed; the Prisma column nullability is unchanged.

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1376,17 +1376,27 @@ export function json<
       const baseSchema = z.unknown()
 
       if (isRequired && operation === 'create') {
-        // Required in create mode: value must be provided (any present JSON
-        // value is accepted, including null). A bare z.unknown() is treated as
-        // optional inside z.object(), so an omitted key would silently pass;
-        // the refinement makes the key genuinely required by rejecting
-        // undefined (which also covers an absent key).
-        return baseSchema.refine((value) => value !== undefined, {
+        // Required in create mode: a value must be provided and it must be
+        // non-null (issue #604 — a required json field means non-null). A bare
+        // z.unknown() is treated as optional inside z.object(), so an omitted
+        // key would silently pass; the refinement makes the key genuinely
+        // required by rejecting undefined (which also covers an absent key) and
+        // rejecting a present null, while still accepting any other present
+        // JSON value (object, array, primitive, including falsy 0/""/false).
+        return baseSchema.refine((value) => value !== undefined && value !== null, {
           message: `${formatFieldName(fieldName)} is required`,
         })
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: omitted keys pass; present values must be valid
-        return baseSchema.optional()
+        // Required in update mode: omitted keys still pass (issue #570 — partial
+        // updates may leave the field untouched), but a present null is rejected
+        // (issue #604 — required json means non-null). The `.refine()` runs
+        // before `.optional()` short-circuits on undefined: absent/undefined
+        // passes, a present null is rejected, and other present values pass.
+        return baseSchema
+          .refine((value) => value !== null, {
+            message: `${formatFieldName(fieldName)} is required`,
+          })
+          .optional()
       } else {
         // Not required: can be undefined or null
         return baseSchema.optional().nullable()

--- a/packages/core/src/validation/schema.test.ts
+++ b/packages/core/src/validation/schema.test.ts
@@ -332,7 +332,8 @@ describe('Zod Schema Generation', () => {
   // A bare `z.unknown()` is treated as optional inside `z.object(...)`, so a
   // required-on-create json field used to pass when the key was omitted. The
   // create branch now refines the schema to reject undefined/absent keys while
-  // still accepting any present JSON value (object, array, primitive, null).
+  // still accepting any present non-null JSON value (object, array, primitive).
+  // A present null is rejected by the issue #604 tightening below.
   describe('required json on create (issue #597)', () => {
     it('rejects an omitted required json field on create (key absent)', () => {
       const fields: Record<string, FieldConfig> = {
@@ -378,15 +379,6 @@ describe('Zod Schema Generation', () => {
       expect(result.success).toBe(true)
     })
 
-    it('accepts a present null value for a required json field on create', () => {
-      const fields: Record<string, FieldConfig> = {
-        meta: json({ validation: { isRequired: true } }),
-      }
-
-      const result = validateWithZod({ meta: null }, fields, 'create')
-      expect(result.success).toBe(true)
-    })
-
     it('accepts a present primitive (0) value for a required json field on create', () => {
       const fields: Record<string, FieldConfig> = {
         meta: json({ validation: { isRequired: true } }),
@@ -404,6 +396,92 @@ describe('Zod Schema Generation', () => {
 
       const result = validateWithZod({ label: 'x' }, fields, 'create')
       expect(result.success).toBe(true)
+    })
+  })
+
+  // Regression: issue #604
+  // A required json field means non-null. A present `null` must be rejected at
+  // the validation layer (with a clear message) instead of surfacing later as a
+  // DB NOT NULL violation. Omission on update must still pass (#570), and
+  // omission on create must still be rejected (#597). Present non-null values
+  // — including falsy 0/""/false — are accepted. The Prisma column stays NOT
+  // NULL; only validation behaviour changes.
+  describe('required json is non-null (issue #604)', () => {
+    it('rejects a present null for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: null }, fields, 'create')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('meta')
+        expect(result.errors.meta).toContain('is required')
+      }
+    })
+
+    it('rejects a present null for a required json field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: null }, fields, 'update')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.errors).toHaveProperty('meta')
+        expect(result.errors.meta).toContain('is required')
+      }
+    })
+
+    it('still allows an omitted required json field on update (preserves #570)', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+        label: text(),
+      }
+
+      const result = validateWithZod({ label: 'x' }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a present object value for a required json field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      const result = validateWithZod({ meta: { a: 1 } }, fields, 'update')
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a present falsy non-null value for a required json field on update', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      expect(validateWithZod({ meta: 0 }, fields, 'update').success).toBe(true)
+      expect(validateWithZod({ meta: '' }, fields, 'update').success).toBe(true)
+      expect(validateWithZod({ meta: false }, fields, 'update').success).toBe(true)
+    })
+
+    it('accepts present falsy non-null values for a required json field on create', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json({ validation: { isRequired: true } }),
+      }
+
+      expect(validateWithZod({ meta: 0 }, fields, 'create').success).toBe(true)
+      expect(validateWithZod({ meta: '' }, fields, 'create').success).toBe(true)
+      expect(validateWithZod({ meta: false }, fields, 'create').success).toBe(true)
+    })
+
+    it('accepts an omitted or present null value for a non-required json field', () => {
+      const fields: Record<string, FieldConfig> = {
+        meta: json(),
+        label: text(),
+      }
+
+      expect(validateWithZod({ label: 'x' }, fields, 'create').success).toBe(true)
+      expect(validateWithZod({ meta: null }, fields, 'create').success).toBe(true)
+      expect(validateWithZod({ label: 'x' }, fields, 'update').success).toBe(true)
+      expect(validateWithZod({ meta: null }, fields, 'update').success).toBe(true)
     })
   })
 })

--- a/packages/core/tests/field-types.test.ts
+++ b/packages/core/tests/field-types.test.ts
@@ -778,21 +778,31 @@ describe('Field Types', () => {
         const field = json({ validation: { isRequired: true } })
         const schema = field.getZodSchema('metadata', 'create')
 
-        // Any present JSON value is accepted, including null (issue #597)
+        // Any present non-null JSON value is accepted, including falsy values
         expect(schema.safeParse({ key: 'value' }).success).toBe(true)
         expect(schema.safeParse([1, 2, 3]).success).toBe(true)
         expect(schema.safeParse(0).success).toBe(true)
-        expect(schema.safeParse(null).success).toBe(true)
+        expect(schema.safeParse('').success).toBe(true)
+        expect(schema.safeParse(false).success).toBe(true)
         // A required json field must reject undefined on create (issue #597)
         expect(schema.safeParse(undefined).success).toBe(false)
+        // A required json field means non-null: reject a present null (issue #604)
+        expect(schema.safeParse(null).success).toBe(false)
       })
 
-      test('allows undefined for required field in update mode', () => {
+      test('allows undefined but rejects null for required field in update mode', () => {
         const field = json({ validation: { isRequired: true } })
         const schema = field.getZodSchema('metadata', 'update')
 
         expect(schema.safeParse({ key: 'value' }).success).toBe(true)
+        // Omitted/undefined still passes on update (issue #570)
         expect(schema.safeParse(undefined).success).toBe(true)
+        // Present non-null falsy values pass
+        expect(schema.safeParse(0).success).toBe(true)
+        expect(schema.safeParse('').success).toBe(true)
+        expect(schema.safeParse(false).success).toBe(true)
+        // A present null is rejected — required json means non-null (issue #604)
+        expect(schema.safeParse(null).success).toBe(false)
       })
     })
 


### PR DESCRIPTION
Closes #604.

## Problem

A required `json` field emits a `NOT NULL` Prisma column, but its validation accepted a present `null` (a legitimate JSON value). So `context.db.<list>.create({ data: { meta: null } })` passed validation and then failed at the database with a `NOT NULL` constraint violation — a late, unfriendly error.

## Decision

Per maintainer decision on #604: **required json = non-null.** Validation now rejects a present `null` for a required json field so the error surfaces at the validation layer. The Prisma column stays `NOT NULL` (storage unchanged).

## Change (`packages/core/src/fields/index.ts`, `json()` `getZodSchema`)

- **create + required:** `z.unknown().refine(v => v !== undefined && v !== null, { message: '<Field> is required' })` — rejects absent key and present `null`; accepts other present values.
- **update + required:** `z.unknown().refine(v => v !== null, { message: '<Field> is required' }).optional()` — still allows omission (partial-update idiom, #570), rejects present `null`, accepts present non-null.
- **non-required:** unchanged.
- `getPrismaType()` / nullability untouched — required json stays `NOT NULL`.

## Verified through the real validation layer (`validateWithZod`)

- required create `{}` (absent) → rejected; `{ meta: null }` → rejected; `{ meta: {} }`/`[]`/`0`/`""`/`false` → accepted
- required update `{}` (absent) → accepted (#570 preserved); `{ meta: null }` → rejected; `{ meta: { a: 1 } }` → accepted
- non-required create/update `{}` and `{ meta: null }` → accepted

## Tests & changeset

- Regression block added to `packages/core/src/validation/schema.test.ts`; field-level tests in `packages/core/tests/field-types.test.ts` updated.
- `.changeset/quiet-foxes-jump.md` — patch bump for `@opensaas/stack-core`.

Build clean, `@opensaas/stack-core` 678/678 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_