### PR TITLE
Enforce field-level scalar narrowing at the write call site (#599)

### DIFF
--- a/.changeset/calm-otters-narrow.md
+++ b/.changeset/calm-otters-narrow.md
@@ -1,0 +1,29 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Enforce field-level scalar narrowing at the write call site, and fix `checkbox({ defaultValue: false })` optionality
+
+The generated `context.db.<list>.create()/update()/createMany()/updateMany()` `data`
+type now narrows scalar fields to their OpenSaaS `getTypeScriptType()` types instead of
+inheriting Prisma's wider input types. Field-level narrowing (e.g. `calendarDay` → `string`)
+is now a genuine compile-time error to violate, not just a runtime validation failure.
+
+```ts
+// calendarDay is a `string` end-to-end:
+await context.db.event.create({ data: { startDate: new Date() } })
+//                                                  ^^^^^^^^^^ Type 'Date' is not assignable to type 'string'.
+await context.db.event.create({ data: { startDate: '2026-01-01' } }) // ✅ compiles
+```
+
+Relationship nested writes (`connect`/`create`/`connectOrCreate`), unchecked foreign keys
+(e.g. `authorId`), and `decimal`/`json` writes are unaffected: `decimal` still accepts
+`Decimal | number | string` and `json` still accepts Prisma's `JsonNull`/`DbNull` sentinels.
+
+Also fixes a latent bug where `checkbox({ defaultValue: false })` (and any field with a
+falsy-but-present default) was generated as a required field on create — it is now correctly
+optional.
+
+Note: this may surface pre-existing type errors in consumer code that passed a `Date` to a
+`calendarDay` field. Such code already failed at runtime; it now fails at compile time. Pass a
+`YYYY-MM-DD` string instead.

--- a/.changeset/swift-foxes-clean.md
+++ b/.changeset/swift-foxes-clean.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Remove unused getRelatedListName helper from the types generator (dead code, no behavior change)

--- a/examples/composable-dashboard/lib/actions.ts
+++ b/examples/composable-dashboard/lib/actions.ts
@@ -19,7 +19,7 @@ export async function createPost(data: PostCreateInput) {
     const post = await context.db.post.create({
       data: {
         ...postData,
-        status: postData.status || 'DRAFT',
+        status: postData.status || 'draft',
         publishedAt: postData.publishedAt ? new Date(postData.publishedAt) : undefined,
       },
     })
@@ -47,7 +47,7 @@ export async function updatePost(id: string, data: PostUpdateInput) {
       title: data.title,
       slug: data.slug,
       content: data.content,
-      status: data.status || 'DRAFT',
+      status: data.status || 'draft',
       internalNotes: data.internalNotes,
       publishedAt: data.publishedAt ? new Date(data.publishedAt) : undefined,
     },

--- a/examples/rag-openai-chatbot/scripts/seed.ts
+++ b/examples/rag-openai-chatbot/scripts/seed.ts
@@ -1,6 +1,7 @@
 import { getContext } from '@/.opensaas/context'
+import type { KnowledgeBaseCreateInput } from '@/.opensaas/types'
 
-const sampleArticles = [
+const sampleArticles: KnowledgeBaseCreateInput[] = [
   {
     title: 'What is OpenSaas Stack?',
     content: `OpenSaas Stack is a Next.js-based framework for building admin-heavy applications with built-in access control. It uses a config-first approach similar to KeystoneJS but modernized for Next.js App Router and designed to be AI-agent-friendly with automatic security guardrails. The stack includes core packages for configuration, authentication, UI components, and specialized integrations like RAG (Retrieval-Augmented Generation). It's built as a pnpm monorepo with packages for core functionality, CLI tools, admin UI, authentication, and various integrations. OpenSaas Stack emphasizes type safety, automatic code generation, and developer experience.`,

--- a/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
@@ -292,16 +292,26 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name' | 'email'> & {
+    name: string
+    email: string
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name' | 'email'> & {
+    name?: string
+    email?: string
+  }
 }
 
 /**
@@ -313,18 +323,26 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name' | 'email'> & {
+    name: string
+    email: string
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name' | 'email'> & {
+    name?: string
+    email?: string
+  }
   select?: UserSelect | null
 }
 

--- a/packages/cli/src/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/types.test.ts.snap
@@ -149,16 +149,24 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -170,18 +178,24 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
 }
 
@@ -395,16 +409,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title' | 'content'> & {
+    title: string
+    content?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title' | 'content'> & {
+    title?: string
+    content?: string | null
+  }
 }
 
 /**
@@ -416,18 +440,26 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for Post with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title' | 'content'> & {
+    title: string
+    content?: string | null
+  }>
   select?: PostSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title' | 'content'> & {
+    title?: string
+    content?: string | null
+  }
   select?: PostSelect | null
 }
 
@@ -722,18 +754,26 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include' | 'data'> & {
   select?: UserSelect | null
   include?: UserInclude | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'include'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: UserSelect | null
   include?: UserInclude | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -746,19 +786,25 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for User with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
   include?: UserInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
   include?: UserInclude | null
 }
@@ -954,18 +1000,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
@@ -978,19 +1032,25 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for Post with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title'> & {
+    title?: string | null
+  }>
   select?: PostSelect | null
   include?: PostInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title'> & {
+    title?: string | null
+  }
   select?: PostSelect | null
   include?: PostInclude | null
 }
@@ -1265,16 +1325,26 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'firstName' | 'lastName'> & {
+    firstName: string
+    lastName: string
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'firstName' | 'lastName'> & {
+    firstName?: string
+    lastName?: string
+  }
 }
 
 /**
@@ -1286,18 +1356,26 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'firstName' | 'lastName'> & {
+    firstName: string
+    lastName: string
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'firstName' | 'lastName'> & {
+    firstName?: string
+    lastName?: string
+  }
   select?: UserSelect | null
 }
 
@@ -1511,16 +1589,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title' | 'content'> & {
+    title: string
+    content?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title' | 'content'> & {
+    title?: string
+    content?: string | null
+  }
 }
 
 /**
@@ -1532,18 +1620,26 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for Post with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title' | 'content'> & {
+    title: string
+    content?: string | null
+  }>
   select?: PostSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title' | 'content'> & {
+    title?: string
+    content?: string | null
+  }
   select?: PostSelect | null
 }
 
@@ -1754,16 +1850,24 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -1775,18 +1879,24 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
 }
 
@@ -2000,16 +2110,26 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name' | 'email'> & {
+    name: string
+    email: string
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name' | 'email'> & {
+    name?: string
+    email?: string
+  }
 }
 
 /**
@@ -2021,18 +2141,26 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name' | 'email'> & {
+    name: string
+    email: string
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name' | 'email'> & {
+    name?: string
+    email?: string
+  }
   select?: UserSelect | null
 }
 
@@ -2243,16 +2371,24 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -2264,18 +2400,24 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
 }
 
@@ -2409,16 +2551,24 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'data'> & {
   select?: PostSelect | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
@@ -2430,18 +2580,24 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for Post with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title'> & {
+    title?: string | null
+  }>
   select?: PostSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title'> & {
+    title?: string | null
+  }
   select?: PostSelect | null
 }
 
@@ -2575,16 +2731,24 @@ export type CommentFindFirstArgs = Omit<Prisma.CommentFindFirstArgs, 'select'> &
 
 /**
  * Custom CreateArgs for Comment with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type CommentCreateArgs = Omit<Prisma.CommentCreateArgs, 'select'> & {
+export type CommentCreateArgs = Omit<Prisma.CommentCreateArgs, 'select' | 'data'> & {
   select?: CommentSelect | null
+  data: Omit<Prisma.CommentCreateArgs['data'], 'content'> & {
+    content?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Comment with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type CommentUpdateArgs = Omit<Prisma.CommentUpdateArgs, 'select'> & {
+export type CommentUpdateArgs = Omit<Prisma.CommentUpdateArgs, 'select' | 'data'> & {
   select?: CommentSelect | null
+  data: Omit<Prisma.CommentUpdateArgs['data'], 'content'> & {
+    content?: string | null
+  }
 }
 
 /**
@@ -2596,18 +2760,24 @@ export type CommentDeleteArgs = Omit<Prisma.CommentDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for Comment with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type CommentCreateManyArgs = {
-  data: Prisma.CommentCreateInput[]
+  data: Array<Omit<Prisma.CommentCreateInput, 'content'> & {
+    content?: string | null
+  }>
   select?: CommentSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for Comment with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type CommentUpdateManyArgs = {
   where?: CommentWhereInput
-  data: Prisma.CommentUpdateInput
+  data: Omit<Prisma.CommentUpdateInput, 'content'> & {
+    content?: string | null
+  }
   select?: CommentSelect | null
 }
 
@@ -2933,18 +3103,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
@@ -2957,19 +3135,25 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for Post with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title'> & {
+    title?: string | null
+  }>
   select?: PostSelect | null
   include?: PostInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title'> & {
+    title?: string | null
+  }
   select?: PostSelect | null
   include?: PostInclude | null
 }
@@ -3104,16 +3288,24 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -3125,18 +3317,24 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
 }
 
@@ -3435,18 +3633,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
@@ -3459,19 +3665,25 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for Post with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title'> & {
+    title?: string | null
+  }>
   select?: PostSelect | null
   include?: PostInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title'> & {
+    title?: string | null
+  }
   select?: PostSelect | null
   include?: PostInclude | null
 }
@@ -3606,16 +3818,24 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select'> & {
 
 /**
  * Custom CreateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'data'> & {
   select?: UserSelect | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -3627,18 +3847,24 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select'> & {
 
 /**
  * Custom CreateManyArgs for User with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
 }
 
@@ -3936,18 +4162,26 @@ export type UserFindFirstArgs = Omit<Prisma.UserFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include'> & {
+export type UserCreateArgs = Omit<Prisma.UserCreateArgs, 'select' | 'include' | 'data'> & {
   select?: UserSelect | null
   include?: UserInclude | null
+  data: Omit<Prisma.UserCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'include'> & {
+export type UserUpdateArgs = Omit<Prisma.UserUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: UserSelect | null
   include?: UserInclude | null
+  data: Omit<Prisma.UserUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -3960,19 +4194,25 @@ export type UserDeleteArgs = Omit<Prisma.UserDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for User with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserCreateManyArgs = {
-  data: Prisma.UserCreateInput[]
+  data: Array<Omit<Prisma.UserCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: UserSelect | null
   include?: UserInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for User with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type UserUpdateManyArgs = {
   where?: UserWhereInput
-  data: Prisma.UserUpdateInput
+  data: Omit<Prisma.UserUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: UserSelect | null
   include?: UserInclude | null
 }
@@ -4168,18 +4408,26 @@ export type PostFindFirstArgs = Omit<Prisma.PostFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include'> & {
+export type PostCreateArgs = Omit<Prisma.PostCreateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostCreateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include'> & {
+export type PostUpdateArgs = Omit<Prisma.PostUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: PostSelect | null
   include?: PostInclude | null
+  data: Omit<Prisma.PostUpdateArgs['data'], 'title'> & {
+    title?: string | null
+  }
 }
 
 /**
@@ -4192,19 +4440,25 @@ export type PostDeleteArgs = Omit<Prisma.PostDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for Post with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostCreateManyArgs = {
-  data: Prisma.PostCreateInput[]
+  data: Array<Omit<Prisma.PostCreateInput, 'title'> & {
+    title?: string | null
+  }>
   select?: PostSelect | null
   include?: PostInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Post with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type PostUpdateManyArgs = {
   where?: PostWhereInput
-  data: Prisma.PostUpdateInput
+  data: Omit<Prisma.PostUpdateInput, 'title'> & {
+    title?: string | null
+  }
   select?: PostSelect | null
   include?: PostInclude | null
 }
@@ -4503,18 +4757,26 @@ export type AccountFindFirstArgs = Omit<Prisma.AccountFindFirstArgs, 'select' | 
 
 /**
  * Custom CreateArgs for Account with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type AccountCreateArgs = Omit<Prisma.AccountCreateArgs, 'select' | 'include'> & {
+export type AccountCreateArgs = Omit<Prisma.AccountCreateArgs, 'select' | 'include' | 'data'> & {
   select?: AccountSelect | null
   include?: AccountInclude | null
+  data: Omit<Prisma.AccountCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Account with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type AccountUpdateArgs = Omit<Prisma.AccountUpdateArgs, 'select' | 'include'> & {
+export type AccountUpdateArgs = Omit<Prisma.AccountUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: AccountSelect | null
   include?: AccountInclude | null
+  data: Omit<Prisma.AccountUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -4527,19 +4789,25 @@ export type AccountDeleteArgs = Omit<Prisma.AccountDeleteArgs, 'select' | 'inclu
 
 /**
  * Custom CreateManyArgs for Account with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type AccountCreateManyArgs = {
-  data: Prisma.AccountCreateInput[]
+  data: Array<Omit<Prisma.AccountCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: AccountSelect | null
   include?: AccountInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Account with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type AccountUpdateManyArgs = {
   where?: AccountWhereInput
-  data: Prisma.AccountUpdateInput
+  data: Omit<Prisma.AccountUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: AccountSelect | null
   include?: AccountInclude | null
 }
@@ -4759,18 +5027,26 @@ export type BillFindFirstArgs = Omit<Prisma.BillFindFirstArgs, 'select' | 'inclu
 
 /**
  * Custom CreateArgs for Bill with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type BillCreateArgs = Omit<Prisma.BillCreateArgs, 'select' | 'include'> & {
+export type BillCreateArgs = Omit<Prisma.BillCreateArgs, 'select' | 'include' | 'data'> & {
   select?: BillSelect | null
   include?: BillInclude | null
+  data: Omit<Prisma.BillCreateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
  * Custom UpdateArgs for Bill with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type BillUpdateArgs = Omit<Prisma.BillUpdateArgs, 'select' | 'include'> & {
+export type BillUpdateArgs = Omit<Prisma.BillUpdateArgs, 'select' | 'include' | 'data'> & {
   select?: BillSelect | null
   include?: BillInclude | null
+  data: Omit<Prisma.BillUpdateArgs['data'], 'name'> & {
+    name?: string | null
+  }
 }
 
 /**
@@ -4783,19 +5059,25 @@ export type BillDeleteArgs = Omit<Prisma.BillDeleteArgs, 'select' | 'include'> &
 
 /**
  * Custom CreateManyArgs for Bill with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type BillCreateManyArgs = {
-  data: Prisma.BillCreateInput[]
+  data: Array<Omit<Prisma.BillCreateInput, 'name'> & {
+    name?: string | null
+  }>
   select?: BillSelect | null
   include?: BillInclude | null
 }
 
 /**
  * Custom UpdateManyArgs for Bill with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type BillUpdateManyArgs = {
   where?: BillWhereInput
-  data: Prisma.BillUpdateInput
+  data: Omit<Prisma.BillUpdateInput, 'name'> & {
+    name?: string | null
+  }
   select?: BillSelect | null
   include?: BillInclude | null
 }

--- a/packages/cli/src/generator/types-write-narrowing.test.ts
+++ b/packages/cli/src/generator/types-write-narrowing.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import ts from 'typescript'
+import { generateTypes } from './types.js'
+import type { OpenSaasConfig } from '@opensaas/stack-core'
+import {
+  text,
+  decimal,
+  json,
+  checkbox,
+  calendarDay,
+  relationship,
+} from '@opensaas/stack-core/fields'
+
+/**
+ * Compile-time type tests for the write-path `data` narrowing (#599 / Approach B).
+ *
+ * The generated `context.db.<list>.create()/update()` `data` member now narrows
+ * scalar fields to their OpenSaaS `getTypeScriptType()` types while leaving
+ * relationship nested writes, unchecked FK fields, and decimal/json on Prisma's
+ * input shape. These tests assert the *real* compile behaviour by feeding the
+ * actual generated `*Args` types — exactly as `generateCustomDBType` wires them
+ * into the `create`/`update`/`createMany`/`updateMany` method signatures
+ * (`<T extends Args>(args: Prisma.SelectSubset<T, Args>) => ...`) — into a real
+ * `tsc` program against a faithful `Prisma` stub.
+ *
+ * What is asserted:
+ *  - `day: new Date()` (a `Date` to a `calendarDay`) is a COMPILE ERROR.
+ *  - `day: '2026-01-01'` (a `string`) compiles.
+ *  - `price` accepts `number` and `string` (decimal not over-narrowed).
+ *  - `meta` accepts a plain JSON value and Prisma's `JsonNull` sentinel.
+ *  - relationship writes (`owner.connect`, unchecked `ownerId`) compile.
+ *  - `active` (`checkbox({ defaultValue: false })`) is OPTIONAL on create.
+ *
+ * The `@ts-expect-error` markers in the consumer fixture make a passing compile
+ * (zero diagnostics) the proof: each marker must catch an error, and every
+ * other line must type-check.
+ */
+
+const COMPILE_TIMEOUT_MS = 60000
+
+/**
+ * A faithful-enough `Prisma` stub: the scalar `*Args['data']` / `*Input` shapes
+ * mirror what Prisma generates for the corresponding column types, so the
+ * generated `Omit<...> & { narrowed }` override composes against realistic input
+ * types (calendarDay -> `Date | string`, decimal -> `Decimal | number | string`,
+ * json -> value | null-sentinel, plus a relationship nested-write + unchecked FK).
+ */
+const PRISMA_STUB = `
+import type { Decimal } from 'decimal.js'
+
+export class PrismaClient {}
+
+export namespace Prisma {
+  // Prisma's SelectSubset narrows excess keys for select/include but still
+  // requires assignability to the constraint U — a known key with the wrong
+  // type is rejected (the calendarDay-Date case). Modelled here as the real
+  // SelectSubset does (T constrained to U via Has/Or, falling back to U).
+  export type SelectSubset<T, U> = {
+    [key in keyof T]: key extends keyof U ? T[key] : never
+  } & U
+
+  export type JsonNullValueInput = { __jsonNull: true }
+  export type InputJsonValue = string | number | boolean | { [k: string]: InputJsonValue } | InputJsonValue[]
+
+  // --- User ---
+  export type UserCreateInput = { name: string }
+  export type UserUpdateInput = { name?: string }
+  export type UserSelect = { name?: boolean }
+  export type UserWhereInput = { name?: string }
+  export type UserCreateArgs = { data: UserCreateInput; select?: UserSelect | null }
+  export type UserUpdateArgs = { where: { id: string }; data: UserUpdateInput; select?: UserSelect | null }
+  export type UserFindUniqueArgs = { where: { id: string }; select?: UserSelect | null }
+  export type UserFindManyArgs = { where?: UserWhereInput; select?: UserSelect | null }
+  export type UserFindFirstArgs = { where?: UserWhereInput; select?: UserSelect | null }
+  export type UserDeleteArgs = { where: { id: string }; select?: UserSelect | null }
+  export type UserCountArgs = { where?: UserWhereInput }
+  export type UserGetPayload<T> = { id: string; name: string }
+
+  // --- Event ---
+  // Scalar inputs mirror Prisma's generated column input types. Nullable
+  // scalars (day/price/meta — no isRequired) are optional, as Prisma emits.
+  // A single (non-union) input is used so the relationship nested-write and the
+  // unchecked FK are both present, sidestepping TS union excess-property quirks
+  // that do not exist against Prisma's real XOR<Checked, Unchecked> inputs.
+  export type EventCreateInput = {
+    title: string
+    day?: Date | string                       // calendarDay backing column: DateTime @db.Date
+    price?: Decimal | number | string
+    meta?: InputJsonValue | JsonNullValueInput
+    active?: boolean
+    owner?: { connect: { id: string } }       // relationship nested write (checked)
+    ownerId?: string | null                   // unchecked FK
+  }
+  export type EventUpdateInput = {
+    title?: string
+    day?: Date | string
+    price?: Decimal | number | string
+    meta?: InputJsonValue | JsonNullValueInput
+    active?: boolean
+    owner?: { connect: { id: string } } | { disconnect: true }
+    ownerId?: string | null
+  }
+
+  export type EventSelect = {
+    title?: boolean; day?: boolean; price?: boolean; meta?: boolean; active?: boolean; owner?: boolean
+  }
+  export type EventInclude = { owner?: boolean }
+  export type EventWhereInput = { title?: string }
+  export type EventCreateArgs = { data: EventCreateInput; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventUpdateArgs = { where: { id: string }; data: EventUpdateInput; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventFindUniqueArgs = { where: { id: string }; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventFindManyArgs = { where?: EventWhereInput; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventFindFirstArgs = { where?: EventWhereInput; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventDeleteArgs = { where: { id: string }; select?: EventSelect | null; include?: EventInclude | null }
+  export type EventCountArgs = { where?: EventWhereInput }
+  export type EventGetPayload<T> = { id: string; title: string; day: string; active: boolean }
+}
+`
+
+/**
+ * Minimal stubs for the `@opensaas/stack-core` + `/internal` symbols the
+ * generated types import. Kept permissive: these are not what we're testing.
+ */
+const CORE_STUB = `
+export interface Session { [key: string]: unknown }
+export type AccessContext<P> = { db: unknown; session: Session }
+`
+
+const CORE_INTERNAL_STUB = `
+export type StorageUtils = unknown
+export type ServerActionProps = unknown
+export type AccessControlledDB<P> = Record<string, unknown>
+export type Fragment<A, B> = unknown
+export type FieldSelection<A> = unknown
+`
+
+const PLUGIN_TYPES_STUB = `export type PluginServices = unknown\n`
+
+/**
+ * The consumer: exercises the generated CustomDB write methods. Passing
+ * lines must compile; `@ts-expect-error` lines must each catch an error.
+ */
+const CONSUMER = `
+import type { CustomDB } from './types.ts'
+
+declare const db: CustomDB
+
+async function run() {
+  // string -> calendarDay: compiles.
+  await db.event.create({ data: { title: 't', day: '2026-01-01' } })
+
+  // Date -> calendarDay: COMPILE ERROR (the #599 win).
+  // @ts-expect-error Date is not assignable to a calendarDay (string) field
+  await db.event.create({ data: { title: 't', day: new Date() } })
+
+  // decimal accepts number and string (not over-narrowed to Decimal).
+  await db.event.create({ data: { title: 't', price: 12.5 } })
+  await db.event.create({ data: { title: 't', price: '12.50' } })
+
+  // json accepts a plain value and Prisma's JsonNull sentinel.
+  await db.event.create({ data: { title: 't', meta: { a: 1 } } })
+
+  // relationship nested write + unchecked FK both compile.
+  await db.event.create({ data: { title: 't', owner: { connect: { id: 'u1' } } } })
+  await db.event.create({ data: { title: 't', ownerId: 'u1' } })
+
+  // checkbox({ defaultValue: false }) is OPTIONAL on create: omitting it compiles.
+  await db.event.create({ data: { title: 't' } })
+
+  // update path: Date -> calendarDay still a COMPILE ERROR.
+  // @ts-expect-error Date is not assignable to a calendarDay (string) field on update
+  await db.event.update({ where: { id: 'e1' }, data: { day: new Date() } })
+
+  // update path: string and decimal-number compile.
+  await db.event.update({ where: { id: 'e1' }, data: { day: '2026-01-02', price: 9 } })
+
+  // createMany element narrowing: Date rejected, string accepted.
+  await db.event.createMany({ data: [{ title: 't', day: '2026-01-01' }] })
+  // @ts-expect-error Date is not assignable to a calendarDay (string) field in createMany
+  await db.event.createMany({ data: [{ title: 't', day: new Date() }] })
+
+  // updateMany narrowing: string accepted.
+  await db.event.updateMany({ data: { day: '2026-01-03' } })
+}
+
+void run
+`
+
+function compileFixture(generatedTypes: string): ts.Diagnostic[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opensaas-write-narrowing-'))
+  try {
+    const prismaClientDir = path.join(dir, 'prisma-client')
+    fs.mkdirSync(prismaClientDir, { recursive: true })
+    fs.writeFileSync(path.join(prismaClientDir, 'client.ts'), PRISMA_STUB)
+    fs.writeFileSync(path.join(dir, 'types.ts'), generatedTypes)
+    fs.writeFileSync(path.join(dir, 'consumer.ts'), CONSUMER)
+
+    // Stub the bare-specifier core imports via a paths mapping.
+    const coreDir = path.join(dir, '_stubs')
+    fs.mkdirSync(coreDir, { recursive: true })
+    fs.writeFileSync(path.join(coreDir, 'core.ts'), CORE_STUB)
+    fs.writeFileSync(path.join(coreDir, 'core-internal.ts'), CORE_INTERNAL_STUB)
+    fs.writeFileSync(path.join(dir, 'plugin-types.ts'), PLUGIN_TYPES_STUB)
+
+    const compilerOptions: ts.CompilerOptions = {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      allowImportingTsExtensions: true,
+      baseUrl: dir,
+      paths: {
+        '@opensaas/stack-core': ['./_stubs/core.ts'],
+        '@opensaas/stack-core/internal': ['./_stubs/core-internal.ts'],
+        'decimal.js': ['./_stubs/decimal.ts'],
+      },
+    }
+    fs.writeFileSync(
+      path.join(coreDir, 'decimal.ts'),
+      'export class Decimal { constructor(_v: string | number) {} }\n',
+    )
+
+    const rootNames = [
+      path.join(dir, 'types.ts'),
+      path.join(dir, 'consumer.ts'),
+      path.join(prismaClientDir, 'client.ts'),
+    ]
+    const program = ts.createProgram({ rootNames, options: compilerOptions })
+    return [...ts.getPreEmitDiagnostics(program)]
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const TEST_CONFIG: OpenSaasConfig = {
+  db: { provider: 'postgresql' },
+  lists: {
+    User: { fields: { name: text({ validation: { isRequired: true } }) } },
+    Event: {
+      fields: {
+        title: text({ validation: { isRequired: true } }),
+        day: calendarDay(),
+        price: decimal(),
+        meta: json(),
+        active: checkbox({ defaultValue: false }),
+        owner: relationship({ ref: 'User' }),
+      },
+    },
+  },
+}
+
+describe('write-path data narrowing (#599)', () => {
+  it(
+    'rejects Date->calendarDay while allowing string/decimal/json/relationship writes',
+    { timeout: COMPILE_TIMEOUT_MS },
+    () => {
+      const generated = generateTypes(TEST_CONFIG)
+      const diagnostics = compileFixture(generated)
+
+      const messages = diagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'))
+
+      // Zero diagnostics: every valid write compiled AND every @ts-expect-error
+      // caught its intended error (an uncaught @ts-expect-error is itself a
+      // diagnostic, so a stray pass would fail here too).
+      expect(messages).toEqual([])
+    },
+  )
+
+  it('narrows day to string and keeps active optional in the generated CreateArgs', () => {
+    const generated = generateTypes(TEST_CONFIG)
+    // Structural assertions on the generated override (cheap, complements tsc).
+    expect(generated).toContain(
+      "data: Omit<Prisma.EventCreateArgs['data'], 'title' | 'day' | 'active'> & {",
+    )
+    expect(generated).toContain('day?: string | null')
+    // checkbox({ defaultValue: false }) is optional on create (the bug fix).
+    expect(generated).toContain('active?: boolean')
+    // decimal/json are NOT narrowed: they stay out of the Omit key list.
+    expect(generated).not.toContain("'price'")
+    expect(generated).not.toContain("'meta'")
+  })
+})

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -418,15 +418,6 @@ function generateUpdateInputType(listName: string, fields: Record<string, FieldC
 }
 
 /**
- * Extract the related list name from a relationship ref
- * @param ref - Relationship ref in format 'ListName' or 'ListName.fieldName'
- * @returns The list name (first part before '.')
- */
-function getRelatedListName(ref: string): string {
-  return ref.split('.')[0]
-}
-
-/**
  * Generate WhereInput type by re-exporting Prisma's native WhereInput
  * This ensures compatibility with all Prisma versions and includes all filter operators
  */

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -212,7 +212,12 @@ function generateCreateInputType(listName: string, fields: Record<string, FieldC
       const tsType = mapFieldTypeToTypeScript(fieldConfig)
       if (!tsType) continue // Skip if no type returned
 
-      const required = !isFieldOptional(fieldConfig) && !fieldConfig.defaultValue
+      // A field is optional on create when it is nullable OR has a default value.
+      // Use an explicit `!== undefined` check rather than a truthiness test:
+      // `!field.defaultValue` is truthy for a falsy-but-present default such as
+      // `checkbox({ defaultValue: false })`, which would wrongly mark the field
+      // required. See #599.
+      const required = !isFieldOptional(fieldConfig) && fieldConfig.defaultValue === undefined
       const optional = required ? '' : '?'
       lines.push(`  ${fieldName}${optional}: ${tsType}`)
     }
@@ -221,6 +226,157 @@ function generateCreateInputType(listName: string, fields: Record<string, FieldC
   lines.push('}')
 
   return lines.join('\n')
+}
+
+/**
+ * Decide whether a scalar field should have its write-path `data` type narrowed
+ * to the OpenSaaS `getTypeScriptType()` type, or left as Prisma's input type.
+ *
+ * Most scalar fields are narrowed so that field-level narrowing (e.g.
+ * `calendarDay` -> `string`) is a genuine compile error to violate at the
+ * `context.db.<list>.create()/update()` call site (#599). Two field shapes are
+ * deliberately left on Prisma's input type to avoid regressing valid writes:
+ *
+ * - `decimal`: OpenSaaS narrows to `Decimal`, but Prisma accepts
+ *   `Decimal | number | string`. A strict override would wrongly reject valid
+ *   `number`/`string` decimal writes.
+ * - `json`: OpenSaaS narrows to `unknown`, but Prisma's input type carries the
+ *   `JsonNull`/`DbNull` sentinels. Overriding to `unknown` would drop them.
+ *
+ * Multi-column / `resultExtension` storage fields (`getColumnNames`) are also
+ * left to Prisma: they back several raw columns rather than a single scalar
+ * column, so there is no single OpenSaaS scalar to narrow to. Their raw backing
+ * columns are still stripped from the override (see `getScalarOverrideOmitKeys`)
+ * so no dangling Prisma keys are left behind — mirroring `generateGetPayload`.
+ */
+function shouldNarrowScalarWrite(fieldConfig: FieldConfig): boolean {
+  if (fieldConfig.type === 'relationship') return false
+  if (fieldConfig.virtual) return false
+  if (!fieldConfig.getTypeScriptType) return false
+  // Keep Prisma's input type for decimal/json (see doc comment above).
+  if (fieldConfig.type === 'decimal' || fieldConfig.type === 'json') return false
+  // Multi-column / storage fields back raw columns, not a single scalar.
+  if (typeof fieldConfig.getColumnNames === 'function') return false
+  return true
+}
+
+/**
+ * The Prisma `data` keys to omit before re-adding narrowed scalar members.
+ * Includes each narrowed scalar field name plus any raw backing columns of
+ * multi-column fields (so no dangling Prisma keys remain after the Omit).
+ */
+function getScalarOverrideOmitKeys(fields: Record<string, FieldConfig>): string[] {
+  const keys: string[] = []
+  for (const [fieldName, fieldConfig] of Object.entries(fields)) {
+    if (shouldNarrowScalarWrite(fieldConfig)) {
+      keys.push(fieldName)
+    }
+    // Strip raw backing columns of multi-column fields regardless of narrowing:
+    // they are assembled from a logical field and must not leak Prisma keys.
+    if (typeof fieldConfig.getColumnNames === 'function') {
+      keys.push(...fieldConfig.getColumnNames(fieldName))
+    }
+  }
+  return keys
+}
+
+/**
+ * Build the narrowed scalar member lines for a write `data` override.
+ * Each narrowed scalar field uses its OpenSaaS `getTypeScriptType()` type with
+ * correct optionality/nullability.
+ *
+ * @param forCreate - create uses required/optional + default semantics; update
+ *   makes every field optional (partial update).
+ */
+function buildScalarOverrideMembers(
+  fields: Record<string, FieldConfig>,
+  forCreate: boolean,
+): string[] {
+  const members: string[] = []
+  for (const [fieldName, fieldConfig] of Object.entries(fields)) {
+    if (!shouldNarrowScalarWrite(fieldConfig)) continue
+
+    const tsType = mapFieldTypeToTypeScript(fieldConfig)
+    if (!tsType) continue
+
+    const nullable = isFieldOptional(fieldConfig)
+    const nullability = nullable ? ' | null' : ''
+
+    if (forCreate) {
+      // Optional on create when nullable OR has a default (see #599 bug fix in
+      // generateCreateInputType for the `defaultValue === undefined` rationale).
+      const required = !nullable && fieldConfig.defaultValue === undefined
+      const optional = required ? '' : '?'
+      members.push(`    ${fieldName}${optional}: ${tsType}${nullability}`)
+    } else {
+      // Partial update: every scalar is optional.
+      members.push(`    ${fieldName}?: ${tsType}${nullability}`)
+    }
+  }
+  return members
+}
+
+/**
+ * Build the write `data` type for a single-record create/update Args type.
+ * Scalars are narrowed to OpenSaaS types while relationship nested writes,
+ * unchecked FK fields, and decimal/json keep Prisma's input shape.
+ *
+ * Shape: `Omit<Prisma.{List}{Create|Update}Args['data'], <omitKeys>> & { <narrowed scalars> }`
+ *
+ * When there are no narrowable scalars and no backing columns to strip, the
+ * Prisma `data` type is used unchanged.
+ */
+function buildWriteDataType(
+  listName: string,
+  fields: Record<string, FieldConfig>,
+  forCreate: boolean,
+): string {
+  const argsType = forCreate ? `${listName}CreateArgs` : `${listName}UpdateArgs`
+  const prismaData = `Prisma.${argsType}['data']`
+
+  const omitKeys = getScalarOverrideOmitKeys(fields)
+  const members = buildScalarOverrideMembers(fields, forCreate)
+
+  if (omitKeys.length === 0 && members.length === 0) {
+    return prismaData
+  }
+
+  const omitUnion = omitKeys.map((k) => `'${k}'`).join(' | ')
+  const base = omitKeys.length > 0 ? `Omit<${prismaData}, ${omitUnion}>` : prismaData
+
+  if (members.length === 0) {
+    return base
+  }
+
+  return `${base} & {\n${members.join('\n')}\n  }`
+}
+
+/**
+ * Build a narrowed write input type over an arbitrary Prisma base input type
+ * expression (e.g. `Prisma.{List}CreateInput`). Used by the createMany /
+ * updateMany variants whose `data` is built from the scalar `*Input` types
+ * rather than the single-record `*Args['data']`.
+ */
+function buildWriteInputOverride(
+  prismaBase: string,
+  fields: Record<string, FieldConfig>,
+  forCreate: boolean,
+): string {
+  const omitKeys = getScalarOverrideOmitKeys(fields)
+  const members = buildScalarOverrideMembers(fields, forCreate)
+
+  if (omitKeys.length === 0 && members.length === 0) {
+    return prismaBase
+  }
+
+  const omitUnion = omitKeys.map((k) => `'${k}'`).join(' | ')
+  const base = omitKeys.length > 0 ? `Omit<${prismaBase}, ${omitUnion}>` : prismaBase
+
+  if (members.length === 0) {
+    return base
+  }
+
+  return `${base} & {\n${members.join('\n')}\n  }`
 }
 
 /**
@@ -731,21 +887,29 @@ export type ${listName}FindFirstArgs = Omit<Prisma.${listName}FindFirstArgs, 'se
  */
 function generateCreateArgsType(listName: string, fields: Record<string, FieldConfig>): string {
   const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+  // Narrow scalar `data` members to OpenSaaS types so field-level narrowing
+  // (e.g. calendarDay -> string) is a compile error at the call site (#599),
+  // while relationship nested writes / decimal / json keep Prisma's shape.
+  const dataType = buildWriteDataType(listName, fields, true)
 
   if (hasRelationships) {
     return `/**
  * Custom CreateArgs for ${listName} with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type ${listName}CreateArgs = Omit<Prisma.${listName}CreateArgs, 'select' | 'include'> & {
+export type ${listName}CreateArgs = Omit<Prisma.${listName}CreateArgs, 'select' | 'include' | 'data'> & {
   select?: ${listName}Select | null
   include?: ${listName}Include | null
+  data: ${dataType}
 }`
   } else {
     return `/**
  * Custom CreateArgs for ${listName} with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type ${listName}CreateArgs = Omit<Prisma.${listName}CreateArgs, 'select'> & {
+export type ${listName}CreateArgs = Omit<Prisma.${listName}CreateArgs, 'select' | 'data'> & {
   select?: ${listName}Select | null
+  data: ${dataType}
 }`
   }
 }
@@ -755,21 +919,27 @@ export type ${listName}CreateArgs = Omit<Prisma.${listName}CreateArgs, 'select'>
  */
 function generateUpdateArgsType(listName: string, fields: Record<string, FieldConfig>): string {
   const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+  // See generateCreateArgsType: narrow scalar `data` members (#599).
+  const dataType = buildWriteDataType(listName, fields, false)
 
   if (hasRelationships) {
     return `/**
  * Custom UpdateArgs for ${listName} with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type ${listName}UpdateArgs = Omit<Prisma.${listName}UpdateArgs, 'select' | 'include'> & {
+export type ${listName}UpdateArgs = Omit<Prisma.${listName}UpdateArgs, 'select' | 'include' | 'data'> & {
   select?: ${listName}Select | null
   include?: ${listName}Include | null
+  data: ${dataType}
 }`
   } else {
     return `/**
  * Custom UpdateArgs for ${listName} with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
-export type ${listName}UpdateArgs = Omit<Prisma.${listName}UpdateArgs, 'select'> & {
+export type ${listName}UpdateArgs = Omit<Prisma.${listName}UpdateArgs, 'select' | 'data'> & {
   select?: ${listName}Select | null
+  data: ${dataType}
 }`
   }
 }
@@ -803,22 +973,26 @@ export type ${listName}DeleteArgs = Omit<Prisma.${listName}DeleteArgs, 'select'>
  */
 function generateCreateManyArgsType(listName: string, fields: Record<string, FieldConfig>): string {
   const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+  // createMany `data` is an array of scalar inputs; narrow each element (#599).
+  const dataElement = buildWriteInputOverride(`Prisma.${listName}CreateInput`, fields, true)
 
   if (hasRelationships) {
     return `/**
  * Custom CreateManyArgs for ${listName} with virtual field support in nested relationships
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type ${listName}CreateManyArgs = {
-  data: Prisma.${listName}CreateInput[]
+  data: Array<${dataElement}>
   select?: ${listName}Select | null
   include?: ${listName}Include | null
 }`
   } else {
     return `/**
  * Custom CreateManyArgs for ${listName} with virtual field support
+ * Each \`data\` element narrows scalar fields to their OpenSaaS types (#599).
  */
 export type ${listName}CreateManyArgs = {
-  data: Prisma.${listName}CreateInput[]
+  data: Array<${dataElement}>
   select?: ${listName}Select | null
 }`
   }
@@ -829,24 +1003,28 @@ export type ${listName}CreateManyArgs = {
  */
 function generateUpdateManyArgsType(listName: string, fields: Record<string, FieldConfig>): string {
   const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+  // updateMany `data` is a single partial scalar input; narrow it (#599).
+  const dataType = buildWriteInputOverride(`Prisma.${listName}UpdateInput`, fields, false)
 
   if (hasRelationships) {
     return `/**
  * Custom UpdateManyArgs for ${listName} with virtual field support in nested relationships
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type ${listName}UpdateManyArgs = {
   where?: ${listName}WhereInput
-  data: Prisma.${listName}UpdateInput
+  data: ${dataType}
   select?: ${listName}Select | null
   include?: ${listName}Include | null
 }`
   } else {
     return `/**
  * Custom UpdateManyArgs for ${listName} with virtual field support
+ * The \`data\` member narrows scalar fields to their OpenSaaS types (#599).
  */
 export type ${listName}UpdateManyArgs = {
   where?: ${listName}WhereInput
-  data: Prisma.${listName}UpdateInput
+  data: ${dataType}
   select?: ${listName}Select | null
 }`
   }


### PR DESCRIPTION
Closes #599

## Problem

After PRD #582, `calendarDay`'s `getTypeScriptType()` returns `string`, so the entity type and the standalone `{List}CreateInput`/`{List}UpdateInput` exports are `string`. But the generated `context.db.<list>.create()/update()` method signatures typed their `data` from **Prisma's** `Prisma.{List}CreateArgs['data']` (where a `@db.Date` column is `Date | string`), so `context.db.event.create({ data: { startDate: new Date() } })` still type-checked. The field-level narrowing was only enforced at runtime (zod), never at the real write call site.

## Approach (B — scalar-only override)

In `packages/cli/src/generator/types.ts`, the `data` member of the call-site `CreateArgs`/`UpdateArgs` (and the `createMany`/`updateMany` variants) now overrides scalar fields with their OpenSaaS `getTypeScriptType()` types while leaving relationship nested-writes on Prisma's shape:

```ts
data: Omit<Prisma.{List}CreateArgs['data'], scalarKeys | backingColumns>
      & { /* each narrowed scalar: its OpenSaaS type, optional per nullability/default */ }
```

For `createMany` the element type wraps `Prisma.{List}CreateInput`; for `updateMany`, `Prisma.{List}UpdateInput`. This flows through `generateCustomDBType` to all four write methods.

### Verified by `tsc` against the real generated Prisma client (blog example)

```
string -> calendarDay   ✅ compiles
Date   -> calendarDay   ❌ error TS2322: Type 'Date' is not assignable to type 'string'.
author.connect / authorId (relationship + unchecked FK)   ✅ compiles
```

## Edge cases

| Field | Handling |
| --- | --- |
| **decimal** | Left on Prisma's input type — still accepts `Decimal | number | string`. A strict override to `Decimal` would wrongly reject valid `number`/`string` writes. It is excluded from both the `Omit` key set and the narrowed members. |
| **json** | Left on Prisma's input type — keeps the `JsonNull`/`DbNull` sentinels (and doesn't regress the #603/#604 json work). Narrowing to `unknown` would drop the sentinels. Excluded like decimal. |
| **multi-column / storage fields** (`getColumnNames`) | Their raw backing columns are added to the `Omit` (so no dangling Prisma keys remain — mirroring `generateGetPayload`), but they are not narrowed to a single scalar. |
| **createMany / updateMany** | Same override applied — createMany over an array element, updateMany over the single partial input. |
| **optionality / nullability** | Each narrowed scalar preserves required/optional and `| null`, from the same source of truth as the standalone input generators. |

## Bonus bug fix

`checkbox({ defaultValue: false })` was generated as a **required** create field because the optionality check used `!field.defaultValue` (truthy for `false`). Fixed to `field.defaultValue === undefined`, in both the call-site override and the standalone `CreateInput` generator. Covered by a test asserting the field is optional on create.

## Tests

New `packages/cli/src/generator/types-write-narrowing.test.ts` compiles the generated write methods (exactly as `generateCustomDBType` wires them, `<T extends Args>(args: Prisma.SelectSubset<T, Args>) => …`) against a faithful `Prisma` stub via `ts.createProgram`, asserting:
- `Date -> calendarDay` errors (create, update, createMany); `string` compiles
- `number`/`string -> decimal` compiles; `json` value compiles
- relationship nested write + unchecked FK compile
- `checkbox({ defaultValue: false })` is optional on create

A mutation check confirmed the Date assertion is load-bearing (removing the `@ts-expect-error` surfaces `Type 'Date' is not assignable to type 'string'.`). Full CLI suite: 310 passed (308 prior + 2 new; 13 snapshots updated for the new `data` shape).

## Known limitation (out of scope)

The generated method generic uses `Prisma.SelectSubset<T, …>`, which weakens excess-property checking. So the guarantee is **"a known scalar with the wrong type is rejected"** (the `calendarDay`-`Date` case), **not** "no unknown keys are allowed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_