### PR TITLE
fix(ui): push initialSort and column sorts to DB orderBy

### DIFF
--- a/.changeset/silent-owls-fix.md
+++ b/.changeset/silent-owls-fix.md
@@ -4,6 +4,6 @@
 
 Fix `ui.listView.initialSort` applying sort client-side instead of as a DB-level `orderBy`
 
-Previously, `initialSort` was applied to the already-fetched page in memory, meaning a 500-row list with `initialSort: { field: 'sentAt', direction: 'desc' }` would only show the 50 most recent rows of the *current page* rather than the 50 most recent rows overall. The sort is now passed as `orderBy` to `findMany` so pagination and sorting compose correctly.
+Previously, `initialSort` was applied to the already-fetched page in memory, meaning a 500-row list with `initialSort: { field: 'sentAt', direction: 'desc' }` would only show the 50 most recent rows of the _current page_ rather than the 50 most recent rows overall. The sort is now passed as `orderBy` to `findMany` so pagination and sorting compose correctly.
 
 Column-header clicks also now navigate with a `?sort=field:direction` URL param (instead of mutating local state), so subsequent sorts are also DB-level and work correctly across pages.

--- a/.changeset/silent-owls-fix.md
+++ b/.changeset/silent-owls-fix.md
@@ -1,0 +1,9 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Fix `ui.listView.initialSort` applying sort client-side instead of as a DB-level `orderBy`
+
+Previously, `initialSort` was applied to the already-fetched page in memory, meaning a 500-row list with `initialSort: { field: 'sentAt', direction: 'desc' }` would only show the 50 most recent rows of the *current page* rather than the 50 most recent rows overall. The sort is now passed as `orderBy` to `findMany` so pagination and sorting compose correctly.
+
+Column-header clicks also now navigate with a `?sort=field:direction` URL param (instead of mutating local state), so subsequent sorts are also DB-level and work correctly across pages.

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -114,6 +114,20 @@ export function AdminUI({
     // no default sort).
     const listView = config.lists[listKey]?.ui?.listView
 
+    // Parse `?sort=field:direction` URL param for user-triggered column sorts.
+    const sortParam = typeof searchParams.sort === 'string' ? searchParams.sort : undefined
+    let urlSort: { field: string; direction: 'asc' | 'desc' } | undefined
+    if (sortParam) {
+      const colonIdx = sortParam.lastIndexOf(':')
+      if (colonIdx > 0) {
+        const field = sortParam.slice(0, colonIdx)
+        const dir = sortParam.slice(colonIdx + 1)
+        if (dir === 'asc' || dir === 'desc') {
+          urlSort = { field, direction: dir }
+        }
+      }
+    }
+
     content = (
       <ListView
         context={context}
@@ -124,6 +138,7 @@ export function AdminUI({
         page={page}
         columns={listView?.initialColumns}
         initialSort={listView?.initialSort}
+        sort={urlSort}
       />
     )
   }

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -49,8 +49,6 @@ export async function ListView({
   initialSort,
   sort,
 }: ListViewProps) {
-  // URL sort takes precedence over config initialSort.
-  const activeSort = sort ?? initialSort
   const key = getDbKey(listKey)
   const urlKey = getUrlKey(listKey)
   const listConfig = config.lists[listKey]
@@ -65,6 +63,11 @@ export async function ListView({
       </div>
     )
   }
+
+  // URL sort takes precedence over config initialSort, but only if the field
+  // actually exists on the list — an unknown field would cause Prisma to throw.
+  const validatedSort = sort && sort.field in listConfig.fields ? sort : undefined
+  const activeSort = validatedSort ?? initialSort
 
   // Fetch items using access-controlled context
   const skip = (page - 1) * pageSize

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -22,10 +22,15 @@ export interface ListViewProps {
   pageSize?: number
   search?: string
   /**
-   * Default sort applied to the table (from the list's `ui.listView.initialSort`).
-   * When omitted, no default sort is applied.
+   * Default sort from the list's `ui.listView.initialSort` config.
+   * Used when no URL sort param is present.
    */
   initialSort?: ListViewSort
+  /**
+   * Active sort from the `?sort=field:direction` URL param.
+   * Takes precedence over `initialSort`.
+   */
+  sort?: ListViewSort
 }
 
 /**
@@ -42,7 +47,10 @@ export async function ListView({
   pageSize = 50,
   search,
   initialSort,
+  sort,
 }: ListViewProps) {
+  // URL sort takes precedence over config initialSort.
+  const activeSort = sort ?? initialSort
   const key = getDbKey(listKey)
   const urlKey = getUrlKey(listKey)
   const listConfig = config.lists[listKey]
@@ -97,9 +105,11 @@ export async function ListView({
     })
     const delegate = dbContext[key]
     if (delegate?.findMany && delegate?.count) {
+      const orderBy = activeSort ? { [activeSort.field]: activeSort.direction } : undefined
       ;[items, total] = await Promise.all([
         delegate.findMany({
           where,
+          orderBy,
           skip,
           take: pageSize,
           ...(Object.keys(include).length > 0 ? { include } : {}),
@@ -157,7 +167,7 @@ export async function ListView({
         )}
         relationshipRefs={relationshipRefs}
         columns={columns}
-        initialSort={initialSort}
+        initialSort={activeSort}
         listKey={listKey}
         urlKey={urlKey}
         basePath={basePath}

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -96,7 +96,12 @@ export function ListViewClient({
 
   const handleClearSearch = () => {
     setSearchInput('')
-    router.push(`${basePath}/${urlKey}`)
+    const params = new URLSearchParams()
+    if (sortBy) {
+      params.set('sort', `${sortBy}:${sortOrder}`)
+    }
+    const qs = params.toString()
+    router.push(`${basePath}/${urlKey}${qs ? `?${qs}` : ''}`)
   }
 
   const buildPaginationUrl = (newPage: number) => {

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { useState } from 'react'
 import Link from 'next/link.js'
 import { useRouter } from 'next/navigation.js'
 import { formatFieldName, getFieldDisplayValue } from '../lib/utils.js'
@@ -56,41 +55,30 @@ export function ListViewClient({
   search: initialSearch,
 }: ListViewClientProps) {
   const router = useRouter()
-  const [sortBy, setSortBy] = useState<string | null>(initialSort?.field ?? null)
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(initialSort?.direction ?? 'asc')
-  const [searchInput, setSearchInput] = useState(initialSearch || '')
+  const sortBy = initialSort?.field ?? null
+  const sortOrder = initialSort?.direction ?? 'asc'
+  const [searchInput, setSearchInput] = React.useState(initialSearch || '')
 
   // Determine which columns to show
   const displayColumns =
     columns ||
     Object.keys(fieldTypes).filter((key) => !['password', 'createdAt', 'updatedAt'].includes(key))
 
-  // Sort items if needed
-  const sortedItems = [...items]
-  if (sortBy) {
-    sortedItems.sort((a, b) => {
-      const aVal = a[sortBy]
-      const bVal = b[sortBy]
-      if (aVal === bVal) return 0
-      // Handle unknown types for comparison - convert to string for safety
-      const aStr = String(aVal ?? '')
-      const bStr = String(bVal ?? '')
-      const comparison = aStr > bStr ? 1 : -1
-      return sortOrder === 'asc' ? comparison : -comparison
-    })
-  }
+  // Items are already sorted by the server via orderBy; no in-memory sort needed.
 
   const totalPages = Math.ceil(total / pageSize)
   const hasNextPage = page < totalPages
   const hasPrevPage = page > 1
 
   const handleSort = (column: string) => {
-    if (sortBy === column) {
-      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
-    } else {
-      setSortBy(column)
-      setSortOrder('asc')
+    const newDirection = sortBy === column ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'asc'
+    const params = new URLSearchParams()
+    if (initialSearch) {
+      params.set('search', initialSearch)
     }
+    params.set('sort', `${column}:${newDirection}`)
+    params.set('page', '1')
+    router.push(`${basePath}/${urlKey}?${params.toString()}`)
   }
 
   const handleSearch = (e: React.FormEvent) => {
@@ -98,6 +86,9 @@ export function ListViewClient({
     const params = new URLSearchParams()
     if (searchInput.trim()) {
       params.set('search', searchInput.trim())
+    }
+    if (sortBy) {
+      params.set('sort', `${sortBy}:${sortOrder}`)
     }
     params.set('page', '1') // Reset to page 1 on new search
     router.push(`${basePath}/${urlKey}?${params.toString()}`)
@@ -112,6 +103,9 @@ export function ListViewClient({
     const params = new URLSearchParams()
     if (initialSearch) {
       params.set('search', initialSearch)
+    }
+    if (sortBy) {
+      params.set('sort', `${sortBy}:${sortOrder}`)
     }
     params.set('page', newPage.toString())
     return `${basePath}/${urlKey}?${params.toString()}`
@@ -225,14 +219,14 @@ export function ListViewClient({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {sortedItems.length === 0 ? (
+            {items.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={displayColumns.length + 1} className="h-24 text-center">
                   No items found
                 </TableCell>
               </TableRow>
             ) : (
-              sortedItems.map((item) => (
+              items.map((item) => (
                 <TableRow key={String(item.id)}>
                   {displayColumns.map((column) => (
                     <TableCell key={column}>

--- a/packages/ui/tests/components/AdminUIListView.test.tsx
+++ b/packages/ui/tests/components/AdminUIListView.test.tsx
@@ -124,6 +124,39 @@ describe('AdminUI ui.listView wiring', () => {
     expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { title: 'asc' } }))
   })
 
+  it('discards URL sort param when field does not exist on the list, falling back to initialSort', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: { title: text(), sentAt: timestamp() },
+          ui: {
+            listView: {
+              initialSort: { field: 'sentAt', direction: 'desc' },
+            },
+          },
+        }),
+      },
+    }
+
+    const context = makeContext({ post: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'Post',
+      basePath: '/admin',
+      initialSort: { field: 'sentAt', direction: 'desc' },
+      sort: { field: 'nonExistentField', direction: 'asc' },
+    })
+
+    // Unknown field is rejected; falls back to initialSort.
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { sentAt: 'desc' } }))
+  })
+
   it('passes initialColumns + initialSort from ui.listView to ListView', async () => {
     const config: OpenSaasConfig = {
       db: { provider: 'sqlite', url: 'file:./test.db' },

--- a/packages/ui/tests/components/AdminUIListView.test.tsx
+++ b/packages/ui/tests/components/AdminUIListView.test.tsx
@@ -61,6 +61,69 @@ function routedContent(tree: React.ReactNode): React.ReactElement {
 }
 
 describe('AdminUI ui.listView wiring', () => {
+  it('passes orderBy to findMany based on initialSort', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: { title: text(), sentAt: timestamp() },
+          ui: {
+            listView: {
+              initialSort: { field: 'sentAt', direction: 'desc' },
+            },
+          },
+        }),
+      },
+    }
+
+    const context = makeContext({ post: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'Post',
+      basePath: '/admin',
+      initialSort: { field: 'sentAt', direction: 'desc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { sentAt: 'desc' } }))
+  })
+
+  it('URL sort param takes precedence over initialSort in orderBy', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: { title: text(), sentAt: timestamp() },
+          ui: {
+            listView: {
+              initialSort: { field: 'sentAt', direction: 'desc' },
+            },
+          },
+        }),
+      },
+    }
+
+    const context = makeContext({ post: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'Post',
+      basePath: '/admin',
+      initialSort: { field: 'sentAt', direction: 'desc' },
+      sort: { field: 'title', direction: 'asc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { title: 'asc' } }))
+  })
+
   it('passes initialColumns + initialSort from ui.listView to ListView', async () => {
     const config: OpenSaasConfig = {
       db: { provider: 'sqlite', url: 'file:./test.db' },

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -90,31 +90,15 @@ describe('ListViewClient', () => {
   })
 
   describe('initialSort', () => {
-    it('should apply default sort from initialSort without any click', () => {
+    it('should show sort indicator on the initialSort column (asc)', () => {
       render(
         <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'asc' }} />,
       )
 
-      const rows = screen.getAllByRole('row')
-      // Sorted ascending by title: First, Second, Third
-      expect(rows[1]).toHaveTextContent('First Post')
-      expect(rows[2]).toHaveTextContent('Second Post')
-      expect(rows[3]).toHaveTextContent('Third Post')
+      expect(screen.getByText('↑')).toBeInTheDocument()
     })
 
-    it('should respect descending direction from initialSort', () => {
-      render(
-        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'desc' }} />,
-      )
-
-      const rows = screen.getAllByRole('row')
-      // Sorted descending by title: Third, Second, First
-      expect(rows[1]).toHaveTextContent('Third Post')
-      expect(rows[2]).toHaveTextContent('Second Post')
-      expect(rows[3]).toHaveTextContent('First Post')
-    })
-
-    it('should show sort indicator on the initialSort column', () => {
+    it('should show sort indicator on the initialSort column (desc)', () => {
       render(
         <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'desc' }} />,
       )
@@ -122,69 +106,74 @@ describe('ListViewClient', () => {
       expect(screen.getByText('↓')).toBeInTheDocument()
     })
 
+    it('should preserve item order provided by server (no in-memory sort)', () => {
+      // Items arrive pre-sorted by the server; the client renders them as-is.
+      const sortedItems = [
+        { id: '3', title: 'Third Post', status: 'published', views: 200 },
+        { id: '2', title: 'Second Post', status: 'draft', views: 50 },
+        { id: '1', title: 'First Post', status: 'published', views: 100 },
+      ]
+      render(
+        <ListViewClient
+          {...defaultProps}
+          items={sortedItems}
+          initialSort={{ field: 'title', direction: 'desc' }}
+        />,
+      )
+
+      const rows = screen.getAllByRole('row')
+      expect(rows[1]).toHaveTextContent('Third Post')
+      expect(rows[2]).toHaveTextContent('Second Post')
+      expect(rows[3]).toHaveTextContent('First Post')
+    })
+
     it('should not apply any default sort when initialSort is absent', () => {
       render(<ListViewClient {...defaultProps} />)
 
-      const rows = screen.getAllByRole('row')
-      // Unchanged: items render in their original (input) order, no indicator.
-      expect(rows[1]).toHaveTextContent('First Post')
-      expect(rows[2]).toHaveTextContent('Second Post')
-      expect(rows[3]).toHaveTextContent('Third Post')
+      // No sort indicator when no initialSort.
       expect(screen.queryByText('↑')).not.toBeInTheDocument()
       expect(screen.queryByText('↓')).not.toBeInTheDocument()
     })
   })
 
   describe('sorting', () => {
-    it('should sort items ascending when header clicked', async () => {
+    it('should navigate with sort param when column header clicked', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} />)
 
       await user.click(screen.getByText('Title'))
 
-      const rows = screen.getAllByRole('row')
-      // First row is header, so data rows start at index 1
-      expect(rows[1]).toHaveTextContent('First Post')
-      expect(rows[2]).toHaveTextContent('Second Post')
-      expect(rows[3]).toHaveTextContent('Third Post')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Aasc&page=1')
     })
 
-    it('should toggle sort order when same header clicked twice', async () => {
+    it('should navigate with toggled direction when already-sorted column clicked', async () => {
       const user = userEvent.setup()
-      render(<ListViewClient {...defaultProps} />)
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'asc' }} />,
+      )
 
-      const titleHeader = screen.getByText('Title')
-      await user.click(titleHeader)
-      await user.click(titleHeader)
+      await user.click(screen.getByText('Title'))
 
-      const rows = screen.getAllByRole('row')
-      // Should be descending now
-      expect(rows[1]).toHaveTextContent('Third Post')
-      expect(rows[2]).toHaveTextContent('Second Post')
-      expect(rows[3]).toHaveTextContent('First Post')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc&page=1')
     })
 
     it('should show sort indicator on active column', async () => {
-      const user = userEvent.setup()
-      render(<ListViewClient {...defaultProps} />)
-
-      await user.click(screen.getByText('Title'))
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'asc' }} />,
+      )
 
       expect(screen.getByText('↑')).toBeInTheDocument()
     })
 
-    it('should sort numeric fields correctly', async () => {
+    it('should navigate with asc when switching to a different column', async () => {
       const user = userEvent.setup()
-      render(<ListViewClient {...defaultProps} />)
+      render(
+        <ListViewClient {...defaultProps} initialSort={{ field: 'title', direction: 'desc' }} />,
+      )
 
       await user.click(screen.getByText('Views'))
 
-      const rows = screen.getAllByRole('row')
-      // Should sort by views: 100, 200, 50 (string comparison)
-      // Note: The current implementation sorts as strings, not numbers
-      expect(rows[1]).toHaveTextContent('100')
-      expect(rows[2]).toHaveTextContent('200')
-      expect(rows[3]).toHaveTextContent('50')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=views%3Aasc&page=1')
     })
   })
 
@@ -323,6 +312,24 @@ describe('ListViewClient', () => {
       await user.click(nextButton)
 
       expect(mockPush).toHaveBeenCalledWith('/admin/post?search=test&page=2')
+    })
+
+    it('should preserve sort in pagination URLs', async () => {
+      const user = userEvent.setup()
+      render(
+        <ListViewClient
+          {...defaultProps}
+          total={100}
+          pageSize={10}
+          page={1}
+          initialSort={{ field: 'title', direction: 'desc' }}
+        />,
+      )
+
+      const nextButton = screen.getByRole('button', { name: /next/i })
+      await user.click(nextButton)
+
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc&page=2')
     })
   })
 

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -230,6 +230,22 @@ describe('ListViewClient', () => {
       expect(mockPush).toHaveBeenCalledWith('/admin/post')
     })
 
+    it('should preserve active sort when search is cleared', async () => {
+      const user = userEvent.setup()
+      render(
+        <ListViewClient
+          {...defaultProps}
+          search="existing"
+          initialSort={{ field: 'title', direction: 'desc' }}
+        />,
+      )
+
+      const clearButton = screen.getByText('✕')
+      await user.click(clearButton)
+
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc')
+    })
+
     it('should reset to page 1 when new search submitted', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} page={3} />)


### PR DESCRIPTION
## Summary

- `ListView.tsx`: accepts a new `sort` prop (from `?sort=field:direction` URL param); computes `activeSort = sort ?? initialSort`; passes it as `orderBy` to `findMany` so the DB sorts the full result set before pagination
- `AdminUI.tsx`: parses `?sort=field:direction` from `searchParams` and forwards it to `ListView` as the `sort` prop
- `ListViewClient.tsx`: removes in-memory sort of the fetched page; column header clicks navigate with `?sort=field:direction` (resetting to page 1) so all subsequent sorts are also DB-level

## Test plan

- [x] New tests verify `findMany` receives `orderBy` for both `initialSort` and URL `sort` param
- [x] New test confirms URL sort takes precedence over `initialSort`
- [x] `initialSort` tests updated: they now assert sort indicators display and item order reflects pre-sorted server data (not in-memory reorder)
- [x] Sort navigation tests confirm column header clicks push `?sort=field:dir&page=1`
- [x] Pagination URL tests confirm sort param is preserved across pages
- [x] All 193 tests pass (`pnpm test` in `packages/ui`)
- [x] `pnpm lint` passes with no new warnings

Closes #561

---
_Generated by [Claude Code](https://claude.ai/code/session_015NX95aBb9SAtQ7EmEyYDpY)_