### PR TITLE
Consolidate create/update input nullability into one shared helper (#608)

### DIFF
--- a/.changeset/clever-foxes-consolidate.md
+++ b/.changeset/clever-foxes-consolidate.md
@@ -1,0 +1,17 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Consolidate nullability between the standalone `{List}CreateInput`/`{List}UpdateInput` exports and the call-site write-`data` override into a single source of truth (#608).
+
+The generated types previously described a list's create/update input shape in two places that disagreed on how a nullable scalar was represented: the write-`data` override emitted `name?: string | null` (matching Prisma's nullable-column input) while the standalone `{List}CreateInput`/`{List}UpdateInput` emitted `name?: string`. Both paths now render each scalar member through one shared helper, so a nullable scalar is consistently `name?: T | null` in every input representation. Required scalars stay required, and `decimal`/`json`/relationship/multi-column handling is unchanged.
+
+This is a non-breaking type refinement, but if you assigned the standalone `{List}CreateInput`/`{List}UpdateInput` types into a stricter local type, a nullable scalar may now be inferred as `T | null`:
+
+```typescript
+// A nullable text() field on Post now generates:
+export type PostCreateInput = {
+  title: string // required scalar — unchanged
+  content?: string | null // nullable scalar — now includes `| null`
+}
+```

--- a/packages/cli/src/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/types.test.ts.snap
@@ -43,11 +43,11 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserWhereInput = Prisma.UserWhereInput
@@ -302,12 +302,12 @@ export type Post = PostOutput
 
 export type PostCreateInput = {
   title: string
-  content?: string
+  content?: string | null
 }
 
 export type PostUpdateInput = {
   title?: string
-  content?: string
+  content?: string | null
 }
 
 export type PostWhereInput = Prisma.PostWhereInput
@@ -565,12 +565,12 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
   posts?: { connect: Array<{ id: string }> }
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
   posts?: { connect: Array<{ id: string }>, disconnect: Array<{ id: string }> }
 }
 
@@ -835,12 +835,12 @@ export type PostOutput = {
 export type Post = PostOutput
 
 export type PostCreateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } }
 }
 
 export type PostUpdateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } } | { disconnect: true }
 }
 
@@ -1482,12 +1482,12 @@ export type Post = PostOutput
 
 export type PostCreateInput = {
   title: string
-  content?: string
+  content?: string | null
 }
 
 export type PostUpdateInput = {
   title?: string
-  content?: string
+  content?: string | null
 }
 
 export type PostWhereInput = Prisma.PostWhereInput
@@ -1744,11 +1744,11 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserWhereInput = Prisma.UserWhereInput
@@ -2265,11 +2265,11 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserWhereInput = Prisma.UserWhereInput
@@ -2445,11 +2445,11 @@ export type PostOutput = {
 export type Post = PostOutput
 
 export type PostCreateInput = {
-  title?: string
+  title?: string | null
 }
 
 export type PostUpdateInput = {
-  title?: string
+  title?: string | null
 }
 
 export type PostWhereInput = Prisma.PostWhereInput
@@ -2625,11 +2625,11 @@ export type CommentOutput = {
 export type Comment = CommentOutput
 
 export type CommentCreateInput = {
-  content?: string
+  content?: string | null
 }
 
 export type CommentUpdateInput = {
-  content?: string
+  content?: string | null
 }
 
 export type CommentWhereInput = Prisma.CommentWhereInput
@@ -2938,12 +2938,12 @@ export type PostOutput = {
 export type Post = PostOutput
 
 export type PostCreateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } }
 }
 
 export type PostUpdateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } } | { disconnect: true }
 }
 
@@ -3182,11 +3182,11 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserWhereInput = Prisma.UserWhereInput
@@ -3468,12 +3468,12 @@ export type PostOutput = {
 export type Post = PostOutput
 
 export type PostCreateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } }
 }
 
 export type PostUpdateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } } | { disconnect: true }
 }
 
@@ -3712,11 +3712,11 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
 }
 
 export type UserWhereInput = Prisma.UserWhereInput
@@ -3997,12 +3997,12 @@ export type UserOutput = {
 export type User = UserOutput
 
 export type UserCreateInput = {
-  name?: string
+  name?: string | null
   posts?: { connect: Array<{ id: string }> }
 }
 
 export type UserUpdateInput = {
-  name?: string
+  name?: string | null
   posts?: { connect: Array<{ id: string }>, disconnect: Array<{ id: string }> }
 }
 
@@ -4243,12 +4243,12 @@ export type PostOutput = {
 export type Post = PostOutput
 
 export type PostCreateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } }
 }
 
 export type PostUpdateInput = {
-  title?: string
+  title?: string | null
   author?: { connect: { id: string } } | { disconnect: true }
 }
 
@@ -4592,12 +4592,12 @@ export type AccountOutput = {
 export type Account = AccountOutput
 
 export type AccountCreateInput = {
-  name?: string
+  name?: string | null
   bills?: { connect: Array<{ id: string }> }
 }
 
 export type AccountUpdateInput = {
-  name?: string
+  name?: string | null
   bills?: { connect: Array<{ id: string }>, disconnect: Array<{ id: string }> }
 }
 
@@ -4838,12 +4838,12 @@ export type BillOutput = {
 export type Bill = BillOutput
 
 export type BillCreateInput = {
-  name?: string
+  name?: string | null
   account?: { connect: { id: string } }
 }
 
 export type BillUpdateInput = {
-  name?: string
+  name?: string | null
   account?: { connect: { id: string } } | { disconnect: true }
 }
 

--- a/packages/cli/src/generator/types.test.ts
+++ b/packages/cli/src/generator/types.test.ts
@@ -387,4 +387,76 @@ describe('Types Generator', () => {
       expect(types).toMatchSnapshot()
     })
   })
+
+  // #608: the standalone {List}CreateInput / {List}UpdateInput exports and the
+  // call-site write-`data` override must agree on how a nullable scalar is
+  // represented (both `?: T | null`). A single shared helper
+  // (renderScalarInputMember) renders the member for both paths; these tests
+  // pin the agreement so the two sources of truth cannot silently drift again.
+  describe('create/update input nullability consolidation (#608)', () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: {
+        Post: {
+          fields: {
+            // Required scalar: stays required, no `?`, no `| null`.
+            title: text({ validation: { isRequired: true } }),
+            // Nullable scalar: optional + `| null` in every input representation.
+            content: text(),
+          },
+        },
+      },
+    }
+
+    it('emits `| null` for a nullable scalar in the standalone CreateInput', () => {
+      const types = generateTypes(config)
+      expect(types).toContain('export type PostCreateInput = {')
+      expect(types).toContain('  content?: string | null')
+    })
+
+    it('emits `| null` for a nullable scalar in the standalone UpdateInput', () => {
+      const types = generateTypes(config)
+      expect(types).toContain('export type PostUpdateInput = {')
+      // UpdateInput keeps every scalar optional and nullable scalars get `| null`.
+      expect(types).toContain('  content?: string | null')
+    })
+
+    it('emits the same nullable-scalar shape in the call-site create `data` override', () => {
+      const types = generateTypes(config)
+      // The CreateArgs `data` override narrows scalars; the nullable `content`
+      // member must match the standalone CreateInput member exactly.
+      expect(types).toContain("data: Omit<Prisma.PostCreateArgs['data'], 'title' | 'content'> & {")
+      expect(types).toContain('    content?: string | null')
+    })
+
+    it('emits the same nullable-scalar shape in the call-site update `data` override', () => {
+      const types = generateTypes(config)
+      expect(types).toContain("data: Omit<Prisma.PostUpdateArgs['data'], 'title' | 'content'> & {")
+      expect(types).toContain('    content?: string | null')
+    })
+
+    it('keeps a required scalar required (no `?`, no `| null`) in both create paths', () => {
+      const types = generateTypes(config)
+      // Standalone CreateInput: required scalar has neither `?` nor `| null`.
+      expect(types).toContain('  title: string\n')
+      // Override create `data`: same required shape.
+      expect(types).toContain('    title: string\n')
+      // A required scalar must never gain `| null` anywhere (create or update).
+      // (`title?: string` IS valid in UpdateInput, where every scalar is
+      // optional, but it must never become `title?: string | null`.)
+      expect(types).not.toContain('title: string | null')
+      expect(types).not.toContain('title?: string | null')
+    })
+
+    it('keeps standalone input and `data` override nullability in lock-step', () => {
+      const types = generateTypes(config)
+      // Both the standalone CreateInput member and the override `data` member
+      // render the nullable scalar identically (modulo indentation): `?: T | null`.
+      const nullableMemberPattern = /content\?: string \| null/g
+      const matches = types.match(nullableMemberPattern) ?? []
+      // At minimum: standalone CreateInput, standalone UpdateInput, create
+      // override, update override, plus createMany/updateMany overrides.
+      expect(matches.length).toBeGreaterThanOrEqual(4)
+    })
+  })
 })

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -186,6 +186,56 @@ function generateModelTypeAlias(listName: string): string {
 }
 
 /**
+ * Render a single scalar create/update input member line — the SINGLE source of
+ * truth for a scalar field's member shape (name, `?` optionality, TypeScript
+ * type, and `| null` nullability).
+ *
+ * Both the standalone `{List}CreateInput`/`{List}UpdateInput` exports and the
+ * call-site write-`data` override (`buildScalarOverrideMembers`) render their
+ * scalar members through this helper so the two cannot drift on how a nullable
+ * scalar is represented (#608).
+ *
+ * Nullability: a nullable scalar (`getTypeScriptType().optional`) gets `| null`,
+ * matching Prisma's nullable-column input. A required scalar gets neither `?`
+ * nor `| null`.
+ *
+ * Optionality:
+ *  - create: optional (`?`) when nullable OR it has a default value. The
+ *    `defaultValue === undefined` check is explicit (not truthiness) so a
+ *    falsy-but-present default such as `checkbox({ defaultValue: false })` is
+ *    still treated as having a default. See #599.
+ *  - update: always optional (partial update).
+ *
+ * Returns `null` for fields whose `getTypeScriptType()` yields no type, so
+ * callers can skip them.
+ *
+ * @param indent - Leading whitespace for the emitted line (call sites differ:
+ *   standalone inputs use 2 spaces, the `data` override uses 4).
+ */
+function renderScalarInputMember(
+  fieldName: string,
+  fieldConfig: FieldConfig,
+  forCreate: boolean,
+  indent: string,
+): string | null {
+  const tsType = mapFieldTypeToTypeScript(fieldConfig)
+  if (!tsType) return null
+
+  const nullable = isFieldOptional(fieldConfig)
+  const nullability = nullable ? ' | null' : ''
+
+  let optional: string
+  if (forCreate) {
+    const required = !nullable && fieldConfig.defaultValue === undefined
+    optional = required ? '' : '?'
+  } else {
+    optional = '?'
+  }
+
+  return `${indent}${fieldName}${optional}: ${tsType}${nullability}`
+}
+
+/**
  * Generate CreateInput type
  */
 function generateCreateInputType(listName: string, fields: Record<string, FieldConfig>): string {
@@ -209,17 +259,11 @@ function generateCreateInputType(listName: string, fields: Record<string, FieldC
         lines.push(`  ${fieldName}?: { connect: { id: string } }`)
       }
     } else {
-      const tsType = mapFieldTypeToTypeScript(fieldConfig)
-      if (!tsType) continue // Skip if no type returned
-
-      // A field is optional on create when it is nullable OR has a default value.
-      // Use an explicit `!== undefined` check rather than a truthiness test:
-      // `!field.defaultValue` is truthy for a falsy-but-present default such as
-      // `checkbox({ defaultValue: false })`, which would wrongly mark the field
-      // required. See #599.
-      const required = !isFieldOptional(fieldConfig) && fieldConfig.defaultValue === undefined
-      const optional = required ? '' : '?'
-      lines.push(`  ${fieldName}${optional}: ${tsType}`)
+      // Shared source of truth with the write-`data` override (#608): same
+      // optionality + `| null` nullability for nullable scalars.
+      const member = renderScalarInputMember(fieldName, fieldConfig, true, '  ')
+      if (!member) continue // Skip if no type returned
+      lines.push(member)
     }
   }
 
@@ -296,22 +340,12 @@ function buildScalarOverrideMembers(
   for (const [fieldName, fieldConfig] of Object.entries(fields)) {
     if (!shouldNarrowScalarWrite(fieldConfig)) continue
 
-    const tsType = mapFieldTypeToTypeScript(fieldConfig)
-    if (!tsType) continue
-
-    const nullable = isFieldOptional(fieldConfig)
-    const nullability = nullable ? ' | null' : ''
-
-    if (forCreate) {
-      // Optional on create when nullable OR has a default (see #599 bug fix in
-      // generateCreateInputType for the `defaultValue === undefined` rationale).
-      const required = !nullable && fieldConfig.defaultValue === undefined
-      const optional = required ? '' : '?'
-      members.push(`    ${fieldName}${optional}: ${tsType}${nullability}`)
-    } else {
-      // Partial update: every scalar is optional.
-      members.push(`    ${fieldName}?: ${tsType}${nullability}`)
-    }
+    // Shared source of truth with generateCreateInputType / generateUpdateInputType
+    // (#608): identical optionality + `| null` nullability rendering. The override
+    // uses 4-space indentation since it is nested inside the `data: ... & { ... }`.
+    const member = renderScalarInputMember(fieldName, fieldConfig, forCreate, '    ')
+    if (!member) continue
+    members.push(member)
   }
   return members
 }
@@ -405,10 +439,11 @@ function generateUpdateInputType(listName: string, fields: Record<string, FieldC
         lines.push(`  ${fieldName}?: { connect: { id: string } } | { disconnect: true }`)
       }
     } else {
-      const tsType = mapFieldTypeToTypeScript(fieldConfig)
-      if (!tsType) continue // Skip if no type returned
-
-      lines.push(`  ${fieldName}?: ${tsType}`)
+      // Shared source of truth with the write-`data` override (#608): partial
+      // update (always optional) with `| null` nullability for nullable scalars.
+      const member = renderScalarInputMember(fieldName, fieldConfig, false, '  ')
+      if (!member) continue // Skip if no type returned
+      lines.push(member)
     }
   }
 


### PR DESCRIPTION
Closes #608

## Problem

After #599 (merged via #606), the generator described a list's create/update input shape in **two** places that disagreed on how a nullable scalar is represented:

- The call-site write-`data` override (`buildScalarOverrideMembers`) emitted `name?: string | null` — matching Prisma's nullable-column input (more correct).
- The standalone `{List}CreateInput` / `{List}UpdateInput` exports (`generateCreateInputType` / `generateUpdateInputType`) emitted `name?: string` (no `| null`).

Two sources of truth for the same shape is a maintenance hazard — a future field change has to be mirrored in both and they can silently drift.

## Change

Introduced a single shared helper, `renderScalarInputMember(fieldName, fieldConfig, forCreate, indent)`, that is now the **one** source of truth for a scalar input member's shape: name, `?` optionality, TypeScript type (from the field's own `getTypeScriptType()`), and `| null` nullability.

Both call paths render through it:
- `generateCreateInputType` and `generateUpdateInputType` (standalone `{List}CreateInput` / `{List}UpdateInput`), and
- `buildScalarOverrideMembers` (the call-site `data` override used by `create`/`update`/`createMany`/`updateMany`).

They now **agree** on the more-correct `| null` representation for nullable scalars — the standalone generators were brought up to the override's representation; the override was not weakened.

### Preserved behavior

- Required scalars stay required: no `?`, no `| null` (e.g. `title: string`).
- Nullable scalars: `?:` and `| null` consistently in both outputs.
- Create vs update optionality semantics unchanged (update members already optional; create optional when nullable or has a default — the `defaultValue === undefined` check from #599 is preserved).
- `calendarDay` stays `string`; decimal/json keep Prisma's input type; relationship and multi-column fields unchanged.
- Runtime/zod layer untouched — this is purely the generated TypeScript type shape.

## Tests

- Updated the `types.test.ts` snapshots: every diff is exactly a nullable scalar `?: T` → `?: T | null` (verified — no required field, relationship, or `Date`/`number` regressions).
- Added a `create/update input nullability consolidation (#608)` describe block that pins: standalone `CreateInput`/`UpdateInput` and the `data` override emit the **same** `content?: string | null` for a nullable scalar, required `title` stays required (never gains `| null`), and the two stay in lock-step — so they can't drift again.
- The existing #599 compile-time `tsc` write-narrowing test continues to pass.

`pnpm --filter @opensaas/stack-cli test run`: 316 passed.

## Examples build (the #599 lesson)

Because this changes the public generated `CreateInput`/`UpdateInput` types, I locally ran `pnpm generate` + `prisma generate` + `next build` (full app typecheck) for **all 12 examples**: blog, auth-demo, custom-field, json-demo, composable-dashboard, mcp-demo, tiptap-demo, file-upload-demo, starter, starter-auth, rag-ollama-demo, rag-openai-chatbot. **All build and typecheck clean** — the change surfaced no genuine type errors in example app code, so no example fixes were needed.

## Versioning

`minor` for `@opensaas/stack-cli`: the standalone `{List}CreateInput`/`{List}UpdateInput` exports now include `| null` on nullable scalars, which is a meaningful (non-breaking but visible) refinement of the public generated types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017JiVKJwhQbG4AfTy65auS4)_