### PR TITLE
fix(storage): make file()/image() fields optional on create/update

### DIFF
--- a/.changeset/file-image-nullish.md
+++ b/.changeset/file-image-nullish.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage': patch
+---
+
+Fix file()/image() fields being required on create/update: their Zod schema now uses key-optionality (.nullish()) so an omitted field validates and stores null (Zod 4).

--- a/packages/storage/src/fields/index.ts
+++ b/packages/storage/src/fields/index.ts
@@ -302,8 +302,11 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
         metadata: z.record(z.string(), z.unknown()).optional(),
       })
 
-      // Allow null or undefined values
-      return z.union([fileMetadataSchema, z.null(), z.undefined()])
+      // Allow null or undefined values. `.nullish()` (= `.nullable().optional()`)
+      // makes the object KEY optional in Zod 4 — a bare union that merely accepts
+      // an `undefined` value does NOT (see issue #618, and the #570 precedent in
+      // core's validation tests).
+      return fileMetadataSchema.nullish()
     },
 
     getPrismaType: (_fieldName: string) => {
@@ -506,8 +509,11 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
           .optional(),
       })
 
-      // Allow null or undefined values
-      return z.union([imageMetadataSchema, z.null(), z.undefined()])
+      // Allow null or undefined values. `.nullish()` (= `.nullable().optional()`)
+      // makes the object KEY optional in Zod 4 — a bare union that merely accepts
+      // an `undefined` value does NOT (see issue #618, and the #570 precedent in
+      // core's validation tests).
+      return imageMetadataSchema.nullish()
     },
 
     getPrismaType: (_fieldName: string) => {

--- a/packages/storage/tests/field-zod-schema.test.ts
+++ b/packages/storage/tests/field-zod-schema.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { image, file } from '../src/fields/index.js'
+import type { ImageMetadata, FileMetadata } from '../src/config/types.js'
+
+/**
+ * Regression tests for issue #618: file()/image() fields were erroneously
+ * required on create/update because getZodSchema() returned
+ * `z.union([metadataSchema, z.null(), z.undefined()])`. In Zod 4, a union that
+ * merely accepts an `undefined` *value* does NOT make the object KEY optional —
+ * an omitted key fails with "expected nonoptional, received undefined". The fix
+ * returns `metadataSchema.nullish()` so the key is genuinely optional.
+ *
+ * Core composes create/update input via `z.object({ <field>: getZodSchema(...) })`
+ * with no extra wrapping (see packages/core/src/validation/schema.ts), so these
+ * tests reproduce that composition exactly.
+ */
+
+/** A correctly-shaped ImageMetadata value. */
+const validImageMetadata: ImageMetadata = {
+  filename: 'photo.png',
+  originalFilename: 'photo.png',
+  url: '/uploads/photo.png',
+  mimeType: 'image/png',
+  size: 1234,
+  width: 100,
+  height: 100,
+  uploadedAt: new Date().toISOString(),
+  storageProvider: 'images',
+}
+
+/** A correctly-shaped FileMetadata value. */
+const validFileMetadata: FileMetadata = {
+  filename: 'doc.pdf',
+  originalFilename: 'doc.pdf',
+  url: '/uploads/doc.pdf',
+  mimeType: 'application/pdf',
+  size: 4096,
+  uploadedAt: new Date().toISOString(),
+  storageProvider: 'documents',
+}
+
+/** Wrap a single field schema the way core's generateZodSchema does. */
+function objectFor(
+  field: { getZodSchema?: (name: string, op: 'create' | 'update') => z.ZodTypeAny },
+  fieldName: string,
+  operation: 'create' | 'update',
+): z.ZodObject<Record<string, z.ZodTypeAny>> {
+  const schema = field.getZodSchema?.(fieldName, operation)
+  if (!schema) throw new Error('field has no getZodSchema')
+  return z.object({ [fieldName]: schema })
+}
+
+describe('image()/file() getZodSchema key-optionality (issue #618)', () => {
+  for (const operation of ['create', 'update'] as const) {
+    describe(`${operation}`, () => {
+      it(`image(): an OMITTED field validates (no key present)`, () => {
+        const obj = objectFor(image({ storage: 'images' }), 'avatar', operation)
+        const result = obj.safeParse({})
+        expect(result.success).toBe(true)
+        if (result.success) {
+          // Omitted optional key reads back as undefined.
+          expect(result.data.avatar).toBeUndefined()
+        }
+      })
+
+      it(`file(): an OMITTED field validates (no key present)`, () => {
+        const obj = objectFor(file({ storage: 'documents' }), 'resume', operation)
+        const result = obj.safeParse({})
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.resume).toBeUndefined()
+        }
+      })
+
+      it(`image(): explicit null validates`, () => {
+        const obj = objectFor(image({ storage: 'images' }), 'avatar', operation)
+        expect(obj.safeParse({ avatar: null }).success).toBe(true)
+      })
+
+      it(`file(): explicit null validates`, () => {
+        const obj = objectFor(file({ storage: 'documents' }), 'resume', operation)
+        expect(obj.safeParse({ resume: null }).success).toBe(true)
+      })
+
+      it(`image(): explicit undefined validates`, () => {
+        const obj = objectFor(image({ storage: 'images' }), 'avatar', operation)
+        expect(obj.safeParse({ avatar: undefined }).success).toBe(true)
+      })
+
+      it(`file(): explicit undefined validates`, () => {
+        const obj = objectFor(file({ storage: 'documents' }), 'resume', operation)
+        expect(obj.safeParse({ resume: undefined }).success).toBe(true)
+      })
+
+      it(`image(): null/omitted validates in multi-column (keystone) mode`, () => {
+        const field = image({ storage: 'images', db: { columns: 'keystone' } })
+        const obj = objectFor(field, 'avatar', operation)
+        expect(obj.safeParse({}).success).toBe(true)
+        expect(obj.safeParse({ avatar: null }).success).toBe(true)
+      })
+
+      it(`file(): null/omitted validates in multi-column (keystone) mode`, () => {
+        const field = file({ storage: 'documents', db: { columns: 'keystone' } })
+        const obj = objectFor(field, 'resume', operation)
+        expect(obj.safeParse({}).success).toBe(true)
+        expect(obj.safeParse({ resume: null }).success).toBe(true)
+      })
+
+      it(`image(): a correctly-shaped metadata object validates`, () => {
+        const obj = objectFor(image({ storage: 'images' }), 'avatar', operation)
+        expect(obj.safeParse({ avatar: validImageMetadata }).success).toBe(true)
+      })
+
+      it(`file(): a correctly-shaped metadata object validates`, () => {
+        const obj = objectFor(file({ storage: 'documents' }), 'resume', operation)
+        expect(obj.safeParse({ resume: validFileMetadata }).success).toBe(true)
+      })
+
+      it(`image(): a malformed metadata object still fails`, () => {
+        const obj = objectFor(image({ storage: 'images' }), 'avatar', operation)
+        // Missing required sub-fields (width/height/size/...).
+        expect(obj.safeParse({ avatar: { filename: 'x.png' } }).success).toBe(false)
+      })
+
+      it(`file(): a malformed metadata object still fails`, () => {
+        const obj = objectFor(file({ storage: 'documents' }), 'resume', operation)
+        // size should be a number, not a string.
+        expect(obj.safeParse({ resume: { ...validFileMetadata, size: 'big' } }).success).toBe(false)
+      })
+    })
+  }
+})


### PR DESCRIPTION
Implements #618.

## Problem

`file()` and `image()` (`@opensaas/stack-storage`) returned their create/update validation schema as:

```ts
return z.union([fileMetadataSchema, z.null(), z.undefined()])   // file()
return z.union([imageMetadataSchema, z.null(), z.undefined()])  // image()
```

In **Zod 4**, a union that merely *accepts* an `undefined` value does **not** make the object key optional. Core composes create/update input via `z.object({ <field>: getZodSchema(...) })` (`generateZodSchema` in `packages/core/src/validation/schema.ts`) with no extra wrapping, so an **omitted** file/image field failed validation:

```
ValidationError: Validation failed: image: Invalid input: expected nonoptional, received undefined
```

This broke seeds and any create/update path that legitimately has no file/image. It's the same class of bug already fixed for core fields under #570.

## Fix

Return `metadataSchema.nullish()` (= `.nullable().optional()`) instead of the bare union, so the object **key** is genuinely optional — matching the established idiom every optional core field (`text`, `integer`, `json`, `checkbox`, `timestamp`, `select`) uses. Out of scope: no "required file/image" capability, no metadata-shape or multi-column-layout changes, no other field types touched.

## Acceptance criteria

- [x] Creating a record with a `file()` field, omitting it, succeeds and stores null.
- [x] Creating a record with an `image()` field, omitting it, succeeds and stores null.
- [x] Same holds for UPDATE operations that omit the field.
- [x] Explicit `null` / `undefined` still validate on create and update, including multi-column (`db: { columns: 'keystone' }`) fields.
- [x] A correctly-shaped metadata object still validates.
- [x] A malformed metadata object still fails validation.
- [x] Regression test covers the omitted-field create case for both `file()` and `image()`.

## Tests

New `packages/storage/tests/field-zod-schema.test.ts` reproduces core's `z.object({ <field>: getZodSchema() })` composition and covers omitted / null / undefined / valid / malformed across create and update, single- and multi-column modes.

- `pnpm --filter @opensaas/stack-storage test`: 147 passed
- `pnpm --filter @opensaas/stack-core test`: 707 passed
- `pnpm lint`: 0 errors (3 pre-existing unrelated warnings)
- Builds: storage + core green

Changeset added (`@opensaas/stack-storage` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SigyUcdxbBsdeLVWiFbYtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SigyUcdxbBsdeLVWiFbYtS)_