### PR TITLE
Fix stack overflow on cyclic readable-relationship auto-include

### DIFF
--- a/.changeset/cyclic-include-stack-overflow.md
+++ b/.changeset/cyclic-include-stack-overflow.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix stack overflow when auto-including relationships on a cyclic readable-relationship graph. The auto-include now stops at cycle back-edges (a relation that closes a cycle is fetched flat) instead of re-descending to MAX_DEPTH.

--- a/packages/core/src/access/access-filter.test.ts
+++ b/packages/core/src/access/access-filter.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { buildIncludeWithAccessControl, mergeIncludeWithAccessControl } from './access-filter.js'
+import type { OpenSaasConfig, FieldConfig } from '../config/types.js'
+import type { AccessContext } from './types.js'
+
+/**
+ * Regression coverage for the cyclic readable-relationship auto-include.
+ *
+ * On a relationship graph that contains a cycle (A → B → C → A) the depth-first
+ * auto-include used to descend the cycle on every branch to `MAX_DEPTH`, and
+ * `mergeIncludeWithAccessControl` re-expanded any bare-`true` leaf back into that
+ * same auto-include. The resulting include tree was deep/large enough to
+ * stack-overflow downstream processing (the RSC serializer). The fix seeds a
+ * cycle guard with the root list and stops the walk at cycle back-edges, so a
+ * relation that closes a cycle comes back FLAT (own columns only).
+ */
+
+// A relationship field pointing at another list.
+function rel(ref: string, many = false): FieldConfig {
+  return { type: 'relationship', ref, many } as unknown as FieldConfig
+}
+
+// A cyclic config: A → B → C → A (plus a scalar on each list).
+function cyclicConfig(): OpenSaasConfig {
+  const allowQuery = () => true
+  return {
+    db: { provider: 'sqlite', url: 'file:./dev.db' },
+    lists: {
+      A: {
+        fields: { name: { type: 'text' } as FieldConfig, b: rel('B.a') },
+        access: { operation: { query: allowQuery } },
+      },
+      B: {
+        fields: { name: { type: 'text' } as FieldConfig, c: rel('C.b') },
+        access: { operation: { query: allowQuery } },
+      },
+      C: {
+        fields: { name: { type: 'text' } as FieldConfig, a: rel('A.c') },
+        access: { operation: { query: allowQuery } },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+  } as any
+}
+
+function makeContext(): AccessContext {
+  return {
+    session: null,
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
+  } as any
+}
+
+// Measure the maximum nesting depth of an include tree.
+function includeDepth(include: unknown): number {
+  if (!include || typeof include !== 'object') return 0
+  let max = 0
+  for (const value of Object.values(include as Record<string, unknown>)) {
+    if (value && typeof value === 'object') {
+      const nested = (value as { include?: unknown }).include
+      if (nested) max = Math.max(max, 1 + includeDepth(nested))
+      else max = Math.max(max, 1)
+    } else {
+      max = Math.max(max, 1)
+    }
+  }
+  return max
+}
+
+describe('buildIncludeWithAccessControl — cyclic graph', () => {
+  it('stops re-descending a relationship cycle instead of walking to MAX_DEPTH', async () => {
+    const config = cyclicConfig()
+    const include = await buildIncludeWithAccessControl(
+      config.lists.A.fields,
+      { session: null, context: makeContext() },
+      config,
+      0,
+      ['A'],
+    )
+
+    // A → B → C, then C.a closes the cycle back to A → flat (no further nesting).
+    expect(include).toEqual({
+      b: { include: { c: { include: { a: true } } } },
+    })
+    // Three distinct lists → depth 3, not the old MAX_DEPTH=5 (which on a cycle
+    // could recurse A→B→C→A→B).
+    expect(includeDepth(include)).toBe(3)
+  })
+
+  it('flattens a self-referential relationship to a single level', async () => {
+    const allowQuery = () => true
+    const config = {
+      db: { provider: 'sqlite', url: 'file:./dev.db' },
+      lists: {
+        Category: {
+          fields: {
+            name: { type: 'text' } as FieldConfig,
+            parent: rel('Category.children'),
+            children: rel('Category.parent', true),
+          },
+          access: { operation: { query: allowQuery } },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any as OpenSaasConfig
+
+    const include = await buildIncludeWithAccessControl(
+      config.lists.Category.fields,
+      { session: null, context: makeContext() },
+      config,
+      0,
+      ['Category'],
+    )
+
+    // Both self-references come back flat — no infinite parent/children descent.
+    expect(include).toEqual({ parent: true, children: true })
+    expect(includeDepth(include)).toBe(1)
+  })
+})
+
+describe('mergeIncludeWithAccessControl — bare-true leaf on a cyclic graph', () => {
+  it('does not re-expand a bare-true leaf beyond the cycle-bounded auto-include', async () => {
+    const config = cyclicConfig()
+    const accessControlledInclude = await buildIncludeWithAccessControl(
+      config.lists.A.fields,
+      { session: null, context: makeContext() },
+      config,
+      0,
+      ['A'],
+    )
+
+    // Caller asks for A → b with a bare-`true` leaf. The merge must keep the
+    // access-controlled (cycle-bounded) nested include rather than re-expanding
+    // the leaf into an unbounded auto-include.
+    const merged = mergeIncludeWithAccessControl(
+      { b: true },
+      accessControlledInclude,
+      config.lists.A.fields,
+      config,
+    )
+
+    expect(merged).toEqual({
+      b: { include: { c: { include: { a: true } } } },
+    })
+    // Still bounded to the acyclic path length.
+    expect(includeDepth(merged)).toBeLessThanOrEqual(3)
+  })
+})

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -30,6 +30,10 @@ export async function buildIncludeWithAccessControl(
   },
   config: OpenSaasConfig,
   depth: number = 0,
+  // List names already on the path from the root to here. Used to detect
+  // relationship cycles (A → B → … → A) and stop the auto-include from
+  // re-descending them. Seed it with the root list name at the call site.
+  visitedLists: readonly string[] = [],
 ) {
   const MAX_DEPTH = 5
   if (depth >= MAX_DEPTH) {
@@ -75,16 +79,31 @@ export async function buildIncludeWithAccessControl(
           includeEntry.where = accessResult
         }
 
-        // Recursively build nested includes
-        const nestedInclude = await buildIncludeWithAccessControl(
-          relatedConfig.listConfig.fields,
-          args,
-          config,
-          depth + 1,
-        )
+        // Cycle guard: if the related list already appears on the path from the
+        // root, DO NOT auto-include its relationships again. On a cyclic
+        // readable-relationship graph (A → B → … → A) the depth-first walk would
+        // otherwise re-descend the cycle on every branch, and — combined with the
+        // bare-`true` leaf re-expansion in `mergeIncludeWithAccessControl` — build
+        // an include tree deep/large enough to overflow the call stack in
+        // downstream processing (the RSC serializer's recursive `Map.set`). This
+        // extends the SF-20 (#566) fix: a bare-`true` leaf must resolve to a
+        // genuine single-level fetch, not a re-expansion of the full auto-include.
+        // The relation itself is still included (as a FLAT fetch of its own
+        // columns); only its onward relationships are pruned at the back-edge.
+        const relatedListName = relatedConfig.listName
+        if (!visitedLists.includes(relatedListName)) {
+          // Recursively build nested includes
+          const nestedInclude = await buildIncludeWithAccessControl(
+            relatedConfig.listConfig.fields,
+            args,
+            config,
+            depth + 1,
+            [...visitedLists, relatedListName],
+          )
 
-        if (nestedInclude && Object.keys(nestedInclude).length > 0) {
-          includeEntry.include = nestedInclude
+          if (nestedInclude && Object.keys(nestedInclude).length > 0) {
+            includeEntry.include = nestedInclude
+          }
         }
 
         // Add to include object

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -699,6 +699,10 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
           context,
         },
         config,
+        0,
+        // Seed the cycle guard with the root list so a relationship cycle back
+        // to it (self-referential or longer) stops re-descending.
+        [listName],
       )
       // MERGE (not replace) a caller-supplied include with the access-controlled
       // include: the caller selects WHICH relations to fetch, access control
@@ -829,6 +833,10 @@ function createFindMany<TPrisma extends PrismaClientLike>(
           context,
         },
         config,
+        0,
+        // Seed the cycle guard with the root list so a relationship cycle back
+        // to it (self-referential or longer) stops re-descending.
+        [listName],
       )
       // MERGE (not replace) a caller-supplied include with the access-controlled
       // include: the caller selects WHICH relations to fetch, access control
@@ -1141,6 +1149,10 @@ function createGet<TPrisma extends PrismaClientLike>(
         context,
       },
       config,
+      0,
+      // Seed the cycle guard with the root list so a relationship cycle back
+      // to it (self-referential or longer) stops re-descending.
+      [listName],
     )
 
     // Try to find the record

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,13 +644,13 @@ importers:
         version: typescript@7.0.2
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.4.27(postcss@8.5.18)
+        version: 10.4.27(postcss@8.5.19)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       postcss:
         specifier: ^8.5.18
-        version: 8.5.18
+        version: 8.5.19
       prettier:
         specifier: ^3.9.5
         version: 3.9.5
@@ -692,7 +692,7 @@ importers:
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss:
         specifier: ^8.5.18
-        version: 8.5.18
+        version: 8.5.19
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -762,7 +762,7 @@ importers:
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss:
         specifier: ^8.5.18
-        version: 8.5.18
+        version: 8.5.19
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1152,7 +1152,7 @@ importers:
         version: 3.27.1
       '@tiptap/react':
         specifier: ^3.20.4
-        version: 3.20.4(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tiptap/starter-kit':
         specifier: ^3.20.1
         version: 3.20.1
@@ -1286,10 +1286,10 @@ importers:
         version: 1.60.0
       postcss:
         specifier: ^8.5.18
-        version: 8.5.18
+        version: 8.5.19
       postcss-cli:
         specifier: ^11.0.1
-        version: 11.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4)
+        version: 11.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -2093,14 +2093,8 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
-  '@floating-ui/core@1.8.0':
-    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
-
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
-
-  '@floating-ui/dom@1.8.0':
-    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
@@ -2108,17 +2102,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react-dom@2.1.9':
-    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@floating-ui/utils@0.2.12':
-    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -6559,12 +6544,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -8535,19 +8516,10 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/core@1.8.0':
-    dependencies:
-      '@floating-ui/utils': 0.2.12
-
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/dom@1.8.0':
-    dependencies:
-      '@floating-ui/core': 1.8.0
-      '@floating-ui/utils': 0.2.12
 
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -8555,15 +8527,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@floating-ui/react-dom@2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   '@floating-ui/utils@0.2.11': {}
-
-  '@floating-ui/utils@0.2.12': {}
 
   '@hono/node-server@1.19.11(hono@4.12.29)':
     dependencies:
@@ -9348,7 +9312,7 @@ snapshots:
 
   '@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
@@ -9849,7 +9813,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
-      postcss: 8.5.18
+      postcss: 8.5.19
       tailwindcss: 4.2.1
 
   '@testing-library/dom@10.4.1':
@@ -9926,9 +9890,9 @@ snapshots:
     dependencies:
       '@tiptap/extensions': 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
 
-  '@tiptap/extension-floating-menu@3.20.4(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+  '@tiptap/extension-floating-menu@3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
     dependencies:
-      '@floating-ui/dom': 1.8.0
+      '@floating-ui/dom': 1.7.6
       '@tiptap/core': 3.20.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
     optional: true
@@ -10018,7 +9982,7 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
-  '@tiptap/react@3.20.4(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tiptap/react@3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tiptap/core': 3.20.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
@@ -10031,7 +9995,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.20.4(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-floating-menu': 3.20.4(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/extension-floating-menu': 3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
@@ -10748,13 +10712,13 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
-  autoprefixer@10.4.27(postcss@8.5.18):
+  autoprefixer@10.4.27(postcss@8.5.19):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001777
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.19
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -11462,8 +11426,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -11489,7 +11453,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11500,22 +11464,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0))
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11526,7 +11490,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12879,15 +12843,15 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-cli@11.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4):
+  postcss-cli@11.0.1(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.4):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.6
       picocolors: 1.1.1
-      postcss: 8.5.18
-      postcss-load-config: 5.1.0(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4)
-      postcss-reporter: 7.1.0(postcss@8.5.18)
+      postcss: 8.5.19
+      postcss-load-config: 5.1.0(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.4)
+      postcss-reporter: 7.1.0(postcss@8.5.19)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -12897,19 +12861,19 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-load-config@5.1.0(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4):
+  postcss-load-config@5.1.0(jiti@2.7.0)(postcss@8.5.19)(tsx@4.22.4):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.18
+      postcss: 8.5.19
       tsx: 4.22.4
 
-  postcss-reporter@7.1.0(postcss@8.5.18):
+  postcss-reporter@7.1.0(postcss@8.5.19):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.19
       thenby: 1.3.4
 
   postcss-value-parser@4.2.0: {}
@@ -12920,13 +12884,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.18:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.18:
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -14050,7 +14008,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.19
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14066,7 +14024,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.19
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

On a **cyclic** readable-relationship graph (A → B → C → … → A), a server read could crash with `RangeError: Maximum call stack size exceeded`. Two triggers share one root cause in `packages/core/src/access/access-filter.ts`:

- **(a) A read with no `include`** auto-includes every readable relationship recursively to `MAX_DEPTH = 5`. On a cycle, the walk re-descends the cycle on *every* branch, producing a large/deep include tree.
- **(b) A read with an explicit `include` whose relationship leaves are bare `true`** — `mergeIncludeWithAccessControl` re-expands each such leaf back into the same depth-5 auto-include, stacking the caller's explicit depth on top of the re-expansion.

Either way, the include tree (and the nested data it fetches) grew deep/large enough to overflow the call stack in downstream recursive processing (the Next RSC serializer's `Map.set`). This extends SF-20 (#566), where a bare-`true` leaf was never bounded.

## Fix

Added a **cycle guard** to `buildIncludeWithAccessControl`. It threads the list names already on the path from the root (`visitedLists`). Before recursing into a related list, it checks whether that list is already an ancestor on the current path:

- If it is (a cycle back-edge), the relation is still included but **flat** — its own columns only — rather than re-descending the cycle.
- If it isn't, the walk proceeds as before (still bounded by `MAX_DEPTH`).

The three read call sites in `packages/core/src/context/index.ts` (`findUnique`/`findFirst`, `findMany`, singleton `get`) seed the guard with the root list name.

Because the visited set is per-path (each branch gets its own copy), acyclic graphs — including diamonds and lists shared across sibling branches — expand exactly as before. Only true back-edges are pruned. The merge path is bounded automatically too, since it reuses the now cycle-bounded auto-include, so a bare-`true` leaf can no longer re-expand past the cycle boundary.

## Testing

- New regression test `packages/core/src/access/access-filter.test.ts` covers a 3-list cycle (A → B → C → A), a self-referential list (flattened to one level), and the bare-`true` merge case.
- Full core suite passes: **769 tests** across 38 files.
- `pnpm build`, `pnpm lint` (no new warnings), `pnpm manypkg fix`, and `pnpm format` all clean.
- Added a patch changeset for `@opensaas/stack-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFHkY8AbfLdMS31zrvqs6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFHkY8AbfLdMS31zrvqs6j)_