### PR TITLE
fix(auth): route plugin schema extensions through the model-key remap

### DIFF
--- a/.changeset/gentle-otters-listen.md
+++ b/.changeset/gentle-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+Fix better-auth plugin schema extensions (e.g. `user`) resolving against a re-derived list key instead of the configured model-key remap, which could silently apply the extension's fields/access to an unrelated host list sharing the default key.

--- a/packages/auth/src/config/plugin.ts
+++ b/packages/auth/src/config/plugin.ts
@@ -46,12 +46,24 @@ export function authPlugin(config: AuthConfig): Plugin {
       // match the developer's live better-auth tables.
       const authLists = getAuthLists(normalized.extendUserList, normalized.models)
 
+      // The same base-model list keys the Auth lists above were derived under
+      // (e.g. `user.modelName: 'AuthUser'`). A provider plugin's schema
+      // extension of a base model (e.g. `user`) must resolve against this
+      // remap too, so it lands on the adopted Auth list rather than a
+      // re-derived key that can collide with an unrelated host list.
+      const baseModelKeys = {
+        user: normalized.models.user.modelName,
+        session: normalized.models.session.modelName,
+        account: normalized.models.account.modelName,
+        verification: normalized.models.verification.modelName,
+      }
+
       // Extract additional lists from Better Auth plugins
       for (const plugin of normalized.betterAuthPlugins) {
         if (plugin && typeof plugin === 'object' && 'schema' in plugin) {
           // Plugin has schema property - convert to OpenSaaS lists
           const pluginSchema = plugin.schema
-          const pluginLists = convertBetterAuthSchema(pluginSchema)
+          const pluginLists = convertBetterAuthSchema(pluginSchema, baseModelKeys)
 
           // Add or extend lists from plugin
           for (const [listName, listConfig] of Object.entries(pluginLists)) {

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -282,18 +282,47 @@ export function convertTableToList(
 }
 
 /**
+ * Base better-auth model keys — the four tables the auth plugin's own model
+ * config (`user`/`session`/`account`/`verification`) can remap via `modelName`.
+ */
+type BaseAuthModelKey = 'user' | 'session' | 'account' | 'verification'
+
+/**
+ * Resolved list key for each base better-auth model, as derived by
+ * {@link deriveAuthLists} from the plugin's configured model-key remap (e.g.
+ * `user.modelName: 'AuthUser'`). Passed to {@link convertBetterAuthSchema} so a
+ * provider plugin's schema extension of a base model (e.g. `user`) lands on the
+ * same adopted Auth list rather than being re-derived from the plugin's own
+ * table name.
+ */
+export type BaseAuthModelKeys = Partial<Record<BaseAuthModelKey, string>>
+
+/**
  * Convert all Better Auth tables to OpenSaaS list configs
  * This is called by authPlugin() to generate lists from Better Auth + plugins
+ *
+ * @param tables - The better-auth plugin's declared schema extension
+ * @param baseModelKeys - The resolved list keys for the four base auth models
+ *   (`user`/`session`/`account`/`verification`), from the same model-key remap
+ *   the Auth lists themselves use. When a table name matches one of these keys
+ *   (case-insensitively), its list key is taken from here instead of being
+ *   re-derived from the table name — so a schema extension targeting `user`
+ *   lands on the adopted Auth list (e.g. `AuthUser`) rather than a re-derived
+ *   `User`, even when that key collides with an unrelated host list.
  */
 export function convertBetterAuthSchema(
   tables: Record<string, BetterAuthTableSchema>,
+  baseModelKeys: BaseAuthModelKeys = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 ): Record<string, ListConfig<any>> {
   const lists: Record<string, ListConfig<any>> = {} // eslint-disable-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 
   for (const [tableName, tableSchema] of Object.entries(tables)) {
-    // Convert table name to PascalCase for OpenSaaS list key
-    const listKey = tableSchema.modelName || toPascalCase(tableName)
+    const baseModelKey = baseModelKeys[tableName.toLowerCase() as BaseAuthModelKey]
+    // A base-model remap always wins: it reflects the actual configured list
+    // key for that model, whereas `tableSchema.modelName`/the table name are
+    // just how the provider plugin happens to describe its own extension.
+    const listKey = baseModelKey || tableSchema.modelName || toPascalCase(tableName)
     lists[listKey] = convertTableToList(tableName, tableSchema)
   }
 

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -298,6 +298,30 @@ type BaseAuthModelKey = 'user' | 'session' | 'account' | 'verification'
 export type BaseAuthModelKeys = Partial<Record<BaseAuthModelKey, string>>
 
 /**
+ * Look up the configured remap for a table name, if it names one of the four
+ * base better-auth models (case-insensitively). Written as an explicit switch
+ * rather than an indexed lookup so no type assertion is needed to narrow the
+ * table name into {@link BaseAuthModelKey}.
+ */
+function resolveBaseModelKey(
+  tableName: string,
+  baseModelKeys: BaseAuthModelKeys,
+): string | undefined {
+  switch (tableName.toLowerCase()) {
+    case 'user':
+      return baseModelKeys.user
+    case 'session':
+      return baseModelKeys.session
+    case 'account':
+      return baseModelKeys.account
+    case 'verification':
+      return baseModelKeys.verification
+    default:
+      return undefined
+  }
+}
+
+/**
  * Convert all Better Auth tables to OpenSaaS list configs
  * This is called by authPlugin() to generate lists from Better Auth + plugins
  *
@@ -318,11 +342,13 @@ export function convertBetterAuthSchema(
   const lists: Record<string, ListConfig<any>> = {} // eslint-disable-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 
   for (const [tableName, tableSchema] of Object.entries(tables)) {
-    const baseModelKey = baseModelKeys[tableName.toLowerCase() as BaseAuthModelKey]
     // A base-model remap always wins: it reflects the actual configured list
     // key for that model, whereas `tableSchema.modelName`/the table name are
     // just how the provider plugin happens to describe its own extension.
-    const listKey = baseModelKey || tableSchema.modelName || toPascalCase(tableName)
+    const listKey =
+      resolveBaseModelKey(tableName, baseModelKeys) ||
+      tableSchema.modelName ||
+      toPascalCase(tableName)
     lists[listKey] = convertTableToList(tableName, tableSchema)
   }
 

--- a/packages/auth/tests/plugin-derived-keys.test.ts
+++ b/packages/auth/tests/plugin-derived-keys.test.ts
@@ -71,6 +71,60 @@ describe('authPlugin - add-vs-extend with derived keys', () => {
     expect(user.fields).toHaveProperty('email') // auth field merged in
     expect(user.fields).toHaveProperty('sessions')
   })
+
+  it('routes a better-auth plugin schema extension of `user` onto the remapped Auth list, not an unrelated host User', async () => {
+    // A better-auth provider plugin (e.g. the `anonymous` plugin) that ships a
+    // schema extension for the base `user` model.
+    const anonymousBetterAuthPlugin = {
+      id: 'anonymous',
+      schema: {
+        user: {
+          fields: {
+            isAnonymous: { type: 'boolean', required: false },
+          },
+        },
+      },
+    }
+
+    const hostUserUpdate = vi.fn(() => false)
+    const result = await config({
+      db: { provider: 'sqlite' },
+      plugins: [
+        authPlugin({
+          user: { modelName: 'AuthUser' },
+          session: { modelName: 'AuthSession' },
+          account: { modelName: 'AuthAccount' },
+          verification: { modelName: 'AuthVerification' },
+          betterAuthPlugins: [anonymousBetterAuthPlugin],
+        }),
+      ],
+      lists: {
+        // An app's own unrelated domain list that happens to share the
+        // default (unmapped) auth user key.
+        User: list({
+          fields: {
+            subjectId: text({ validation: { isRequired: true } }),
+          },
+          access: { operation: { update: hostUserUpdate } },
+        }),
+      },
+    })
+
+    // The plugin's schema extension lands on the adopted Auth list...
+    expect(result.lists.AuthUser.fields).toHaveProperty('isAnonymous')
+    expect(result.lists.AuthUser.fields).toHaveProperty('email')
+
+    // ...and the unrelated host `User` list is left completely untouched: no
+    // injected column, and its own (admin-only-style) access control survives
+    // instead of being overwritten by the plugin's permissive defaults.
+    const appUser = result.lists.User
+    expect(appUser.fields).toHaveProperty('subjectId')
+    expect(appUser.fields).not.toHaveProperty('isAnonymous')
+    expect(appUser.fields).not.toHaveProperty('email')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access control parameters are runtime values
+    expect(appUser.access?.operation?.update?.({} as any)).toBe(false)
+    expect(appUser.access?.operation?.update).toBe(hostUserUpdate)
+  })
 })
 
 describe('authPlugin - runtime user-key resolution', () => {

--- a/packages/auth/tests/schema-converter.test.ts
+++ b/packages/auth/tests/schema-converter.test.ts
@@ -276,6 +276,54 @@ describe('convertBetterAuthSchema', () => {
     expect(lists).toEqual({})
   })
 
+  it('should resolve a base-model table against the configured baseModelKeys remap instead of the table name', () => {
+    const schema = {
+      user: {
+        modelName: '',
+        fields: {
+          isAnonymous: { type: 'boolean' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema, { user: 'AuthUser' })
+
+    expect(lists).toHaveProperty('AuthUser')
+    expect(lists).not.toHaveProperty('User')
+    expect(lists.AuthUser.fields).toHaveProperty('isAnonymous')
+  })
+
+  it('should prefer the baseModelKeys remap over an explicit tableSchema.modelName', () => {
+    const schema = {
+      user: {
+        modelName: 'User',
+        fields: {
+          isAnonymous: { type: 'boolean' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema, { user: 'AuthUser' })
+
+    expect(lists).toHaveProperty('AuthUser')
+    expect(lists).not.toHaveProperty('User')
+  })
+
+  it('should leave non-base tables unaffected by baseModelKeys', () => {
+    const schema = {
+      oauth_application: {
+        modelName: '',
+        fields: {
+          data: { type: 'string' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema, { user: 'AuthUser' })
+
+    expect(lists).toHaveProperty('OauthApplication')
+  })
+
   it('should convert complex schema with multiple field types', () => {
     const schema = {
       test_table: {


### PR DESCRIPTION
## Summary

- A better-auth provider plugin's `schema` extension of a base model (e.g. `user`) was converted to an OpenSaaS list key by re-deriving it from the plugin's own table name (`tableSchema.modelName || toPascalCase(tableName)`), ignoring the auth plugin's configured model-key remap (e.g. `user: { modelName: 'AuthUser' }`).
- This meant that when the base `user` model was remapped away from `User` (to avoid colliding with an app's own domain `User` list — the ADR-0007 pattern), a plugin schema extension of `user` still resolved to `User` and got applied to the unrelated host list, injecting the plugin's field(s) and overwriting that list's access control with the plugin's permissive defaults.
- `convertBetterAuthSchema()` (`packages/auth/src/server/schema-converter.ts`) now accepts an optional `baseModelKeys` map (the same remapped list keys `deriveAuthLists` computes for `user`/`session`/`account`/`verification`) and prefers that remap over the plugin's own `modelName`/table name for those four base models. Other plugin-declared tables (e.g. `oauthApplication`) are unaffected.
- `authPlugin()` (`packages/auth/src/config/plugin.ts`) now builds this remap from `normalized.models` and passes it into `convertBetterAuthSchema`.

## Test plan

- [x] Added a regression test (`packages/auth/tests/plugin-derived-keys.test.ts`) covering the exact acceptance-criteria scenario: a remapped `user` model (`AuthUser`) + an unrelated host `User` list + a `betterAuthPlugins` entry with a `schema` extending `user` — asserts the extension's field lands on `AuthUser` and the host `User` keeps its own fields and access untouched.
- [x] Added unit tests in `packages/auth/tests/schema-converter.test.ts` for `convertBetterAuthSchema`'s new `baseModelKeys` parameter (remap wins over table name, remap wins over an explicit `tableSchema.modelName`, non-base tables unaffected).
- [x] `pnpm --filter @opensaas/stack-auth test` — 137 passed
- [x] `pnpm --filter @opensaas/stack-auth build`
- [x] `pnpm lint`
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed

Closes #677


---
_Generated by [Claude Code](https://claude.ai/code/session_01WHRXKviN2SEXgbNUm1YyJ4)_