### PR TITLE
docs(deployment): document non-interactive migration authoring for CI/agent environments

### DIFF
--- a/docs/content/guides/deployment.md
+++ b/docs/content/guides/deployment.md
@@ -464,12 +464,12 @@ This is the same command used in [Step 4](#step-4-author-the-first-migration) ab
 Requirements:
 
 - A reachable database. Any disposable Postgres works for CI (a `postgres:16` service container is the common choice).
-- Postgres additionally needs a **shadow database**, which Prisma creates and drops automatically using the same connection — this requires the connecting role to have `CREATEDB`, or a separate `shadowDatabaseUrl` configured. See [Prisma's shadow database docs](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database) if the CI role can't create databases.
+- Postgres additionally needs a **shadow database**, which Prisma creates and drops automatically using the same connection — this requires the connecting role to have `CREATEDB`, or a separate database with `shadowDatabaseUrl` set on the `datasource` block in `prisma.config.ts` (alongside `url`). See [Prisma's shadow database docs](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database) if the CI role can't create databases.
 - The existing migration history must apply cleanly against that database — if it's drifted, `migrate dev` falls back to its reset-confirmation prompt (see below).
 
-**DB-less fallback — `prisma migrate diff`**
+**Fallback — `prisma migrate diff` against a throwaway database**
 
-Where a database genuinely can't run (e.g. a fully sandboxed agent with no way to provision Postgres), author the migration from a pure schema diff instead:
+Where authoring against your actual project database isn't possible or desirable (e.g. a sandboxed agent that can't reach it), `prisma migrate diff` computes the same migration SQL without ever touching your project's database — it only needs somewhere disposable to replay the existing migration history:
 
 ```bash
 pnpm generate # regenerate prisma/schema.prisma from opensaas.config.ts
@@ -479,13 +479,16 @@ mkdir -p "$DIR"
 
 npx prisma migrate diff \
   --from-migrations prisma/migrations \
-  --to-schema-datamodel prisma/schema.prisma \
+  --to-schema prisma/schema.prisma \
   --script > "$DIR/migration.sql"
 ```
 
+- **SQLite:** this is genuinely database-less — Prisma creates and discards a temporary file automatically, no extra config needed.
+- **PostgreSQL / MySQL:** `--from-migrations` still needs somewhere to replay the migration history into, via `shadowDatabaseUrl` set on the `datasource` block in `prisma.config.ts` (alongside `url`). It can be any empty, disposable database of the right provider — it doesn't need to be reachable from your app, match your project's current state, or grant `CREATEDB` on your real connection, unlike `migrate dev`'s auto-managed shadow database (which piggybacks on the same connection as your target DB).
+
 `migration_lock.toml` (just the provider name) is created once per project by the first migration and doesn't need to be recreated by hand for subsequent ones.
 
-> **Fidelity caveat.** `migrate diff` compares the target schema against the migration history's resulting schema on paper — it does not replay the history against a real database via a shadow DB the way `migrate dev` does. It won't catch drift between your committed migrations and what's actually deployed, and it can miss provider-specific behaviour that only surfaces against a live database. Treat its output as a starting point to review, not a guarantee, and prefer the primary `migrate dev` path whenever a database is available.
+> **Fidelity caveat.** `migrate diff` never connects to your actual deployed database — it only replays your committed migration history onto the disposable shadow database and diffs the result against the target schema file. So it won't catch drift between what's actually deployed and what your migration history says should be deployed (e.g. a manual hotfix applied outside migrations). Treat its output as a starting point to review, and prefer the primary `migrate dev` path — which does check against your real target database — whenever that's available.
 
 **Why the "non-interactive...not supported" error appears**
 

--- a/docs/content/guides/deployment.md
+++ b/docs/content/guides/deployment.md
@@ -444,6 +444,53 @@ pnpm migrate:deploy
 
 `migrate deploy` only applies existing committed migrations; it never edits your schema, which makes it safe to run in an automated pipeline.
 
+### Authoring Migrations in CI / Agent Environments
+
+The above covers _applying_ migrations, which `migrate deploy` already does non-interactively. _Authoring_ a new migration (`migrate dev`) in a CI runner or a sandboxed coding agent is a different question, and the requirement is a **database to diff against, not a TTY**.
+
+**Primary path — `prisma migrate dev --name <name>` against a real database**
+
+`migrate dev` only prompts when it needs a decision it can't make on its own: the migration name (supplied via `--name`), or how to handle detected drift/reset. On a clean, in-sync migration history, supplying `--name` is enough — the command runs headless:
+
+```bash
+# Point DATABASE_URL / DIRECT_DATABASE_URL at a disposable database first
+# (a CI Postgres service container, Docker, or a throwaway Neon branch — SQLite needs no extra setup)
+pnpm generate
+pnpm migrate -- --name add_status_field
+```
+
+This is the same command used in [Step 4](#step-4-author-the-first-migration) above — it produces a correctly named, timestamped migration directory (`migration.sql` + updated `migration_lock.toml`), identical to what an interactive local run would produce.
+
+Requirements:
+
+- A reachable database. Any disposable Postgres works for CI (a `postgres:16` service container is the common choice).
+- Postgres additionally needs a **shadow database**, which Prisma creates and drops automatically using the same connection — this requires the connecting role to have `CREATEDB`, or a separate `shadowDatabaseUrl` configured. See [Prisma's shadow database docs](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database) if the CI role can't create databases.
+- The existing migration history must apply cleanly against that database — if it's drifted, `migrate dev` falls back to its reset-confirmation prompt (see below).
+
+**DB-less fallback — `prisma migrate diff`**
+
+Where a database genuinely can't run (e.g. a fully sandboxed agent with no way to provision Postgres), author the migration from a pure schema diff instead:
+
+```bash
+pnpm generate # regenerate prisma/schema.prisma from opensaas.config.ts
+
+DIR="prisma/migrations/$(date +%Y%m%d%H%M%S)_add_status_field"
+mkdir -p "$DIR"
+
+npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script > "$DIR/migration.sql"
+```
+
+`migration_lock.toml` (just the provider name) is created once per project by the first migration and doesn't need to be recreated by hand for subsequent ones.
+
+> **Fidelity caveat.** `migrate diff` compares the target schema against the migration history's resulting schema on paper — it does not replay the history against a real database via a shadow DB the way `migrate dev` does. It won't catch drift between your committed migrations and what's actually deployed, and it can miss provider-specific behaviour that only surfaces against a live database. Treat its output as a starting point to review, not a guarantee, and prefer the primary `migrate dev` path whenever a database is available.
+
+**Why the "non-interactive...not supported" error appears**
+
+If you've hit `Prisma Migrate has detected that the environment is non-interactive, which is not supported`, it isn't because `migrate dev` requires a TTY in general — it's the **reset/confirmation path**: either there's no reachable database/shadow database to diff against, or the migration history has drifted from it, and Prisma needs to ask "reset the database?" with no way to answer non-interactively. Point the command at a clean, reachable database (and pass `--name`) and it runs headless.
+
 ## Production Considerations
 
 ### Bundling the Generated `.opensaas` bundle


### PR DESCRIPTION
## Summary

- Adds an "Authoring Migrations in CI / Agent Environments" section to the deployment guide, resolving the triage brief on #681: this was reframed from a tooling gap to a documentation gap during a grilling session (see issue comment).
- Documents `prisma migrate dev --name <name>` as the primary headless path (works on a clean, in-sync history against any reachable database), including the Postgres shadow-database requirement.
- Documents the DB-less `prisma migrate diff` fallback (assembling a timestamped migration directory) with an explicit fidelity caveat versus `migrate dev`'s shadow-DB replay.
- Clarifies that the "environment is non-interactive...not supported" error comes from the reset/drift-confirmation path (no reachable database, or drifted history), not an inherent TTY requirement of `migrate dev`.

No package code changed, so no changeset is required.

## Test plan

- [x] `pnpm lint` — passes (pre-existing unrelated warnings only)
- [x] `pnpm format` — clean
- [x] `pnpm manypkg fix` — no issues
- [x] Docs-only change; reviewed rendered content for accuracy against Prisma's documented `migrate dev` / `migrate diff` behaviour

Closes #681


---
_Generated by [Claude Code](https://claude.ai/code/session_013Pg9tqstvNcRWUvQaVV2W7)_