### PR TITLE
fix(cli): preserve host-added datasource keys in prisma.config.ts

### DIFF
--- a/.changeset/tame-eels-wonder.md
+++ b/.changeset/tame-eels-wonder.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Preserve host-added `datasource` keys (e.g. `shadowDatabaseUrl`) in `prisma.config.ts` across `generate` runs instead of overwriting the block wholesale.

--- a/packages/cli/src/generator/prisma-config.test.ts
+++ b/packages/cli/src/generator/prisma-config.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest'
-import { generatePrismaConfig } from './prisma-config.js'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import {
+  generatePrismaConfig,
+  extractExtraDatasourceLines,
+  writePrismaConfig,
+} from './prisma-config.js'
 import type { OpenSaasConfig } from '@opensaas/stack-core'
 import { text } from '@opensaas/stack-core/fields'
 
@@ -43,6 +50,106 @@ describe('Prisma Config Generator', () => {
 
     it('matches the full snapshot', () => {
       expect(generatePrismaConfig(config)).toMatchSnapshot()
+    })
+
+    it('re-emits host-added datasource keys after the managed url key', () => {
+      const output = generatePrismaConfig(config, undefined, [
+        "shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),",
+      ])
+      expect(output).toContain(
+        "url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),\n    shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),",
+      )
+    })
+  })
+
+  describe('extractExtraDatasourceLines', () => {
+    it('returns host-added keys, excluding the managed url key', () => {
+      const existing = `
+export default defineConfig({
+  schema: 'prisma',
+  datasource: {
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
+    shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),
+  },
+})
+`
+      expect(extractExtraDatasourceLines(existing)).toEqual([
+        "shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),",
+      ])
+    })
+
+    it('returns an empty array when there is no extra key', () => {
+      const existing = `
+export default defineConfig({
+  datasource: {
+    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),
+  },
+})
+`
+      expect(extractExtraDatasourceLines(existing)).toEqual([])
+    })
+
+    it('returns an empty array when there is no datasource block', () => {
+      expect(extractExtraDatasourceLines('export default defineConfig({})\n')).toEqual([])
+    })
+  })
+
+  describe('writePrismaConfig', () => {
+    let tempDir: string
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-config-test-'))
+    })
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    })
+
+    it('preserves a host-added datasource key across a re-generate', () => {
+      const outputPath = path.join(tempDir, 'prisma.config.ts')
+      fs.writeFileSync(
+        outputPath,
+        `import 'dotenv/config'
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma',
+  datasource: {
+    url: 'file:./stale.db',
+    shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),
+  },
+})
+`,
+        'utf-8',
+      )
+
+      writePrismaConfig(config, outputPath)
+
+      const result = fs.readFileSync(outputPath, 'utf-8')
+      expect(result).toContain("shadowDatabaseUrl: env('SHADOW_DATABASE_URL'),")
+      // The managed key is regenerated, not left as the stale on-disk value.
+      expect(result).toContain("url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),")
+      expect(result).not.toContain("'file:./stale.db'")
+    })
+
+    it('produces byte-identical output to today when there are no extra datasource keys', () => {
+      const outputPath = path.join(tempDir, 'prisma.config.ts')
+      writePrismaConfig(config, outputPath)
+      const first = fs.readFileSync(outputPath, 'utf-8')
+
+      writePrismaConfig(config, outputPath)
+      const second = fs.readFileSync(outputPath, 'utf-8')
+
+      expect(second).toBe(first)
+      expect(second).toBe(generatePrismaConfig(config))
+    })
+
+    it('writes the file when none exists yet', () => {
+      const outputPath = path.join(tempDir, 'nested', 'prisma.config.ts')
+      writePrismaConfig(config, outputPath)
+
+      expect(fs.existsSync(outputPath)).toBe(true)
+      expect(fs.readFileSync(outputPath, 'utf-8')).toBe(generatePrismaConfig(config))
     })
   })
 })

--- a/packages/cli/src/generator/prisma-config.ts
+++ b/packages/cli/src/generator/prisma-config.ts
@@ -24,8 +24,17 @@ import * as path from 'path'
  * because the upstream helper throws when a variable is unset, which would break
  * the `??` fallback. The local helper returns `undefined` for missing variables
  * so the fallback can take effect.
+ *
+ * @param extraDatasourceLines - Verbatim `datasource` block entries the
+ *   generator does not itself manage (e.g. a host-added `shadowDatabaseUrl`),
+ *   extracted from a pre-existing file by {@link extractExtraDatasourceLines}.
+ *   Re-emitted after the managed `url` key so a re-generate does not drop them.
  */
-export function generatePrismaConfig(_config: OpenSaasConfig, schemaPath?: string): string {
+export function generatePrismaConfig(
+  _config: OpenSaasConfig,
+  schemaPath?: string,
+  extraDatasourceLines: string[] = [],
+): string {
   const lines: string[] = []
 
   // The schema path Prisma's CLI resolves (a directory or a `.prisma` file).
@@ -48,6 +57,9 @@ export function generatePrismaConfig(_config: OpenSaasConfig, schemaPath?: strin
   lines.push(`  schema: '${schema}',`)
   lines.push('  datasource: {')
   lines.push("    url: env('DIRECT_DATABASE_URL') ?? env('DATABASE_URL'),")
+  for (const extraLine of extraDatasourceLines) {
+    lines.push(`    ${extraLine}`)
+  }
   lines.push('  },')
   lines.push('})')
   lines.push('')
@@ -56,7 +68,37 @@ export function generatePrismaConfig(_config: OpenSaasConfig, schemaPath?: strin
 }
 
 /**
+ * Extract host-added `datasource` block entries from a pre-existing
+ * `prisma.config.ts` file, so a re-generate can preserve them instead of
+ * clobbering the block wholesale.
+ *
+ * Only the `url` key is generator-managed; every other entry in the block
+ * (e.g. `shadowDatabaseUrl`) is treated as host-owned and returned verbatim
+ * for re-emission by {@link generatePrismaConfig}.
+ *
+ * This is a lightweight line-based extraction, not a TypeScript parser: it
+ * assumes the `datasource` block contains flat, single-line `key: value,`
+ * entries with no nested braces, which matches every entry this generator or
+ * documented host customization emits.
+ */
+export function extractExtraDatasourceLines(existingContent: string): string[] {
+  const match = existingContent.match(/datasource:\s*\{([^}]*)\}/)
+  if (!match) {
+    return []
+  }
+
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('url:'))
+}
+
+/**
  * Write Prisma config to file
+ *
+ * If a `prisma.config.ts` already exists at `outputPath`, its `datasource`
+ * block is read first so host-added keys the generator does not manage (e.g.
+ * `shadowDatabaseUrl`) survive the rewrite — see {@link extractExtraDatasourceLines}.
  *
  * @param schemaPath - Optional override for the `schema` field, forwarded to
  *   {@link generatePrismaConfig}.
@@ -66,7 +108,11 @@ export function writePrismaConfig(
   outputPath: string,
   schemaPath?: string,
 ): void {
-  const prismaConfig = generatePrismaConfig(config, schemaPath)
+  const extraDatasourceLines = fs.existsSync(outputPath)
+    ? extractExtraDatasourceLines(fs.readFileSync(outputPath, 'utf-8'))
+    : []
+
+  const prismaConfig = generatePrismaConfig(config, schemaPath, extraDatasourceLines)
 
   // Ensure directory exists
   const dir = path.dirname(outputPath)


### PR DESCRIPTION
## Summary
- `writePrismaConfig` previously overwrote `prisma.config.ts` wholesale on every `generate` run, silently dropping any host-added `datasource` keys (e.g. a `shadowDatabaseUrl` used for local migration diffing).
- `writePrismaConfig` now reads the pre-existing file (if any) and extracts `datasource` entries it doesn't manage via a new `extractExtraDatasourceLines` helper, then re-emits them alongside the generator-managed `url` key.
- `generatePrismaConfig` gained an optional `extraDatasourceLines` parameter so it stays a pure generator function; `writePrismaConfig` is the only caller that reads from disk.
- No change in output for projects that haven't added extra `datasource` keys — byte-identical to before.

## Test plan
- [x] Added tests covering `extractExtraDatasourceLines` (extra key preserved / no extra key / no datasource block)
- [x] Added `writePrismaConfig` tests: a pre-existing file with an extra `shadowDatabaseUrl` key survives a re-generate, output is unchanged/byte-identical when there are no extra keys, and the file is created correctly when none exists yet
- [x] `pnpm --filter @opensaas/stack-cli` full test suite passes (323 tests)
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` run clean (no new warnings/errors)
- [x] `pnpm build` passes for `@opensaas/stack-cli`

Closes #680


---
_Generated by [Claude Code](https://claude.ai/code/session_01BL4EUk6wgRJpFPeQKtCDv2)_