### PR TITLE
fix: enforce ADR-0013 — plugin extensions can't override existing list access

### DIFF
--- a/.changeset/silent-plugins-guard-access.md
+++ b/.changeset/silent-plugins-guard-access.md
@@ -1,0 +1,6 @@
+---
+'@opensaas/stack-core': patch
+'@opensaas/stack-auth': patch
+---
+
+Fix a plugin's `extendList()` silently overwriting a pre-existing list's operation-level access. Per ADR-0013, an extension that carries `access.operation` for an existing list now throws a config-time error naming the plugin and the list; the auth plugin no longer forwards its own access when extending a list an app already declared.

--- a/packages/auth/src/config/plugin.ts
+++ b/packages/auth/src/config/plugin.ts
@@ -68,11 +68,13 @@ export function authPlugin(config: AuthConfig): Plugin {
           // Add or extend lists from plugin
           for (const [listName, listConfig] of Object.entries(pluginLists)) {
             if (context.config.lists[listName]) {
-              // List exists, extend it
+              // List already exists — merge fields/hooks/mcp in only. Access
+              // control belongs to whoever owns the list; per ADR-0013 an
+              // extension must never carry operation-level access for a
+              // pre-existing list (the plugin engine throws if it does).
               context.extendList(listName, {
                 fields: listConfig.fields,
                 hooks: listConfig.hooks,
-                access: listConfig.access,
                 mcp: listConfig.mcp,
               })
             } else {
@@ -94,11 +96,13 @@ export function authPlugin(config: AuthConfig): Plugin {
       // "merge auth fields into my User" behaviour.
       for (const [listName, listConfig] of Object.entries(authLists)) {
         if (context.config.lists[listName]) {
-          // A list already exists under this derived key — merge auth fields in.
+          // A list already exists under this derived key — merge auth fields
+          // in only. Access control belongs to whoever owns the list (the
+          // application declared it first), so the plugin never forwards its
+          // own access here — see ADR-0013.
           context.extendList(listName, {
             fields: listConfig.fields,
             hooks: listConfig.hooks,
-            access: listConfig.access,
             mcp: listConfig.mcp,
           })
         } else {

--- a/packages/auth/tests/plugin-derived-keys.test.ts
+++ b/packages/auth/tests/plugin-derived-keys.test.ts
@@ -72,6 +72,42 @@ describe('authPlugin - add-vs-extend with derived keys', () => {
     expect(user.fields).toHaveProperty('sessions')
   })
 
+  it("does not overwrite an app's admin-only access when the auth plugin extends the same default key (ADR-0013)", async () => {
+    // Regression test for #678: the auth plugin ships permissive defaults
+    // (query: () => true, self-only update/delete) for its own User list.
+    // Before the ADR-0013 fix, extending an app-declared `User` at the
+    // default key forwarded those permissive defaults and silently replaced
+    // the app's admin-only access. Now the plugin must not forward `access`
+    // at all on its extend path, so the app's access survives untouched.
+    const adminOnlyUpdate = vi.fn(() => false)
+    const adminOnlyQuery = vi.fn(() => false)
+
+    const result = await config({
+      db: { provider: 'sqlite' },
+      plugins: [authPlugin({})],
+      lists: {
+        User: list({
+          fields: { bio: text() },
+          access: {
+            operation: {
+              query: adminOnlyQuery,
+              update: adminOnlyUpdate,
+            },
+          },
+        }),
+      },
+    })
+
+    const user = result.lists.User
+    expect(user.fields).toHaveProperty('email') // auth fields still merged in
+    // The app's admin-only access is intact — not replaced by the plugin's
+    // permissive `query: () => true` / self-only `update` defaults.
+    expect(user.access?.operation?.query).toBe(adminOnlyQuery)
+    expect(user.access?.operation?.update).toBe(adminOnlyUpdate)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- access control parameters are runtime values
+    expect(user.access?.operation?.query?.({} as any)).toBe(false)
+  })
+
   it('routes a better-auth plugin schema extension of `user` onto the remapped Auth list, not an unrelated host User', async () => {
     // A better-auth provider plugin (e.g. the `anonymous` plugin) that ships a
     // schema extension for the base `user` model.

--- a/packages/core/src/config/plugin-engine.ts
+++ b/packages/core/src/config/plugin-engine.ts
@@ -4,7 +4,6 @@ import type {
   PluginContext,
   ListConfig,
   Hooks,
-  OperationAccess,
   McpCustomTool,
   BaseFieldConfig,
 } from './types.js'
@@ -126,29 +125,6 @@ function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): 
 }
 
 /**
- * Merge access control from extension into existing access
- */
-function mergeAccess(
-  existing: { operation?: OperationAccess } | undefined,
-  extension: { operation?: OperationAccess } | undefined,
-): { operation?: OperationAccess } | undefined {
-  if (!extension) return existing
-  if (!existing) return extension
-
-  const merged: { operation?: OperationAccess } = {}
-
-  // Merge operation access (use extension if provided, otherwise keep existing)
-  if (existing.operation || extension.operation) {
-    merged.operation = {
-      ...existing.operation,
-      ...extension.operation,
-    }
-  }
-
-  return merged
-}
-
-/**
  * Execute plugins and transform config
  * Returns modified config with plugin data attached
  */
@@ -197,6 +173,19 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
           )
         }
 
+        // Operation-level access belongs to whoever owns the list (the
+        // application, or an earlier plugin that created it via addList).
+        // An extension of a pre-existing list must never define or override
+        // that access — see ADR-0013. Fields/hooks/relationships/mcp may
+        // still be merged in below.
+        if (extension.access?.operation) {
+          throw new Error(
+            `Plugin "${plugin.name}" tried to set operation-level access while extending list "${name}", ` +
+              `but access control belongs to the application (or whichever party created the list), never a ` +
+              `plugin extending it. Remove "access" from this extension — see ADR-0013.`,
+          )
+        }
+
         // Deep merge fields
         const mergedFields = {
           ...existing.fields,
@@ -205,9 +194,6 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
 
         // Merge hooks
         const mergedHooks = mergeHooks(existing.hooks, extension.hooks)
-
-        // Merge access control
-        const mergedAccess = mergeAccess(existing.access, extension.access)
 
         // Merge MCP config
         const mergedMcp = extension.mcp
@@ -221,7 +207,6 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
           ...existing,
           fields: mergedFields,
           hooks: mergedHooks,
-          access: mergedAccess,
           mcp: mergedMcp,
         }
       },

--- a/packages/core/tests/plugin-engine.test.ts
+++ b/packages/core/tests/plugin-engine.test.ts
@@ -681,8 +681,8 @@ describe('Plugin Engine', () => {
     })
   })
 
-  describe('access control merging', () => {
-    test('merges access control from plugins', async () => {
+  describe('access control guardrail (ADR-0013)', () => {
+    test('throws when an extension carries operation access for a pre-existing list', async () => {
       const plugin: Plugin = {
         name: 'test-plugin',
         init: async (context) => {
@@ -711,23 +711,19 @@ describe('Plugin Engine', () => {
         plugins: [plugin],
       }
 
-      const result = await executePlugins(config)
-
-      expect(result.lists.Post.access?.operation?.query).toBeDefined()
-      expect(result.lists.Post.access?.operation?.create).toBeDefined()
-      expect(result.lists.Post.access?.operation?.update).toBeDefined()
+      await expect(executePlugins(config)).rejects.toThrow(
+        'Plugin "test-plugin" tried to set operation-level access while extending list "Post"',
+      )
     })
 
-    test('plugin access control overrides existing', async () => {
-      const pluginQuery = vi.fn(() => false)
-
+    test('extension attempting to override existing access throws instead of silently winning', async () => {
       const plugin: Plugin = {
         name: 'test-plugin',
         init: async (context) => {
           context.extendList('Post', {
             access: {
               operation: {
-                query: pluginQuery,
+                query: () => false,
               },
             },
           })
@@ -750,10 +746,67 @@ describe('Plugin Engine', () => {
         plugins: [plugin],
       }
 
+      await expect(executePlugins(config)).rejects.toThrow('Post')
+
+      // The host's access is untouched — the throw happens before any mutation.
+      expect(config.lists.Post.access?.operation?.query).toBe(originalQuery)
+    })
+
+    test('extension providing only fields/hooks for a pre-existing list leaves its access untouched', async () => {
+      const originalQuery = vi.fn(() => true)
+
+      const plugin: Plugin = {
+        name: 'test-plugin',
+        init: async (context) => {
+          context.extendList('Post', {
+            fields: { views: integer() },
+          })
+        },
+      }
+
+      const config: OpenSaasConfig = {
+        lists: {
+          Post: {
+            fields: { title: text() },
+            access: {
+              operation: {
+                query: originalQuery,
+              },
+            },
+          },
+        },
+        plugins: [plugin],
+      }
+
       const result = await executePlugins(config)
 
-      // Plugin's access control should override original
-      expect(result.lists.Post.access?.operation?.query).toBe(pluginQuery)
+      expect(result.lists.Post.fields.views).toBeDefined()
+      expect(result.lists.Post.access?.operation?.query).toBe(originalQuery)
+    })
+
+    test('a plugin creating a new list may still set its access via addList', async () => {
+      const plugin: Plugin = {
+        name: 'test-plugin',
+        init: async (context) => {
+          context.addList('Widget', {
+            fields: { name: text() },
+            access: {
+              operation: {
+                query: () => true,
+              },
+            },
+          })
+        },
+      }
+
+      const config: OpenSaasConfig = {
+        lists: {},
+        plugins: [plugin],
+      }
+
+      const result = await executePlugins(config)
+
+      expect(result.lists.Widget.access?.operation?.query).toBeDefined()
     })
   })
 


### PR DESCRIPTION
## Summary

- `extendList()` in the plugin engine now throws a config-time error naming the plugin and the list when an extension carries `access.operation` for a list that **already exists** — per ADR-0013, operation-level access belongs to whoever owns the list (the application, or whichever party created it via `addList`), never a plugin extending it. Extending with only fields/hooks/mcp still works and leaves the target list's access untouched. `addList()` is unaffected — a plugin creating a new list may still set its access at creation.
- Removed the now-unused `mergeAccess()` per-key-spread helper that let an extension's access win per operation.
- The auth plugin (`packages/auth/src/config/plugin.ts`) no longer forwards `access` on either of its `extendList` paths (its own derived auth lists, and better-auth provider-plugin schema extensions) — it merges `fields`/`hooks`/`mcp` only. This was the reported footgun: an app's own `User` list (or any list colliding with a derived auth key) could have its access silently replaced by the auth plugin's permissive defaults (`query: () => true`, self-only update/delete).

## Test plan

- [x] `packages/core/tests/plugin-engine.test.ts` — replaced the two access-merging tests with: throws when an extension carries operation access for a pre-existing list; extension attempting to override existing access throws instead of silently winning; fields/hooks-only extension leaves access untouched; a plugin creating a new list may still set access via `addList`.
- [x] `packages/auth/tests/plugin-derived-keys.test.ts` — added a regression test: an app-declared `User` list with admin-only `query`/`update` access, extended by `authPlugin({})` at the default key, keeps its own access after the plugin runs (the acceptance-criteria scenario from #678).
- [x] `pnpm test` green in `packages/core` (773 tests), `packages/auth` (137 tests), `packages/rag` (178 tests)
- [x] `pnpm lint` — no new warnings/errors
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed
- [x] Changeset added (`@opensaas/stack-core` + `@opensaas/stack-auth`, patch)

Closes #678


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdv6YDJxoG3XWZzPHoc4Rq)_