### PR TITLE
fix(auth): mirror better-auth FK shape on Session.user/Account.user

### DIFF
--- a/.changeset/mirror-auth-fk-cascade.md
+++ b/.changeset/mirror-auth-fk-cascade.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-auth': minor
+---
+
+The derived `Session.user` and `Account.user` foreign keys now mirror a live better-auth database's shape: no `@@index([userId])` (better-auth carries no separate FK index) and `onDelete: Cascade` (Prisma's default was `Restrict`). This applies to both greenfield installs and adopted databases, so a generated Auth schema diffs clean against a standard better-auth Prisma schema.
+
+Migration note: existing greenfield stack-auth apps will see a schema diff on next `pnpm generate` — a migration that drops the `userId` index on `Session`/`Account` and adds `onDelete: Cascade` to both foreign keys. Review the generated migration before applying it; deleting a user now cascades to their sessions and accounts instead of being blocked.

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -27,6 +27,7 @@
 import { list } from '@opensaas/stack-core'
 import { text, timestamp, checkbox, relationship } from '@opensaas/stack-core/fields'
 import type { ListConfig } from '@opensaas/stack-core'
+import type { RelationshipField } from '@opensaas/stack-core/fields'
 import type { ExtendUserListConfig } from '../lists/index.js'
 import type { AuthAccessConfig, NormalizedAuthModelConfig, NormalizedAuthModels } from './types.js'
 
@@ -106,14 +107,23 @@ function fieldDb(fieldName: string, fields: Record<string, string>): { map: stri
 }
 
 /**
- * Build the foreign-key `db` config for a `user` relationship, honouring a
- * `userId` column override from the better-auth `fields` map.
+ * Build the `db` config for a `user` relationship (`Session.user` /
+ * `Account.user`), honouring a `userId` column override from the better-auth
+ * `fields` map and mirroring better-auth's own FK shape: no separate FK index
+ * — the index is applied at the field level via `isIndexed: false` — and
+ * `onDelete: Cascade`, so a generated Auth schema diffs clean against a live
+ * better-auth database on both dimensions instead of showing a spurious index
+ * drop and a referential-action change (issue #679).
  */
-function userForeignKeyDb(
-  fields: Record<string, string>,
-): { foreignKey: { map: string } } | undefined {
+function userRelationshipDb(fields: Record<string, string>): NonNullable<RelationshipField['db']> {
   const column = fields.userId
-  return column ? { foreignKey: { map: column } } : undefined
+  return {
+    ...(column ? { foreignKey: { map: column } } : {}),
+    extendPrismaSchema: ({ fkLine, relationLine }) => ({
+      fkLine,
+      relationLine: relationLine.replace('@relation(', '@relation(onDelete: Cascade, '),
+    }),
+  }
 }
 
 /**
@@ -182,7 +192,8 @@ function createSessionList(
       userAgent: text({ db: fieldDb('userAgent', f) }),
       user: relationship({
         ref: `${keys.user}.sessions`,
-        db: userForeignKeyDb(f),
+        isIndexed: false,
+        db: userRelationshipDb(f),
       }),
     },
     db: listDb(model, DEFAULT_MODEL_NAMES.session),
@@ -209,7 +220,8 @@ function createAccountList(
       providerId: text({ validation: { isRequired: true }, db: fieldDb('providerId', f) }),
       user: relationship({
         ref: `${keys.user}.accounts`,
-        db: userForeignKeyDb(f),
+        isIndexed: false,
+        db: userRelationshipDb(f),
       }),
       accessToken: text({ db: fieldDb('accessToken', f) }),
       refreshToken: text({ db: fieldDb('refreshToken', f) }),

--- a/packages/auth/tests/derive-auth-lists.test.ts
+++ b/packages/auth/tests/derive-auth-lists.test.ts
@@ -55,7 +55,7 @@ describe('deriveAuthLists - default behaviour (no overrides)', () => {
     expect(lists.User.fields.name.db?.map).toBeUndefined()
     expect(lists.Session.fields.token.db?.map).toBeUndefined()
     // FK column not overridden -> no foreignKey map on the relationship
-    expect(lists.Session.fields.user.db).toBeUndefined()
+    expect(lists.Session.fields.user.db?.foreignKey).toBeUndefined()
   })
 
   it('opts every auth list into auto-timestamps', () => {
@@ -69,6 +69,59 @@ describe('deriveAuthLists - default behaviour (no overrides)', () => {
     expect(lists.Session.db?.timestamps).toBe(true)
     expect(lists.Account.db?.timestamps).toBe(true)
     expect(lists.Verification.db?.timestamps).toBe(true)
+  })
+})
+
+describe('deriveAuthLists - user FK shape mirrors better-auth (issue #679)', () => {
+  it('disables the default FK index on Session.user and Account.user', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+
+    expect(lists.Session.fields.user.isIndexed).toBe(false)
+    expect(lists.Account.fields.user.isIndexed).toBe(false)
+  })
+
+  it('does not touch isIndexed on the email/token unique fields', () => {
+    // Existing @@unique mirroring must be unaffected by the FK shape change.
+    const { lists } = deriveAuthLists(defaultModels)
+
+    expect(lists.User.fields.email.isIndexed).toBe('unique')
+    expect(lists.Session.fields.token.isIndexed).toBe('unique')
+  })
+
+  it('adds onDelete: Cascade to the user relation line via extendPrismaSchema', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+
+    for (const field of [lists.Session.fields.user, lists.Account.fields.user]) {
+      const extend = field.db?.extendPrismaSchema
+      expect(extend).toBeTypeOf('function')
+
+      const result = extend!({
+        fkLine: '  userId       String?',
+        relationLine: '  user         User?  @relation(fields: [userId], references: [id])',
+      })
+
+      expect(result.relationLine).toBe(
+        '  user         User?  @relation(onDelete: Cascade, fields: [userId], references: [id])',
+      )
+      // The FK line itself is untouched by the cascade rewrite.
+      expect(result.fkLine).toBe('  userId       String?')
+    }
+  })
+
+  it('keeps the cascade extendPrismaSchema alongside a userId column override', () => {
+    const models: NormalizedAuthModels = {
+      user: { modelName: 'User', fields: {} },
+      session: { modelName: 'Session', fields: { userId: 'user_id' } },
+      account: { modelName: 'Account', fields: { userId: 'user_id' } },
+      verification: { modelName: 'Verification', fields: {} },
+    }
+
+    const { lists } = deriveAuthLists(models)
+
+    expect(lists.Session.fields.user.db?.foreignKey).toEqual({ map: 'user_id' })
+    expect(lists.Session.fields.user.db?.extendPrismaSchema).toBeTypeOf('function')
+    expect(lists.Account.fields.user.db?.foreignKey).toEqual({ map: 'user_id' })
+    expect(lists.Account.fields.user.db?.extendPrismaSchema).toBeTypeOf('function')
   })
 })
 


### PR DESCRIPTION
## Summary

- `Session.user` and `Account.user` (the many-to-one FKs on `userId`) are now derived with `isIndexed: false` and an `onDelete: Cascade` referential action (via the relationship's field-level `db.extendPrismaSchema`), matching a live better-auth database's shape.
- Previously the derived relationships only set the FK column map, so the generator emitted a default `@@index([userId])` and the default Prisma referential action (`Restrict`) — neither of which a standard better-auth schema has. This meant `migrate diff` always showed a spurious index drop and a referential-action change on every auth FK, in both greenfield and adopted installs.
- Both greenfield (`deriveAuthLists` with default models) and adoption (`adoptBetterAuthTables` + custom `modelName`/`fields`) go through the same `deriveAuthLists` derivation, so this is a single fix covering both paths — no new config surface.
- Existing `@@unique` mirroring on `User.email` / `Session.token` is unchanged.

## Test plan

- [x] Added regression tests in `packages/auth/tests/derive-auth-lists.test.ts` asserting:
  - `Session.user` / `Account.user` carry `isIndexed: false`
  - the `db.extendPrismaSchema` callback rewrites the relation line to include `onDelete: Cascade` (and leaves the FK line untouched)
  - the cascade `extendPrismaSchema` is retained alongside a `userId` column override (adoption case)
  - `@@unique` mirroring on `email`/`token` is unaffected
- [x] `pnpm test` in `packages/auth` (138 tests passing)
- [x] `pnpm test` in `packages/cli` (323 tests passing) — the underlying `isIndexed: false` + `extendPrismaSchema` generator mechanism is exercised there
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format`
- [x] Changeset added (`minor`, per the issue's own guidance — this changes generated schema output for existing greenfield stack-auth apps)

## Migration note

Existing greenfield stack-auth apps will see a schema diff on the next `pnpm generate`: a migration that drops the `userId` index on `Session`/`Account` and adds `onDelete: Cascade` to both foreign keys. Deleting a user will now cascade to their sessions/accounts instead of being blocked — call this out to app owners before they apply the generated migration.

Closes #679


---
_Generated by [Claude Code](https://claude.ai/code/session_01CX4WgRfZKRUf89Wh7921wC)_