### PR TITLE
Design system 1/7: token contract + theme compiler, proven through Button

### DIFF
--- a/.changeset/theme-token-contract.md
+++ b/.changeset/theme-token-contract.md
@@ -1,0 +1,27 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add the theming token contract and a pure `ui.theme` compiler, proven end-to-end through Button.
+
+The UI package stylesheet now defines the full Theme token vocabulary as a single, un-driftable contract: the shadcn color set plus `success`/`warning` (with foregrounds) and a `gradientFrom`/`gradientTo` pair, `--font-sans`/`--font-mono`/`--font-heading` (heading defaults to sans), a single `--radius` knob with derived sm/md/lg sizes, and `--shadow-sm`/`--shadow-md`/`--shadow-lg` — all with light and dark values side by side via `light-dark()`.
+
+`ThemeConfig` is a clean break (ADR-0015). Colors accept any valid CSS color string and are emitted verbatim — the compiler never parses colors. Bare HSL triplets (`'220 20% 97%'`) are no longer accepted and fire a dev-mode warning suggesting an `hsl()` wrap.
+
+```typescript
+ui: {
+  theme: {
+    preset: 'modern', // 'modern' | 'classic' | 'neon'
+    colors: { primary: '#16a34a' }, // hex, oklch(...), rgb(...), hsl(...)
+    darkColors: { primary: '#4ade80' },
+    fonts: { sans: 'var(--font-inter), system-ui, sans-serif' }, // compose with next/font
+    radius: 0.5, // rem
+    shadows: { sm: 'none', md: 'none', lg: 'none' }, // flat theme
+  },
+}
+```
+
+The config layer compiles onto the same CSS custom properties the stylesheet declares, so the two can never drift. `Button` is restyled to consume only these tokens (color, radius, shadow, font) and carries a stable `data-slot="button"`.
+
+Migration: wrap any old bare-triplet color value in `hsl()` (`'220 20% 97%'` → `'hsl(220 20% 97%)'`). Preset-only configs need no changes.

--- a/docs/content/api-reference/config.md
+++ b/docs/content/api-reference/config.md
@@ -807,14 +807,18 @@ Theme customization options.
 
 ### `ThemeConfig`
 
-Theme customization for the admin UI.
+Theme customization for the admin UI. Compiles to CSS custom property overrides
+written onto the same tokens the UI package stylesheet declares, so the config
+layer and the stylesheet can never drift (ADR-0015).
 
 ```typescript
 theme: {
   preset?: 'modern' | 'classic' | 'neon',
-  colors?: ThemeColors,
-  darkColors?: ThemeColors,
-  radius?: number,
+  colors?: ThemeColors,       // light-mode overrides
+  darkColors?: ThemeColors,   // dark-mode overrides
+  fonts?: { sans?: string, mono?: string, heading?: string },
+  radius?: number,            // rem; derived sm/md/lg sizes computed from it
+  shadows?: { sm?: string, md?: string, lg?: string },
 }
 ```
 
@@ -822,84 +826,78 @@ theme: {
 
 ##### `preset`
 
-Predefined theme preset.
+Predefined theme preset, used as a starting point for token overrides.
 
 **Type:** `'modern' | 'classic' | 'neon'`
 **Default:** `'modern'`
 
-##### `colors`
+##### `colors` / `darkColors`
 
-Custom color overrides for light mode.
-
-**Type:** [`ThemeColors`](#themecolors)
-
-##### `darkColors`
-
-Custom color overrides for dark mode.
+Custom color overrides for light and dark mode respectively.
 
 **Type:** [`ThemeColors`](#themecolors)
+
+##### `fonts`
+
+Font family tokens (`--font-sans`, `--font-mono`, `--font-heading`). Designed to
+compose with `next/font`: set a value to the font's CSS variable. `heading`
+defaults to `sans`.
+
+**Type:** `{ sans?: string; mono?: string; heading?: string }`
 
 ##### `radius`
 
-Border radius in rem units.
+Base border radius in rem units. Derived `sm`/`md`/`lg` radii are computed from it.
 
 **Type:** `number`
-**Default:** `0.75`
+**Default:** `0.625`
+
+##### `shadows`
+
+Elevation shadow tokens (`--shadow-sm`, `--shadow-md`, `--shadow-lg`). Set them
+to `'none'` for a fully flat theme.
+
+**Type:** `{ sm?: string; md?: string; lg?: string }`
 
 ---
 
 ### `ThemeColors`
 
-Custom theme color values (HSL format without `hsl()` wrapper).
+Custom theme color values. Each value is passed through **verbatim** to a CSS
+custom property, so any valid CSS color string works — `oklch(…)`, `#hex`,
+`rgb(…)`, or a wrapped `hsl(…)`.
 
-```typescript
-colors: {
-  background?: string,        // e.g., "220 20% 97%"
-  foreground?: string,
-  primary?: string,
-  primaryForeground?: string,
-  secondary?: string,
-  // ... more color options
-}
-```
-
-**Format:** HSL values as string: `"hue saturation% lightness%"`
-
-**Example:**
+> **Clean break (ADR-0015):** bare HSL triplets (`"220 20% 97%"`, the old
+> shadcn format) are no longer accepted. Passing one triggers a dev-mode warning
+> that suggests wrapping it in `hsl()`. Wrap old values — `"220 20% 97%"` →
+> `"hsl(220 20% 97%)"` — or move to any other CSS color format.
 
 ```typescript
 theme: {
   colors: {
-    primary: "221 83% 53%",           // Blue
-    primaryForeground: "0 0% 100%",   // White
-    background: "220 20% 97%",        // Light gray
+    primary: '#16a34a', // hex
+    primaryForeground: 'oklch(1 0 0)', // oklch
+    background: 'hsl(220 20% 97%)', // wrapped hsl
   }
 }
 ```
 
 #### Available Colors
 
-- `background` - Main background color
-- `foreground` - Main text color
-- `card` - Card background
-- `cardForeground` - Card text
-- `popover` - Popover background
-- `popoverForeground` - Popover text
-- `primary` - Primary action color
-- `primaryForeground` - Primary action text
-- `secondary` - Secondary action color
-- `secondaryForeground` - Secondary action text
-- `muted` - Muted background
-- `mutedForeground` - Muted text
-- `accent` - Accent color
-- `accentForeground` - Accent text
-- `destructive` - Destructive action color
-- `destructiveForeground` - Destructive action text
+- `background` / `foreground` - Main surface and text
+- `card` / `cardForeground` - Card surface and text
+- `popover` / `popoverForeground` - Popover surface and text
+- `primary` / `primaryForeground` - Primary action color and text
+- `secondary` / `secondaryForeground` - Secondary action color and text
+- `muted` / `mutedForeground` - Muted background and text
+- `accent` / `accentForeground` - Accent color and text
+- `destructive` / `destructiveForeground` - Destructive action color and text
+- `success` / `successForeground` - Success status color and text
+- `warning` / `warningForeground` - Warning status color and text
 - `border` - Border color
 - `input` - Input border color
 - `ring` - Focus ring color
-- `gradientFrom` - Gradient start color
-- `gradientTo` - Gradient end color
+- `gradientFrom` / `gradientTo` - Signature gradient pair
 
 ---
 

--- a/examples/starter/app/layout.tsx
+++ b/examples/starter/app/layout.tsx
@@ -1,6 +1,12 @@
 import '@opensaas/stack-ui/styles'
 import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
 import React from 'react'
+
+// Load a product font with next/font and expose it as a CSS variable. The
+// admin theme (see opensaas.config.ts) maps `--font-sans` onto this variable,
+// so the admin UI renders with the app's typography and proper font loading.
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' })
 
 export const metadata: Metadata = {
   title: 'OpenSaas Blog Admin',
@@ -9,7 +15,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.variable}>
       <body>{children}</body>
     </html>
   )

--- a/examples/starter/opensaas.config.ts
+++ b/examples/starter/opensaas.config.ts
@@ -180,5 +180,25 @@ export default config({
 
   ui: {
     basePath: '/admin',
+    // Demonstrates the token pipeline end-to-end: a brand color (any valid CSS
+    // color string — hex here) and a next/font family both flow through to the
+    // admin's buttons, focus rings, and text. `--font-inter` is provided by
+    // next/font in app/layout.tsx.
+    theme: {
+      preset: 'modern',
+      colors: {
+        primary: '#16a34a',
+        primaryForeground: '#ffffff',
+        ring: '#16a34a',
+      },
+      darkColors: {
+        primary: '#4ade80',
+        primaryForeground: '#052e16',
+        ring: '#4ade80',
+      },
+      fonts: {
+        sans: 'var(--font-inter), system-ui, sans-serif',
+      },
+    },
   },
 })

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -153,6 +153,8 @@ export type {
   ThemeConfig,
   ThemePreset,
   ThemeColors,
+  ThemeFonts,
+  ThemeShadows,
   McpConfig,
   McpToolsConfig,
   McpAuthConfig,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2029,8 +2029,13 @@ export type SessionConfig = {
 export type ThemePreset = 'modern' | 'classic' | 'neon'
 
 /**
- * Custom theme colors (HSL values without hsl() wrapper)
- * Format: "220 20% 97%" (hue saturation lightness)
+ * Custom theme colors.
+ *
+ * Each value is passed through verbatim to the corresponding CSS custom
+ * property, so any valid CSS color string works: `oklch(…)`, `#hex`, `rgb(…)`,
+ * or a wrapped `hsl(…)`. Bare HSL triplets (`"220 20% 97%"`) are a clean break —
+ * they are no longer accepted and trigger a dev-mode warning. See
+ * `specs/THEMING.md` and ADR-0015.
  */
 export type ThemeColors = {
   background?: string
@@ -2049,6 +2054,10 @@ export type ThemeColors = {
   accentForeground?: string
   destructive?: string
   destructiveForeground?: string
+  success?: string
+  successForeground?: string
+  warning?: string
+  warningForeground?: string
   border?: string
   input?: string
   ring?: string
@@ -2057,27 +2066,59 @@ export type ThemeColors = {
 }
 
 /**
- * Theme configuration
+ * Font family tokens. Each value is a CSS `font-family` string, designed to
+ * compose with `next/font`: set the value to the font's CSS variable, e.g.
+ * `sans: 'var(--font-inter), system-ui, sans-serif'`. `heading` defaults to the
+ * `sans` value when omitted.
+ */
+export type ThemeFonts = {
+  sans?: string
+  mono?: string
+  heading?: string
+}
+
+/**
+ * Elevation shadow tokens. Each value is a CSS `box-shadow` string. Set them to
+ * `'none'` for a fully flat theme without forking components.
+ */
+export type ThemeShadows = {
+  sm?: string
+  md?: string
+  lg?: string
+}
+
+/**
+ * Theme configuration. Compiles to token overrides written onto the same CSS
+ * custom properties the UI package stylesheet declares — the config layer and
+ * the stylesheet write to one token set so they can never drift (ADR-0015).
  */
 export type ThemeConfig = {
   /**
-   * Preset theme to use
+   * Preset theme to start from. Individual tokens can be overridden on top.
    * @default "modern"
    */
   preset?: ThemePreset
   /**
-   * Custom color overrides for light mode
+   * Custom color overrides for light mode.
    */
   colors?: ThemeColors
   /**
-   * Custom color overrides for dark mode
+   * Custom color overrides for dark mode.
    */
   darkColors?: ThemeColors
   /**
-   * Border radius in rem
-   * @default 0.75
+   * Font family overrides (`--font-sans`, `--font-mono`, `--font-heading`).
+   */
+  fonts?: ThemeFonts
+  /**
+   * Base border radius in rem. Derived sm/md/lg radii are computed from it.
+   * @default 0.625
    */
   radius?: number
+  /**
+   * Elevation shadow overrides (`--shadow-sm`, `--shadow-md`, `--shadow-lg`).
+   */
+  shadows?: ThemeShadows
 }
 
 /**

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -43,6 +43,8 @@ export type {
   ThemeConfig,
   ThemePreset,
   ThemeColors,
+  ThemeFonts,
+  ThemeShadows,
   FileMetadata,
   ImageMetadata,
   ImageTransformationResult,

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -12,7 +12,7 @@ import {
   getUrlKey,
   OpenSaasConfig,
 } from '@opensaas/stack-core'
-import { generateThemeCSS } from '../lib/theme.js'
+import { compileTheme } from '../lib/theme.js'
 
 export interface AdminUIProps {
   context: AccessContext<unknown>
@@ -144,7 +144,7 @@ export function AdminUI({
   }
 
   // Generate theme styles if custom theme is configured
-  const themeStyles = config.ui?.theme ? generateThemeCSS(config.ui.theme) : null
+  const themeStyles = config.ui?.theme ? compileTheme(config.ui.theme) : null
 
   return (
     <>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -79,4 +79,4 @@ export { getRelationshipOptions } from './lib/getRelationshipOptions.js'
 export type { RelationshipOption, RelationshipOptionsArgs } from './lib/getRelationshipOptions.js'
 
 // Theme utilities
-export { generateThemeCSS, getThemeStyleTag, presetThemes } from './lib/theme.js'
+export { compileTheme, presetThemes } from './lib/theme.js'

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -1,202 +1,264 @@
 import type { ThemeColors, ThemeConfig, ThemePreset } from '@opensaas/stack-core/internal'
 
 /**
- * Preset theme definitions
+ * Preset theme catalogs. Each preset supplies a full light + dark color set.
+ *
+ * `modern` is the default and MUST stay in sync with the raw `--color-*-light`
+ * / `--color-*-dark` values declared in `styles/globals.css`, so a preset-only
+ * (or default) config produces the same visuals the stylesheet already ships.
+ *
+ * Values are any valid CSS color string (ADR-0015) — the compiler never parses
+ * them, it emits them verbatim.
  */
 export const presetThemes: Record<ThemePreset, { light: ThemeColors; dark: ThemeColors }> = {
   modern: {
     light: {
-      background: '220 20% 97%',
-      foreground: '220 30% 10%',
-      card: '0 0% 100%',
-      cardForeground: '220 30% 10%',
-      popover: '0 0% 100%',
-      popoverForeground: '220 30% 10%',
-      primary: '190 95% 55%',
-      primaryForeground: '220 30% 10%',
-      secondary: '220 15% 94%',
-      secondaryForeground: '220 30% 10%',
-      muted: '220 15% 94%',
-      mutedForeground: '220 15% 45%',
-      accent: '280 85% 65%',
-      accentForeground: '0 0% 100%',
-      destructive: '0 84% 60%',
-      destructiveForeground: '0 0% 100%',
-      border: '220 15% 88%',
-      input: '220 15% 88%',
-      ring: '190 95% 55%',
-      gradientFrom: '190 95% 55%',
-      gradientTo: '280 85% 65%',
+      background: 'oklch(0.99 0.002 264)',
+      foreground: 'oklch(0.21 0.02 264)',
+      card: 'oklch(1 0 0)',
+      cardForeground: 'oklch(0.21 0.02 264)',
+      popover: 'oklch(1 0 0)',
+      popoverForeground: 'oklch(0.21 0.02 264)',
+      primary: 'oklch(0.55 0.2 264)',
+      primaryForeground: 'oklch(0.99 0.003 264)',
+      secondary: 'oklch(0.96 0.005 264)',
+      secondaryForeground: 'oklch(0.24 0.02 264)',
+      muted: 'oklch(0.96 0.005 264)',
+      mutedForeground: 'oklch(0.52 0.015 264)',
+      accent: 'oklch(0.96 0.01 300)',
+      accentForeground: 'oklch(0.24 0.02 264)',
+      destructive: 'oklch(0.58 0.22 27)',
+      destructiveForeground: 'oklch(0.99 0.003 264)',
+      success: 'oklch(0.62 0.17 150)',
+      successForeground: 'oklch(0.99 0.003 150)',
+      warning: 'oklch(0.75 0.16 75)',
+      warningForeground: 'oklch(0.27 0.05 75)',
+      border: 'oklch(0.92 0.006 264)',
+      input: 'oklch(0.92 0.006 264)',
+      ring: 'oklch(0.55 0.2 264)',
+      gradientFrom: 'oklch(0.55 0.2 264)',
+      gradientTo: 'oklch(0.62 0.19 320)',
     },
     dark: {
-      background: '220 25% 8%',
-      foreground: '220 15% 95%',
-      card: '220 20% 12%',
-      cardForeground: '220 15% 95%',
-      popover: '220 20% 12%',
-      popoverForeground: '220 15% 95%',
-      primary: '190 100% 60%',
-      primaryForeground: '220 30% 10%',
-      secondary: '220 20% 18%',
-      secondaryForeground: '220 15% 95%',
-      muted: '220 20% 18%',
-      mutedForeground: '220 10% 55%',
-      accent: '280 90% 70%',
-      accentForeground: '220 30% 10%',
-      destructive: '0 84% 65%',
-      destructiveForeground: '0 0% 100%',
-      border: '220 20% 22%',
-      input: '220 20% 22%',
-      ring: '190 100% 60%',
-      gradientFrom: '190 100% 60%',
-      gradientTo: '280 90% 70%',
+      background: 'oklch(0.17 0.015 264)',
+      foreground: 'oklch(0.96 0.005 264)',
+      card: 'oklch(0.21 0.018 264)',
+      cardForeground: 'oklch(0.96 0.005 264)',
+      popover: 'oklch(0.21 0.018 264)',
+      popoverForeground: 'oklch(0.96 0.005 264)',
+      primary: 'oklch(0.62 0.19 264)',
+      primaryForeground: 'oklch(0.15 0.02 264)',
+      secondary: 'oklch(0.27 0.02 264)',
+      secondaryForeground: 'oklch(0.96 0.005 264)',
+      muted: 'oklch(0.27 0.02 264)',
+      mutedForeground: 'oklch(0.68 0.015 264)',
+      accent: 'oklch(0.3 0.03 300)',
+      accentForeground: 'oklch(0.96 0.005 264)',
+      destructive: 'oklch(0.62 0.21 27)',
+      destructiveForeground: 'oklch(0.98 0.003 264)',
+      success: 'oklch(0.68 0.16 150)',
+      successForeground: 'oklch(0.15 0.02 150)',
+      warning: 'oklch(0.78 0.15 75)',
+      warningForeground: 'oklch(0.2 0.04 75)',
+      border: 'oklch(0.3 0.02 264)',
+      input: 'oklch(0.3 0.02 264)',
+      ring: 'oklch(0.62 0.19 264)',
+      gradientFrom: 'oklch(0.62 0.19 264)',
+      gradientTo: 'oklch(0.68 0.18 320)',
     },
   },
   classic: {
     light: {
-      background: '0 0% 100%',
-      foreground: '222.2 84% 4.9%',
-      card: '0 0% 100%',
-      cardForeground: '222.2 84% 4.9%',
-      popover: '0 0% 100%',
-      popoverForeground: '222.2 84% 4.9%',
-      primary: '221.2 83.2% 53.3%',
-      primaryForeground: '210 40% 98%',
-      secondary: '210 40% 96.1%',
-      secondaryForeground: '222.2 47.4% 11.2%',
-      muted: '210 40% 96.1%',
-      mutedForeground: '215.4 16.3% 46.9%',
-      accent: '210 40% 96.1%',
-      accentForeground: '222.2 47.4% 11.2%',
-      destructive: '0 84.2% 60.2%',
-      destructiveForeground: '210 40% 98%',
-      border: '214.3 31.8% 91.4%',
-      input: '214.3 31.8% 91.4%',
-      ring: '221.2 83.2% 53.3%',
-      gradientFrom: '221.2 83.2% 53.3%',
-      gradientTo: '221.2 83.2% 53.3%',
+      background: 'hsl(0 0% 100%)',
+      foreground: 'hsl(222 47% 11%)',
+      card: 'hsl(0 0% 100%)',
+      cardForeground: 'hsl(222 47% 11%)',
+      popover: 'hsl(0 0% 100%)',
+      popoverForeground: 'hsl(222 47% 11%)',
+      primary: 'hsl(221 83% 53%)',
+      primaryForeground: 'hsl(210 40% 98%)',
+      secondary: 'hsl(210 40% 96%)',
+      secondaryForeground: 'hsl(222 47% 11%)',
+      muted: 'hsl(210 40% 96%)',
+      mutedForeground: 'hsl(215 16% 47%)',
+      accent: 'hsl(210 40% 96%)',
+      accentForeground: 'hsl(222 47% 11%)',
+      destructive: 'hsl(0 84% 60%)',
+      destructiveForeground: 'hsl(210 40% 98%)',
+      success: 'hsl(142 71% 45%)',
+      successForeground: 'hsl(0 0% 100%)',
+      warning: 'hsl(38 92% 50%)',
+      warningForeground: 'hsl(0 0% 100%)',
+      border: 'hsl(214 32% 91%)',
+      input: 'hsl(214 32% 91%)',
+      ring: 'hsl(221 83% 53%)',
+      gradientFrom: 'hsl(221 83% 53%)',
+      gradientTo: 'hsl(221 83% 53%)',
     },
     dark: {
-      background: '222.2 84% 4.9%',
-      foreground: '210 40% 98%',
-      card: '222.2 84% 8%',
-      cardForeground: '210 40% 98%',
-      popover: '222.2 84% 8%',
-      popoverForeground: '210 40% 98%',
-      primary: '221.2 83.2% 53.3%',
-      primaryForeground: '210 40% 98%',
-      secondary: '217.2 32.6% 17.5%',
-      secondaryForeground: '210 40% 98%',
-      muted: '217.2 32.6% 17.5%',
-      mutedForeground: '215 20.2% 65.1%',
-      accent: '217.2 32.6% 17.5%',
-      accentForeground: '210 40% 98%',
-      destructive: '0 84.2% 60.2%',
-      destructiveForeground: '210 40% 98%',
-      border: '217.2 32.6% 17.5%',
-      input: '217.2 32.6% 17.5%',
-      ring: '221.2 83.2% 53.3%',
-      gradientFrom: '221.2 83.2% 53.3%',
-      gradientTo: '221.2 83.2% 53.3%',
+      background: 'hsl(222 47% 11%)',
+      foreground: 'hsl(210 40% 98%)',
+      card: 'hsl(222 47% 14%)',
+      cardForeground: 'hsl(210 40% 98%)',
+      popover: 'hsl(222 47% 14%)',
+      popoverForeground: 'hsl(210 40% 98%)',
+      primary: 'hsl(217 91% 60%)',
+      primaryForeground: 'hsl(222 47% 11%)',
+      secondary: 'hsl(217 33% 18%)',
+      secondaryForeground: 'hsl(210 40% 98%)',
+      muted: 'hsl(217 33% 18%)',
+      mutedForeground: 'hsl(215 20% 65%)',
+      accent: 'hsl(217 33% 18%)',
+      accentForeground: 'hsl(210 40% 98%)',
+      destructive: 'hsl(0 63% 50%)',
+      destructiveForeground: 'hsl(210 40% 98%)',
+      success: 'hsl(142 71% 45%)',
+      successForeground: 'hsl(0 0% 100%)',
+      warning: 'hsl(38 92% 50%)',
+      warningForeground: 'hsl(222 47% 11%)',
+      border: 'hsl(217 33% 22%)',
+      input: 'hsl(217 33% 22%)',
+      ring: 'hsl(217 91% 60%)',
+      gradientFrom: 'hsl(217 91% 60%)',
+      gradientTo: 'hsl(217 91% 60%)',
     },
   },
   neon: {
     light: {
-      background: '0 0% 100%',
-      foreground: '240 10% 5%',
-      card: '0 0% 100%',
-      cardForeground: '240 10% 5%',
-      popover: '0 0% 100%',
-      popoverForeground: '240 10% 5%',
-      primary: '330 100% 50%',
-      primaryForeground: '0 0% 100%',
-      secondary: '240 5% 96%',
-      secondaryForeground: '240 10% 5%',
-      muted: '240 5% 96%',
-      mutedForeground: '240 5% 45%',
-      accent: '155 100% 50%',
-      accentForeground: '240 10% 5%',
-      destructive: '0 100% 50%',
-      destructiveForeground: '0 0% 100%',
-      border: '240 5.9% 90%',
-      input: '240 5.9% 90%',
-      ring: '330 100% 50%',
-      gradientFrom: '330 100% 50%',
-      gradientTo: '155 100% 50%',
+      background: 'hsl(0 0% 100%)',
+      foreground: 'hsl(240 10% 5%)',
+      card: 'hsl(0 0% 100%)',
+      cardForeground: 'hsl(240 10% 5%)',
+      popover: 'hsl(0 0% 100%)',
+      popoverForeground: 'hsl(240 10% 5%)',
+      primary: 'hsl(330 100% 50%)',
+      primaryForeground: 'hsl(0 0% 100%)',
+      secondary: 'hsl(240 5% 96%)',
+      secondaryForeground: 'hsl(240 10% 5%)',
+      muted: 'hsl(240 5% 96%)',
+      mutedForeground: 'hsl(240 5% 45%)',
+      accent: 'hsl(155 100% 50%)',
+      accentForeground: 'hsl(240 10% 5%)',
+      destructive: 'hsl(0 100% 50%)',
+      destructiveForeground: 'hsl(0 0% 100%)',
+      success: 'hsl(155 100% 45%)',
+      successForeground: 'hsl(0 0% 100%)',
+      warning: 'hsl(45 100% 50%)',
+      warningForeground: 'hsl(240 10% 5%)',
+      border: 'hsl(240 6% 90%)',
+      input: 'hsl(240 6% 90%)',
+      ring: 'hsl(330 100% 50%)',
+      gradientFrom: 'hsl(330 100% 50%)',
+      gradientTo: 'hsl(155 100% 50%)',
     },
     dark: {
-      background: '240 10% 5%',
-      foreground: '0 0% 98%',
-      card: '240 10% 8%',
-      cardForeground: '0 0% 98%',
-      popover: '240 10% 8%',
-      popoverForeground: '0 0% 98%',
-      primary: '330 100% 60%',
-      primaryForeground: '240 10% 5%',
-      secondary: '240 5% 15%',
-      secondaryForeground: '0 0% 98%',
-      muted: '240 5% 15%',
-      mutedForeground: '240 5% 60%',
-      accent: '155 100% 60%',
-      accentForeground: '240 10% 5%',
-      destructive: '0 100% 60%',
-      destructiveForeground: '0 0% 100%',
-      border: '240 5% 20%',
-      input: '240 5% 20%',
-      ring: '330 100% 60%',
-      gradientFrom: '330 100% 60%',
-      gradientTo: '155 100% 60%',
+      background: 'hsl(240 10% 5%)',
+      foreground: 'hsl(0 0% 98%)',
+      card: 'hsl(240 10% 8%)',
+      cardForeground: 'hsl(0 0% 98%)',
+      popover: 'hsl(240 10% 8%)',
+      popoverForeground: 'hsl(0 0% 98%)',
+      primary: 'hsl(330 100% 60%)',
+      primaryForeground: 'hsl(240 10% 5%)',
+      secondary: 'hsl(240 5% 15%)',
+      secondaryForeground: 'hsl(0 0% 98%)',
+      muted: 'hsl(240 5% 15%)',
+      mutedForeground: 'hsl(240 5% 60%)',
+      accent: 'hsl(155 100% 60%)',
+      accentForeground: 'hsl(240 10% 5%)',
+      destructive: 'hsl(0 100% 60%)',
+      destructiveForeground: 'hsl(0 0% 100%)',
+      success: 'hsl(155 100% 55%)',
+      successForeground: 'hsl(240 10% 5%)',
+      warning: 'hsl(45 100% 60%)',
+      warningForeground: 'hsl(240 10% 5%)',
+      border: 'hsl(240 5% 20%)',
+      input: 'hsl(240 5% 20%)',
+      ring: 'hsl(330 100% 60%)',
+      gradientFrom: 'hsl(330 100% 60%)',
+      gradientTo: 'hsl(155 100% 60%)',
     },
   },
 }
 
 /**
- * Generate CSS variables from theme configuration
+ * A bare HSL triplet like `220 20% 97%` (the old shadcn value format). No longer
+ * a valid theme value — it must be wrapped in `hsl(...)` or replaced with any
+ * other CSS color string (ADR-0015).
  */
-export function generateThemeCSS(config?: ThemeConfig): string {
-  const preset = config?.preset || 'modern'
-  const radius = config?.radius ?? 0.75
+const BARE_HSL_TRIPLET = /^[\d.]+\s+[\d.]+%\s+[\d.]+%$/
 
-  // Get base colors from preset
-  const baseLight = presetThemes[preset].light
-  const baseDark = presetThemes[preset].dark
-
-  // Merge with custom overrides
-  const lightColors = { ...baseLight, ...config?.colors }
-  const darkColors = { ...baseDark, ...config?.darkColors }
-
-  // Convert colors to CSS variables
-  const colorToCSSVar = (key: string, value: string) => {
-    // Convert camelCase to kebab-case with --color- prefix
-    const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase()
-    return `  --color-${cssKey}: ${value};`
-  }
-
-  const lightVars = Object.entries(lightColors)
-    .map(([key, value]) => colorToCSSVar(key, value as string))
-    .join('\n')
-
-  const darkVars = Object.entries(darkColors)
-    .map(([key, value]) => colorToCSSVar(key, value as string))
-    .join('\n')
-
-  return `
-:root {
-${lightVars}
-  --radius: ${radius}rem;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-${darkVars}
-  }
-}
-`.trim()
+function isProduction(): boolean {
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
 }
 
 /**
- * Get theme CSS as a style tag content
+ * Dev-mode guard for the clean break on the color value format. Fires a
+ * `console.warn` when a color override is a bare HSL triplet, telling the
+ * developer to wrap it in `hsl(...)`. Silent in production.
  */
-export function getThemeStyleTag(config?: ThemeConfig): string {
-  return `<style id="opensaas-theme">${generateThemeCSS(config)}</style>`
+function warnOnBareTriplet(tokenKey: string, value: string): void {
+  if (isProduction()) return
+  if (BARE_HSL_TRIPLET.test(value.trim())) {
+    console.warn(
+      `[stack-ui] Theme color "${tokenKey}" is set to a bare HSL triplet ("${value}"), ` +
+        `which is no longer a valid theme value. Wrap it in hsl(): "hsl(${value})" ` +
+        `(or use any CSS color string, e.g. oklch(...)/#hex). See specs/THEMING.md.`,
+    )
+  }
+}
+
+/** camelCase token key → kebab-case CSS variable segment. */
+function toKebabCase(key: string): string {
+  return key.replace(/([A-Z])/g, '-$1').toLowerCase()
+}
+
+/**
+ * Compile a {@link ThemeConfig} to a CSS `:root { … }` string of token overrides.
+ *
+ * Pure function — no side effects beyond the dev-mode bare-triplet `console.warn`.
+ * The emitted overrides land on the SAME custom properties the package
+ * stylesheet declares (`--color-*-light` / `--color-*-dark` for colors, and the
+ * `--font-*` / `--radius` / `--shadow-*` contract tokens), so config theming and
+ * the stylesheet can never drift (ADR-0015).
+ *
+ * - Colors: preset (default `modern`) merged with `colors` (light) and
+ *   `darkColors` (dark), emitted verbatim.
+ * - Fonts / radius / shadows: emitted only when provided (the stylesheet ships
+ *   the defaults).
+ */
+export function compileTheme(theme: ThemeConfig): string {
+  const preset = theme.preset ?? 'modern'
+  const base = presetThemes[preset]
+  const light: ThemeColors = { ...base.light, ...theme.colors }
+  const dark: ThemeColors = { ...base.dark, ...theme.darkColors }
+
+  // Warn only on developer-supplied overrides — preset values are always valid.
+  for (const [key, value] of Object.entries(theme.colors ?? {})) {
+    if (typeof value === 'string') warnOnBareTriplet(key, value)
+  }
+  for (const [key, value] of Object.entries(theme.darkColors ?? {})) {
+    if (typeof value === 'string') warnOnBareTriplet(key, value)
+  }
+
+  const lines: string[] = []
+
+  for (const [key, value] of Object.entries(light)) {
+    if (typeof value === 'string') lines.push(`  --color-${toKebabCase(key)}-light: ${value};`)
+  }
+  for (const [key, value] of Object.entries(dark)) {
+    if (typeof value === 'string') lines.push(`  --color-${toKebabCase(key)}-dark: ${value};`)
+  }
+
+  if (theme.fonts?.sans) lines.push(`  --font-sans: ${theme.fonts.sans};`)
+  if (theme.fonts?.mono) lines.push(`  --font-mono: ${theme.fonts.mono};`)
+  if (theme.fonts?.heading) lines.push(`  --font-heading: ${theme.fonts.heading};`)
+
+  if (theme.radius !== undefined) lines.push(`  --radius: ${theme.radius}rem;`)
+
+  if (theme.shadows?.sm) lines.push(`  --shadow-sm: ${theme.shadows.sm};`)
+  if (theme.shadows?.md) lines.push(`  --shadow-md: ${theme.shadows.md};`)
+  if (theme.shadows?.lg) lines.push(`  --shadow-lg: ${theme.shadows.lg};`)
+
+  return `:root {\n${lines.join('\n')}\n}`
 }

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -4,15 +4,21 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '../lib/utils.js'
 
+// Restrained default direction (specs/THEMING.md). Every visual value resolves
+// through a theme token: colors (`bg-primary`, `text-*-foreground`, `ring`),
+// radius (`rounded-md`), elevation (`shadow-sm`/`shadow-md` shadow tokens), and
+// typography (`font-sans`). No hardcoded colors, radii, or shadows.
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-sans text-sm font-medium transition-[color,background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
@@ -39,7 +45,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button'
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
     )
   },
 )

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,55 +1,86 @@
 @import 'tailwindcss';
 
-@theme inline {
-  /* Light mode colors */
-  --color-background-light: oklch(0.97 0.01 264);
-  --color-foreground-light: oklch(0.2 0.02 264);
+/*
+ * Theme token contract — the single source of truth for the admin UI's visual
+ * design (ADR-0015, specs/THEMING.md).
+ *
+ * Structure:
+ *   1. Raw light/dark color values live side by side in `:root` as internal
+ *      `--color-*-light` / `--color-*-dark` variables. These are NOT the public
+ *      contract; they exist so a single `light-dark()` definition can reference
+ *      both modes without a duplicated `.dark` block.
+ *   2. The `@theme` block below declares the CONTRACT tokens — `--color-*`,
+ *      `--font-*`, `--radius*`, `--shadow-*`. These names are the compatibility
+ *      promise. Every component consumes them via Tailwind utilities
+ *      (`bg-primary`, `rounded-md`, `shadow-sm`, `font-sans`, …).
+ *
+ * The `ui.theme` config compiler writes onto these SAME variables (the raw
+ * `-light`/`-dark` vars for colors, and the contract tokens for fonts/radius/
+ * shadows), so the config layer and this stylesheet can never drift.
+ */
+
+:root {
+  /* Modern preset — light. Restrained, low-chroma surfaces with one saturated
+     brand color. Kept in sync with `presetThemes.modern.light` in lib/theme.ts. */
+  --color-background-light: oklch(0.99 0.002 264);
+  --color-foreground-light: oklch(0.21 0.02 264);
   --color-card-light: oklch(1 0 0);
-  --color-card-foreground-light: oklch(0.2 0.02 264);
+  --color-card-foreground-light: oklch(0.21 0.02 264);
   --color-popover-light: oklch(1 0 0);
-  --color-popover-foreground-light: oklch(0.2 0.02 264);
+  --color-popover-foreground-light: oklch(0.21 0.02 264);
+  --color-primary-light: oklch(0.55 0.2 264);
+  --color-primary-foreground-light: oklch(0.99 0.003 264);
+  --color-secondary-light: oklch(0.96 0.005 264);
+  --color-secondary-foreground-light: oklch(0.24 0.02 264);
+  --color-muted-light: oklch(0.96 0.005 264);
+  --color-muted-foreground-light: oklch(0.52 0.015 264);
+  --color-accent-light: oklch(0.96 0.01 300);
+  --color-accent-foreground-light: oklch(0.24 0.02 264);
+  --color-destructive-light: oklch(0.58 0.22 27);
+  --color-destructive-foreground-light: oklch(0.99 0.003 264);
+  --color-success-light: oklch(0.62 0.17 150);
+  --color-success-foreground-light: oklch(0.99 0.003 150);
+  --color-warning-light: oklch(0.75 0.16 75);
+  --color-warning-foreground-light: oklch(0.27 0.05 75);
+  --color-border-light: oklch(0.92 0.006 264);
+  --color-input-light: oklch(0.92 0.006 264);
+  --color-ring-light: oklch(0.55 0.2 264);
+  --color-gradient-from-light: oklch(0.55 0.2 264);
+  --color-gradient-to-light: oklch(0.62 0.19 320);
 
-  --color-primary-light: oklch(0.68 0.19 210);
-  --color-primary-foreground-light: oklch(0.2 0.02 264);
-
-  --color-secondary-light: oklch(0.95 0.01 264);
-  --color-secondary-foreground-light: oklch(0.2 0.02 264);
-  --color-muted-light: oklch(0.95 0.01 264);
-  --color-muted-foreground-light: oklch(0.5 0.01 264);
-  --color-accent-light: oklch(0.7 0.21 320);
-  --color-accent-foreground-light: oklch(1 0 0);
-
-  --color-destructive-light: oklch(0.65 0.23 25);
-  --color-destructive-foreground-light: oklch(1 0 0);
-  --color-border-light: oklch(0.9 0.01 264);
-  --color-input-light: oklch(0.9 0.01 264);
-  --color-ring-light: oklch(0.68 0.19 210);
-
-  /* Dark mode colors */
-  --color-background-dark: oklch(0.15 0.02 264);
-  --color-foreground-dark: oklch(0.95 0.01 264);
-  --color-card-dark: oklch(0.18 0.02 264);
-  --color-card-foreground-dark: oklch(0.95 0.01 264);
-  --color-popover-dark: oklch(0.18 0.02 264);
-  --color-popover-foreground-dark: oklch(0.95 0.01 264);
-
-  --color-primary-dark: oklch(0.72 0.2 210);
-  --color-primary-foreground-dark: oklch(0.2 0.02 264);
-
-  --color-secondary-dark: oklch(0.25 0.02 264);
-  --color-secondary-foreground-dark: oklch(0.95 0.01 264);
-  --color-muted-dark: oklch(0.25 0.02 264);
-  --color-muted-foreground-dark: oklch(0.6 0.01 264);
-  --color-accent-dark: oklch(0.75 0.22 320);
-  --color-accent-foreground-dark: oklch(0.2 0.02 264);
-
-  --color-destructive-dark: oklch(0.68 0.24 25);
-  --color-destructive-foreground-dark: oklch(1 0 0);
+  /* Modern preset — dark. Kept in sync with `presetThemes.modern.dark`. */
+  --color-background-dark: oklch(0.17 0.015 264);
+  --color-foreground-dark: oklch(0.96 0.005 264);
+  --color-card-dark: oklch(0.21 0.018 264);
+  --color-card-foreground-dark: oklch(0.96 0.005 264);
+  --color-popover-dark: oklch(0.21 0.018 264);
+  --color-popover-foreground-dark: oklch(0.96 0.005 264);
+  --color-primary-dark: oklch(0.62 0.19 264);
+  --color-primary-foreground-dark: oklch(0.15 0.02 264);
+  --color-secondary-dark: oklch(0.27 0.02 264);
+  --color-secondary-foreground-dark: oklch(0.96 0.005 264);
+  --color-muted-dark: oklch(0.27 0.02 264);
+  --color-muted-foreground-dark: oklch(0.68 0.015 264);
+  --color-accent-dark: oklch(0.3 0.03 300);
+  --color-accent-foreground-dark: oklch(0.96 0.005 264);
+  --color-destructive-dark: oklch(0.62 0.21 27);
+  --color-destructive-foreground-dark: oklch(0.98 0.003 264);
+  --color-success-dark: oklch(0.68 0.16 150);
+  --color-success-foreground-dark: oklch(0.15 0.02 150);
+  --color-warning-dark: oklch(0.78 0.15 75);
+  --color-warning-foreground-dark: oklch(0.2 0.04 75);
   --color-border-dark: oklch(0.3 0.02 264);
   --color-input-dark: oklch(0.3 0.02 264);
-  --color-ring-dark: oklch(0.72 0.2 210);
+  --color-ring-dark: oklch(0.62 0.19 264);
+  --color-gradient-from-dark: oklch(0.62 0.19 264);
+  --color-gradient-to-dark: oklch(0.68 0.18 320);
 
-  /* Semantic tokens using light-dark() */
+  /* Base radius knob — derived sizes are computed from it in @theme below. */
+  --radius: 0.625rem;
+}
+
+@theme {
+  /* ── Colors: single-definition contract tokens via light-dark() ────────── */
   --color-background: light-dark(var(--color-background-light), var(--color-background-dark));
   --color-foreground: light-dark(var(--color-foreground-light), var(--color-foreground-dark));
   --color-card: light-dark(var(--color-card-light), var(--color-card-dark));
@@ -62,13 +93,11 @@
     var(--color-popover-foreground-light),
     var(--color-popover-foreground-dark)
   );
-
   --color-primary: light-dark(var(--color-primary-light), var(--color-primary-dark));
   --color-primary-foreground: light-dark(
     var(--color-primary-foreground-light),
     var(--color-primary-foreground-dark)
   );
-
   --color-secondary: light-dark(var(--color-secondary-light), var(--color-secondary-dark));
   --color-secondary-foreground: light-dark(
     var(--color-secondary-foreground-light),
@@ -84,29 +113,63 @@
     var(--color-accent-foreground-light),
     var(--color-accent-foreground-dark)
   );
-
   --color-destructive: light-dark(var(--color-destructive-light), var(--color-destructive-dark));
   --color-destructive-foreground: light-dark(
     var(--color-destructive-foreground-light),
     var(--color-destructive-foreground-dark)
   );
+  --color-success: light-dark(var(--color-success-light), var(--color-success-dark));
+  --color-success-foreground: light-dark(
+    var(--color-success-foreground-light),
+    var(--color-success-foreground-dark)
+  );
+  --color-warning: light-dark(var(--color-warning-light), var(--color-warning-dark));
+  --color-warning-foreground: light-dark(
+    var(--color-warning-foreground-light),
+    var(--color-warning-foreground-dark)
+  );
   --color-border: light-dark(var(--color-border-light), var(--color-border-dark));
   --color-input: light-dark(var(--color-input-light), var(--color-input-dark));
   --color-ring: light-dark(var(--color-ring-light), var(--color-ring-dark));
+  --color-gradient-from: light-dark(
+    var(--color-gradient-from-light),
+    var(--color-gradient-from-dark)
+  );
+  --color-gradient-to: light-dark(var(--color-gradient-to-light), var(--color-gradient-to-dark));
 
-  --radius: 0.75rem;
+  /* ── Typography: family tokens only. Heading defaults to sans. ─────────── */
+  --font-sans:
+    system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji';
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  --font-heading: var(--font-sans);
 
-  /* Gradient colors for modern effects */
-  --gradient-from-light: oklch(0.68 0.19 210);
-  --gradient-to-light: oklch(0.7 0.21 320);
-  --gradient-from-dark: oklch(0.72 0.2 210);
-  --gradient-to-dark: oklch(0.75 0.22 320);
-  --gradient-from: light-dark(var(--gradient-from-light), var(--gradient-from-dark));
-  --gradient-to: light-dark(var(--gradient-to-light), var(--gradient-to-dark));
+  /* ── Shape: single radius knob with derived sizes ──────────────────────── */
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  /* ── Elevation: shadow tokens. A flat theme sets these to `none`. ──────── */
+  --shadow-sm: 0 1px 2px 0 oklch(0.2 0.02 264 / 0.06);
+  --shadow-md: 0 2px 4px -1px oklch(0.2 0.02 264 / 0.08), 0 4px 8px -2px oklch(0.2 0.02 264 / 0.08);
+  --shadow-lg:
+    0 4px 6px -2px oklch(0.2 0.02 264 / 0.08), 0 12px 20px -4px oklch(0.2 0.02 264 / 0.12);
 }
 
+/*
+ * Dark mode mechanism (~6 lines): `color-scheme` drives `light-dark()`. Absent
+ * `data-theme` follows the system preference; a `data-theme` attribute pins it.
+ */
 :root {
   color-scheme: light dark;
+}
+:root[data-theme='light'] {
+  color-scheme: light;
+}
+:root[data-theme='dark'] {
+  color-scheme: dark;
 }
 
 * {
@@ -116,8 +179,5 @@
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
-  font-family:
-    system-ui,
-    -apple-system,
-    sans-serif;
+  font-family: var(--font-sans);
 }

--- a/packages/ui/tests/lib/theme.test.ts
+++ b/packages/ui/tests/lib/theme.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { compileTheme, presetThemes } from '../../src/lib/theme.js'
+
+// The compiler is a pure `ThemeConfig -> CSS string` function. These tests
+// assert external behaviour only: the exact token overrides the CSS contains,
+// which token groups are emitted, verbatim value pass-through, and the
+// dev-mode bare-HSL-triplet warning. They never inspect internal structure.
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('compileTheme', () => {
+  it('wraps output in a :root block', () => {
+    const css = compileTheme({})
+    expect(css.startsWith(':root {')).toBe(true)
+    expect(css.trimEnd().endsWith('}')).toBe(true)
+  })
+
+  describe('preset selection', () => {
+    it('defaults to the modern preset when no preset is given', () => {
+      const css = compileTheme({})
+      expect(css).toContain(`--color-primary-light: ${presetThemes.modern.light.primary};`)
+      expect(css).toContain(`--color-primary-dark: ${presetThemes.modern.dark.primary};`)
+    })
+
+    it('emits the classic preset when selected', () => {
+      const css = compileTheme({ preset: 'classic' })
+      expect(css).toContain('--color-primary-light: hsl(221 83% 53%);')
+      expect(css).toContain('--color-background-light: hsl(0 0% 100%);')
+    })
+
+    it('emits the neon preset when selected', () => {
+      const css = compileTheme({ preset: 'neon' })
+      expect(css).toContain('--color-primary-light: hsl(330 100% 50%);')
+      expect(css).toContain('--color-primary-dark: hsl(330 100% 60%);')
+    })
+  })
+
+  describe('light/dark override merge', () => {
+    it('overrides only the specified tokens, keeping the preset for the rest', () => {
+      const css = compileTheme({
+        preset: 'classic',
+        colors: { primary: 'oklch(0.6 0.2 20)' },
+        darkColors: { primary: '#123456' },
+      })
+      // Overridden token uses the supplied light and dark values
+      expect(css).toContain('--color-primary-light: oklch(0.6 0.2 20);')
+      expect(css).toContain('--color-primary-dark: #123456;')
+      // Untouched tokens fall back to the classic preset
+      expect(css).toContain('--color-background-light: hsl(0 0% 100%);')
+    })
+
+    it('emits light and dark values side by side for every color token', () => {
+      const css = compileTheme({})
+      for (const token of ['primary', 'background', 'success', 'warning', 'gradient-from']) {
+        expect(css).toContain(`--color-${token}-light:`)
+        expect(css).toContain(`--color-${token}-dark:`)
+      }
+    })
+  })
+
+  describe('token groups', () => {
+    it('emits success and warning color tokens (with foregrounds)', () => {
+      const css = compileTheme({})
+      expect(css).toContain('--color-success-light:')
+      expect(css).toContain('--color-success-foreground-light:')
+      expect(css).toContain('--color-warning-light:')
+      expect(css).toContain('--color-warning-foreground-light:')
+    })
+
+    it('emits the gradient pair', () => {
+      const css = compileTheme({})
+      expect(css).toContain('--color-gradient-from-light:')
+      expect(css).toContain('--color-gradient-to-dark:')
+    })
+
+    it('emits font tokens only when provided', () => {
+      expect(compileTheme({})).not.toContain('--font-')
+      const css = compileTheme({
+        fonts: {
+          sans: 'var(--font-inter), system-ui, sans-serif',
+          mono: 'ui-monospace, monospace',
+          heading: 'Georgia, serif',
+        },
+      })
+      expect(css).toContain('--font-sans: var(--font-inter), system-ui, sans-serif;')
+      expect(css).toContain('--font-mono: ui-monospace, monospace;')
+      expect(css).toContain('--font-heading: Georgia, serif;')
+    })
+
+    it('emits radius only when provided, in rem', () => {
+      expect(compileTheme({})).not.toContain('--radius:')
+      expect(compileTheme({ radius: 0.5 })).toContain('--radius: 0.5rem;')
+    })
+
+    it('emits shadow tokens only when provided, including a flat none theme', () => {
+      expect(compileTheme({})).not.toContain('--shadow-')
+      const css = compileTheme({ shadows: { sm: 'none', md: 'none', lg: 'none' } })
+      expect(css).toContain('--shadow-sm: none;')
+      expect(css).toContain('--shadow-md: none;')
+      expect(css).toContain('--shadow-lg: none;')
+    })
+
+    it('emits only the shadow sizes that are supplied', () => {
+      const css = compileTheme({ shadows: { md: '0 4px 8px black' } })
+      expect(css).toContain('--shadow-md: 0 4px 8px black;')
+      expect(css).not.toContain('--shadow-sm:')
+      expect(css).not.toContain('--shadow-lg:')
+    })
+  })
+
+  describe('verbatim value pass-through', () => {
+    it('emits any valid CSS color string exactly as given, without parsing', () => {
+      const css = compileTheme({
+        colors: {
+          primary: 'rgb(1 2 3 / 50%)',
+          accent: '#abcdef',
+          background: 'color-mix(in oklch, red, blue)',
+        },
+      })
+      expect(css).toContain('--color-primary-light: rgb(1 2 3 / 50%);')
+      expect(css).toContain('--color-accent-light: #abcdef;')
+      expect(css).toContain('--color-background-light: color-mix(in oklch, red, blue);')
+    })
+  })
+
+  describe('bare-HSL-triplet dev warning', () => {
+    it('warns and suggests hsl() wrapping for a bare triplet in light colors', () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      compileTheme({ colors: { primary: '222 47% 11%' } })
+      expect(warn).toHaveBeenCalledTimes(1)
+      const message = warn.mock.calls[0]?.[0]
+      expect(message).toContain('primary')
+      expect(message).toContain('hsl(222 47% 11%)')
+    })
+
+    it('warns for bare triplets supplied in darkColors', () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      compileTheme({ darkColors: { background: '220 20% 97%' } })
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0]?.[0]).toContain('hsl(220 20% 97%)')
+    })
+
+    it('does not warn for valid CSS color strings', () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      compileTheme({
+        colors: { primary: 'hsl(222 47% 11%)', accent: 'oklch(0.6 0.2 20)', ring: '#fff' },
+      })
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('does not warn for a preset-only config', () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      compileTheme({ preset: 'neon' })
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('is silent in production even for a bare triplet', () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      compileTheme({ colors: { primary: '222 47% 11%' } })
+      expect(warn).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Implements #705. Part of #704.

Foundation slice of the admin UI design system: the single theming contract and the config layer that compiles onto it, proven by one primitive (Button) consuming it end-to-end.

## What changed

### Token contract (ui stylesheet — `packages/ui/src/styles/globals.css`)
- Full Theme token vocabulary: shadcn color set **plus `success`/`warning` (+foregrounds)** and the `gradientFrom`/`gradientTo` pair, `--font-sans`/`--font-mono`/`--font-heading` (heading defaults to sans), a single `--radius` knob with derived `sm`/`md`/`lg` sizes, and `--shadow-sm`/`--shadow-md`/`--shadow-lg`.
- Single-definition `light-dark()` structure: raw `--color-*-light` / `--color-*-dark` values live side by side in `:root`; the `@theme` block declares the contract tokens as `light-dark(var(--…-light), var(--…-dark))`. Utilities (`bg-primary`, `rounded-md`, `shadow-sm`, `font-sans`) resolve through these vars, so overriding either the raw `-light`/`-dark` vars or the contract token propagates.
- `data-theme` mechanism (light/dark/system via `color-scheme`) for later slices.

### Config layer (core — `packages/core/src/config/types.ts`)
- New `ThemeConfig` = `{ preset?, colors?, darkColors?, fonts?, radius?, shadows? }`; added `ThemeFonts`/`ThemeShadows`. Old bare-HSL-triplet `ThemeColors` format is gone (clean break, ADR-0015). Values are any valid CSS color string.

### Compiler (ui — `packages/ui/src/lib/theme.ts`)
- `compileTheme(theme: ThemeConfig): string` — pure `ThemeConfig → CSS` function. Preset merge (default `modern`) + light/dark override merge; emits color overrides onto the **same** `--color-*-light`/`-dark` vars the stylesheet declares, and fonts/radius/shadows onto their contract tokens (only when provided). Colors pass through **verbatim** — the compiler never parses color values.
- **Bare-triplet warning:** developer-supplied color values are tested against `/^[\d.]+\s+[\d.]+%\s+[\d.]+%$/`; a match fires a dev-mode `console.warn` suggesting an `hsl(...)` wrap (silent in production). Preset values are always valid, so only user input can trigger it.

### Button restyle (`packages/ui/src/primitives/button.tsx`)
- Restrained direction consuming only tokens: `bg-primary`/`text-primary-foreground`, `rounded-md`, `shadow-sm`/`hover:shadow-md`, `font-sans`, `ring`. No hardcoded values. Carries `data-slot="button"`.

### Example (`examples/starter`)
- `next/font` (Inter) exposed as `--font-inter` in `app/layout.tsx`; `opensaas.config.ts` sets a brand `primary` (hex, demonstrating verbatim pass-through) and `fonts.sans: 'var(--font-inter), …'`. Both flow through to the admin's buttons and fonts.

## Tests / checks
- New compiler unit suite (`packages/ui/tests/lib/theme.test.ts`, 18 tests): presets, light/dark override merge, all token groups, verbatim pass-through, and the bare-triplet warning (fires in dev, silent in prod).
- `pnpm build` (core + ui): pass. `pnpm exec tsc --noEmit` (ui): pass.
- ui vitest: 233 passed. core vitest: 774 passed. lint: 0 errors. `manypkg fix` + `prettier` applied.
- Browser-mode suite (Button etc.) could not run here — Chromium download is blocked by the sandbox network. The Button diff preserves every class those tests assert (`bg-primary`, `bg-destructive`, `border`, `hover:bg-accent`, `h-9`/`h-11`/`h-10 w-10`, `disabled:*`, `custom-class`).

Changesets: `.changeset/theme-token-contract.md` (minor for `@opensaas/stack-core` and `@opensaas/stack-ui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_