### PR TITLE
feat(ui): user-controllable dark mode — data-theme mechanism + ThemeToggle

### DIFF
--- a/.changeset/dark-mode-theme-toggle.md
+++ b/.changeset/dark-mode-theme-toggle.md
@@ -1,0 +1,37 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Add user-controllable dark mode: `ThemeToggle` and `ThemeScript`
+
+The admin chrome now ships a light/dark/system color-scheme control built on the
+`light-dark()` token contract. A `data-theme` attribute on the document root pins
+`color-scheme` (overriding the OS preference); its absence follows the system.
+
+- `ThemeToggle` — a client component that cycles light → dark → system, writes
+  `data-theme` on `<html>`, persists the choice to `localStorage`
+  (`opensaas-theme`), and restores it on mount. It appears in the default Admin
+  chrome's user menu and is opt-out via composition (custom chrome omits it).
+- `ThemeScript` — a server-safe inline `<script>` for the document `<head>` that
+  applies the saved choice before first paint, preventing a flash of the wrong
+  scheme.
+
+```tsx
+import { ThemeScript } from '@opensaas/stack-ui'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+To pin the admin to a single scheme, omit both and set the attribute statically,
+e.g. `<html data-theme="dark">`. The `ThemeChoice` type and the
+`applyThemeChoice` / `readStoredChoice` / `themeInitScript` / `THEME_STORAGE_KEY`
+helpers are also exported for building custom controls.

--- a/examples/starter/app/layout.tsx
+++ b/examples/starter/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@opensaas/stack-ui/styles'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { ThemeScript } from '@opensaas/stack-ui'
 import React from 'react'
 
 // Load a product font with next/font and expose it as a CSS variable. The
@@ -14,8 +15,19 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // `suppressHydrationWarning` is required on <html> because ThemeScript pins the
+  // `data-theme` attribute before hydration, so the server-rendered markup and
+  // the first client render legitimately differ on that attribute.
+  //
+  // To pin the admin to a single scheme instead of offering the toggle, drop
+  // ThemeScript and set the attribute statically, e.g. `data-theme="dark"` here.
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
+      <head>
+        {/* Restores the saved light/dark/system choice before first paint to
+            prevent a flash of the wrong scheme. */}
+        <ThemeScript />
+      </head>
       <body>{children}</body>
     </html>
   )

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -330,6 +330,61 @@ import '@opensaas/stack-ui/styles'
 
 Custom theming via CSS variables (follows shadcn/ui conventions).
 
+## Dark mode / color scheme
+
+The token sheet defines every color once with `light-dark()`, driven by
+`color-scheme`. A `data-theme="light" | "dark"` attribute on the document root
+pins the scheme (overriding the OS preference); its absence follows the system
+preference. This is the whole mechanism — no duplicated `.dark` block.
+
+Two pieces make it user-controllable:
+
+- **`ThemeToggle`** — a `'use client'` control that cycles light → dark →
+  system, writes `data-theme` on `<html>`, persists the choice to
+  `localStorage` (`opensaas-theme`), and restores it on mount. It ships in the
+  default Admin chrome's user menu (footer). It is composable: custom chrome
+  that builds its own `Navigation`/`UserMenu` simply omits it, or the exported
+  `ThemeToggle` can be placed anywhere.
+- **`ThemeScript`** — a server-safe inline `<script>` for the document `<head>`
+  that applies the saved choice **before first paint**, preventing a flash of
+  the wrong scheme before hydration. Add it once in your root layout:
+
+  ```tsx
+  import { ThemeScript } from '@opensaas/stack-ui'
+
+  export default function RootLayout({ children }) {
+    return (
+      <html lang="en" suppressHydrationWarning>
+        <head>
+          <ThemeScript />
+        </head>
+        <body>{children}</body>
+      </html>
+    )
+  }
+  ```
+
+  `suppressHydrationWarning` is needed because the script mutates `data-theme`
+  before React hydrates.
+
+### Pinning the admin to a single scheme
+
+To lock the admin to light-only or dark-only (matching a product with a fixed
+appearance), **omit `ThemeToggle` and `ThemeScript`** and set the attribute
+statically in your root layout:
+
+```tsx
+// Dark-only admin — no toggle, no localStorage.
+<html lang="en" data-theme="dark">
+  <body>{children}</body>
+</html>
+```
+
+Because `data-theme` overrides the OS preference, the admin then renders in that
+scheme regardless of the visitor's system setting. Lower-level helpers
+(`applyThemeChoice`, `readStoredChoice`, `themeInitScript`, `THEME_STORAGE_KEY`,
+and the `ThemeChoice` type) are also exported for custom toggles.
+
 ## Type Safety
 
 All components are fully typed:

--- a/packages/ui/src/components/Navigation.tsx
+++ b/packages/ui/src/components/Navigation.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link.js'
 import { formatListName } from '../lib/utils.js'
 import { type AccessContext, getUrlKey, OpenSaasConfig } from '@opensaas/stack-core'
 import { UserMenu } from './UserMenu.js'
+import { ThemeToggle } from './ThemeToggle.js'
 
 export interface NavigationProps {
   context: AccessContext<unknown>
@@ -150,13 +151,21 @@ export function Navigation({
         </div>
       </div>
 
-      {/* Footer - User Menu */}
-      {context.session && (
+      {/* Footer - User Menu (authenticated) or a bare theme toggle (anonymous).
+          The ThemeToggle lives in the user menu when signed in; when there is
+          no session (e.g. the starter example) it still appears in the footer
+          so the color-scheme control is always reachable. Custom chrome that
+          builds its own Navigation opts out simply by not rendering it. */}
+      {context.session ? (
         <UserMenu
           userName={String((context.session.data as Record<string, unknown>)?.name) || 'User'}
           userEmail={String((context.session.data as Record<string, unknown>)?.email) || ''}
           onSignOut={onSignOut}
         />
+      ) : (
+        <div className="p-4 border-t border-border flex justify-end">
+          <ThemeToggle />
+        </div>
       )}
     </nav>
   )

--- a/packages/ui/src/components/ThemeScript.tsx
+++ b/packages/ui/src/components/ThemeScript.tsx
@@ -1,0 +1,31 @@
+import { themeInitScript } from '../lib/theme-mode.js'
+
+/**
+ * Pre-hydration inline script that restores the persisted color-scheme choice
+ * before first paint, preventing a flash of the wrong scheme.
+ *
+ * Render it as early as possible in the document — ideally the first child of
+ * `<head>` (or the top of `<body>`) in your root layout — so it runs before the
+ * admin chrome paints:
+ *
+ * ```tsx
+ * import { ThemeScript } from '@opensaas/stack-ui'
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html lang="en" suppressHydrationWarning>
+ *       <head>
+ *         <ThemeScript />
+ *       </head>
+ *       <body>{children}</body>
+ *     </html>
+ *   )
+ * }
+ * ```
+ *
+ * It is a plain server-safe element (no client runtime); the `ThemeToggle`
+ * component reads and writes the same `localStorage` key at runtime.
+ */
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+}

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import * as React from 'react'
+import { Monitor, Moon, Sun } from 'lucide-react'
+import { Button } from '../primitives/button.js'
+import {
+  type ThemeChoice,
+  applyThemeChoice,
+  readStoredChoice,
+  storeChoice,
+  subscribeThemeChoice,
+} from '../lib/theme-mode.js'
+
+export interface ThemeToggleProps {
+  /** Extra classes merged onto the toggle button. */
+  className?: string
+}
+
+// Cycle order for the single-button control: light → dark → system → light.
+const NEXT_CHOICE: Record<ThemeChoice, ThemeChoice> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+}
+
+const LABELS: Record<ThemeChoice, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+}
+
+const ICONS: Record<ThemeChoice, typeof Sun> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+}
+
+// Stable server snapshot: before hydration we can't read localStorage, so the
+// server (and first client paint) assume 'system'. `useSyncExternalStore` then
+// reconciles to the persisted value on the client without a hydration warning.
+const getServerChoice = (): ThemeChoice => 'system'
+
+/**
+ * User-facing color-scheme control for the admin chrome. A single button that
+ * cycles light → dark → system, writing the choice to the document root's
+ * `data-theme` attribute (see `styles/globals.css`) and persisting it to
+ * `localStorage`. On mount it restores the persisted choice; a first-paint
+ * flash is prevented separately by the `ThemeScript` inline script in `<head>`.
+ *
+ * This is a Client Component. It is mounted in the default chrome's user menu
+ * but is fully composable — custom chrome simply omits it, or places it
+ * anywhere via the exported component.
+ */
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  // Read the persisted choice through an external store so the rendered icon
+  // stays in sync with `localStorage` (this tab and others) without a
+  // setState-in-effect or a hydration mismatch.
+  const choice = React.useSyncExternalStore(subscribeThemeChoice, readStoredChoice, getServerChoice)
+
+  // Reconcile the DOM attribute with the current choice. On mount this restores
+  // the persisted scheme (the inline ThemeScript may already have pinned it
+  // before paint); on change it applies the new choice.
+  React.useEffect(() => {
+    applyThemeChoice(choice)
+  }, [choice])
+
+  const handleClick = React.useCallback(() => {
+    storeChoice(NEXT_CHOICE[readStoredChoice()])
+  }, [])
+
+  const Icon = ICONS[choice]
+  const label = LABELS[choice]
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      data-slot="theme-toggle"
+      aria-label={`Theme: ${label}. Activate to change.`}
+      title={`Theme: ${label}`}
+      className={className}
+    >
+      <Icon aria-hidden="true" />
+      <span>{label}</span>
+    </Button>
+  )
+}

--- a/packages/ui/src/components/UserMenu.tsx
+++ b/packages/ui/src/components/UserMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation.js'
 import { Button } from '../primitives/button.js'
+import { ThemeToggle } from './ThemeToggle.js'
 
 export interface UserMenuProps {
   userName?: string
@@ -36,9 +37,12 @@ export function UserMenu({ userName, userEmail, onSignOut }: UserMenuProps) {
           <p className="text-xs text-muted-foreground truncate">{userEmail || ''}</p>
         </div>
       </div>
-      <Button onClick={handleSignOut} variant="outline" size="sm" className="w-full text-sm">
-        Sign Out
-      </Button>
+      <div className="flex items-center gap-2">
+        <ThemeToggle className="flex-1 justify-start" />
+        <Button onClick={handleSignOut} variant="outline" size="sm" className="flex-1 text-sm">
+          Sign Out
+        </Button>
+      </div>
     </div>
   )
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,8 @@ export { AdminUI } from './components/AdminUI.js'
 export { Dashboard } from './components/Dashboard.js'
 export { Navigation } from './components/Navigation.js'
 export { UserMenu } from './components/UserMenu.js'
+export { ThemeToggle } from './components/ThemeToggle.js'
+export { ThemeScript } from './components/ThemeScript.js'
 export { ListView } from './components/ListView.js'
 export { ListViewClient } from './components/ListViewClient.js'
 export { ItemForm } from './components/ItemForm.js'
@@ -32,6 +34,7 @@ export type { AdminUIProps } from './components/AdminUI.js'
 export type { DashboardProps } from './components/Dashboard.js'
 export type { NavigationProps } from './components/Navigation.js'
 export type { UserMenuProps } from './components/UserMenu.js'
+export type { ThemeToggleProps } from './components/ThemeToggle.js'
 export type { ListViewProps } from './components/ListView.js'
 export type { ListViewClientProps } from './components/ListViewClient.js'
 export type { ItemFormProps } from './components/ItemForm.js'
@@ -80,3 +83,12 @@ export type { RelationshipOption, RelationshipOptionsArgs } from './lib/getRelat
 
 // Theme utilities
 export { compileTheme, presetThemes } from './lib/theme.js'
+
+// Color-scheme (dark mode) utilities
+export {
+  type ThemeChoice,
+  THEME_STORAGE_KEY,
+  themeInitScript,
+  applyThemeChoice,
+  readStoredChoice,
+} from './lib/theme-mode.js'

--- a/packages/ui/src/lib/theme-mode.ts
+++ b/packages/ui/src/lib/theme-mode.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared vocabulary for the user-controllable color scheme.
+ *
+ * The admin's dark-mode mechanism lives in `styles/globals.css`: a
+ * `data-theme="light" | "dark"` attribute on the document root pins
+ * `color-scheme` (which drives every `light-dark()` token), while the
+ * attribute's absence follows the OS preference. This module centralises the
+ * storage key, the three-state choice type, and the helpers that read/apply/
+ * persist it, so the pre-hydration inline script and the `ThemeToggle`
+ * component can never disagree about how the choice is stored or applied.
+ */
+
+/** The three states a user can pick: pin light, pin dark, or follow the OS. */
+export type ThemeChoice = 'light' | 'dark' | 'system'
+
+/** localStorage key the choice is persisted under. Part of the public contract. */
+export const THEME_STORAGE_KEY = 'opensaas-theme'
+
+function isThemeChoice(value: string | null): value is ThemeChoice {
+  return value === 'light' || value === 'dark' || value === 'system'
+}
+
+/**
+ * Apply a choice to the document root: pin the `data-theme` attribute for
+ * light/dark, or remove it so `color-scheme` follows the system preference.
+ */
+export function applyThemeChoice(choice: ThemeChoice): void {
+  const root = document.documentElement
+  if (choice === 'system') {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', choice)
+  }
+}
+
+/** Read the persisted choice, defaulting to `'system'` when unset or unreadable. */
+export function readStoredChoice(): ThemeChoice {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY)
+    return isThemeChoice(stored) ? stored : 'system'
+  } catch {
+    return 'system'
+  }
+}
+
+// In-page subscribers so a same-tab write re-renders the toggle. The browser's
+// `storage` event only fires in *other* tabs, so we notify locally on write.
+const listeners = new Set<() => void>()
+
+/**
+ * Subscribe to color-scheme choice changes (this tab's writes + other tabs'
+ * `storage` events). Returns an unsubscribe function. Designed for
+ * `React.useSyncExternalStore`, which keeps the control hydration-safe without
+ * calling `setState` inside an effect.
+ */
+export function subscribeThemeChoice(listener: () => void): () => void {
+  listeners.add(listener)
+  try {
+    window.addEventListener('storage', listener)
+  } catch {
+    // `window` may be unavailable; the in-tab listener set still works.
+  }
+  return () => {
+    listeners.delete(listener)
+    try {
+      window.removeEventListener('storage', listener)
+    } catch {
+      // Ignore — mirror of the add above.
+    }
+  }
+}
+
+/** Persist the choice, ignoring failures (private mode / disabled storage). */
+export function storeChoice(choice: ThemeChoice): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, choice)
+  } catch {
+    // Storage can be unavailable (private browsing, quota); the in-page choice
+    // still applies for this session, so a write failure is non-fatal.
+  }
+  for (const listener of listeners) listener()
+}
+
+/**
+ * Self-contained inline script for the document `<head>`. It runs before first
+ * paint — ahead of any module or React hydration — reading the persisted
+ * choice and pinning `data-theme` so the correct scheme is painted immediately,
+ * with no flash of the wrong scheme. Kept dependency-free because it executes
+ * before the bundle loads; keep it in sync with {@link applyThemeChoice} /
+ * {@link readStoredChoice}.
+ */
+export const themeInitScript = `(function(){try{var c=localStorage.getItem(${JSON.stringify(
+  THEME_STORAGE_KEY,
+)});var r=document.documentElement;if(c==='light'||c==='dark'){r.setAttribute('data-theme',c)}else{r.removeAttribute('data-theme')}}catch(e){}})()`

--- a/packages/ui/tests/browser/components/ThemeToggle.browser.test.tsx
+++ b/packages/ui/tests/browser/components/ThemeToggle.browser.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { userEvent } from 'vitest/browser'
+import { ThemeToggle } from '../../../src/components/ThemeToggle.js'
+import { THEME_STORAGE_KEY, themeInitScript } from '../../../src/lib/theme-mode.js'
+
+// External behaviour only: the `data-theme` attribute on the document root, the
+// `localStorage` entry, and restore-on-mount. Never the component's internal
+// state or DOM structure.
+
+const root = document.documentElement
+
+function reset() {
+  root.removeAttribute('data-theme')
+  localStorage.clear()
+}
+
+describe('ThemeToggle (Browser)', () => {
+  beforeEach(reset)
+  afterEach(() => {
+    cleanup()
+    reset()
+  })
+
+  it('starts in system mode with no data-theme attribute when nothing is stored', async () => {
+    render(<ThemeToggle />)
+    // Wait for the restore-on-mount effect to run.
+    await waitFor(() => expect(screen.getByRole('button')).toBeInTheDocument())
+    expect(root.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('cycles light → dark → system, setting the root attribute each step', async () => {
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button) // system → light
+    expect(root.getAttribute('data-theme')).toBe('light')
+
+    await userEvent.click(button) // light → dark
+    expect(root.getAttribute('data-theme')).toBe('dark')
+
+    await userEvent.click(button) // dark → system
+    expect(root.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('persists every choice to localStorage', async () => {
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button) // → light
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+
+    await userEvent.click(button) // → dark
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+
+    await userEvent.click(button) // → system
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+  })
+
+  it('restores the persisted choice on mount without user interaction', async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    render(<ThemeToggle />)
+    await waitFor(() => expect(root.getAttribute('data-theme')).toBe('dark'))
+  })
+
+  it('restore-on-mount reconciles a stale attribute back to the stored choice', async () => {
+    // Simulate a wrong scheme painted before hydration.
+    root.setAttribute('data-theme', 'dark')
+    localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    render(<ThemeToggle />)
+    await waitFor(() => expect(root.getAttribute('data-theme')).toBe('light'))
+  })
+
+  it('inline init script pins the stored scheme before hydration (flash prevention)', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    // Executing the script tag synchronously mirrors first-paint in <head>.
+    const el = document.createElement('script')
+    el.textContent = themeInitScript
+    document.head.appendChild(el)
+    expect(root.getAttribute('data-theme')).toBe('dark')
+    el.remove()
+  })
+
+  it('inline init script leaves the attribute absent for system (no stored choice)', () => {
+    root.setAttribute('data-theme', 'dark') // stale value from a prior visitor
+    const el = document.createElement('script')
+    el.textContent = themeInitScript
+    document.head.appendChild(el)
+    expect(root.hasAttribute('data-theme')).toBe(false)
+    el.remove()
+  })
+})

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -29,7 +29,14 @@ export default defineConfig({
           browser: 'chromium',
         },
       ],
-      provider: playwright(),
+      // Allow pointing at a preinstalled Chromium binary (e.g. sandboxed CI
+      // environments where Playwright cannot download browsers). Unset in
+      // normal CI, so Playwright uses its own managed browser.
+      provider: playwright(
+        process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE
+          ? { launchOptions: { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE } }
+          : {},
+      ),
       headless: true,
       screenshotFailures: true,
     },


### PR DESCRIPTION
Implements #706. Part of #704.

Completes the user-facing dark-mode story on top of the `light-dark()` token contract and `data-theme` / `color-scheme` mechanism already merged in #705 (#713 on `main`). No CSS was re-added — the token sheet already flips every token when `data-theme` is set and follows the system preference when it's absent.

## What's new

- **`ThemeToggle`** (`'use client'`) — a single-button control that cycles light → dark → system, writes `data-theme` on `<html>`, persists the choice to `localStorage` (`opensaas-theme`), and restores it on mount. Reads the persisted value through `React.useSyncExternalStore`, which is hydration-safe (stable `'system'` server snapshot) and avoids `setState`-in-effect; a single effect reconciles the DOM attribute.
- **`ThemeScript`** — a server-safe inline `<script>` for the document `<head>` that applies the saved scheme **before first paint**, preventing a flash of the wrong scheme before hydration. This is the flash-prevention mechanism; `suppressHydrationWarning` on `<html>` covers the intentional attribute diff.
- **Shared `lib/theme-mode.ts`** — single source for the storage key, `ThemeChoice` type, apply/read/persist helpers, a tiny same-tab subscribe store, and the inline-script source, so the script and component can never disagree.
- **Default chrome** — `ThemeToggle` appears in the user menu (`UserMenu`). It is **opt-out via composition**: custom chrome that builds its own `Navigation`/`UserMenu` simply omits it. When there is no session (e.g. the `starter`), the `Navigation` footer still renders the toggle so it stays reachable and demoable.
- **Docs** — `packages/ui/CLAUDE.md` documents the toggle, the `ThemeScript` setup, and the recipe for **pinning to a single scheme** statically (`<html data-theme="dark">`, no toggle/script). The `starter` layout wires `ThemeScript` in `<head>`.

## How the flash is prevented

`ThemeScript` runs a dependency-free inline script in `<head>` before any module loads: it reads `localStorage` and sets/removes `data-theme` synchronously, so the correct scheme is painted immediately. `ThemeToggle` then restores the same value on mount via `useSyncExternalStore` (no visible re-flash).

## Opt-out composition

The toggle is not forced by `AdminUI`. It lives inside the composable `UserMenu` (and the anonymous footer branch of `Navigation`). Any app assembling its own chrome from `/standalone` + `/primitives` gets it only if it renders `ThemeToggle`.

## Tests

- Browser-mode suite `tests/browser/components/ThemeToggle.browser.test.tsx` (7 tests): attribute setting across the cycle, `localStorage` persistence, restore-on-mount, stale-attribute reconciliation, and the pre-hydration script's effect. Asserts external behaviour only (root attribute, storage entry) — never internal state.
- `vitest.config.ts` gained an optional `PLAYWRIGHT_CHROMIUM_EXECUTABLE` env passthrough (unset in normal CI, so no behaviour change) to allow pointing at a preinstalled Chromium in sandboxed environments.

## Checks

- `pnpm lint`: pass (0 errors; 3 pre-existing warnings in blog/cli/core, none in changed files)
- Typecheck / `pnpm build` (ui + core): pass
- `pnpm test` (ui): 233 passed
- `pnpm test:browser` (ui): 61 passed (incl. the 7 new ThemeToggle tests)
- Changeset added (`@opensaas/stack-ui` minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_