### PR TITLE
Design system 4/7: primitives pass — restyle, data-slot, className contract

### DIFF
--- a/.changeset/quiet-slots-restyle.md
+++ b/.changeset/quiet-slots-restyle.md
@@ -1,0 +1,36 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Restyle every primitive onto the design system tokens, with a stable `data-slot` contract and a tailwind-merge'd `className` on every part
+
+Following Button (#705), all remaining primitives — Input, Textarea, Label,
+Checkbox, Card, Table, Dialog, Select, Popover, Calendar, TimePicker,
+DateTimePicker, and Combobox — now consume only theme tokens (no hardcoded
+colours or shadows remain; e.g. the Dialog no longer uses `bg-white` /
+`border-gray-200` / `shadow-2xl` / `bg-black/80`).
+
+Every primitive and composite part now carries a documented, stable `data-slot`
+attribute, and merges a caller `className` via tailwind-merge so instance
+overrides win:
+
+```tsx
+// Instance override (tailwind-merge — caller wins over the default radius)
+<Card className="rounded-none" />
+
+// Deep restyle from plain CSS, no Tailwind pipeline required (ADR-0016)
+[data-slot='table-row']:nth-child(even) { background: rgba(0, 0, 0, 0.04); }
+```
+
+The `data-slot` name set is a public compatibility promise. Full contract:
+`input`, `textarea`, `label`, `checkbox`, `checkbox-indicator`, `card`,
+`card-header`, `card-title`, `card-description`, `card-content`, `card-footer`,
+`table-container`, `table`, `table-header`, `table-body`, `table-footer`,
+`table-row`, `table-head`, `table-cell`, `table-caption`, `dialog-overlay`,
+`dialog-content`, `dialog-header`, `dialog-footer`, `dialog-title`,
+`dialog-description`, `dialog-close`, `select-trigger`, `select-content`,
+`select-viewport`, `select-label`, `select-item`, `select-separator`,
+`select-scroll-up-button`, `select-scroll-down-button`, `popover-content`,
+`calendar`, `time-picker`, `datetime-picker`, `combobox-trigger`,
+`combobox-content`, `combobox-search`, `combobox-list`, `combobox-empty`,
+`combobox-item`, `combobox-separator` (plus `button` from #705).

--- a/examples/plain-css-theming/README.md
+++ b/examples/plain-css-theming/README.md
@@ -1,0 +1,48 @@
+# Plain-CSS theming via `data-slot` (no Tailwind pipeline)
+
+This example demonstrates the third rung of the admin UI customization ladder
+(`specs/THEMING.md`, ADR-0016): **restyling primitives from plain CSS by
+targeting stable `data-slot` selectors, in an app that consumes only the
+package's precompiled stylesheet and runs no Tailwind pipeline of its own.**
+
+Every exported primitive and composite part in `@opensaas/stack-ui/primitives`
+carries a documented, stable `data-slot` attribute (`data-slot="button"`,
+`data-slot="table-row"`, `data-slot="dialog-content"`, …). Those names are a
+public compatibility promise, so a stylesheet that targets them keeps working
+across releases — no forking, no Tailwind, no build step.
+
+## Files
+
+- **`index.html`** — the exact markup the `@opensaas/stack-ui` primitives emit
+  (same `data-slot` attributes and token utility classes). It links two
+  stylesheets and nothing else:
+  1. `@opensaas/stack-ui/styles` — the package's **precompiled** CSS
+     (`packages/ui/dist/styles/globals.css`).
+  2. `theme-overrides.css` — our restyle.
+- **`theme-overrides.css`** — hand-written plain CSS. Each rule targets a
+  `[data-slot=…]` selector to flatten cards, pill the primary button,
+  zebra-stripe table rows, and square the inputs — without touching any
+  component source.
+
+## Run it
+
+```bash
+# Build the ui package once so the precompiled stylesheet exists.
+pnpm --filter @opensaas/stack-ui build
+
+# Then open the file directly — no dev server, no bundler, no Tailwind.
+open examples/plain-css-theming/index.html   # macOS
+# or: xdg-open examples/plain-css-theming/index.html
+```
+
+You will see the overrides applied on top of the package's default look. There
+is no JavaScript, no Tailwind config, and no `@source` scan involved — only the
+precompiled package CSS and a plain stylesheet targeting `data-slot` selectors.
+
+## Automated proof
+
+The same promise is enforced as a test:
+`packages/ui/tests/browser/primitives/data-slot.browser.test.tsx` renders the
+real primitives, injects a plain `<style>` rule targeting `[data-slot="input"]`
+and `[data-slot="table-row"]`, and asserts via `getComputedStyle` that the plain
+CSS wins. If a `data-slot` name ever changes, that suite fails.

--- a/examples/plain-css-theming/index.html
+++ b/examples/plain-css-theming/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Plain-CSS theming via data-slot (no Tailwind)</title>
+
+    <!--
+      1. The package's PRECOMPILED stylesheet (built by `pnpm --filter
+         @opensaas/stack-ui build`). This is the only stylesheet an app that
+         imports `@opensaas/stack-ui/styles` ships — no Tailwind runs here.
+    -->
+    <link rel="stylesheet" href="../../packages/ui/dist/styles/globals.css" />
+
+    <!--
+      2. Our plain-CSS overrides, targeting the stable `data-slot` selectors.
+         Loaded AFTER the package styles so instance rules win. No build step.
+    -->
+    <link rel="stylesheet" href="./theme-overrides.css" />
+  </head>
+  <body style="padding: 2rem; max-width: 40rem; margin: 0 auto">
+    <!--
+      The markup below is exactly what the `@opensaas/stack-ui` primitives emit:
+      the same `data-slot` attributes and the same token utility classes. Open
+      this file in a browser with zero tooling and the restyle from
+      `theme-overrides.css` is applied — proving the ADR-0016 promise.
+    -->
+
+    <div
+      data-slot="card"
+      class="rounded-lg border border-border bg-card text-card-foreground shadow-sm"
+    >
+      <div data-slot="card-header" class="flex flex-col space-y-1.5 p-6">
+        <div
+          data-slot="card-title"
+          class="font-heading text-2xl font-semibold leading-none tracking-tight"
+        >
+          Posts
+        </div>
+        <div data-slot="card-description" class="text-sm text-muted-foreground">
+          Restyled entirely from plain CSS — no component was forked.
+        </div>
+      </div>
+
+      <div data-slot="card-content" class="p-6 pt-0">
+        <input
+          data-slot="input"
+          class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 font-sans text-base"
+          placeholder="Filter posts…"
+        />
+
+        <div data-slot="table-container" class="relative mt-4 w-full overflow-auto">
+          <table data-slot="table" class="w-full caption-bottom font-sans text-sm">
+            <thead data-slot="table-header" class="[&_tr]:border-b">
+              <tr data-slot="table-row" class="border-b">
+                <th data-slot="table-head" class="h-12 px-4 text-left align-middle font-medium">
+                  Title
+                </th>
+                <th data-slot="table-head" class="h-12 px-4 text-left align-middle font-medium">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody data-slot="table-body">
+              <tr data-slot="table-row" class="border-b">
+                <td data-slot="table-cell" class="p-4 align-middle tabular-nums">Hello world</td>
+                <td data-slot="table-cell" class="p-4 align-middle tabular-nums">Published</td>
+              </tr>
+              <tr data-slot="table-row" class="border-b">
+                <td data-slot="table-cell" class="p-4 align-middle tabular-nums">Draft idea</td>
+                <td data-slot="table-cell" class="p-4 align-middle tabular-nums">Draft</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div data-slot="card-footer" class="flex items-center p-6 pt-0">
+        <button
+          data-slot="button"
+          class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 font-sans text-sm font-medium text-primary-foreground"
+        >
+          New post
+        </button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/examples/plain-css-theming/package.json
+++ b/examples/plain-css-theming/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "opensaas-plain-css-theming-example",
+  "version": "0.1.0",
+  "private": true
+}

--- a/examples/plain-css-theming/theme-overrides.css
+++ b/examples/plain-css-theming/theme-overrides.css
@@ -1,0 +1,47 @@
+/*
+ * Plain-CSS restyle of the admin UI primitives — NO Tailwind, NO build step.
+ *
+ * Every rule targets a stable `data-slot` selector. Per ADR-0016 the
+ * `data-slot` name set is a public compatibility promise, so these selectors
+ * keep working in an app that consumes only the package's precompiled CSS
+ * (`@opensaas/stack-ui/styles`) and never runs its own Tailwind pipeline.
+ *
+ * This file is hand-written CSS. It is the lowest rung of the customization
+ * ladder that still works without any tooling: token overrides and this.
+ */
+
+/* Make every card a flat, square, high-contrast panel. */
+[data-slot='card'] {
+  border-radius: 0;
+  border-width: 2px;
+  box-shadow: none;
+}
+
+[data-slot='card-title'] {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* Recolour the primary button without touching component source. */
+[data-slot='button'] {
+  border-radius: 9999px;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+/* Zebra-stripe table rows purely from the row slot. */
+[data-slot='table-row']:nth-child(even) {
+  background-color: rgba(15, 23, 42, 0.04);
+}
+
+[data-slot='table-head'] {
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+}
+
+/* Square, tinted inputs. */
+[data-slot='input'] {
+  border-radius: 0;
+  border-color: #0f172a;
+}

--- a/packages/ui/src/primitives/calendar.tsx
+++ b/packages/ui/src/primitives/calendar.tsx
@@ -63,7 +63,7 @@ export function Calendar({ selected, onSelect, disabled, className }: CalendarPr
   }
 
   return (
-    <div className={cn('p-3', className)}>
+    <div data-slot="calendar" className={cn('p-3 font-sans', className)}>
       <div className="flex items-center justify-between mb-4">
         <Button
           variant="outline"

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -6,6 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
+      data-slot="card"
       className={cn(
         'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
         className,
@@ -18,7 +19,12 @@ Card.displayName = 'Card'
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+    <div
+      ref={ref}
+      data-slot="card-header"
+      className={cn('flex flex-col space-y-1.5 p-6', className)}
+      {...props}
+    />
   ),
 )
 CardHeader.displayName = 'CardHeader'
@@ -27,7 +33,8 @@ const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivE
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      data-slot="card-title"
+      className={cn('font-heading text-2xl font-semibold leading-none tracking-tight', className)}
       {...props}
     />
   ),
@@ -36,21 +43,31 @@ CardTitle.displayName = 'CardTitle'
 
 const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+    <div
+      ref={ref}
+      data-slot="card-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
   ),
 )
 CardDescription.displayName = 'CardDescription'
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+    <div ref={ref} data-slot="card-content" className={cn('p-6 pt-0', className)} {...props} />
   ),
 )
 CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+    <div
+      ref={ref}
+      data-slot="card-footer"
+      className={cn('flex items-center p-6 pt-0', className)}
+      {...props}
+    />
   ),
 )
 CardFooter.displayName = 'CardFooter'

--- a/packages/ui/src/primitives/checkbox.tsx
+++ b/packages/ui/src/primitives/checkbox.tsx
@@ -9,13 +9,17 @@ const Checkbox = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
+    data-slot="checkbox"
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background transition-[color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
+    <CheckboxPrimitive.Indicator
+      data-slot="checkbox-indicator"
+      className={cn('flex items-center justify-center text-current')}
+    >
       <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
       </svg>

--- a/packages/ui/src/primitives/combobox.tsx
+++ b/packages/ui/src/primitives/combobox.tsx
@@ -10,8 +10,9 @@ const ComboboxTrigger = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <PopoverPrimitive.Trigger
     ref={ref}
+    data-slot="combobox-trigger"
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 font-sans text-sm ring-offset-background transition-[color,box-shadow] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}
@@ -41,10 +42,11 @@ const ComboboxContent = React.forwardRef<
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
+      data-slot="combobox-content"
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-full min-w-[var(--radix-popover-trigger-width)] rounded-md border border-border bg-popover p-0 text-popover-foreground shadow-md outline-none',
+        'z-50 w-full min-w-[var(--radix-popover-trigger-width)] rounded-md border border-border bg-popover p-0 font-sans text-popover-foreground shadow-md outline-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
@@ -77,8 +79,9 @@ const ComboboxSearch = React.forwardRef<
     </svg>
     <input
       ref={ref}
+      data-slot="combobox-search"
       className={cn(
-        'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-10 w-full rounded-md bg-transparent py-3 font-sans text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}
@@ -91,6 +94,7 @@ const ComboboxList = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLD
   ({ className, children, ...props }, ref) => (
     <div
       ref={ref}
+      data-slot="combobox-list"
       className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
       {...props}
     >
@@ -104,6 +108,7 @@ const ComboboxEmpty = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
   ({ className, children = 'No results found.', ...props }, ref) => (
     <div
       ref={ref}
+      data-slot="combobox-empty"
       className={cn('py-6 text-center text-sm text-muted-foreground', className)}
       {...props}
     >
@@ -119,6 +124,7 @@ const ComboboxItem = React.forwardRef<
 >(({ className, children, selected, ...props }, ref) => (
   <div
     ref={ref}
+    data-slot="combobox-item"
     className={cn(
       'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
       'hover:bg-accent hover:text-accent-foreground',
@@ -142,7 +148,12 @@ ComboboxItem.displayName = 'ComboboxItem'
 
 const ComboboxSeparator = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('-mx-1 my-1 h-px bg-border', className)} {...props} />
+    <div
+      ref={ref}
+      data-slot="combobox-separator"
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
   ),
 )
 ComboboxSeparator.displayName = 'ComboboxSeparator'

--- a/packages/ui/src/primitives/datetime-picker.tsx
+++ b/packages/ui/src/primitives/datetime-picker.tsx
@@ -84,7 +84,7 @@ export function DateTimePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
-        <div className="p-4 space-y-4">
+        <div data-slot="datetime-picker" className="p-4 space-y-4">
           <Calendar selected={selectedDate} onSelect={handleDateSelect} disabled={disabled} />
 
           <div className="border-t pt-4">

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -17,8 +17,9 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
+    data-slot="dialog-overlay"
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -34,14 +35,18 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      data-slot="dialog-content"
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-2/3 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-2 border-gray-200 bg-white p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-2/3 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close
+        data-slot="dialog-close"
+        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+      >
         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             strokeLinecap="round"
@@ -58,12 +63,17 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+  <div
+    data-slot="dialog-header"
+    className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+    {...props}
+  />
 )
 DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
+    data-slot="dialog-footer"
     className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
     {...props}
   />
@@ -76,7 +86,8 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    data-slot="dialog-title"
+    className={cn('font-heading text-lg font-semibold leading-none tracking-tight', className)}
     {...props}
   />
 ))
@@ -88,6 +99,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
+    data-slot="dialog-description"
     className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -9,8 +9,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         type={type}
+        data-slot="input"
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 font-sans text-base text-foreground ring-offset-background transition-[color,box-shadow] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
         ref={ref}

--- a/packages/ui/src/primitives/label.tsx
+++ b/packages/ui/src/primitives/label.tsx
@@ -5,14 +5,19 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '../lib/utils.js'
 
 const labelVariants = cva(
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  'font-sans text-sm font-medium leading-none text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 )
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+  <LabelPrimitive.Root
+    ref={ref}
+    data-slot="label"
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
 ))
 Label.displayName = LabelPrimitive.Root.displayName
 

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -16,10 +16,11 @@ const PopoverContent = React.forwardRef<
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
+      data-slot="popover-content"
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-card p-4 text-card-foreground shadow-lg outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-lg outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -15,8 +15,9 @@ const SelectTrigger = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
+    data-slot="select-trigger"
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 font-sans text-sm ring-offset-background transition-[color,box-shadow] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
@@ -37,6 +38,7 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
+    data-slot="select-scroll-up-button"
     className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
@@ -53,6 +55,7 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
+    data-slot="select-scroll-down-button"
     className={cn('flex cursor-default items-center justify-center py-1', className)}
     {...props}
   >
@@ -70,8 +73,9 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
+      data-slot="select-content"
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover font-sans text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -81,6 +85,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
+        data-slot="select-viewport"
         className={cn(
           'p-1',
           position === 'popper' &&
@@ -101,6 +106,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
+    data-slot="select-label"
     className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
     {...props}
   />
@@ -113,6 +119,7 @@ const SelectItem = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
+    data-slot="select-item"
     className={cn(
       'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
@@ -138,6 +145,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
+    data-slot="select-separator"
     className={cn('-mx-1 my-1 h-px bg-muted', className)}
     {...props}
   />

--- a/packages/ui/src/primitives/table.tsx
+++ b/packages/ui/src/primitives/table.tsx
@@ -4,8 +4,13 @@ import { cn } from '../lib/utils.js'
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    <div data-slot="table-container" className="relative w-full overflow-auto">
+      <table
+        ref={ref}
+        data-slot="table"
+        className={cn('w-full caption-bottom font-sans text-sm', className)}
+        {...props}
+      />
     </div>
   ),
 )
@@ -15,7 +20,12 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  <thead
+    ref={ref}
+    data-slot="table-header"
+    className={cn('[&_tr]:border-b', className)}
+    {...props}
+  />
 ))
 TableHeader.displayName = 'TableHeader'
 
@@ -23,7 +33,12 @@ const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  <tbody
+    ref={ref}
+    data-slot="table-body"
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
 ))
 TableBody.displayName = 'TableBody'
 
@@ -33,6 +48,7 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
+    data-slot="table-footer"
     className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
     {...props}
   />
@@ -43,6 +59,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
+      data-slot="table-row"
       className={cn(
         'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
         className,
@@ -59,6 +76,7 @@ const TableHead = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <th
     ref={ref}
+    data-slot="table-head"
     className={cn(
       'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
       className,
@@ -74,7 +92,8 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    data-slot="table-cell"
+    className={cn('p-4 align-middle tabular-nums [&:has([role=checkbox])]:pr-0', className)}
     {...props}
   />
 ))
@@ -84,7 +103,12 @@ const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+  <caption
+    ref={ref}
+    data-slot="table-caption"
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
 ))
 TableCaption.displayName = 'TableCaption'
 

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -9,8 +9,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (
       <textarea
+        data-slot="textarea"
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 font-sans text-base text-foreground ring-offset-background transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
         ref={ref}

--- a/packages/ui/src/primitives/time-picker.tsx
+++ b/packages/ui/src/primitives/time-picker.tsx
@@ -38,7 +38,7 @@ export function TimePicker({ value, onChange, disabled, className }: TimePickerP
   }
 
   return (
-    <div className={cn('flex items-center gap-2', className)}>
+    <div data-slot="time-picker" className={cn('flex items-center gap-2', className)}>
       <div className="flex items-center">
         <Input
           type="number"

--- a/packages/ui/tests/browser/primitives/data-slot.browser.test.tsx
+++ b/packages/ui/tests/browser/primitives/data-slot.browser.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { Input } from '../../../src/primitives/input.js'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '../../../src/primitives/dialog.js'
+import {
+  Select,
+  SelectGroup,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+} from '../../../src/primitives/select.js'
+import { Popover, PopoverTrigger, PopoverContent } from '../../../src/primitives/popover.js'
+import {
+  Combobox,
+  ComboboxTrigger,
+  ComboboxContent,
+  ComboboxSearch,
+  ComboboxList,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxSeparator,
+} from '../../../src/primitives/combobox.js'
+import { Table, TableBody, TableRow, TableCell } from '../../../src/primitives/table.js'
+import { DateTimePicker } from '../../../src/primitives/datetime-picker.js'
+import { userEvent } from 'vitest/browser'
+
+/**
+ * Browser-mode half of the `data-slot` contract suite (issue #708, ADR-0016).
+ *
+ * Covers the portalled / open-state composite parts that Radix mounts into a
+ * portal (Dialog, Select, Popover, Combobox content) plus the plain-CSS
+ * override demonstration — the enforceable proof that a `[data-slot=…]` plain
+ * CSS rule restyles a primitive with NO Tailwind pipeline. Assertions are on
+ * external behaviour only: the rendered node's `data-slot` attribute, its
+ * merged class list, and its computed style under an injected plain stylesheet.
+ */
+
+afterEach(() => cleanup())
+
+const slot = (name: string): Element | null => document.body.querySelector(`[data-slot="${name}"]`)
+
+/** Query a slot and narrow to HTMLElement without casting (fails loudly if absent). */
+const requireSlot = (name: string): HTMLElement => {
+  const node = slot(name)
+  if (!(node instanceof HTMLElement)) {
+    throw new Error(`Expected a rendered element for data-slot="${name}"`)
+  }
+  return node
+}
+
+describe('Dialog data-slot contract (browser)', () => {
+  it('exposes stable data-slot names on every part', () => {
+    render(
+      <Dialog open>
+        <DialogContent className="os-dialog">
+          <DialogHeader>
+            <DialogTitle>Title</DialogTitle>
+            <DialogDescription>Description</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>footer</DialogFooter>
+        </DialogContent>
+      </Dialog>,
+    )
+
+    expect(slot('dialog-overlay')).toHaveAttribute('data-slot', 'dialog-overlay')
+    expect(slot('dialog-content')).toHaveAttribute('data-slot', 'dialog-content')
+    expect(slot('dialog-header')).toHaveAttribute('data-slot', 'dialog-header')
+    expect(slot('dialog-footer')).toHaveAttribute('data-slot', 'dialog-footer')
+    expect(slot('dialog-title')).toHaveAttribute('data-slot', 'dialog-title')
+    expect(slot('dialog-description')).toHaveAttribute('data-slot', 'dialog-description')
+    expect(slot('dialog-close')).toHaveAttribute('data-slot', 'dialog-close')
+  })
+
+  it('merges and overrides a caller className on the content (tailwind-merge)', () => {
+    render(
+      <Dialog open>
+        <DialogContent className="os-dialog p-2">
+          <DialogTitle>Title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    )
+    const content = slot('dialog-content')
+    expect(content).toHaveClass('os-dialog')
+    // Default padding `p-6` is dropped in favour of the caller's `p-2`.
+    expect(content).toHaveClass('p-2')
+    expect(content).not.toHaveClass('p-6')
+  })
+})
+
+describe('Select data-slot contract (browser)', () => {
+  it('exposes stable data-slot names on every open part', () => {
+    render(
+      <Select open>
+        <SelectTrigger className="os-trigger">
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent className="os-content">
+          <SelectGroup>
+            <SelectLabel>Group</SelectLabel>
+            <SelectItem value="a">A</SelectItem>
+            <SelectSeparator />
+            <SelectItem value="b">B</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    )
+
+    expect(slot('select-trigger')).toHaveAttribute('data-slot', 'select-trigger')
+    expect(slot('select-content')).toHaveAttribute('data-slot', 'select-content')
+    expect(slot('select-viewport')).toHaveAttribute('data-slot', 'select-viewport')
+    expect(slot('select-label')).toHaveAttribute('data-slot', 'select-label')
+    expect(slot('select-item')).toHaveAttribute('data-slot', 'select-item')
+    expect(slot('select-separator')).toHaveAttribute('data-slot', 'select-separator')
+
+    expect(slot('select-content')).toHaveClass('os-content')
+  })
+})
+
+describe('Popover data-slot contract (browser)', () => {
+  it('exposes a stable data-slot on the content and merges className', () => {
+    render(
+      <Popover open>
+        <PopoverTrigger>trigger</PopoverTrigger>
+        <PopoverContent className="os-popover rounded-none">body</PopoverContent>
+      </Popover>,
+    )
+    const content = slot('popover-content')
+    expect(content).toHaveAttribute('data-slot', 'popover-content')
+    expect(content).toHaveClass('os-popover')
+    // Default `rounded-md` gives way to the caller's `rounded-none`.
+    expect(content).toHaveClass('rounded-none')
+    expect(content).not.toHaveClass('rounded-md')
+  })
+})
+
+describe('Combobox data-slot contract (browser)', () => {
+  it('exposes stable data-slot names on every open part', () => {
+    render(
+      <Combobox open>
+        <ComboboxTrigger className="os-trigger">trigger</ComboboxTrigger>
+        <ComboboxContent className="os-content">
+          <ComboboxSearch placeholder="search" />
+          <ComboboxList>
+            <ComboboxItem>item</ComboboxItem>
+            <ComboboxSeparator />
+          </ComboboxList>
+          <ComboboxEmpty>none</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>,
+    )
+
+    expect(slot('combobox-trigger')).toHaveAttribute('data-slot', 'combobox-trigger')
+    expect(slot('combobox-content')).toHaveAttribute('data-slot', 'combobox-content')
+    expect(slot('combobox-search')).toHaveAttribute('data-slot', 'combobox-search')
+    expect(slot('combobox-list')).toHaveAttribute('data-slot', 'combobox-list')
+    expect(slot('combobox-item')).toHaveAttribute('data-slot', 'combobox-item')
+    expect(slot('combobox-separator')).toHaveAttribute('data-slot', 'combobox-separator')
+    expect(slot('combobox-empty')).toHaveAttribute('data-slot', 'combobox-empty')
+
+    expect(slot('combobox-content')).toHaveClass('os-content')
+  })
+})
+
+describe('DateTimePicker data-slot contract (browser)', () => {
+  it('exposes a stable data-slot on the open picker panel', async () => {
+    render(<DateTimePicker placeholder="Pick a date" />)
+    // The trigger is a Button; opening it mounts the picker panel in a portal.
+    await userEvent.click(requireSlot('button'))
+    expect(slot('datetime-picker')).toHaveAttribute('data-slot', 'datetime-picker')
+  })
+})
+
+describe('plain-CSS override via [data-slot] (no Tailwind pipeline)', () => {
+  it('restyles primitives from a plain stylesheet, precompiled styles only', () => {
+    // A raw, hand-written stylesheet — no Tailwind, no @apply, no build step.
+    // This is exactly what an app that consumes only the package's precompiled
+    // CSS would add to restyle a primitive (ADR-0016 stable-selector promise).
+    const style = document.createElement('style')
+    style.setAttribute('data-test', 'plain-css-override')
+    style.textContent = `
+      [data-slot="input"] { background-color: rgb(1, 2, 3); }
+      [data-slot="table-row"] { background-color: rgb(4, 5, 6); }
+    `
+    document.head.appendChild(style)
+
+    try {
+      render(
+        <div>
+          <Input />
+          <Table>
+            <TableBody>
+              <TableRow>
+                <TableCell>cell</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>,
+      )
+
+      const input = requireSlot('input')
+      const row = requireSlot('table-row')
+
+      // The plain-CSS rule targeting the stable data-slot selector wins.
+      expect(getComputedStyle(input).backgroundColor).toBe('rgb(1, 2, 3)')
+      expect(getComputedStyle(row).backgroundColor).toBe('rgb(4, 5, 6)')
+    } finally {
+      style.remove()
+    }
+  })
+})

--- a/packages/ui/tests/primitives/data-slot.test.tsx
+++ b/packages/ui/tests/primitives/data-slot.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+
+import { Input } from '../../src/primitives/input.js'
+import { Textarea } from '../../src/primitives/textarea.js'
+import { Label } from '../../src/primitives/label.js'
+import { Checkbox } from '../../src/primitives/checkbox.js'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '../../src/primitives/card.js'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+} from '../../src/primitives/table.js'
+import { DialogHeader, DialogFooter } from '../../src/primitives/dialog.js'
+import { Select, SelectTrigger, SelectValue } from '../../src/primitives/select.js'
+import { Combobox, ComboboxTrigger } from '../../src/primitives/combobox.js'
+import { Calendar } from '../../src/primitives/calendar.js'
+import { TimePicker } from '../../src/primitives/time-picker.js'
+
+/**
+ * Contract test suite for the `data-slot` public compatibility promise
+ * (issue #708, ADR-0016). Each primitive and composite part must expose a
+ * stable `data-slot` name and merge a caller `className` via tailwind-merge so
+ * that instance overrides win. These tests assert external behaviour only —
+ * the rendered DOM node's `data-slot` attribute and its resolved class list —
+ * never internal component structure.
+ *
+ * Portalled / open-state parts (Dialog content, Select content, Popover /
+ * Combobox content, and the plain-CSS override demonstration) are covered by
+ * the browser-mode suite in `tests/browser/primitives/data-slot.browser.test.tsx`.
+ */
+
+type Case = {
+  /** Documented, stable data-slot name (the public contract). */
+  slot: string
+  /** Render the component with the given className applied to this slot. */
+  render: (className: string) => ReactElement
+  /** A default utility on the slot that a same-group override must replace. */
+  defaultClass?: string
+  /** A caller override in the same utility group as `defaultClass`. */
+  overrideClass?: string
+  /**
+   * Structural parts (the checkbox indicator, the table scroll container) carry
+   * a stable data-slot for plain-CSS targeting but are not independently
+   * rendered with their own `className` prop — only their attribute is asserted.
+   */
+  slotOnly?: boolean
+}
+
+const cases: Case[] = [
+  {
+    slot: 'input',
+    render: (c) => <Input className={c} />,
+    defaultClass: 'px-3',
+    overrideClass: 'px-8',
+  },
+  {
+    slot: 'textarea',
+    render: (c) => <Textarea className={c} />,
+    defaultClass: 'px-3',
+    overrideClass: 'px-8',
+  },
+  {
+    slot: 'label',
+    render: (c) => <Label className={c}>Name</Label>,
+    defaultClass: 'text-sm',
+    overrideClass: 'text-2xl',
+  },
+  {
+    slot: 'checkbox',
+    render: (c) => <Checkbox className={c} defaultChecked />,
+    defaultClass: 'h-4',
+    overrideClass: 'h-8',
+  },
+  {
+    slot: 'checkbox-indicator',
+    render: () => <Checkbox defaultChecked />,
+    slotOnly: true,
+  },
+  {
+    slot: 'card',
+    render: (c) => <Card className={c} />,
+    defaultClass: 'rounded-lg',
+    overrideClass: 'rounded-none',
+  },
+  {
+    slot: 'card-header',
+    render: (c) => (
+      <Card>
+        <CardHeader className={c} />
+      </Card>
+    ),
+    defaultClass: 'p-6',
+    overrideClass: 'p-2',
+  },
+  {
+    slot: 'card-title',
+    render: (c) => (
+      <Card>
+        <CardTitle className={c}>Title</CardTitle>
+      </Card>
+    ),
+    defaultClass: 'text-2xl',
+    overrideClass: 'text-base',
+  },
+  {
+    slot: 'card-description',
+    render: (c) => (
+      <Card>
+        <CardDescription className={c}>Desc</CardDescription>
+      </Card>
+    ),
+    defaultClass: 'text-sm',
+    overrideClass: 'text-lg',
+  },
+  {
+    slot: 'card-content',
+    render: (c) => (
+      <Card>
+        <CardContent className={c}>Body</CardContent>
+      </Card>
+    ),
+    defaultClass: 'p-6',
+    overrideClass: 'p-2',
+  },
+  {
+    slot: 'card-footer',
+    render: (c) => (
+      <Card>
+        <CardFooter className={c}>Footer</CardFooter>
+      </Card>
+    ),
+    defaultClass: 'p-6',
+    overrideClass: 'p-2',
+  },
+  {
+    slot: 'table-container',
+    render: () => (
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+    slotOnly: true,
+  },
+  {
+    slot: 'table',
+    render: (c) => (
+      <Table className={c}>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+    defaultClass: 'text-sm',
+    overrideClass: 'text-lg',
+  },
+  {
+    slot: 'table-header',
+    render: (c) => (
+      <Table>
+        <TableHeader className={c}>
+          <TableRow>
+            <TableHead>head</TableHead>
+          </TableRow>
+        </TableHeader>
+      </Table>
+    ),
+  },
+  {
+    slot: 'table-body',
+    render: (c) => (
+      <Table>
+        <TableBody className={c}>
+          <TableRow>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+  },
+  {
+    slot: 'table-footer',
+    render: (c) => (
+      <Table>
+        <TableFooter className={c}>
+          <TableRow>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    ),
+    defaultClass: 'bg-muted/50',
+    overrideClass: 'bg-transparent',
+  },
+  {
+    slot: 'table-row',
+    render: (c) => (
+      <Table>
+        <TableBody>
+          <TableRow className={c}>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+    defaultClass: 'border-b',
+    overrideClass: 'border-0',
+  },
+  {
+    slot: 'table-head',
+    render: (c) => (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className={c}>head</TableHead>
+          </TableRow>
+        </TableHeader>
+      </Table>
+    ),
+    defaultClass: 'px-4',
+    overrideClass: 'px-8',
+  },
+  {
+    slot: 'table-cell',
+    render: (c) => (
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell className={c}>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+    defaultClass: 'p-4',
+    overrideClass: 'p-8',
+  },
+  {
+    slot: 'table-caption',
+    render: (c) => (
+      <Table>
+        <TableCaption className={c}>caption</TableCaption>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    ),
+    defaultClass: 'mt-4',
+    overrideClass: 'mt-8',
+  },
+  {
+    slot: 'dialog-header',
+    render: (c) => <DialogHeader className={c} />,
+    defaultClass: 'text-center',
+    overrideClass: 'text-left',
+  },
+  {
+    slot: 'dialog-footer',
+    render: (c) => <DialogFooter className={c} />,
+    defaultClass: 'flex-col-reverse',
+    overrideClass: 'flex-row',
+  },
+  {
+    slot: 'select-trigger',
+    render: (c) => (
+      <Select>
+        <SelectTrigger className={c}>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+      </Select>
+    ),
+    defaultClass: 'px-3',
+    overrideClass: 'px-8',
+  },
+  {
+    slot: 'combobox-trigger',
+    render: (c) => (
+      <Combobox>
+        <ComboboxTrigger className={c}>Pick</ComboboxTrigger>
+      </Combobox>
+    ),
+    defaultClass: 'px-3',
+    overrideClass: 'px-8',
+  },
+  {
+    slot: 'calendar',
+    render: (c) => <Calendar className={c} />,
+    defaultClass: 'p-3',
+    overrideClass: 'p-8',
+  },
+  {
+    slot: 'time-picker',
+    render: (c) => <TimePicker className={c} />,
+    defaultClass: 'gap-2',
+    overrideClass: 'gap-8',
+  },
+]
+
+describe('primitive data-slot contract (happy-dom)', () => {
+  for (const { slot, render: renderCase, defaultClass, overrideClass, slotOnly } of cases) {
+    describe(`data-slot="${slot}"`, () => {
+      it('carries the stable data-slot attribute', () => {
+        const { container } = render(renderCase('os-marker'))
+        const node = container.querySelector(`[data-slot="${slot}"]`)
+        expect(node).not.toBeNull()
+        expect(node).toHaveAttribute('data-slot', slot)
+      })
+
+      if (!slotOnly) {
+        it('merges a caller className onto the slot', () => {
+          const { container } = render(renderCase('os-custom-class'))
+          const node = container.querySelector(`[data-slot="${slot}"]`)
+          expect(node).toHaveClass('os-custom-class')
+        })
+      }
+
+      if (defaultClass && overrideClass) {
+        it('lets a caller className override a default (tailwind-merge)', () => {
+          const withDefault = render(renderCase('unrelated-marker'))
+          const defaultNode = withDefault.container.querySelector(`[data-slot="${slot}"]`)
+          // Sanity: the default utility is present when not overridden.
+          expect(defaultNode).toHaveClass(defaultClass)
+
+          const withOverride = render(renderCase(overrideClass))
+          const overriddenNode = withOverride.container.querySelector(`[data-slot="${slot}"]`)
+          expect(overriddenNode).toHaveClass(overrideClass)
+          // tailwind-merge drops the same-group default so the override wins.
+          expect(overriddenNode).not.toHaveClass(defaultClass)
+        })
+      }
+    })
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,8 @@ importers:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
 
+  examples/plain-css-theming: {}
+
   examples/rag-ollama-demo:
     dependencies:
       '@opensaas/stack-core':


### PR DESCRIPTION
Implements #708. Part of #704.

Brings every remaining primitive onto the design system, following the Button pattern established in #705 (tokens, `data-slot`, tailwind-merge'd `className`). Button's contract is untouched.

## What changed

- **Token-only styling** — no hardcoded colors/shadows remain. Notably `Dialog` dropped `bg-white` / `border-gray-200` / `shadow-2xl` / `bg-black/80` for `bg-card` / `border-border` / `shadow-lg` and a tokenized `bg-background/80 backdrop-blur-sm` scrim. Popover moved to `bg-popover`/`border-border`. Controls consume `font-sans`, titles `font-heading`, elevation uses the shadow tokens, and table cells gain `tabular-nums`.
- **Stable `data-slot` on every primitive and composite part** — the public compatibility promise (ADR-0016).
- **`className` merged via tailwind-merge (`cn`) on every part** so caller classes override defaults (e.g. `<Card className="rounded-none" />` wins over the default radius).

## The `data-slot` public contract (name set)

`button` (from #705), `input`, `textarea`, `label`, `checkbox`, `checkbox-indicator`, `card`, `card-header`, `card-title`, `card-description`, `card-content`, `card-footer`, `table-container`, `table`, `table-header`, `table-body`, `table-footer`, `table-row`, `table-head`, `table-cell`, `table-caption`, `dialog-overlay`, `dialog-content`, `dialog-header`, `dialog-footer`, `dialog-title`, `dialog-description`, `dialog-close`, `select-trigger`, `select-content`, `select-viewport`, `select-label`, `select-item`, `select-separator`, `select-scroll-up-button`, `select-scroll-down-button`, `popover-content`, `calendar`, `time-picker`, `datetime-picker`, `combobox-trigger`, `combobox-content`, `combobox-search`, `combobox-list`, `combobox-empty`, `combobox-item`, `combobox-separator`.

## How `className` merge works

Each part renders `className={cn('<token defaults>', className)}` (Button uses cva with `className` threaded last). tailwind-merge resolves same-group conflicts in the caller's favour, so `rounded-none` drops the default `rounded-lg`, `p-2` drops `p-6`, etc. Composite parts that have no own `className` prop (the checkbox indicator, the table scroll container) still carry a `data-slot` for plain-CSS targeting.

## Contract tests (assert external behaviour only)

- `packages/ui/tests/primitives/data-slot.test.tsx` (happy-dom, 72 assertions): each inline primitive/part asserts its `data-slot` name, that a caller `className` merges in, and that a same-group override wins.
- `packages/ui/tests/browser/primitives/data-slot.browser.test.tsx` (browser mode): the portalled/open-state parts (Dialog, Select, Popover, Combobox, DateTimePicker) that Radix mounts in a portal, plus the plain-CSS override demonstration.

## Plain-CSS override demonstration (no app-side Tailwind)

Two ways, both proving the ADR-0016 promise that `[data-slot=…]` restyling works over precompiled styles with no Tailwind pipeline:

1. **Automated / enforceable** — the browser test injects a raw `<style>` targeting `[data-slot="input"]` and `[data-slot="table-row"]`, renders the real primitives, and asserts via `getComputedStyle` that the plain-CSS rule wins.
2. **Viewable example** — `examples/plain-css-theming/` links the package's precompiled `@opensaas/stack-ui/styles` plus a hand-written `theme-overrides.css` that restyles cards/buttons/table rows/inputs purely through `[data-slot]` selectors. No JS, no Tailwind, no build step (open `index.html`).

## Checks

- ui build (tsc) — pass
- lint (`eslint .`) — pass (0 errors; 3 pre-existing warnings unrelated to these files)
- `pnpm manypkg fix` / `pnpm format` — clean
- happy-dom vitest — 305 passed (20 files), incl. the new 72 contract assertions
- browser-mode vitest — 60 passed across the existing suite; the new suite 7 passed. Preinstalled Chromium is playwright rev 1194 while the pinned `playwright@1.60.0` expects the rev-1223 headless shell, so the provider must be pointed at the preinstalled binary via `launchOptions.executablePath` (`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`) — done through a local run config, not committed. With that, the full browser suite runs green.

Changeset: `.changeset/quiet-slots-restyle.md` (ui minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_