### PR TITLE
Design system 5/7: fields &amp; standalone pass — classNames slots, status tokens, form rhythm

### DIFF
--- a/.changeset/fields-standalone-design-system.md
+++ b/.changeset/fields-standalone-design-system.md
@@ -1,0 +1,33 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Design system pass for field components and standalone composites: token-only styling, structured `classNames` slots, status tokens, and shared form rhythm.
+
+**Field components** now share one label / help / error rhythm via a small shell (`FieldRoot`, `FieldLabel`, `FieldHelp`, `FieldError`, `FieldWarning`, `FieldReadValue`). Every field consumes theme tokens only — the previously hardcoded status colours (a green upload check, an amber JSON warning) now use the `success` / `warning` tokens. All fields accept a consistent `helpText` prop.
+
+**Composites accept structured, strongly-typed `classNames` slots** merged per part via tailwind-merge, and every part carries a stable `data-slot`:
+
+- `ListTable` — `classNames={{ root, frame, table, header, headerRow, headerCell, body, row, cell, actionsHeader, actionsCell, empty }}`; root `data-slot="list-table"`.
+- `SearchBar` — `classNames={{ root, form, inputWrapper, input, clearButton, submit }}`; root `data-slot="search-bar"`.
+- `DeleteButton` — `classNames={{ button, error }}`; error `data-slot="delete-button-error"`.
+- `ItemCreateForm` / `ItemEditForm` — `classNames={{ root, error, fields, actions, submit, cancel }}`; roots `data-slot="item-create-form"` / `"item-edit-form"`.
+- `RelationshipManager` — `classNames={{ root, label, frame, row, cell, emptyState, actions, connectButton, error }}`; root `data-slot="relationship-manager"`.
+
+**New `Badge` primitive** for status rendering, with `success` / `warning` / `destructive` / `default` / `secondary` / `outline` variants driven entirely by tokens:
+
+```tsx
+import { Badge } from '@opensaas/stack-ui/primitives'
+
+;<Badge variant={post.status === 'published' ? 'success' : 'warning'}>{post.status}</Badge>
+```
+
+Example: restyle just the rows of a table without forking it:
+
+```tsx
+<ListTable
+  items={posts}
+  fieldTypes={{ title: 'text', status: 'select' }}
+  classNames={{ frame: 'shadow-sm', headerCell: 'uppercase text-xs', row: 'hover:bg-accent/40' }}
+/>
+```

--- a/examples/composable-dashboard/README.md
+++ b/examples/composable-dashboard/README.md
@@ -16,8 +16,27 @@ This example demonstrates building a custom admin interface using OpenSaas stand
 
 - **Card** - Stats cards and content containers
 - **Button** - Navigation and actions
+- **Badge** - Status rendering via the `success`/`warning` design-system tokens
 - **Dialog** - Modal for creating posts
 - **Table** components (via ListTable)
+
+### Design system parity (issue #709)
+
+The fully custom create form, edit form, and list page are assembled from the
+same field components and standalone composites the prebuilt admin uses, so they
+look native to the design system:
+
+- **Status tokens** — post status (published/draft) renders through the shared
+  `Badge` primitive (`success`/`warning` tokens) via `components/PostStatusBadge`.
+  No hardcoded status colours anywhere in the example.
+- **Structured `classNames` slots** — the composites expose per-part class
+  overrides merged via tailwind-merge, demonstrated here without forking:
+  - `ListTable classNames={{ frame, headerCell, row }}` on the posts list page
+  - `SearchBar classNames={{ input }}` on the posts search bar
+  - `ItemCreateForm` / `ItemEditForm classNames={{ actions }}` on the forms
+- **Stable `data-slot` attributes** — every composite part carries one
+  (`list-table`, `search-bar`, `item-create-form`, `item-edit-form`, …) so the
+  same pages can be restyled from plain CSS.
 
 ### Key Features
 

--- a/examples/composable-dashboard/app/page.tsx
+++ b/examples/composable-dashboard/app/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@opensaas/stack-ui/pri
 import { Button } from '@opensaas/stack-ui/primitives'
 import { config, getContext } from '@/.opensaas/context'
 import { CreatePostDialog } from '../components/CreatePostDialog'
+import { PostStatusBadge } from '../components/PostStatusBadge'
 import { connection } from 'next/server'
 
 export default async function HomePage() {
@@ -67,7 +68,7 @@ export default async function HomePage() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Published</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-3xl font-bold text-green-600">{publishedPosts}</p>
+              <p className="text-3xl font-bold text-success">{publishedPosts}</p>
             </CardContent>
           </Card>
 
@@ -76,7 +77,7 @@ export default async function HomePage() {
               <CardTitle className="text-sm font-medium text-muted-foreground">Drafts</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-3xl font-bold text-yellow-600">{draftPosts}</p>
+              <p className="text-3xl font-bold text-warning">{draftPosts}</p>
             </CardContent>
           </Card>
 
@@ -138,15 +139,7 @@ export default async function HomePage() {
                             {new Date(post.createdAt).toLocaleDateString()}
                           </p>
                         </div>
-                        <span
-                          className={`px-2 py-1 text-xs font-medium rounded ${
-                            post.status === 'published'
-                              ? 'bg-green-100 text-green-800'
-                              : 'bg-yellow-100 text-yellow-800'
-                          }`}
-                        >
-                          {post.status}
-                        </span>
+                        <PostStatusBadge status={post.status} />
                       </div>
                     </Link>
                   ))}

--- a/examples/composable-dashboard/app/posts/[id]/PostEditor.tsx
+++ b/examples/composable-dashboard/app/posts/[id]/PostEditor.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@opensaas/stack-ui/pri
 import { Button } from '@opensaas/stack-ui/primitives'
 import { ItemEditForm, DeleteButton } from '@opensaas/stack-ui/standalone'
 import { updatePost, deletePost } from '../../../lib/actions'
+import { PostStatusBadge } from '../../../components/PostStatusBadge'
 import type { Post, PostUpdateInput } from '@/.opensaas/types'
 import { FieldConfig } from '@opensaas/stack-core'
 
@@ -35,6 +36,9 @@ export function PostEditor({ post, fields }: { post: Post; fields: Record<string
               return { success: true }
             }}
             onCancel={() => setEditing(false)}
+            // Structured per-part classNames slots (issue #709) — tune the
+            // actions footer without forking the form.
+            classNames={{ actions: 'justify-end' }}
           />
         </CardContent>
       </Card>
@@ -54,15 +58,7 @@ export function PostEditor({ post, fields }: { post: Post; fields: Record<string
                 <span>•</span>
                 <span>{new Date(post.createdAt).toLocaleDateString()}</span>
                 <span>•</span>
-                <span
-                  className={`px-2 py-1 text-xs font-medium rounded ${
-                    post.status === 'published'
-                      ? 'bg-green-100 text-green-800'
-                      : 'bg-yellow-100 text-yellow-800'
-                  }`}
-                >
-                  {post.status}
-                </span>
+                <PostStatusBadge status={post.status} />
               </div>
             </div>
             <div className="flex gap-2">

--- a/examples/composable-dashboard/app/posts/page.tsx
+++ b/examples/composable-dashboard/app/posts/page.tsx
@@ -55,9 +55,14 @@ export default async function PostsPage(props: { searchParams: Promise<{ search?
           <CreatePostDialog fields={(await config).lists.Post.fields} />
         </div>
 
-        {/* Search Bar */}
+        {/* Search Bar — structured classNames slots (issue #709) let us tune a
+            single part (widen the input) without forking the component. */}
         <div className="mb-6">
-          <SearchBar defaultValue={search} placeholder="Search posts by title or content..." />
+          <SearchBar
+            defaultValue={search}
+            placeholder="Search posts by title or content..."
+            classNames={{ input: 'h-11' }}
+          />
         </div>
 
         {/* Posts Table */}
@@ -76,6 +81,13 @@ export default async function PostsPage(props: { searchParams: Promise<{ search?
               }}
               columns={['title', 'authorName', 'status', 'createdAt']}
               sortable
+              // Structured per-part classNames slots (issue #709) — restyle
+              // individual table parts without forking the composite.
+              classNames={{
+                frame: 'shadow-sm',
+                headerCell: 'uppercase text-xs tracking-wide',
+                row: 'hover:bg-accent/40',
+              }}
               emptyMessage={
                 search
                   ? `No posts found matching "${search}"`

--- a/examples/composable-dashboard/components/CreatePostDialog.tsx
+++ b/examples/composable-dashboard/components/CreatePostDialog.tsx
@@ -44,6 +44,8 @@ export function CreatePostDialog({ fields }: { fields: Record<string, FieldConfi
             onCancel={() => setOpen(false)}
             submitLabel="Create Post"
             className="space-y-6"
+            // Structured per-part classNames slots (issue #709).
+            classNames={{ actions: 'justify-end' }}
           />
         </DialogContent>
       </Dialog>

--- a/examples/composable-dashboard/components/PostStatusBadge.tsx
+++ b/examples/composable-dashboard/components/PostStatusBadge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@opensaas/stack-ui/primitives'
+
+/**
+ * Maps a post's status onto the design-system status tokens (issue #709).
+ *
+ * Published → `success`, everything else (draft / unset) → `warning`. No
+ * hardcoded status colours — the shared `Badge` primitive renders the token
+ * variants so the custom dashboard matches the prebuilt admin's status
+ * rendering.
+ */
+export function PostStatusBadge({ status }: { status: string | null }) {
+  return <Badge variant={status === 'published' ? 'success' : 'warning'}>{status ?? 'draft'}</Badge>
+}

--- a/packages/ui/src/components/fields/CheckboxField.tsx
+++ b/packages/ui/src/components/fields/CheckboxField.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Checkbox } from '../../primitives/checkbox.js'
-import { Label } from '../../primitives/label.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface CheckboxFieldProps {
   name: string
@@ -11,6 +11,7 @@ export interface CheckboxFieldProps {
   error?: string
   disabled?: boolean
   mode?: 'read' | 'edit'
+  helpText?: string
 }
 
 export function CheckboxField({
@@ -21,18 +22,19 @@ export function CheckboxField({
   error,
   disabled,
   mode = 'edit',
+  helpText,
 }: CheckboxFieldProps) {
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{value ? 'Yes' : 'No'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{value ? 'Yes' : 'No'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
+    <FieldRoot>
       <div className="flex items-center space-x-2">
         <Checkbox
           id={name}
@@ -41,14 +43,12 @@ export function CheckboxField({
           onCheckedChange={(checked) => onChange(checked === true)}
           disabled={disabled}
         />
-        <Label
-          htmlFor={name}
-          className="leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
+        <FieldLabel htmlFor={name} className="leading-none">
           {label}
-        </Label>
+        </FieldLabel>
       </div>
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/ComboboxField.tsx
+++ b/packages/ui/src/components/fields/ComboboxField.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../primitives/combobox.js'
 import { useRelationshipSearch } from '../../lib/useRelationshipSearch.js'
 import type { ServerActionInput } from '../../server/types.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface ComboboxFieldProps {
   name: string
@@ -26,6 +27,7 @@ export interface ComboboxFieldProps {
   mode?: 'read' | 'edit'
   isLoading?: boolean
   placeholder?: string
+  helpText?: string
   /** Raw list key of the list being edited — required (with `serverAction`) to live-search. */
   listKey?: string
   /** Generic server action used to resolve `relationshipOptions`. */
@@ -49,6 +51,7 @@ export function ComboboxField({
   listKey,
   serverAction,
   debounceMs = 300,
+  helpText,
 }: ComboboxFieldProps) {
   const [open, setOpen] = useState(false)
   const { searchQuery, setSearchQuery, searchResults, isSearching, resolveLabel } =
@@ -68,19 +71,18 @@ export function ComboboxField({
   // Read mode
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <label className="text-sm font-medium text-muted-foreground">{label}</label>
-        <p className="text-sm">{selectedLabel || '-'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{selectedLabel || '-'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <label htmlFor={name} className="text-sm font-medium">
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
+      </FieldLabel>
       <Combobox open={open} onOpenChange={setOpen}>
         <ComboboxTrigger disabled={disabled || isLoading}>
           <span className={!selectedLabel ? 'text-muted-foreground' : ''}>
@@ -138,7 +140,8 @@ export function ComboboxField({
           </ComboboxList>
         </ComboboxContent>
       </Combobox>
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/FileField.tsx
+++ b/packages/ui/src/components/fields/FileField.tsx
@@ -5,7 +5,7 @@ import type { FileMetadata } from '@opensaas/stack-core/internal'
 import { Button } from '../../primitives/button.js'
 import { Input } from '../../primitives/input.js'
 import { Upload, X, File, Check } from 'lucide-react'
-import { FieldLabel, FieldError } from './field-shell.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError } from './field-shell.js'
 
 export interface FileFieldProps {
   name: string
@@ -100,7 +100,7 @@ export function FileField({
   // Read-only mode
   if (mode === 'read') {
     return (
-      <div className="space-y-2">
+      <FieldRoot mode="read">
         {label && (
           <FieldLabel htmlFor={name} required={required}>
             {label}
@@ -129,13 +129,13 @@ export function FileField({
         ) : (
           <p className="text-sm text-muted-foreground">No file uploaded</p>
         )}
-      </div>
+      </FieldRoot>
     )
   }
 
   // Edit mode
   return (
-    <div className="space-y-2">
+    <FieldRoot>
       {label && (
         <FieldLabel htmlFor={name} required={required}>
           {label}
@@ -201,14 +201,14 @@ export function FileField({
             <div className="flex flex-col items-center gap-2 text-center">
               <Upload className="h-8 w-8 text-muted-foreground" />
               <p className="text-sm font-medium">{placeholder}</p>
-              {helpText && <p className="text-xs text-muted-foreground">{helpText}</p>}
             </div>
           </div>
         </>
       )}
 
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
       {error && <FieldError>{error}</FieldError>}
-    </div>
+    </FieldRoot>
   )
 }
 

--- a/packages/ui/src/components/fields/FileField.tsx
+++ b/packages/ui/src/components/fields/FileField.tsx
@@ -4,8 +4,8 @@ import React, { useCallback, useState } from 'react'
 import type { FileMetadata } from '@opensaas/stack-core/internal'
 import { Button } from '../../primitives/button.js'
 import { Input } from '../../primitives/input.js'
-import { Label } from '../../primitives/label.js'
 import { Upload, X, File, Check } from 'lucide-react'
+import { FieldLabel, FieldError } from './field-shell.js'
 
 export interface FileFieldProps {
   name: string
@@ -102,10 +102,9 @@ export function FileField({
     return (
       <div className="space-y-2">
         {label && (
-          <Label htmlFor={name}>
+          <FieldLabel htmlFor={name} required={required}>
             {label}
-            {required && <span className="text-destructive ml-1">*</span>}
-          </Label>
+          </FieldLabel>
         )}
         {isFileMetadata ? (
           <div className="flex items-center gap-2 p-3 border rounded-md bg-muted">
@@ -138,16 +137,15 @@ export function FileField({
   return (
     <div className="space-y-2">
       {label && (
-        <Label htmlFor={name}>
+        <FieldLabel htmlFor={name} required={required}>
           {label}
-          {required && <span className="text-destructive ml-1">*</span>}
-        </Label>
+        </FieldLabel>
       )}
 
       {isFile || isFileMetadata ? (
         // File selected/uploaded - show file info
         <div className="flex items-center gap-2 p-3 border rounded-md">
-          <Check className="h-4 w-4 text-green-600" />
+          <Check className="h-4 w-4 text-success" />
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium truncate">
               {isFile ? (value as File).name : (value as FileMetadata).originalFilename}
@@ -209,7 +207,7 @@ export function FileField({
         </>
       )}
 
-      {error && <p className="text-sm text-destructive">{error}</p>}
+      {error && <FieldError>{error}</FieldError>}
     </div>
   )
 }

--- a/packages/ui/src/components/fields/ImageField.tsx
+++ b/packages/ui/src/components/fields/ImageField.tsx
@@ -5,7 +5,7 @@ import type { ImageMetadata } from '@opensaas/stack-core/internal'
 import { Button } from '../../primitives/button.js'
 import { Input } from '../../primitives/input.js'
 import { Upload, X, Eye, ImageIcon } from 'lucide-react'
-import { FieldLabel, FieldError } from './field-shell.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError } from './field-shell.js'
 import Image from 'next/image.js'
 
 export interface ImageFieldProps {
@@ -121,7 +121,7 @@ export function ImageField({
   // Read-only mode
   if (mode === 'read') {
     return (
-      <div className="space-y-2">
+      <FieldRoot mode="read">
         {label && (
           <FieldLabel htmlFor={name} required={required}>
             {label}
@@ -179,13 +179,13 @@ export function ImageField({
         ) : (
           <p className="text-sm text-muted-foreground">No image uploaded</p>
         )}
-      </div>
+      </FieldRoot>
     )
   }
 
   // Edit mode
   return (
-    <div className="space-y-2">
+    <FieldRoot>
       {label && (
         <FieldLabel htmlFor={name} required={required}>
           {label}
@@ -306,14 +306,14 @@ export function ImageField({
                 <Upload className="h-8 w-8 text-muted-foreground" />
               )}
               <p className="text-sm font-medium">{placeholder}</p>
-              {helpText && <p className="text-xs text-muted-foreground">{helpText}</p>}
             </div>
           </div>
         </>
       )}
 
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
       {error && <FieldError>{error}</FieldError>}
-    </div>
+    </FieldRoot>
   )
 }
 

--- a/packages/ui/src/components/fields/ImageField.tsx
+++ b/packages/ui/src/components/fields/ImageField.tsx
@@ -4,8 +4,8 @@ import React, { useCallback, useState } from 'react'
 import type { ImageMetadata } from '@opensaas/stack-core/internal'
 import { Button } from '../../primitives/button.js'
 import { Input } from '../../primitives/input.js'
-import { Label } from '../../primitives/label.js'
 import { Upload, X, Eye, ImageIcon } from 'lucide-react'
+import { FieldLabel, FieldError } from './field-shell.js'
 import Image from 'next/image.js'
 
 export interface ImageFieldProps {
@@ -123,10 +123,9 @@ export function ImageField({
     return (
       <div className="space-y-2">
         {label && (
-          <Label htmlFor={name}>
+          <FieldLabel htmlFor={name} required={required}>
             {label}
-            {required && <span className="text-destructive ml-1">*</span>}
-          </Label>
+          </FieldLabel>
         )}
         {isImageMetadata ? (
           <div className="space-y-2">
@@ -188,10 +187,9 @@ export function ImageField({
   return (
     <div className="space-y-2">
       {label && (
-        <Label htmlFor={name}>
+        <FieldLabel htmlFor={name} required={required}>
           {label}
-          {required && <span className="text-destructive ml-1">*</span>}
-        </Label>
+        </FieldLabel>
       )}
 
       {previewUrl || isImageMetadata ? (
@@ -314,7 +312,7 @@ export function ImageField({
         </>
       )}
 
-      {error && <p className="text-sm text-destructive">{error}</p>}
+      {error && <FieldError>{error}</FieldError>}
     </div>
   )
 }

--- a/packages/ui/src/components/fields/IntegerField.tsx
+++ b/packages/ui/src/components/fields/IntegerField.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { Input } from '../../primitives/input.js'
-import { Label } from '../../primitives/label.js'
 import { cn } from '../../lib/utils.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface IntegerFieldProps {
   name: string
@@ -16,6 +16,7 @@ export interface IntegerFieldProps {
   mode?: 'read' | 'edit'
   min?: number
   max?: number
+  helpText?: string
 }
 
 export function IntegerField({
@@ -30,22 +31,22 @@ export function IntegerField({
   mode = 'edit',
   min,
   max,
+  helpText,
 }: IntegerFieldProps) {
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{value !== null ? value : '-'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{value !== null ? value : '-'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={name}>
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </Label>
+      </FieldLabel>
       <Input
         id={name}
         name={name}
@@ -60,9 +61,10 @@ export function IntegerField({
         required={required}
         min={min}
         max={max}
-        className={cn(error && 'border-destructive')}
+        className={cn('tabular-nums', error && 'border-destructive')}
       />
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/JsonField.tsx
+++ b/packages/ui/src/components/fields/JsonField.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useMemo } from 'react'
 import { Textarea } from '../../primitives/textarea.js'
-import { Label } from '../../primitives/label.js'
 import { cn } from '../../lib/utils.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldWarning } from './field-shell.js'
 
 export interface JsonFieldProps {
   name: string
@@ -17,6 +17,7 @@ export interface JsonFieldProps {
   mode?: 'read' | 'edit'
   rows?: number
   formatted?: boolean
+  helpText?: string
 }
 
 export function JsonField({
@@ -31,6 +32,7 @@ export function JsonField({
   mode = 'edit',
   rows = 8,
   formatted = true,
+  helpText,
 }: JsonFieldProps) {
   // Track the string being edited separately from the prop value
   const [editingValue, setEditingValue] = useState<string | null>(null)
@@ -82,19 +84,23 @@ export function JsonField({
 
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <pre className="text-sm bg-muted rounded-md p-3 overflow-x-auto">{displayValue || '-'}</pre>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <pre
+          data-slot="field-value"
+          className="text-sm bg-muted rounded-md p-3 overflow-x-auto font-mono"
+        >
+          {displayValue || '-'}
+        </pre>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={name}>
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </Label>
+      </FieldLabel>
       <Textarea
         id={name}
         name={name}
@@ -107,8 +113,9 @@ export function JsonField({
         rows={rows}
         className={cn('font-mono text-sm', (error || parseError) && 'border-destructive')}
       />
-      {parseError && <p className="text-sm text-amber-600">{parseError}</p>}
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {parseError && <FieldWarning>{parseError}</FieldWarning>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/PasswordField.tsx
+++ b/packages/ui/src/components/fields/PasswordField.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Input } from '../../primitives/input.js'
-import { Label } from '../../primitives/label.js'
 import { Button } from '../../primitives/button.js'
 import { cn } from '../../lib/utils.js'
 import { useState } from 'react'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface PasswordFieldProps {
   name: string
@@ -17,6 +17,7 @@ export interface PasswordFieldProps {
   required?: boolean
   mode?: 'read' | 'edit'
   showConfirm?: boolean
+  helpText?: string
 }
 
 export function PasswordField({
@@ -30,6 +31,7 @@ export function PasswordField({
   required,
   mode = 'edit',
   showConfirm = true,
+  helpText,
 }: PasswordFieldProps) {
   // Check if value is the isSet object
   const isSetObject = typeof value === 'object' && value !== null && 'isSet' in value
@@ -42,18 +44,18 @@ export function PasswordField({
 
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{isPasswordSet ? '••••••••' : 'Not set'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{isPasswordSet ? '••••••••' : 'Not set'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   // If not changing password and it's set, show the button
   if (!isChangingPassword && isSetObject) {
     return (
-      <div className="space-y-2">
-        <Label>{label}</Label>
+      <FieldRoot>
+        <FieldLabel>{label}</FieldLabel>
         <div>
           <Button
             type="button"
@@ -64,7 +66,8 @@ export function PasswordField({
             {isPasswordSet ? 'Change Password' : 'Set Password'}
           </Button>
         </div>
-      </div>
+        {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      </FieldRoot>
     )
   }
 
@@ -92,11 +95,10 @@ export function PasswordField({
 
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor={name}>
+      <FieldRoot>
+        <FieldLabel htmlFor={name} required={required && !isPasswordSet}>
           {label}
-          {required && !isPasswordSet && <span className="text-destructive ml-1">*</span>}
-        </Label>
+        </FieldLabel>
         <div className="relative">
           <Input
             id={name}
@@ -117,15 +119,15 @@ export function PasswordField({
             {showPassword ? '👁️' : '👁️‍🗨️'}
           </button>
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-      </div>
+        {helpText && <FieldHelp>{helpText}</FieldHelp>}
+        {error && <FieldError>{error}</FieldError>}
+      </FieldRoot>
 
       {showConfirm && (
-        <div className="space-y-2">
-          <Label htmlFor={`${name}-confirm`}>
+        <FieldRoot>
+          <FieldLabel htmlFor={`${name}-confirm`} required={required && !isPasswordSet}>
             Confirm {label}
-            {required && !isPasswordSet && <span className="text-destructive ml-1">*</span>}
-          </Label>
+          </FieldLabel>
           <Input
             id={`${name}-confirm`}
             name={`${name}-confirm`}
@@ -137,8 +139,8 @@ export function PasswordField({
             required={required && !isPasswordSet}
             className={cn(confirmError && 'border-destructive')}
           />
-          {confirmError && <p className="text-sm text-destructive">{confirmError}</p>}
-        </div>
+          {confirmError && <FieldError>{confirmError}</FieldError>}
+        </FieldRoot>
       )}
 
       {isSetObject && (

--- a/packages/ui/src/components/fields/RelationshipManager.tsx
+++ b/packages/ui/src/components/fields/RelationshipManager.tsx
@@ -23,6 +23,33 @@ import {
 import { Button } from '../../primitives/button.js'
 import { useRelationshipSearch } from '../../lib/useRelationshipSearch.js'
 import type { ServerActionInput } from '../../server/types.js'
+import { cn } from '../../lib/utils.js'
+import { FieldRoot, FieldLabel, FieldError, FieldReadValue } from './field-shell.js'
+
+/**
+ * Per-part `classNames` slots for `RelationshipManager` (issue #709). Each merges
+ * onto its `data-slot` part via `cn`/tailwind-merge.
+ */
+export interface RelationshipManagerClassNames {
+  /** Outer wrapper (`data-slot="relationship-manager"`). */
+  root?: string
+  /** The field label (`data-slot="field-label"`). */
+  label?: string
+  /** The bordered frame around the connected-items table (`data-slot="relationship-manager-frame"`). */
+  frame?: string
+  /** Each connected-item row (`data-slot="table-row"`). */
+  row?: string
+  /** Each connected-item cell (`data-slot="table-cell"`). */
+  cell?: string
+  /** The empty state box (`data-slot="relationship-manager-empty"`). */
+  emptyState?: string
+  /** The action-button row (`data-slot="relationship-manager-actions"`). */
+  actions?: string
+  /** The connect-existing trigger (`data-slot="combobox-trigger"`). */
+  connectButton?: string
+  /** The error message (`data-slot="field-error"`). */
+  error?: string
+}
 
 export interface RelationshipManagerProps {
   name: string
@@ -43,6 +70,8 @@ export interface RelationshipManagerProps {
   serverAction?: (input: ServerActionInput) => Promise<unknown>
   /** Debounce delay (ms) before a typed query issues a server search. @default 300 */
   debounceMs?: number
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: RelationshipManagerClassNames
 }
 
 export function RelationshipManager({
@@ -61,6 +90,7 @@ export function RelationshipManager({
   listKey,
   serverAction,
   debounceMs = 300,
+  classNames,
 }: RelationshipManagerProps) {
   const [showConnectModal, setShowConnectModal] = useState(false)
 
@@ -85,12 +115,14 @@ export function RelationshipManager({
   // Read mode
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <label className="text-sm font-medium text-muted-foreground">{label}</label>
-        <p className="text-sm">
+      <FieldRoot mode="read" data-slot="relationship-manager" className={classNames?.root}>
+        <FieldLabel muted className={classNames?.label}>
+          {label}
+        </FieldLabel>
+        <FieldReadValue>
           {selectedItems.length > 0 ? selectedItems.map((item) => item.label).join(', ') : '-'}
-        </p>
-      </div>
+        </FieldReadValue>
+      </FieldRoot>
     )
   }
 
@@ -105,15 +137,17 @@ export function RelationshipManager({
   }
 
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium">
+    <FieldRoot data-slot="relationship-manager" className={classNames?.root}>
+      <FieldLabel required={required} className={classNames?.label}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
+      </FieldLabel>
 
       {/* Selected Items Table */}
       {selectedItems.length > 0 ? (
-        <div className="rounded-md border border-input">
+        <div
+          data-slot="relationship-manager-frame"
+          className={cn('rounded-md border border-input', classNames?.frame)}
+        >
           <Table>
             <TableHeader>
               <TableRow>
@@ -123,8 +157,8 @@ export function RelationshipManager({
             </TableHeader>
             <TableBody>
               {selectedItems.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell>
+                <TableRow key={item.id} className={classNames?.row}>
+                  <TableCell className={classNames?.cell}>
                     {relatedListKey ? (
                       <Link
                         href={`${basePath}/${relatedListKey}/${item.id}`}
@@ -136,7 +170,7 @@ export function RelationshipManager({
                       item.label
                     )}
                   </TableCell>
-                  <TableCell className="text-right">
+                  <TableCell className={cn('text-right', classNames?.cell)}>
                     <Button
                       type="button"
                       variant="ghost"
@@ -153,7 +187,13 @@ export function RelationshipManager({
           </Table>
         </div>
       ) : (
-        <div className="rounded-md border border-input border-dashed p-8 text-center">
+        <div
+          data-slot="relationship-manager-empty"
+          className={cn(
+            'rounded-md border border-input border-dashed p-8 text-center',
+            classNames?.emptyState,
+          )}
+        >
           <p className="text-sm text-muted-foreground">
             No items connected. Click &quot;Connect Existing&quot; to add items.
           </p>
@@ -161,9 +201,15 @@ export function RelationshipManager({
       )}
 
       {/* Action Buttons */}
-      <div className="flex gap-2">
+      <div
+        data-slot="relationship-manager-actions"
+        className={cn('flex gap-2', classNames?.actions)}
+      >
         <Combobox open={showConnectModal} onOpenChange={setShowConnectModal}>
-          <ComboboxTrigger disabled={disabled || isLoading} className="h-9 px-3">
+          <ComboboxTrigger
+            disabled={disabled || isLoading}
+            className={cn('h-9 px-3', classNames?.connectButton)}
+          >
             <span>{isLoading ? 'Loading...' : 'Connect Existing'}</span>
           </ComboboxTrigger>
           <ComboboxContent>
@@ -197,7 +243,7 @@ export function RelationshipManager({
             and form rendering logic. For now, we'll leave it as a placeholder or implement in a future iteration */}
       </div>
 
-      {error && <p className="text-sm text-destructive mt-2">{error}</p>}
-    </div>
+      {error && <FieldError className={cn('mt-2', classNames?.error)}>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/SelectField.tsx
+++ b/packages/ui/src/components/fields/SelectField.tsx
@@ -7,7 +7,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../primitives/select.js'
-import { Label } from '../../primitives/label.js'
+import { cn } from '../../lib/utils.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface SelectFieldProps {
   name: string
@@ -19,6 +20,7 @@ export interface SelectFieldProps {
   disabled?: boolean
   required?: boolean
   mode?: 'read' | 'edit'
+  helpText?: string
 }
 
 export function SelectField({
@@ -31,30 +33,30 @@ export function SelectField({
   disabled,
   required,
   mode = 'edit',
+  helpText,
 }: SelectFieldProps) {
   if (mode === 'read') {
     const selectedOption = options.find((opt) => opt.value === value)
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{selectedOption?.label || '-'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{selectedOption?.label || '-'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={name}>
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </Label>
+      </FieldLabel>
       <Select
         value={value || undefined}
         onValueChange={(val) => onChange(val || null)}
         disabled={disabled}
         required={required}
       >
-        <SelectTrigger id={name} className={error ? 'border-destructive' : ''}>
+        <SelectTrigger id={name} className={cn(error && 'border-destructive')}>
           <SelectValue placeholder="Select an option..." />
         </SelectTrigger>
         <SelectContent>
@@ -65,7 +67,8 @@ export function SelectField({
           ))}
         </SelectContent>
       </Select>
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/TextField.tsx
+++ b/packages/ui/src/components/fields/TextField.tsx
@@ -2,8 +2,8 @@
 
 import { Input } from '../../primitives/input.js'
 import { Textarea } from '../../primitives/textarea.js'
-import { Label } from '../../primitives/label.js'
 import { cn } from '../../lib/utils.js'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface TextFieldProps {
   name: string
@@ -16,6 +16,7 @@ export interface TextFieldProps {
   required?: boolean
   mode?: 'read' | 'edit'
   displayMode?: 'input' | 'textarea'
+  helpText?: string
 }
 
 export function TextField({
@@ -29,24 +30,24 @@ export function TextField({
   required,
   mode = 'edit',
   displayMode = 'input',
+  helpText,
 }: TextFieldProps) {
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{value || '-'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{value || '-'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   const InputComponent = displayMode === 'textarea' ? Textarea : Input
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={name}>
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </Label>
+      </FieldLabel>
       <InputComponent
         id={name}
         name={name}
@@ -58,7 +59,8 @@ export function TextField({
         required={required}
         className={cn(error && 'border-destructive')}
       />
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/TimestampField.tsx
+++ b/packages/ui/src/components/fields/TimestampField.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Label } from '../../primitives/label.js'
 import { DateTimePicker } from '../../primitives/datetime-picker.js'
 import { format } from 'date-fns'
+import { FieldRoot, FieldLabel, FieldHelp, FieldError, FieldReadValue } from './field-shell.js'
 
 export interface TimestampFieldProps {
   name: string
@@ -13,6 +13,7 @@ export interface TimestampFieldProps {
   disabled?: boolean
   required?: boolean
   mode?: 'read' | 'edit'
+  helpText?: string
 }
 
 export function TimestampField({
@@ -24,26 +25,27 @@ export function TimestampField({
   disabled,
   required,
   mode = 'edit',
+  helpText,
 }: TimestampFieldProps) {
   const dateValue = value ? new Date(value) : null
 
   if (mode === 'read') {
     return (
-      <div className="space-y-1">
-        <Label className="text-muted-foreground">{label}</Label>
-        <p className="text-sm">{dateValue ? format(dateValue, 'PPpp') : '-'}</p>
-      </div>
+      <FieldRoot mode="read">
+        <FieldLabel muted>{label}</FieldLabel>
+        <FieldReadValue>{dateValue ? format(dateValue, 'PPpp') : '-'}</FieldReadValue>
+      </FieldRoot>
     )
   }
 
   return (
-    <div className="space-y-2">
-      <Label htmlFor={name}>
+    <FieldRoot>
+      <FieldLabel htmlFor={name} required={required}>
         {label}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </Label>
+      </FieldLabel>
       <DateTimePicker value={dateValue} onChange={onChange} disabled={disabled} />
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </div>
+      {helpText && <FieldHelp>{helpText}</FieldHelp>}
+      {error && <FieldError>{error}</FieldError>}
+    </FieldRoot>
   )
 }

--- a/packages/ui/src/components/fields/field-shell.tsx
+++ b/packages/ui/src/components/fields/field-shell.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import * as React from 'react'
+import { Label } from '../../primitives/label.js'
+import { cn } from '../../lib/utils.js'
+
+/**
+ * Shared field-shell primitives (issue #709).
+ *
+ * Every field component composes its label / help / error rhythm from these
+ * pieces so that spacing, typography, and status colours are identical across
+ * text, integer, checkbox, select, timestamp, password, relationship, json,
+ * image/file, and combobox fields. All visual values resolve through theme
+ * tokens — `text-muted-foreground`, `text-destructive`, `text-warning`, and the
+ * radius/typography tokens the underlying primitives consume. No hardcoded
+ * status colours live here or in any field that uses this shell.
+ *
+ * These parts carry stable `data-slot` names (`field`, `field-label`,
+ * `field-help`, `field-error`, `field-warning`, `field-value`) so a plain-CSS
+ * restyle can target them, and every part merges a caller `className` via `cn`.
+ */
+
+export interface FieldRootProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Read view uses a tighter rhythm than the editable stack. */
+  mode?: 'read' | 'edit'
+}
+
+/** Outer wrapper providing the field's vertical rhythm. */
+export const FieldRoot = React.forwardRef<HTMLDivElement, FieldRootProps>(
+  ({ className, mode = 'edit', ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="field"
+      className={cn(mode === 'read' ? 'space-y-1' : 'space-y-2', className)}
+      {...props}
+    />
+  ),
+)
+FieldRoot.displayName = 'FieldRoot'
+
+export interface FieldLabelProps extends React.ComponentPropsWithoutRef<typeof Label> {
+  /** Renders the required marker (`*`) after the label text. */
+  required?: boolean
+  /** Muted styling used by read views. */
+  muted?: boolean
+}
+
+/** Field label with a consistent required marker. */
+export function FieldLabel({ required, muted, className, children, ...props }: FieldLabelProps) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(muted && 'text-muted-foreground', className)}
+      {...props}
+    >
+      {children}
+      {required && (
+        <span data-slot="field-required" className="ml-1 text-destructive">
+          *
+        </span>
+      )}
+    </Label>
+  )
+}
+
+/** Secondary help / description text below the control. */
+export function FieldHelp({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p
+      data-slot="field-help"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+/** Destructive validation message. */
+export function FieldError({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p data-slot="field-error" className={cn('text-sm text-destructive', className)} {...props} />
+  )
+}
+
+/** Non-blocking warning message (e.g. an in-progress invalid JSON edit). */
+export function FieldWarning({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p data-slot="field-warning" className={cn('text-sm text-warning', className)} {...props} />
+  )
+}
+
+/** Read-mode scalar value display shared by field read views. */
+export function FieldReadValue({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p data-slot="field-value" className={cn('text-sm', className)} {...props} />
+}

--- a/packages/ui/src/components/fields/index.ts
+++ b/packages/ui/src/components/fields/index.ts
@@ -13,6 +13,17 @@ export { FieldRenderer } from './FieldRenderer.js'
 export { FileField } from './FileField.js'
 export { ImageField } from './ImageField.js'
 
+// Shared field shell primitives (consistent label / help / error rhythm)
+export {
+  FieldRoot,
+  FieldLabel,
+  FieldHelp,
+  FieldError,
+  FieldWarning,
+  FieldReadValue,
+} from './field-shell.js'
+export type { FieldRootProps, FieldLabelProps } from './field-shell.js'
+
 // Registry for custom field types
 export { fieldComponentRegistry, registerFieldComponent, getFieldComponent } from './registry.js'
 
@@ -26,7 +37,10 @@ export type { PasswordFieldProps } from './PasswordField.js'
 export type { RelationshipFieldProps } from './RelationshipField.js'
 export type { JsonFieldProps } from './JsonField.js'
 export type { ComboboxFieldProps } from './ComboboxField.js'
-export type { RelationshipManagerProps } from './RelationshipManager.js'
+export type {
+  RelationshipManagerProps,
+  RelationshipManagerClassNames,
+} from './RelationshipManager.js'
 export type { FieldRendererProps } from './FieldRenderer.js'
 export type { FileFieldProps } from './FileField.js'
 export type { ImageFieldProps } from './ImageField.js'

--- a/packages/ui/src/components/standalone/DeleteButton.tsx
+++ b/packages/ui/src/components/standalone/DeleteButton.tsx
@@ -4,6 +4,18 @@ import { useState } from 'react'
 import { Button } from '../../primitives/button.js'
 import { ConfirmDialog } from '../ConfirmDialog.js'
 import { LoadingSpinner } from '../LoadingSpinner.js'
+import { cn } from '../../lib/utils.js'
+
+/**
+ * Per-part `classNames` slots for `DeleteButton` (issue #709). Each merges onto
+ * its `data-slot` part via `cn`/tailwind-merge.
+ */
+export interface DeleteButtonClassNames {
+  /** The trigger button (`data-slot="button"`). */
+  button?: string
+  /** The inline error banner (`data-slot="delete-button-error"`). */
+  error?: string
+}
 
 export interface DeleteButtonProps {
   onDelete: () => Promise<{ success: boolean; error?: string }>
@@ -17,6 +29,8 @@ export interface DeleteButtonProps {
   buttonVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
   size?: 'default' | 'sm' | 'lg' | 'icon'
   className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: DeleteButtonClassNames
   disabled?: boolean
 }
 
@@ -48,6 +62,7 @@ export function DeleteButton({
   buttonVariant = 'destructive',
   size = 'default',
   className,
+  classNames,
   disabled = false,
 }: DeleteButtonProps) {
   const [showConfirm, setShowConfirm] = useState(false)
@@ -79,7 +94,7 @@ export function DeleteButton({
         size={size}
         onClick={() => setShowConfirm(true)}
         disabled={disabled || isPending}
-        className={className}
+        className={cn(className, classNames?.button)}
       >
         {isPending && (
           <LoadingSpinner
@@ -91,7 +106,13 @@ export function DeleteButton({
       </Button>
 
       {error && (
-        <div className="mt-2 bg-destructive/10 border border-destructive text-destructive rounded-lg p-3">
+        <div
+          data-slot="delete-button-error"
+          className={cn(
+            'mt-2 bg-destructive/10 border border-destructive text-destructive rounded-lg p-3',
+            classNames?.error,
+          )}
+        >
           <p className="text-sm font-medium">{error}</p>
         </div>
       )}

--- a/packages/ui/src/components/standalone/ItemCreateForm.tsx
+++ b/packages/ui/src/components/standalone/ItemCreateForm.tsx
@@ -8,6 +8,8 @@ import { Button } from '../../primitives/button.js'
 import type { FieldConfig } from '@opensaas/stack-core'
 import { serializeFieldConfigs } from '../../lib/serializeFieldConfig.js'
 import { useItemForm } from '../../lib/useItemForm.js'
+import { cn } from '../../lib/utils.js'
+import type { ItemFormClassNames } from './form-classnames.js'
 
 export interface ItemCreateFormProps<TData = Record<string, unknown>> {
   fields: Record<string, FieldConfig>
@@ -17,6 +19,8 @@ export interface ItemCreateFormProps<TData = Record<string, unknown>> {
   submitLabel?: string
   cancelLabel?: string
   className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: ItemFormClassNames
 }
 
 /**
@@ -43,6 +47,7 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
   submitLabel = 'Create',
   cancelLabel = 'Cancel',
   className,
+  classNames,
 }: ItemCreateFormProps<TData>) {
   // Serialize field configs to remove non-serializable properties
   const serializedFields = useMemo(() => serializeFieldConfigs(fields), [fields])
@@ -68,16 +73,26 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
   })
 
   return (
-    <form onSubmit={handleSubmit} className={className}>
+    <form
+      data-slot="item-create-form"
+      onSubmit={handleSubmit}
+      className={cn(className, classNames?.root)}
+    >
       {/* General Error */}
       {generalError && (
-        <div className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6">
+        <div
+          data-slot="form-error"
+          className={cn(
+            'bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6',
+            classNames?.error,
+          )}
+        >
           <p className="text-sm font-medium">{generalError}</p>
         </div>
       )}
 
       {/* Form Fields */}
-      <div className="space-y-6">
+      <div data-slot="form-fields" className={cn('space-y-6', classNames?.fields)}>
         {editableFields.map(([fieldName, fieldConfig]) => (
           <FieldRenderer
             key={fieldName}
@@ -95,15 +110,24 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
       </div>
 
       {/* Form Actions */}
-      <div className="flex gap-3 pt-6 mt-6 border-t border-border">
-        <Button type="submit" disabled={isPending} className="gap-2">
+      <div
+        data-slot="form-actions"
+        className={cn('flex gap-3 pt-6 mt-6 border-t border-border', classNames?.actions)}
+      >
+        <Button type="submit" disabled={isPending} className={cn('gap-2', classNames?.submit)}>
           {isPending && (
             <LoadingSpinner size="sm" className="border-primary-foreground border-t-transparent" />
           )}
           {isPending ? 'Creating...' : submitLabel}
         </Button>
         {onCancel && (
-          <Button type="button" variant="secondary" onClick={onCancel} disabled={isPending}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCancel}
+            disabled={isPending}
+            className={classNames?.cancel}
+          >
             {cancelLabel}
           </Button>
         )}

--- a/packages/ui/src/components/standalone/ItemEditForm.tsx
+++ b/packages/ui/src/components/standalone/ItemEditForm.tsx
@@ -8,6 +8,8 @@ import { Button } from '../../primitives/button.js'
 import type { FieldConfig } from '@opensaas/stack-core'
 import { serializeFieldConfigs } from '../../lib/serializeFieldConfig.js'
 import { useItemForm, transformInitialData } from '../../lib/useItemForm.js'
+import { cn } from '../../lib/utils.js'
+import type { ItemFormClassNames } from './form-classnames.js'
 
 export interface ItemEditFormProps<TData = Record<string, unknown>> {
   fields: Record<string, FieldConfig>
@@ -18,6 +20,8 @@ export interface ItemEditFormProps<TData = Record<string, unknown>> {
   submitLabel?: string
   cancelLabel?: string
   className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: ItemFormClassNames
   basePath?: string
 }
 
@@ -47,6 +51,7 @@ export function ItemEditForm<TData = Record<string, unknown>>({
   submitLabel = 'Save',
   cancelLabel = 'Cancel',
   className,
+  classNames,
   basePath = '/admin',
 }: ItemEditFormProps<TData>) {
   // Serialize field configs to remove non-serializable properties
@@ -80,16 +85,26 @@ export function ItemEditForm<TData = Record<string, unknown>>({
   })
 
   return (
-    <form onSubmit={handleSubmit} className={className}>
+    <form
+      data-slot="item-edit-form"
+      onSubmit={handleSubmit}
+      className={cn(className, classNames?.root)}
+    >
       {/* General Error */}
       {generalError && (
-        <div className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6">
+        <div
+          data-slot="form-error"
+          className={cn(
+            'bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6',
+            classNames?.error,
+          )}
+        >
           <p className="text-sm font-medium">{generalError}</p>
         </div>
       )}
 
       {/* Form Fields */}
-      <div className="space-y-6">
+      <div data-slot="form-fields" className={cn('space-y-6', classNames?.fields)}>
         {editableFields.map(([fieldName, fieldConfig]) => (
           <FieldRenderer
             key={fieldName}
@@ -108,15 +123,24 @@ export function ItemEditForm<TData = Record<string, unknown>>({
       </div>
 
       {/* Form Actions */}
-      <div className="flex gap-3 pt-6 mt-6 border-t border-border">
-        <Button type="submit" disabled={isPending} className="gap-2">
+      <div
+        data-slot="form-actions"
+        className={cn('flex gap-3 pt-6 mt-6 border-t border-border', classNames?.actions)}
+      >
+        <Button type="submit" disabled={isPending} className={cn('gap-2', classNames?.submit)}>
           {isPending && (
             <LoadingSpinner size="sm" className="border-primary-foreground border-t-transparent" />
           )}
           {isPending ? 'Saving...' : submitLabel}
         </Button>
         {onCancel && (
-          <Button type="button" variant="secondary" onClick={onCancel} disabled={isPending}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCancel}
+            disabled={isPending}
+            className={classNames?.cancel}
+          >
             {cancelLabel}
           </Button>
         )}

--- a/packages/ui/src/components/standalone/ListTable.tsx
+++ b/packages/ui/src/components/standalone/ListTable.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { useState } from 'react'
 import Link from 'next/link.js'
-import { formatFieldName, getFieldDisplayValue } from '../../lib/utils.js'
+import { cn, formatFieldName, getFieldDisplayValue } from '../../lib/utils.js'
 import { getUrlKey } from '@opensaas/stack-core'
 import {
   Table,
@@ -12,6 +12,38 @@ import {
   TableHeader,
   TableRow,
 } from '../../primitives/table.js'
+
+/**
+ * Per-part `classNames` slots for `ListTable` (issue #709). Each slot is merged
+ * onto the matching part via `cn`/tailwind-merge so caller classes win, and the
+ * part carries a stable `data-slot` for plain-CSS restyling.
+ */
+export interface ListTableClassNames {
+  /** Outer wrapper (`data-slot="list-table"`). */
+  root?: string
+  /** Bordered frame around the table (`data-slot="list-table-frame"`). */
+  frame?: string
+  /** The `<table>` element (`data-slot="table"`). */
+  table?: string
+  /** The `<thead>` (`data-slot="table-header"`). */
+  header?: string
+  /** The header `<tr>` (`data-slot="table-row"`). */
+  headerRow?: string
+  /** Each header `<th>` (`data-slot="table-head"`). */
+  headerCell?: string
+  /** The `<tbody>` (`data-slot="table-body"`). */
+  body?: string
+  /** Each body `<tr>` (`data-slot="table-row"`). */
+  row?: string
+  /** Each body `<td>` (`data-slot="table-cell"`). */
+  cell?: string
+  /** The actions column header, when `renderActions` is set. */
+  actionsHeader?: string
+  /** The actions column cell, when `renderActions` is set. */
+  actionsCell?: string
+  /** The empty-state cell (`data-slot="list-table-empty"`). */
+  empty?: string
+}
 
 /**
  * `ListTable` is a standalone component embedded by consumers with raw
@@ -54,6 +86,8 @@ export interface ListTableProps {
   sortable?: boolean
   emptyMessage?: string
   className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: ListTableClassNames
   renderActions?: (item: Record<string, unknown>) => React.ReactNode
 }
 
@@ -85,6 +119,7 @@ export function ListTable({
   sortable = true,
   emptyMessage = 'No items found',
   className,
+  classNames,
   renderActions,
 }: ListTableProps) {
   const [sortBy, setSortBy] = useState<string | null>(null)
@@ -180,15 +215,18 @@ export function ListTable({
   }
 
   return (
-    <div className={className}>
-      <div className="rounded-lg border">
-        <Table>
-          <TableHeader>
-            <TableRow>
+    <div data-slot="list-table" className={cn(className, classNames?.root)}>
+      <div data-slot="list-table-frame" className={cn('rounded-lg border', classNames?.frame)}>
+        <Table className={classNames?.table}>
+          <TableHeader className={classNames?.header}>
+            <TableRow className={classNames?.headerRow}>
               {displayColumns.map((column) => (
                 <TableHead
                   key={column}
-                  className={sortable ? 'cursor-pointer hover:bg-muted/70 transition-colors' : ''}
+                  className={cn(
+                    sortable && 'cursor-pointer hover:bg-muted/70 transition-colors',
+                    classNames?.headerCell,
+                  )}
                   onClick={() => handleSort(column)}
                 >
                   <div className="flex items-center space-x-1">
@@ -199,15 +237,20 @@ export function ListTable({
                   </div>
                 </TableHead>
               ))}
-              {renderActions && <TableHead className="text-right">Actions</TableHead>}
+              {renderActions && (
+                <TableHead className={cn('text-right', classNames?.actionsHeader)}>
+                  Actions
+                </TableHead>
+              )}
             </TableRow>
           </TableHeader>
-          <TableBody>
+          <TableBody className={classNames?.body}>
             {sortedItems.length === 0 ? (
-              <TableRow>
+              <TableRow className={classNames?.row}>
                 <TableCell
+                  data-slot="list-table-empty"
                   colSpan={displayColumns.length + (renderActions ? 1 : 0)}
-                  className="h-24 text-center"
+                  className={cn('h-24 text-center', classNames?.empty)}
                 >
                   {emptyMessage}
                 </TableCell>
@@ -216,18 +259,21 @@ export function ListTable({
               sortedItems.map((item) => (
                 <TableRow
                   key={String(item.id)}
-                  className={onRowClick ? 'cursor-pointer' : ''}
+                  className={cn(onRowClick && 'cursor-pointer', classNames?.row)}
                   onClick={() => onRowClick?.(item)}
                 >
                   {displayColumns.map((column) => (
-                    <TableCell key={column}>
+                    <TableCell key={column} className={classNames?.cell}>
                       {fieldTypes[column] === 'relationship'
                         ? renderRelationshipCell(item[column], column)
                         : getFieldDisplayValue(item[column], fieldTypes[column])}
                     </TableCell>
                   ))}
                   {renderActions && (
-                    <TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
+                    <TableCell
+                      className={cn('text-right', classNames?.actionsCell)}
+                      onClick={(e) => e.stopPropagation()}
+                    >
                       {renderActions(item)}
                     </TableCell>
                   )}

--- a/packages/ui/src/components/standalone/SearchBar.tsx
+++ b/packages/ui/src/components/standalone/SearchBar.tsx
@@ -5,7 +5,27 @@ import { useState } from 'react'
 import { Input } from '../../primitives/input.js'
 import { Button } from '../../primitives/button.js'
 import { Card } from '../../primitives/card.js'
+import { cn } from '../../lib/utils.js'
 import { usePathname, useRouter } from 'next/navigation.js'
+
+/**
+ * Per-part `classNames` slots for `SearchBar` (issue #709). Each merges onto its
+ * `data-slot` part via `cn`/tailwind-merge.
+ */
+export interface SearchBarClassNames {
+  /** Card wrapper (`data-slot="search-bar"`). */
+  root?: string
+  /** The `<form>` (`data-slot="search-bar-form"`). */
+  form?: string
+  /** Wrapper around the input + clear button. */
+  inputWrapper?: string
+  /** The search `<input>` (`data-slot="input"`). */
+  input?: string
+  /** The inline clear button (`data-slot="search-bar-clear"`). */
+  clearButton?: string
+  /** The submit button (`data-slot="button"`). */
+  submit?: string
+}
 
 export interface SearchBarProps {
   onSearch?: (query: string) => void
@@ -14,6 +34,8 @@ export interface SearchBarProps {
   defaultValue?: string
   searchLabel?: string
   className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: SearchBarClassNames
 }
 
 /**
@@ -42,6 +64,7 @@ export function SearchBar({
   defaultValue = '',
   searchLabel = 'Search',
   className,
+  classNames,
 }: SearchBarProps) {
   const router = useRouter()
   const pathname = usePathname()
@@ -59,27 +82,37 @@ export function SearchBar({
   }
 
   return (
-    <Card className={`p-4 ${className || ''}`}>
-      <form onSubmit={handleSubmit} className="flex gap-2">
-        <div className="flex-1 relative">
+    <Card data-slot="search-bar" className={cn('p-4', className, classNames?.root)}>
+      <form
+        data-slot="search-bar-form"
+        onSubmit={handleSubmit}
+        className={cn('flex gap-2', classNames?.form)}
+      >
+        <div className={cn('flex-1 relative', classNames?.inputWrapper)}>
           <Input
             type="text"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder={placeholder}
-            className="pr-10"
+            className={cn('pr-10', classNames?.input)}
           />
           {searchInput && (
             <button
               type="button"
+              data-slot="search-bar-clear"
               onClick={handleClear}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              className={cn(
+                'absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground',
+                classNames?.clearButton,
+              )}
             >
               ✕
             </button>
           )}
         </div>
-        <Button type="submit">{searchLabel}</Button>
+        <Button type="submit" className={classNames?.submit}>
+          {searchLabel}
+        </Button>
       </form>
     </Card>
   )

--- a/packages/ui/src/components/standalone/form-classnames.ts
+++ b/packages/ui/src/components/standalone/form-classnames.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-part `classNames` slots shared by `ItemCreateForm` and `ItemEditForm`
+ * (issue #709). Each slot merges onto its `data-slot` part via
+ * `cn`/tailwind-merge so caller classes win. The forms apply the spec's section
+ * rhythm: a `space-y-6` fields section and a bordered actions footer.
+ */
+export interface ItemFormClassNames {
+  /** The `<form>` root (`data-slot="item-create-form"` / `"item-edit-form"`). */
+  root?: string
+  /** The general (form-level) error banner (`data-slot="form-error"`). */
+  error?: string
+  /** The fields section (`data-slot="form-fields"`). */
+  fields?: string
+  /** The actions footer (`data-slot="form-actions"`). */
+  actions?: string
+  /** The submit button (`data-slot="button"`). */
+  submit?: string
+  /** The cancel button (`data-slot="button"`). */
+  cancel?: string
+}

--- a/packages/ui/src/components/standalone/index.ts
+++ b/packages/ui/src/components/standalone/index.ts
@@ -8,6 +8,9 @@ export { DeleteButton } from './DeleteButton.js'
 // Types
 export type { ItemCreateFormProps } from './ItemCreateForm.js'
 export type { ItemEditFormProps } from './ItemEditForm.js'
-export type { ListTableProps } from './ListTable.js'
-export type { SearchBarProps } from './SearchBar.js'
-export type { DeleteButtonProps } from './DeleteButton.js'
+export type { ListTableProps, ListTableClassNames } from './ListTable.js'
+export type { SearchBarProps, SearchBarClassNames } from './SearchBar.js'
+export type { DeleteButtonProps, DeleteButtonClassNames } from './DeleteButton.js'
+
+// Shared per-part classNames slot shape for the create / edit forms
+export type { ItemFormClassNames } from './form-classnames.js'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,10 @@ export { ConfirmDialog } from './components/ConfirmDialog.js'
 export { LoadingSpinner } from './components/LoadingSpinner.js'
 export { SkeletonLoader, TableSkeleton, FormSkeleton } from './components/SkeletonLoader.js'
 
+// Status badge primitive (success / warning / destructive tokens)
+export { Badge, badgeVariants } from './primitives/badge.js'
+export type { BadgeProps } from './primitives/badge.js'
+
 // Field components
 export {
   TextField,
@@ -27,6 +31,12 @@ export {
   fieldComponentRegistry,
   registerFieldComponent,
   getFieldComponent,
+  FieldRoot,
+  FieldLabel,
+  FieldHelp,
+  FieldError,
+  FieldWarning,
+  FieldReadValue,
 } from './components/fields/index.js'
 
 // Types
@@ -70,8 +80,12 @@ export type {
   ItemCreateFormProps,
   ItemEditFormProps,
   ListTableProps,
+  ListTableClassNames,
   SearchBarProps,
+  SearchBarClassNames,
   DeleteButtonProps,
+  DeleteButtonClassNames,
+  ItemFormClassNames,
 } from './components/standalone/index.js'
 
 // Utility functions

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '../lib/utils.js'
+
+/**
+ * Status badge primitive (issue #709). Every intent variant resolves through a
+ * theme token — `success`, `warning`, and `destructive` render published /
+ * draft / error states with NO hardcoded status colours. Radius comes from the
+ * `--radius` token (`rounded-md`) and typography from `font-sans`.
+ */
+const badgeVariants = cva(
+  'inline-flex items-center gap-1 rounded-md border px-2 py-0.5 font-sans text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary/10 text-primary',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        success: 'border-transparent bg-success/15 text-success',
+        warning: 'border-transparent bg-warning/15 text-warning',
+        destructive: 'border-transparent bg-destructive/15 text-destructive',
+        outline: 'border-border text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,5 +1,6 @@
 // Primitive components from shadcn/ui
 export { Button, buttonVariants, type ButtonProps } from './button.js'
+export { Badge, badgeVariants, type BadgeProps } from './badge.js'
 export { Input, type InputProps } from './input.js'
 export { Textarea, type TextareaProps } from './textarea.js'
 export { Label } from './label.js'

--- a/packages/ui/tests/browser/components/composite-data-slot.browser.test.tsx
+++ b/packages/ui/tests/browser/components/composite-data-slot.browser.test.tsx
@@ -32,7 +32,7 @@ describe('status/composite plain-CSS override via [data-slot] (no Tailwind pipel
     style.setAttribute('data-test', 'status-plain-css')
     style.textContent = `
       [data-slot="badge"] { background-color: rgb(10, 11, 12); }
-      [data-slot="delete-button"] { background-color: rgb(13, 14, 15); }
+      [data-slot="button"] { background-color: rgb(13, 14, 15); }
     `
     document.head.appendChild(style)
 
@@ -48,11 +48,10 @@ describe('status/composite plain-CSS override via [data-slot] (no Tailwind pipel
       )
 
       expect(getComputedStyle(requireSlot('badge')).backgroundColor).toBe('rgb(10, 11, 12)')
-      const deleteButton = document.body.querySelector('.delete-button')
-      if (!(deleteButton instanceof HTMLElement)) {
-        throw new Error('Expected the DeleteButton trigger to render')
-      }
-      // The caller classNames.button slot landed on the trigger.
+      // The DeleteButton trigger restyles from a plain rule targeting its stable
+      // `data-slot="button"`, and the caller classNames.button slot also landed.
+      const deleteButton = requireSlot('button')
+      expect(getComputedStyle(deleteButton).backgroundColor).toBe('rgb(13, 14, 15)')
       expect(deleteButton).toHaveClass('delete-button')
     } finally {
       style.remove()

--- a/packages/ui/tests/browser/components/composite-data-slot.browser.test.tsx
+++ b/packages/ui/tests/browser/components/composite-data-slot.browser.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { DeleteButton } from '../../../src/components/standalone/DeleteButton.js'
+import { Badge } from '../../../src/primitives/badge.js'
+
+/**
+ * Browser-mode half of the #709 status/slot contract. Proves the enforceable
+ * promise that a plain-CSS rule targeting a stable `data-slot` restyles a #709
+ * component with NO Tailwind pipeline — extended here to the status `Badge`
+ * (new) and the `DeleteButton` composite. Assertion is on external behaviour
+ * only: the computed style under an injected plain stylesheet.
+ *
+ * (Composites that render `next/link`, like `ListTable`, are exercised by the
+ * happy-dom contract suite instead; `next/link` is not importable in the
+ * browser-mode runner.)
+ */
+
+afterEach(() => cleanup())
+
+const requireSlot = (name: string): HTMLElement => {
+  const node = document.body.querySelector(`[data-slot="${name}"]`)
+  if (!(node instanceof HTMLElement)) {
+    throw new Error(`Expected a rendered element for data-slot="${name}"`)
+  }
+  return node
+}
+
+describe('status/composite plain-CSS override via [data-slot] (no Tailwind pipeline)', () => {
+  it('restyles a status Badge and a DeleteButton trigger from a plain stylesheet', () => {
+    const style = document.createElement('style')
+    style.setAttribute('data-test', 'status-plain-css')
+    style.textContent = `
+      [data-slot="badge"] { background-color: rgb(10, 11, 12); }
+      [data-slot="delete-button"] { background-color: rgb(13, 14, 15); }
+    `
+    document.head.appendChild(style)
+
+    try {
+      render(
+        <div>
+          <Badge variant="success">Published</Badge>
+          <DeleteButton
+            onDelete={async () => ({ success: true })}
+            classNames={{ button: 'delete-button' }}
+          />
+        </div>,
+      )
+
+      expect(getComputedStyle(requireSlot('badge')).backgroundColor).toBe('rgb(10, 11, 12)')
+      const deleteButton = document.body.querySelector('.delete-button')
+      if (!(deleteButton instanceof HTMLElement)) {
+        throw new Error('Expected the DeleteButton trigger to render')
+      }
+      // The caller classNames.button slot landed on the trigger.
+      expect(deleteButton).toHaveClass('delete-button')
+    } finally {
+      style.remove()
+    }
+  })
+})

--- a/packages/ui/tests/components/composite-classnames.test.tsx
+++ b/packages/ui/tests/components/composite-classnames.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { text } from '@opensaas/stack-core/fields'
+import type { FieldConfig } from '@opensaas/stack-core'
+
+import { ListTable } from '../../src/components/standalone/ListTable.js'
+import { SearchBar } from '../../src/components/standalone/SearchBar.js'
+import { DeleteButton } from '../../src/components/standalone/DeleteButton.js'
+import { ItemCreateForm } from '../../src/components/standalone/ItemCreateForm.js'
+import { ItemEditForm } from '../../src/components/standalone/ItemEditForm.js'
+import { RelationshipManager } from '../../src/components/fields/RelationshipManager.js'
+
+// Next.js navigation is used by SearchBar.
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/admin/posts',
+}))
+
+/**
+ * Contract test suite for the composite `data-slot` + structured `classNames`
+ * promise (issue #709). Each composite part must expose a stable `data-slot`
+ * name AND merge a caller `classNames` slot via tailwind-merge so instance
+ * overrides win. Assertions are on external behaviour only — the rendered
+ * node's `data-slot` attribute and its resolved class list — never internal
+ * structure.
+ */
+
+const findSlot = (container: HTMLElement, slot: string): Element | null =>
+  container.querySelector(`[data-slot="${slot}"]`)
+
+describe('ListTable classNames + data-slot contract', () => {
+  const items = [
+    { id: '1', title: 'First', status: 'published' },
+    { id: '2', title: 'Second', status: 'draft' },
+  ]
+  const fieldTypes = { title: 'text', status: 'select' }
+
+  it('exposes the list-table root data-slot', () => {
+    const { container } = render(<ListTable items={items} fieldTypes={fieldTypes} />)
+    expect(findSlot(container, 'list-table')).toHaveAttribute('data-slot', 'list-table')
+  })
+
+  it('merges classNames.root onto the root and classNames.frame onto the frame', () => {
+    const { container } = render(
+      <ListTable
+        items={items}
+        fieldTypes={fieldTypes}
+        classNames={{ root: 'os-root', frame: 'os-frame' }}
+      />,
+    )
+    expect(findSlot(container, 'list-table')).toHaveClass('os-root')
+    expect(findSlot(container, 'list-table-frame')).toHaveClass('os-frame')
+  })
+
+  it('overrides a body cell default via classNames.cell (tailwind-merge)', () => {
+    const withDefault = render(<ListTable items={items} fieldTypes={fieldTypes} />)
+    const defaultCell = withDefault.container.querySelector(
+      '[data-slot="table-body"] [data-slot="table-cell"]',
+    )
+    expect(defaultCell).toHaveClass('p-4')
+
+    const withOverride = render(
+      <ListTable items={items} fieldTypes={fieldTypes} classNames={{ cell: 'p-8' }} />,
+    )
+    const overriddenCell = withOverride.container.querySelector(
+      '[data-slot="table-body"] [data-slot="table-cell"]',
+    )
+    expect(overriddenCell).toHaveClass('p-8')
+    expect(overriddenCell).not.toHaveClass('p-4')
+  })
+
+  it('merges classNames.row onto body rows and classNames.headerCell onto head cells', () => {
+    const { container } = render(
+      <ListTable
+        items={items}
+        fieldTypes={fieldTypes}
+        classNames={{ row: 'os-row', headerCell: 'os-head' }}
+      />,
+    )
+    const bodyRow = container.querySelector('[data-slot="table-body"] [data-slot="table-row"]')
+    expect(bodyRow).toHaveClass('os-row')
+    expect(findSlot(container, 'table-head')).toHaveClass('os-head')
+  })
+
+  it('carries the empty-state data-slot and merges classNames.empty', () => {
+    const { container } = render(
+      <ListTable items={[]} fieldTypes={fieldTypes} classNames={{ empty: 'os-empty' }} />,
+    )
+    const empty = findSlot(container, 'list-table-empty')
+    expect(empty).toHaveAttribute('data-slot', 'list-table-empty')
+    expect(empty).toHaveClass('os-empty')
+  })
+})
+
+describe('SearchBar classNames + data-slot contract', () => {
+  it('exposes the search-bar and form data-slots', () => {
+    const { container } = render(<SearchBar />)
+    expect(findSlot(container, 'search-bar')).toHaveAttribute('data-slot', 'search-bar')
+    expect(findSlot(container, 'search-bar-form')).toHaveAttribute('data-slot', 'search-bar-form')
+  })
+
+  it('merges classNames.form and overrides the input padding default', () => {
+    const { container } = render(<SearchBar classNames={{ form: 'os-form', input: 'pr-2' }} />)
+    expect(findSlot(container, 'search-bar-form')).toHaveClass('os-form')
+    const input = findSlot(container, 'input')
+    expect(input).toHaveClass('pr-2')
+    // Default `pr-10` gives way to the caller's `pr-2`.
+    expect(input).not.toHaveClass('pr-10')
+  })
+})
+
+describe('DeleteButton classNames + data-slot contract', () => {
+  it('merges classNames.button onto the trigger button', () => {
+    const { container } = render(
+      <DeleteButton onDelete={vi.fn()} classNames={{ button: 'os-delete' }} />,
+    )
+    expect(findSlot(container, 'button')).toHaveClass('os-delete')
+  })
+})
+
+describe('Item forms classNames + data-slot contract', () => {
+  const fields: Record<string, FieldConfig> = {
+    title: text({ validation: { isRequired: true } }),
+  }
+
+  it('ItemCreateForm exposes its data-slots and merges classNames slots', () => {
+    const { container } = render(
+      <ItemCreateForm
+        fields={fields}
+        onSubmit={vi.fn().mockResolvedValue({ success: true })}
+        onCancel={vi.fn()}
+        classNames={{ root: 'os-form', fields: 'os-fields', actions: 'os-actions' }}
+      />,
+    )
+    const form = findSlot(container, 'item-create-form')
+    expect(form).toHaveAttribute('data-slot', 'item-create-form')
+    expect(form).toHaveClass('os-form')
+    expect(findSlot(container, 'form-fields')).toHaveClass('os-fields')
+    expect(findSlot(container, 'form-actions')).toHaveClass('os-actions')
+  })
+
+  it('ItemEditForm exposes its data-slots and merges classNames slots', () => {
+    const { container } = render(
+      <ItemEditForm
+        fields={fields}
+        initialData={{ title: 'Hi' }}
+        onSubmit={vi.fn().mockResolvedValue({ success: true })}
+        classNames={{ root: 'os-form', actions: 'os-actions' }}
+      />,
+    )
+    const form = findSlot(container, 'item-edit-form')
+    expect(form).toHaveAttribute('data-slot', 'item-edit-form')
+    expect(form).toHaveClass('os-form')
+    expect(findSlot(container, 'form-actions')).toHaveClass('os-actions')
+  })
+})
+
+describe('RelationshipManager classNames + data-slot contract', () => {
+  const items = [
+    { id: 't1', label: 'engineering' },
+    { id: 't2', label: 'design' },
+  ]
+
+  it('exposes the relationship-manager root and merges classNames.frame', () => {
+    const { container } = render(
+      <RelationshipManager
+        name="tags"
+        value={['t1']}
+        onChange={vi.fn()}
+        label="Tags"
+        items={items}
+        classNames={{ root: 'os-rm', frame: 'os-frame' }}
+      />,
+    )
+    const root = findSlot(container, 'relationship-manager')
+    expect(root).toHaveAttribute('data-slot', 'relationship-manager')
+    expect(root).toHaveClass('os-rm')
+    expect(findSlot(container, 'relationship-manager-frame')).toHaveClass('os-frame')
+  })
+
+  it('merges classNames.emptyState onto the empty state and connectButton onto the trigger', () => {
+    const { container } = render(
+      <RelationshipManager
+        name="tags"
+        value={[]}
+        onChange={vi.fn()}
+        label="Tags"
+        items={items}
+        classNames={{ emptyState: 'os-empty', connectButton: 'os-connect' }}
+      />,
+    )
+    expect(findSlot(container, 'relationship-manager-empty')).toHaveClass('os-empty')
+    expect(findSlot(container, 'combobox-trigger')).toHaveClass('os-connect')
+  })
+})
+
+describe('required field marker (shared shell) still renders', () => {
+  it('shows the * marker for a required field in a form', () => {
+    const fields: Record<string, FieldConfig> = {
+      title: text({ validation: { isRequired: true } }),
+    }
+    render(
+      <ItemCreateForm fields={fields} onSubmit={vi.fn().mockResolvedValue({ success: true })} />,
+    )
+    expect(screen.getByText('*')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/tests/components/composite-classnames.test.tsx
+++ b/packages/ui/tests/components/composite-classnames.test.tsx
@@ -153,6 +153,25 @@ describe('Item forms classNames + data-slot contract', () => {
     expect(form).toHaveClass('os-form')
     expect(findSlot(container, 'form-actions')).toHaveClass('os-actions')
   })
+
+  it('overrides the form-actions padding default via classNames.actions (tailwind-merge)', () => {
+    const withDefault = render(
+      <ItemCreateForm fields={fields} onSubmit={vi.fn().mockResolvedValue({ success: true })} />,
+    )
+    expect(findSlot(withDefault.container, 'form-actions')).toHaveClass('pt-6')
+
+    const withOverride = render(
+      <ItemCreateForm
+        fields={fields}
+        onSubmit={vi.fn().mockResolvedValue({ success: true })}
+        classNames={{ actions: 'pt-2' }}
+      />,
+    )
+    const actions = findSlot(withOverride.container, 'form-actions')
+    // Caller's `pt-2` wins; the default `pt-6` is dropped.
+    expect(actions).toHaveClass('pt-2')
+    expect(actions).not.toHaveClass('pt-6')
+  })
 })
 
 describe('RelationshipManager classNames + data-slot contract', () => {
@@ -191,6 +210,35 @@ describe('RelationshipManager classNames + data-slot contract', () => {
     )
     expect(findSlot(container, 'relationship-manager-empty')).toHaveClass('os-empty')
     expect(findSlot(container, 'combobox-trigger')).toHaveClass('os-connect')
+  })
+
+  it('overrides a connected-item cell default via classNames.cell (tailwind-merge)', () => {
+    const withDefault = render(
+      <RelationshipManager
+        name="tags"
+        value={['t1']}
+        onChange={vi.fn()}
+        label="Tags"
+        items={items}
+      />,
+    )
+    const defaultCell = withDefault.container.querySelector('[data-slot="table-cell"]')
+    expect(defaultCell).toHaveClass('p-4')
+
+    const withOverride = render(
+      <RelationshipManager
+        name="tags"
+        value={['t1']}
+        onChange={vi.fn()}
+        label="Tags"
+        items={items}
+        classNames={{ cell: 'p-8' }}
+      />,
+    )
+    const overriddenCell = withOverride.container.querySelector('[data-slot="table-cell"]')
+    // Caller's `p-8` wins; the default `p-4` is dropped.
+    expect(overriddenCell).toHaveClass('p-8')
+    expect(overriddenCell).not.toHaveClass('p-4')
   })
 })
 

--- a/packages/ui/tests/primitives/badge.test.tsx
+++ b/packages/ui/tests/primitives/badge.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { Badge } from '../../src/primitives/badge.js'
+
+/**
+ * Status rendering contract (issue #709): the Badge primitive renders
+ * `success` / `warning` / `destructive` states through theme-token utilities
+ * only — no hardcoded status colours. Assertions are on external behaviour: the
+ * `data-slot` attribute and the token-based classes present on the rendered
+ * node.
+ */
+describe('Badge status tokens', () => {
+  it('carries the stable data-slot', () => {
+    const { container } = render(<Badge>New</Badge>)
+    expect(container.querySelector('[data-slot="badge"]')).toHaveAttribute('data-slot', 'badge')
+  })
+
+  it('renders the success variant from the success token', () => {
+    const { container } = render(<Badge variant="success">Published</Badge>)
+    expect(container.querySelector('[data-slot="badge"]')).toHaveClass('text-success')
+  })
+
+  it('renders the warning variant from the warning token', () => {
+    const { container } = render(<Badge variant="warning">Draft</Badge>)
+    expect(container.querySelector('[data-slot="badge"]')).toHaveClass('text-warning')
+  })
+
+  it('renders the destructive variant from the destructive token', () => {
+    const { container } = render(<Badge variant="destructive">Error</Badge>)
+    expect(container.querySelector('[data-slot="badge"]')).toHaveClass('text-destructive')
+  })
+
+  it('merges a caller className onto the badge', () => {
+    const { container } = render(<Badge className="os-badge">Tag</Badge>)
+    expect(container.querySelector('[data-slot="badge"]')).toHaveClass('os-badge')
+  })
+})


### PR DESCRIPTION
Implements #709. Part of #704 (spec: `specs/THEMING.md`).

Builds on the merged token contract (#705), dark mode (#706), and primitives pass (#708). Extends the same `data-slot` + tailwind-merge'd `className` conventions #708 established for primitives out to the field components and standalone composites.

## Field components
All fields (text, integer, checkbox, select, timestamp, password, relationship, json, image/file, combobox) now share one label / help / error rhythm via a small shared shell — `FieldRoot`, `FieldLabel`, `FieldHelp`, `FieldError`, `FieldWarning`, `FieldReadValue` (exported from `/fields` and the root). Every field consumes theme tokens only and accepts a consistent `helpText` prop.

## Composites — structured `classNames` slots + `data-slot`
Each composite accepts a strongly-typed `classNames` object; each slot is merged onto its part via `cn`/tailwind-merge so caller classes win, and every part carries a stable `data-slot`:

| Composite | root `data-slot` | `classNames` slots |
| --- | --- | --- |
| `ListTable` | `list-table` | `root, frame, table, header, headerRow, headerCell, body, row, cell, actionsHeader, actionsCell, empty` |
| `SearchBar` | `search-bar` | `root, form, inputWrapper, input, clearButton, submit` |
| `DeleteButton` | (`button` on the trigger) | `button, error` (error part `data-slot="delete-button-error"`) |
| `ItemCreateForm` | `item-create-form` | `root, error, fields, actions, submit, cancel` |
| `ItemEditForm` | `item-edit-form` | `root, error, fields, actions, submit, cancel` |
| `RelationshipManager` | `relationship-manager` | `root, label, frame, row, cell, emptyState, actions, connectButton, error` |

Additional stable part slots introduced: `list-table-frame`, `list-table-empty`, `search-bar-form`, `search-bar-clear`, `form-error`, `form-fields`, `form-actions`, `relationship-manager-frame`, `relationship-manager-empty`, `relationship-manager-actions`, and the field-shell slots `field`, `field-label`, `field-help`, `field-error`, `field-warning`, `field-value`.

Forms apply the spec's section rhythm: a `space-y-6` fields section (`data-slot="form-fields"`) and a bordered actions footer (`data-slot="form-actions"`).

## Status tokens — no hardcoded colours
New `Badge` primitive (`success` / `warning` / `destructive` / `default` / `secondary` / `outline`) drives all status rendering through tokens. The last hardcoded status colours were replaced: the file-upload check (`text-green-600` → `text-success`) and the JSON parse warning (`text-amber-600` → `text-warning` via `FieldWarning`). Destructive confirmations/error banners already flowed through `destructive`. Grep proof:

```
$ grep -rnE '(text|bg|border|ring|from|to)-(green|red|amber|yellow|orange|emerald|rose|lime)-[0-9]' packages/ui/src/
NONE
```

## Contract tests
- `tests/components/composite-classnames.test.tsx` (happy-dom) — for every composite: asserts the `data-slot` name **and** that a passed `classNames` slot merges/overrides via tailwind-merge (external behaviour only).
- `tests/primitives/badge.test.tsx` — Badge renders the success/warning/destructive **tokens** and carries `data-slot="badge"`.
- `tests/browser/components/composite-data-slot.browser.test.tsx` — browser-mode plain-CSS restyle proof (no Tailwind pipeline) for the new Badge + a DeleteButton slot.

## Demo (composable-dashboard)
The example composes a fully custom create form, edit form, and list page from the same components the prebuilt admin uses. Status renders through the token `Badge` (`components/PostStatusBadge`); the pages demonstrate the new slot APIs (`ListTable classNames={{ frame, headerCell, row }}`, `SearchBar classNames={{ input }}`, `ItemCreate/EditForm classNames={{ actions }}`). No hardcoded status colours remain in the example.

## Verification
- `pnpm lint` — 0 errors (3 pre-existing unrelated warnings)
- `pnpm manypkg fix`, `pnpm format` — clean
- ui `tsc` build — clean; composable-dashboard `tsc --noEmit` — clean (after `pnpm generate`)
- ui vitest: **323 passed** (unit) and **69 passed** (browser mode, run against the pre-installed Chromium)
- Changeset added (`@opensaas/stack-ui` minor)

Scope stayed within fields + composites + the composable-dashboard demo; app-shell/admin-chrome polish (#710) was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_