### PR TITLE
feat(ui): optional nonce prop on ThemeScript for strict-CSP apps

### DIFF
--- a/.changeset/spicy-owls-nonce.md
+++ b/.changeset/spicy-owls-nonce.md
@@ -1,0 +1,30 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Add optional `nonce` prop to `ThemeScript` for strict-CSP compatibility
+
+`ThemeScript` renders the flash-prevention code as an inline `<script>`, which a
+strict nonce-based `script-src` Content-Security-Policy blocks unless the tag
+carries a matching `nonce`. You can now forward the per-request nonce:
+
+```tsx
+import { headers } from 'next/headers'
+import { ThemeScript } from '@opensaas/stack-ui'
+
+export default async function RootLayout({ children }) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript nonce={nonce} />
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+The prop is optional — omitting it is byte-identical to before (no `nonce`
+attribute emitted). When provided, the value is forwarded only to the
+`<script>`'s `nonce` attribute; it is never interpolated into the script body.

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -367,6 +367,31 @@ Two pieces make it user-controllable:
   `suppressHydrationWarning` is needed because the script mutates `data-theme`
   before React hydrates.
 
+  **Strict-CSP apps:** a nonce-based `script-src` policy blocks inline scripts
+  unless they carry a matching `nonce`. Pass the per-request nonce (the same one
+  your middleware/CSP emits) so the flash-prevention script survives the policy:
+
+  ```tsx
+  import { headers } from 'next/headers'
+  import { ThemeScript } from '@opensaas/stack-ui'
+
+  export default async function RootLayout({ children }) {
+    const nonce = (await headers()).get('x-nonce') ?? undefined
+    return (
+      <html lang="en" suppressHydrationWarning>
+        <head>
+          <ThemeScript nonce={nonce} />
+        </head>
+        <body>{children}</body>
+      </html>
+    )
+  }
+  ```
+
+  `nonce` is optional: omit it and the output is byte-identical to before (no
+  `nonce` attribute emitted). The value is forwarded only to the `<script>`'s
+  `nonce` attribute — it is never interpolated into the script body.
+
 ### Pinning the admin to a single scheme
 
 To lock the admin to light-only or dark-only (matching a product with a fixed

--- a/packages/ui/src/components/ThemeScript.tsx
+++ b/packages/ui/src/components/ThemeScript.tsx
@@ -25,7 +25,42 @@ import { themeInitScript } from '../lib/theme-mode.js'
  *
  * It is a plain server-safe element (no client runtime); the `ThemeToggle`
  * component reads and writes the same `localStorage` key at runtime.
+ *
+ * Apps with a strict nonce-based `script-src` Content-Security-Policy block
+ * inline scripts unless they carry a matching `nonce`. Pass the per-request
+ * nonce so the flash-prevention script survives the policy:
+ *
+ * ```tsx
+ * import { headers } from 'next/headers'
+ * import { ThemeScript } from '@opensaas/stack-ui'
+ *
+ * export default async function RootLayout({ children }) {
+ *   const nonce = (await headers()).get('x-nonce') ?? undefined
+ *   return (
+ *     <html lang="en" suppressHydrationWarning>
+ *       <head>
+ *         <ThemeScript nonce={nonce} />
+ *       </head>
+ *       <body>{children}</body>
+ *     </html>
+ *   )
+ * }
+ * ```
+ *
+ * The nonce is forwarded only to the `<script>`'s `nonce` attribute; it is never
+ * interpolated into the script body (which contains no user input). When
+ * `nonce` is omitted the rendered output is byte-identical to before — no
+ * `nonce` attribute is emitted.
  */
-export function ThemeScript() {
-  return <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+export interface ThemeScriptProps {
+  /**
+   * Optional CSP nonce forwarded to the inline `<script nonce>` attribute so the
+   * flash-prevention script is permitted under a strict nonce-based
+   * `script-src` policy. Omit it when your app has no such policy.
+   */
+  nonce?: string
+}
+
+export function ThemeScript({ nonce }: ThemeScriptProps = {}) {
+  return <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeInitScript }} />
 }

--- a/packages/ui/tests/components/ThemeScript.test.tsx
+++ b/packages/ui/tests/components/ThemeScript.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ThemeScript } from '../../src/components/ThemeScript.js'
+import { themeInitScript } from '../../src/lib/theme-mode.js'
+
+// External behaviour only: the server-rendered `<script>` markup, which is what
+// a strict nonce-based `script-src` CSP evaluates. ThemeScript is a server-safe
+// element with no client runtime, so the rendered output is the whole contract.
+
+describe('ThemeScript', () => {
+  it('emits no nonce attribute when the prop is omitted', () => {
+    const html = renderToStaticMarkup(<ThemeScript />)
+    expect(html).not.toContain('nonce')
+    // The flash-prevention script itself is always present, unchanged.
+    expect(html).toContain(themeInitScript)
+  })
+
+  it('forwards the given value to the script nonce attribute when provided', () => {
+    const html = renderToStaticMarkup(<ThemeScript nonce="abc123==" />)
+    expect(html).toContain('nonce="abc123=="')
+    // The script body never interpolates the nonce — only the attribute carries it.
+    expect(html).toContain(themeInitScript)
+    expect(themeInitScript).not.toContain('abc123==')
+  })
+})


### PR DESCRIPTION
## Summary

`ThemeScript` renders the flash-prevention code as an inline `<script dangerouslySetInnerHTML=…>`. A strict nonce-based `script-src` Content-Security-Policy (common in Next.js apps) blocks inline scripts without a matching nonce, so CSP-hardened apps lose the pre-paint scheme fix.

This adds an optional `nonce?: string` prop to `ThemeScript`, forwarded to the `<script nonce={nonce}>` attribute.

- **`nonce` is optional** — when omitted, behavior is byte-identical to today: React does not render the attribute, so no `nonce` is emitted (confirmed true no-op).
- When provided, the value is forwarded **only** to the `<script>`'s `nonce` attribute. The script body still contains only `JSON.stringify(THEME_STORAGE_KEY)` — the nonce is never interpolated into the script content.
- Strongly typed via a new `ThemeScriptProps` interface (`nonce?: string`); no `any`/casts. Component stays server-safe (no client runtime).

## Usage

```tsx
import { headers } from 'next/headers'
import { ThemeScript } from '@opensaas/stack-ui'

export default async function RootLayout({ children }) {
  const nonce = (await headers()).get('x-nonce') ?? undefined
  return (
    <html lang="en" suppressHydrationWarning>
      <head>
        <ThemeScript nonce={nonce} />
      </head>
      <body>{children}</body>
    </html>
  )
}
```

## Changes

- `packages/ui/src/components/ThemeScript.tsx` — new optional `nonce` prop + `ThemeScriptProps` interface, updated JSDoc with the CSP recipe.
- `packages/ui/tests/components/ThemeScript.test.tsx` — new test asserting external rendered output (`renderToStaticMarkup`):
  - (a) no `nonce` attribute when the prop is omitted;
  - (b) the `nonce` attribute is present with the given value when passed, and the value never leaks into the script body.
- `packages/ui/CLAUDE.md` — documented the per-request nonce recipe in the Dark mode / color scheme section, noting the omitted-nonce no-op.
- `.changeset/spicy-owls-nonce.md` — `@opensaas/stack-ui` **minor** (new optional prop).

## Verification

- `pnpm --filter @opensaas/stack-ui build` (tsc typecheck) — clean.
- `pnpm --filter @opensaas/stack-ui test` — 26 files / 368 tests pass (incl. the 2 new cases).
- `pnpm lint` — 0 errors (only pre-existing unrelated warnings); `pnpm manypkg fix`; `pnpm format` — clean.

Closes #717
Follow-up to #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_