### PR TITLE
Wire field helpText through FieldRenderer via ui.description

### DIFF
--- a/.changeset/quiet-otters-wave.md
+++ b/.changeset/quiet-otters-wave.md
@@ -1,0 +1,23 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Wire field help text through the admin renderer via `ui.description`
+
+Field authors can now set help/description text on a field's `ui.description`
+and have it render beneath the control in the prebuilt admin UI. `FieldRenderer`
+surfaces `ui.description` to the rendered field component as its `helpText` prop,
+which displays through the shared field-shell `FieldHelp` (data-slot="field-help").
+Previously `helpText` only worked when a field component was composed by hand.
+
+```typescript
+fields: {
+  slug: text({
+    ui: { description: 'URL-friendly identifier, lowercase only.' },
+  }),
+}
+```
+
+The option is optional and non-breaking; fields without a description render no
+help text, exactly as before.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -594,6 +594,21 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
      */
     fieldType?: string
     /**
+     * Help / description text rendered beneath the field control in the admin UI.
+     *
+     * `FieldRenderer` surfaces this to the rendered field component as its
+     * `helpText` prop, so it appears via the shared field-shell `FieldHelp`
+     * rhythm (data-slot="field-help") for admin-rendered fields.
+     *
+     * @example
+     * ```typescript
+     * fields: {
+     *   slug: text({ ui: { description: 'URL-friendly identifier, lowercase only.' } })
+     * }
+     * ```
+     */
+    description?: string
+    /**
      * Transform field value before sending to client (browser)
      * Useful for sensitive fields (e.g., passwords) or complex data structures
      * that shouldn't be serialized in their raw form

--- a/packages/ui/src/components/fields/FieldRenderer.tsx
+++ b/packages/ui/src/components/fields/FieldRenderer.tsx
@@ -76,8 +76,19 @@ function FieldRendererInner({
 
   // Pass through any UI options from fieldConfig.ui (excluding component and fieldType)
   if (fieldConfig.ui) {
-    const { component: _component, fieldType: _fieldType, ...uiOptions } = fieldConfig.ui
+    const {
+      component: _component,
+      fieldType: _fieldType,
+      description,
+      ...uiOptions
+    } = fieldConfig.ui
     Object.assign(specificProps, uiOptions)
+    // Surface the field's help/description text to the component as `helpText`
+    // (rendered through the shared field-shell `FieldHelp`). Config exposes this
+    // as `ui.description` (Keystone-aligned); the component prop is `helpText`.
+    if (description !== undefined && specificProps.helpText === undefined) {
+      specificProps.helpText = description
+    }
   }
 
   const allProps = { ...baseProps, ...specificProps }

--- a/packages/ui/src/lib/serializeFieldConfig.ts
+++ b/packages/ui/src/lib/serializeFieldConfig.ts
@@ -21,6 +21,8 @@ export type SerializableFieldConfig = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     component?: ComponentType<any>
     fieldType?: string
+    /** Help / description text surfaced to the field component as `helpText`. */
+    description?: string
     [key: string]: unknown
   }
 }

--- a/packages/ui/tests/components/FieldRenderer.test.tsx
+++ b/packages/ui/tests/components/FieldRenderer.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FieldRenderer } from '../../src/components/fields/FieldRenderer.js'
+import type { SerializableFieldConfig } from '../../src/lib/serializeFieldConfig.js'
+
+/**
+ * FieldRenderer wires the field config's help/description text through to the
+ * rendered field component (issue #721). A field author sets `ui.description`
+ * in their `opensaas.config.ts`; FieldRenderer surfaces it as the component's
+ * `helpText`, which renders via the shared field-shell `FieldHelp`
+ * (data-slot="field-help"). Assertions are on external behaviour only — the
+ * rendered help text and its `data-slot` — not internal structure.
+ */
+const findHelp = (container: HTMLElement): Element | null =>
+  container.querySelector('[data-slot="field-help"]')
+
+describe('FieldRenderer helpText wiring', () => {
+  it('renders ui.description as help text via the field shell', () => {
+    const fieldConfig: SerializableFieldConfig = {
+      type: 'text',
+      label: 'Slug',
+      ui: { description: 'URL-friendly identifier, lowercase only.' },
+    }
+
+    const { container } = render(
+      <FieldRenderer fieldName="slug" fieldConfig={fieldConfig} value="" onChange={vi.fn()} />,
+    )
+
+    const help = findHelp(container)
+    expect(help).not.toBeNull()
+    expect(help).toHaveTextContent('URL-friendly identifier, lowercase only.')
+    expect(screen.getByText('URL-friendly identifier, lowercase only.')).toBeInTheDocument()
+  })
+
+  it('renders no help text when the field config has no description', () => {
+    const fieldConfig: SerializableFieldConfig = {
+      type: 'text',
+      label: 'Slug',
+    }
+
+    const { container } = render(
+      <FieldRenderer fieldName="slug" fieldConfig={fieldConfig} value="" onChange={vi.fn()} />,
+    )
+
+    expect(findHelp(container)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

PRD #709 added a `helpText` prop to the field components (rendered via the shared field-shell `FieldHelp`), but it was **inert in the prebuilt admin** — `FieldRenderer` never sourced it from field config, so it only rendered when a caller composed a field component by hand. This wires it through from config.

## What changed

- **Reused/added config option:** No existing option fit, so I added **one** minimal, optional, non-breaking option: **`ui.description?: string`** on the core `BaseFieldConfig['ui']` (Keystone-aligned naming). It sits alongside the existing `ui.component` / `ui.fieldType` keys.
- **Threading to the component:** `FieldRenderer` extracts `ui.description` from the field config and passes it as the field component's existing **`helpText`** prop (only when not already provided), so it renders through the shared field-shell `FieldHelp` (`data-slot="field-help"`) — the same rhythm #709 introduced.
- Added `description?: string` to the UI package's `SerializableFieldConfig['ui']` for type clarity (values already flowed through the `[key: string]: unknown` index signature).

```typescript
fields: {
  slug: text({
    ui: { description: 'URL-friendly identifier, lowercase only.' },
  }),
}
```

## Test

`packages/ui/tests/components/FieldRenderer.test.tsx` — external-behaviour assertions matching existing style:
- With `ui.description` set, `FieldRenderer` renders the text via `data-slot="field-help"`.
- With no description, no `field-help` node is rendered.

## Verification

- `pnpm build` for core, cli, ui — clean.
- `pnpm generate` in `examples/blog` with a `text({ ui: { description, displayMode } })` field — succeeds (confirms the types/generator pipeline is unaffected and `ui.description` coexists with `ui.displayMode`). Example change reverted.
- Tests: ui `368 passed`, core `774 passed` (incl. the new test).
- `pnpm lint` (0 errors, pre-existing warnings only), `pnpm manypkg fix`, `pnpm format` clean.

Changeset: `@opensaas/stack-core` minor + `@opensaas/stack-ui` minor.

Closes #721
Follow-up to #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_