### PR TITLE
Make the modern preset baseline un-driftable (single-source stylesheet defaults)

### DIFF
--- a/.changeset/tidy-preset-baseline.md
+++ b/.changeset/tidy-preset-baseline.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Derive the stylesheet's `modern` color defaults from `presetThemes.modern` via a `generate:css` codegen step (wired into build), so the preset and `globals.css` can no longer drift. No visual or behavioral change — the emitted CSS is byte-identical to the previous values.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,7 +33,9 @@
     "./styles": "./dist/styles/globals.css"
   },
   "scripts": {
-    "build": "tsc && npm run build:css",
+    "build": "npm run generate:css && tsc && npm run build:css",
+    "generate:css": "node --experimental-strip-types scripts/generate-globals-css.mts",
+    "generate:css:check": "node --experimental-strip-types scripts/generate-globals-css.mts --check",
     "build:css": "mkdir -p dist/styles && postcss ./src/styles/globals.css -o ./dist/styles/globals.css",
     "dev": "tsc --watch",
     "test": "vitest",

--- a/packages/ui/scripts/generate-globals-css.mts
+++ b/packages/ui/scripts/generate-globals-css.mts
@@ -1,0 +1,100 @@
+/*
+ * Codegen: emit the baked-in `modern`-preset color defaults in
+ * `src/styles/globals.css` from the single source of truth — `presetThemes.modern`
+ * in `src/lib/theme.ts`.
+ *
+ * Why: the default `modern` baseline used to live in two hand-maintained copies
+ * (the preset catalog AND the raw `--color-*-light`/`-dark` `:root` vars),
+ * reconciled only by a test that CAUGHT drift after the fact. This script makes
+ * the stylesheet's copy DERIVED, so the two can never diverge (issue #714).
+ *
+ * The generated region is delimited by the `stack:generated-*` marker comments
+ * in globals.css; everything outside them (the `@theme` contract tokens, the
+ * radius knob, the dark-mode mechanism, body styles) stays hand-written.
+ *
+ * Run directly (`pnpm --filter @opensaas/stack-ui generate:css`) or as the first
+ * step of `build`. `--check` mode verifies the checked-in file is already in sync
+ * (used by the test suite) instead of writing.
+ *
+ * Runs on Node's native TypeScript type-stripping — `presetThemes` uses only
+ * `import type`, so importing `theme.ts` here pulls in no runtime dependencies.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { presetThemes } from '../src/lib/theme.ts'
+import type { ThemeColors } from '@opensaas/stack-core/internal'
+
+const START_MARKER = '  /* stack:generated-start modern-preset-colors */'
+const END_MARKER = '  /* stack:generated-end modern-preset-colors */'
+
+/** camelCase token key → kebab-case CSS variable segment (matches lib/theme.ts). */
+function toKebabCase(key: string): string {
+  return key.replace(/([A-Z])/g, '-$1').toLowerCase()
+}
+
+function emitBlock(colors: ThemeColors, suffix: 'light' | 'dark'): string {
+  return Object.entries(colors)
+    .map(([key, value]) => `  --color-${toKebabCase(key)}-${suffix}: ${value};`)
+    .join('\n')
+}
+
+/**
+ * The full generated region body (between the marker lines). Derived entirely
+ * from `presetThemes.modern`, so re-tuning the preset is the only edit needed.
+ */
+function generateRegion(): string {
+  const { light, dark } = presetThemes.modern
+  return [
+    '  /* GENERATED from `presetThemes.modern` in lib/theme.ts — the single source',
+    '     of truth for the baked-in default palette. Do NOT edit these values by',
+    '     hand; run `pnpm --filter @opensaas/stack-ui generate:css` (also runs on',
+    '     build). See issue #714. */',
+    '',
+    '  /* Modern preset — light. Restrained, low-chroma surfaces with one saturated',
+    '     brand color. */',
+    emitBlock(light, 'light'),
+    '',
+    '  /* Modern preset — dark. */',
+    emitBlock(dark, 'dark'),
+  ].join('\n')
+}
+
+function render(existing: string, region: string): string {
+  const startIndex = existing.indexOf(START_MARKER)
+  const endIndex = existing.indexOf(END_MARKER)
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(
+      `generate-globals-css: could not find the "${START_MARKER.trim()}" / ` +
+        `"${END_MARKER.trim()}" markers in globals.css.`,
+    )
+  }
+  const before = existing.slice(0, startIndex + START_MARKER.length)
+  const after = existing.slice(endIndex)
+  return `${before}\n${region}\n${after}`
+}
+
+const CSS_PATH = join(dirname(fileURLToPath(import.meta.url)), '../src/styles/globals.css')
+
+function main(): void {
+  const existing = readFileSync(CSS_PATH, 'utf8')
+  const next = render(existing, generateRegion())
+  const check = process.argv.includes('--check')
+
+  if (next === existing) {
+    return
+  }
+
+  if (check) {
+    console.error(
+      'globals.css is out of sync with presetThemes.modern.\n' +
+        'Run `pnpm --filter @opensaas/stack-ui generate:css` and commit the result.',
+    )
+    process.exit(1)
+  }
+
+  writeFileSync(CSS_PATH, next)
+  console.log('generate-globals-css: wrote src/styles/globals.css')
+}
+
+main()

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -11,8 +11,8 @@ import type {
  * preset). Shape (`radius`) and elevation (`shadows`) are optional: when a
  * preset omits them it inherits the stylesheet defaults declared in
  * `styles/globals.css`. This lets a preset express its own personality
- * (`classic` is flat, `neon` is rounder) while the default `modern` preset
- * stays byte-for-byte in sync with the stylesheet.
+ * (`classic` is flat, `neon` is rounder) while the default `modern` preset is
+ * the single source the stylesheet's baked-in color defaults are generated from.
  */
 export type PresetDefinition = {
   light: ThemeColors
@@ -28,10 +28,12 @@ export type PresetDefinition = {
  *
  * - `modern` (default) — the restrained, Linear-class direction: low-chroma
  *   neutral surfaces, one saturated brand color used sparingly, the gradient
- *   pair as garnish, quiet muted text, softer radius. It MUST stay in sync with
- *   the raw `--color-*-light` / `--color-*-dark` values in `styles/globals.css`
- *   (a test enforces this), so it deliberately omits `radius`/`shadows` and
- *   inherits the stylesheet defaults rather than duplicating them.
+ *   pair as garnish, quiet muted text, softer radius. It is the SINGLE SOURCE
+ *   for the raw `--color-*-light` / `--color-*-dark` defaults in
+ *   `styles/globals.css`: the `generate:css` codegen emits that `:root` block
+ *   from these values (a test enforces the two are in sync), so they can never
+ *   drift. It deliberately omits `radius`/`shadows` and inherits the stylesheet
+ *   defaults rather than duplicating them.
  * - `classic` — flat and enterprise-safe: blue primary, no gradient (the pair
  *   collapses to a single color), squared-off radius, and elevation removed
  *   (shadows `none`) so hierarchy comes from crisp borders alone.
@@ -97,7 +99,8 @@ export const presetThemes: Record<ThemePreset, PresetDefinition> = {
       gradientFrom: 'oklch(0.62 0.19 264)',
       gradientTo: 'oklch(0.68 0.18 320)',
     },
-    // radius + shadows inherited from styles/globals.css (kept in sync there).
+    // radius + shadows inherited from styles/globals.css. The colors above are
+    // the source the stylesheet's `--color-*` defaults are generated from.
   },
   classic: {
     // Squared-off corners and no elevation — hierarchy from borders alone.

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -20,8 +20,14 @@
  */
 
 :root {
+  /* stack:generated-start modern-preset-colors */
+  /* GENERATED from `presetThemes.modern` in lib/theme.ts — the single source
+     of truth for the baked-in default palette. Do NOT edit these values by
+     hand; run `pnpm --filter @opensaas/stack-ui generate:css` (also runs on
+     build). See issue #714. */
+
   /* Modern preset — light. Restrained, low-chroma surfaces with one saturated
-     brand color. Kept in sync with `presetThemes.modern.light` in lib/theme.ts. */
+     brand color. */
   --color-background-light: oklch(0.99 0.002 264);
   --color-foreground-light: oklch(0.21 0.02 264);
   --color-card-light: oklch(1 0 0);
@@ -48,7 +54,7 @@
   --color-gradient-from-light: oklch(0.55 0.2 264);
   --color-gradient-to-light: oklch(0.62 0.19 320);
 
-  /* Modern preset — dark. Kept in sync with `presetThemes.modern.dark`. */
+  /* Modern preset — dark. */
   --color-background-dark: oklch(0.17 0.015 264);
   --color-foreground-dark: oklch(0.96 0.005 264);
   --color-card-dark: oklch(0.21 0.018 264);
@@ -74,6 +80,7 @@
   --color-ring-dark: oklch(0.62 0.19 264);
   --color-gradient-from-dark: oklch(0.62 0.19 264);
   --color-gradient-to-dark: oklch(0.68 0.18 320);
+  /* stack:generated-end modern-preset-colors */
 
   /* Base radius knob — derived sizes are computed from it in @theme below. */
   --radius: 0.625rem;

--- a/packages/ui/tests/lib/theme.test.ts
+++ b/packages/ui/tests/lib/theme.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, it, expect, vi, afterEach } from 'vitest'
@@ -238,13 +239,25 @@ describe('preset catalog completeness', () => {
 })
 
 describe('modern preset ↔ stylesheet sync', () => {
-  // The default `modern` preset and the raw `--color-*-light`/`-dark` variables
-  // declared in globals.css are two copies of one palette. This test fails if
-  // they drift — whether a token is added, removed, or renamed (the key set
-  // changes) OR a token's value is re-tuned on one side only (the value
-  // changes) — enforcing the "un-driftable" goal (ADR-0015) for the palette the
-  // stylesheet ships as its baked-in default.
+  // The stylesheet's raw `--color-*-light`/`-dark` `:root` defaults are no longer
+  // a hand-maintained second copy of `presetThemes.modern` — the `generate:css`
+  // codegen emits that block FROM the preset (issue #714). These tests are the
+  // enforcement layer: the generator's `--check` mode fails if the checked-in
+  // globals.css is not byte-identical to a fresh regeneration, and the value-map
+  // comparison additionally documents that the two agree token-for-token.
   const globalsCss = readFileSync(join(import.meta.dirname, '../../src/styles/globals.css'), 'utf8')
+
+  it('checked-in globals.css is byte-identical to a fresh regeneration', () => {
+    // Runs the real codegen in --check mode against the single source of truth.
+    // Exit 0 means the checked-in stylesheet matches what presetThemes.modern
+    // generates; a non-zero exit (drift) throws with the generator's guidance.
+    const scriptPath = join(import.meta.dirname, '../../scripts/generate-globals-css.mts')
+    expect(() =>
+      execFileSync(process.execPath, ['--experimental-strip-types', scriptPath, '--check'], {
+        stdio: 'pipe',
+      }),
+    ).not.toThrow()
+  })
 
   // Parse `--color-<name>-<suffix>: <value>;` declarations into a
   // `{ '<name>-<suffix>': '<value>' }` map. Applied to both the raw `:root`

--- a/specs/THEMING.md
+++ b/specs/THEMING.md
@@ -113,7 +113,7 @@ Out of scope (future specs, on this foundation): command palette, saved views, n
 
 - `ui.theme` color values: wrap old triplets in `hsl()` — `'220 20% 97%'` → `'hsl(220 20% 97%)'` — or move to any other CSS color format.
 - Preset-only configs: no change required; the upgrade is strictly a fix.
-- The old `generateThemeCSS` HSL output and the `--color-*-light/-dark` split in `globals.css` are internal details that may change; only the token names above are contract.
+- The `--color-*-light/-dark` split in `globals.css` is an internal detail that may change; only the token names above are contract. Its `modern`-default values are not hand-maintained — a `generate:css` codegen step emits that `:root` block from `presetThemes.modern` (the single source), so the stylesheet and preset can never drift.
 
 ## Suggested implementation sequence
 


### PR DESCRIPTION
Closes #714. Follow-up to #704.

## Problem

The default `modern` palette lived in **two** hand-maintained copies, reconciled only by a "keep in sync" test that *caught* drift after the fact rather than *preventing* it:

- `presetThemes.modern` in `packages/ui/src/lib/theme.ts`
- the raw `--color-*-light`/`-dark` values in `packages/ui/src/styles/globals.css` `:root`

Runtime consequence flagged in the issue: when `ui.theme` is set, `AdminUI` injects `compileTheme` output (theme.ts's numbers); when it isn't, `globals.css`'s numbers win. If the two ever diverged, identical-looking configs would render differently depending on whether `ui.theme` was present.

## Approach — single source via codegen

`presetThemes.modern` is now the **single source of truth**; the stylesheet's baked-in color defaults are **derived** from it.

- New `packages/ui/scripts/generate-globals-css.mts` emits the `--color-*-light`/`-dark` `:root` block from `presetThemes.modern`, splicing it between stable `stack:generated-start/-end modern-preset-colors` marker comments. Everything outside the markers (`@theme` contract tokens, the radius knob, dark-mode mechanism, body styles) stays hand-written.
- Wired as the first step of the ui `build` (`npm run generate:css && tsc && npm run build:css`). Also exposed as `generate:css` / `generate:css:check` scripts.
- **No new dependencies**: runs on Node's native TypeScript type-stripping. `presetThemes` uses only `import type`, so importing `theme.ts` from the script pulls in no runtime deps.
- `--check` mode fails if the checked-in `globals.css` isn't byte-identical to a fresh regeneration.

## Tests

The `modern preset ↔ stylesheet sync` suite is strengthened: alongside the existing value-map comparison, a new test runs the real generator in `--check` mode and asserts it exits 0 — so drift is now impossible to commit without a failing test, not merely detectable. All theme tests pass (40), full ui suite passes (367 node + 69 browser).

## Proof of no visual change

The `--color-*` values in `globals.css` are **unchanged** — the diff adds only marker comments and trims the two "kept in sync" comments. `git diff` of the color-value lines is empty, and the generator's `--check` confirms the committed CSS is byte-identical to what the single source produces. No theme (`modern`/`classic`/`neon`) changes appearance.

## Also folded in (from the same review)

- Tightened the stale `generateThemeCSS` wording in `specs/THEMING.md:116` (that internal helper is fully removed) and documented that the `--color-*` defaults are now generated from `presetThemes.modern`.

## Out of scope

No change to the public `ThemeConfig` API or token vocabulary — this is purely an internal de-duplication of the default baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcxC6tmZjdcWSGEbV7BtPr)_