### PR TITLE
Add design-sync inputs for stack-ui → claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,118 @@
+# design-sync NOTES — @opensaas/stack-ui
+
+Repo-specific gotchas for future syncs. Read this before re-syncing.
+
+## Build & shape
+
+- **Shape: package** (no Storybook). Bundle entry: `packages/ui/dist/index.js`. Run the converter
+  from the **repo root** with `--entry ./packages/ui/dist/index.js --node-modules packages/ui/node_modules`.
+  That entry makes PKG_DIR resolve to `packages/ui`, so all `cfg.*` package-relative paths work.
+- **Build first**: `pnpm install` then `cfg.buildCmd` (`pnpm -F "@opensaas/stack-ui..." build`). The
+  package self-installs nothing in its own node_modules for `@opensaas/stack-ui`, hence `--entry`.
+- react/react-dom/@types/react resolve in `packages/ui/node_modules` (react 19.2.4).
+
+## CRITICAL: the main entry only re-exports Badge from primitives
+
+`dist/index.js` exports the composites/fields/standalone + **only Badge** from primitives. Button,
+Card, Input, Select, Dialog, Table, Checkbox, Textarea, Label, Popover, Calendar, Combobox,
+TimePicker, DateTimePicker live under the `./primitives` subpath. To get them into the bundle
+(`window.StackUI.*`) AND discovered as components:
+- `cfg.extraEntries: ["./dist/primitives/index.js"]` merges all primitives onto the global (the
+  converter's `__dsMainNs` footer makes main's Badge win the one collision — the `[EXPORT_COLLISION]
+  Badge` warning is EXPECTED and harmless).
+- `cfg.componentSrcMap` pins each primitive to its `src/primitives/*.tsx` for discovery + `.d.ts`.
+- Authored previews import primitives from the **bare** `'@opensaas/stack-ui'` (not `/primitives`) —
+  the story-import shim maps the bare package to the global, which has everything. Importing from
+  `/primitives` or a relative path bundles a broken duplicate.
+
+## CRITICAL: Next.js stubs (why the bundle doesn't crash)
+
+Many components import `next/link`, `next/navigation`, `next/image`. Next's module-scope
+`process.env.*` reads crash a bare browser and blanked the ENTIRE bundle at load. Fix (config-native,
+no lib fork): `cfg.tsconfig: "../../.design-sync/next-stub-tsconfig.json"` maps those specifiers
+(note the `.js` suffixes: `next/link.js` etc.) to browser-safe stubs in `.design-sync/stubs/next/`.
+- These stubs (link→`<a>`, navigation→noop router, image→`<img>`) are committed durable inputs.
+- `next/headers` is only a JSDoc comment (ThemeScript) — not imported, no stub needed.
+- If a future component adds a new `next/*` import, add a stub + a paths entry (with the exact
+  specifier suffix the dist uses) or the bundle blanks again.
+- Beware: the tsconfig-paths plugin JSON parser strips `//` naively — do NOT put a `"//"` comment
+  key in `next-stub-tsconfig.json` (it corrupts the JSON and silently disables the paths plugin).
+
+## Overlays & dialogs need cardMode:single
+
+Radix overlays (Select, Dialog, Popover, Combobox) + ConfirmDialog portal their open content to
+`<body>`. `cfg.overrides.<Name>: {cardMode:"single", viewport:"WxH"}` makes the whole page the card
+so the open state captures. Authored with `defaultOpen` (Radix Root) / `isOpen` (ConfirmDialog).
+
+## Process gotcha: set overrides BEFORE authoring/scoped-rebuild
+
+Adding `cfg.overrides` (or titleMap) AFTER a full build makes `preview-rebuild --components` abort
+with `[CONFIG_STALE]` (per-component cfgSlice stamp is stale). Only `package-build.mjs` re-stamps.
+So: set all overlay/override config first, run one full `package-build`, THEN fan out scoped
+subagents. (This bit the overlay wave once; fixed by a full rebuild.)
+
+## Components that stay FLOOR CARDS (by design)
+
+- **Dashboard, ListView, ItemForm, SingletonView** (and AdminUI/Navigation render only shells):
+  require a live `AccessContext` (Prisma) + full `OpenSaasConfig`; several are async/data-fetching
+  server components. They CANNOT render statically. Their value to the design agent is the accurate
+  `.d.ts` + `.prompt.md` contract, not a preview. Do not try to mock a full context.
+- **ThemeScript**: injects a `<script>` (no visual output) — floor card is correct.
+
+## Per-component authoring notes (for re-authoring/updates)
+
+- Fields follow the controlled shape (name/value/onChange/label/error/disabled/required/mode/helpText).
+  SelectField `options: {label,value}[]`. RelationshipField uses `items: {id,label}[]` + `value:
+  string|string[]`, `many` toggles combobox vs connected table; omit `relatedListKey`/`basePath` to
+  avoid the `next/link` row path in static capture. PasswordField `value: string | {isSet}`; the
+  visible input is internal-state driven (passed string doesn't prefill). CheckboxField has no
+  `required`/`placeholder`. TimestampField `value: string|Date` (date-fns). IntegerField `value:
+  number` (required).
+- FieldRenderer config is `SerializableFieldConfig` — plain JSON `{type,label?,validation?,options?,
+  ui?}`; dispatches by `type` through the registry.
+- Field* shell primitives only render as visual leaves — always compose inside a `FieldRoot` + `Input`.
+- Badge variants: default/secondary/success/warning/destructive/outline.
+
+## Known render warns
+
+- `[EXPORT_COLLISION] Badge` on every build — EXPECTED (see extraEntries note above). Not a failure.
+- No `[FONT_MISSING]` — the DS uses system font stacks (Tailwind v4 `@theme` `--font-*`), nothing to ship.
+- No `bad` components after authoring; DateTimePicker/TimePicker/PasswordField "closed trigger / empty
+  form" renders are intentional (interaction-only interiors aren't statically renderable).
+
+## Styling idiom
+
+Tailwind CSS v4. Tokens live in `dist/styles/globals.css` (`@theme` block) → `cfg.cssEntry`, and are
+reachable to designs via `styles.css` → `_ds_bundle.css`. `light-dark()` tokens; default render is
+light. Contract tokens: `--color-{background,foreground,card,primary,secondary,muted,accent,
+destructive,success,warning,border,input,ring,...}`, `--radius`, `--font-sans/heading/mono`.
+
+## Presentational & standalone authoring notes
+
+- **SkeletonLoader** only reads `{className, variant}` — it does NOT spread `style`/rest props, and
+  its `circular`/`rectangular` variants carry no intrinsic size. Size them with **className utilities
+  that already exist in `packages/ui/src`** (Tailwind only compiles classes seen in component source,
+  not in previews): e.g. `h-12 w-12` (circular), `h-16 w-64` (rectangular), `w-48`/`w-32` (text).
+  `grep -rhoE '\bh-(full|[0-9]+)\b' packages/ui/src | sort -u` shows what's compiled.
+- **ConfirmDialog** `variant` only changes the confirm-button color (`danger`→red, `warning`→blue) on
+  identical chrome — use distinct copy per cell. Already has a `cardMode:single` override; author with `isOpen`.
+- **ItemCreateForm/ItemEditForm** accept `fields: Record<string,FieldConfig>` but internally run
+  `serializeFieldConfigs`, which reads only `{type,label?,validation?,options?,many?,ref?,ui?}` — so
+  previews pass **plain serializable objects**, no field-builder methods. ItemEditForm `initialData`
+  is values keyed by field name (timestamp = ISO string, select = an option `value`).
+- **ListTable**: `items` + `fieldTypes` (use plain `'text'`/`'integer'`, NOT `'relationship'` which
+  emits `next/link` row paths) + `columns`; `items=[]` + `emptyMessage` renders the empty state.
+- **DeleteButton** / **SearchBar** / **UserMenu** / **ThemeToggle**: pure prop-driven client
+  components, no override needed (DeleteButton's confirm dialog is click-only so the static card shows
+  the trigger). `onSubmit`/`onDelete` → `async () => ({success:true})`; `onSignOut` → `async () => {}`.
+
+## Re-sync risks (what can silently go stale)
+
+- **Next stubs**: if the package upgrades Next or adds a new `next/*` import path, the stub tsconfig
+  `paths` must be updated (match the exact specifier suffix in `dist/`), else the bundle blanks. Re-check
+  `grep -rhoE "from ['\"]next/[a-z.]+" packages/ui/dist` after any dep bump.
+- **Primitive set**: if `src/primitives/*` gains/loses a component, update `cfg.componentSrcMap`.
+- **Composite floor cards**: Dashboard/ListView/ItemForm/SingletonView are tied to upstream context
+  APIs; their `.d.ts`/`.prompt.md` update automatically but they stay floor cards.
+- Authored previews are static compositions of the real components; a breaking prop-rename upstream
+  would surface as a failed preview compile on the next build — re-check the affected `previews/*.tsx`.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -87,6 +87,19 @@ reachable to designs via `styles.css` → `_ds_bundle.css`. `light-dark()` token
 light. Contract tokens: `--color-{background,foreground,card,primary,secondary,muted,accent,
 destructive,success,warning,border,input,ring,...}`, `--radius`, `--font-sans/heading/mono`.
 
+## Preview color-scheme (readability on the design pane)
+
+The DS tokens use CSS `light-dark()` driven by `color-scheme`; the default `:root { color-scheme:
+light dark }` (no pinned `data-theme`) follows the VIEWER's OS preference. The claude.ai/design pane
+draws every card on a white canvas, so a dark-mode viewer got near-white `text-foreground` (e.g.
+CheckboxField/field labels, read values) on white = unreadable. Fix (preview-only, does NOT force
+light on shipped designs): `.design-sync/preview-theme.tsx` exports `DsPreviewLight` (wraps children
+in `<div style={{colorScheme:'light'}}>`), wired via `cfg.extraEntries` + `cfg.provider:
+{component:"DsPreviewLight"}`. `color-scheme` is inherited, so pinning it on the preview root cascades
+to every `light-dark()` token. Verified: field label goes 0.96 (near-white) → 0.21 (near-black) under
+a dark viewer. Real designs should pin their own theme (see conventions.md) — the wrapper only affects
+preview cards, not the exported bundle.
+
 ## Presentational & standalone authoring notes
 
 - **SkeletonLoader** only reads `{className, variant}` — it does NOT spread `style`/rest props, and

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -7,7 +7,8 @@
   "cssEntry": "dist/styles/globals.css",
   "readmeHeader": ".design-sync/conventions.md",
   "tsconfig": "../../.design-sync/next-stub-tsconfig.json",
-  "extraEntries": ["./dist/primitives/index.js"],
+  "extraEntries": ["./dist/primitives/index.js", "../../.design-sync/preview-theme.tsx"],
+  "provider": { "component": "DsPreviewLight" },
   "overrides": {
     "Dialog": { "cardMode": "single", "viewport": "560x420" },
     "Popover": { "cardMode": "single", "viewport": "420x320" },

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,34 @@
+{
+  "pkg": "@opensaas/stack-ui",
+  "globalName": "StackUI",
+  "projectId": "08206dc2-60c0-4681-969c-a12af2587f76",
+  "shape": "package",
+  "buildCmd": "pnpm -F \"@opensaas/stack-ui...\" build",
+  "cssEntry": "dist/styles/globals.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "tsconfig": "../../.design-sync/next-stub-tsconfig.json",
+  "extraEntries": ["./dist/primitives/index.js"],
+  "overrides": {
+    "Dialog": { "cardMode": "single", "viewport": "560x420" },
+    "Popover": { "cardMode": "single", "viewport": "420x320" },
+    "Combobox": { "cardMode": "single", "viewport": "420x360" },
+    "Select": { "cardMode": "single", "viewport": "420x360" },
+    "ConfirmDialog": { "cardMode": "single", "viewport": "520x360" }
+  },
+  "componentSrcMap": {
+    "Button": "src/primitives/button.tsx",
+    "Input": "src/primitives/input.tsx",
+    "Textarea": "src/primitives/textarea.tsx",
+    "Label": "src/primitives/label.tsx",
+    "Card": "src/primitives/card.tsx",
+    "Table": "src/primitives/table.tsx",
+    "Dialog": "src/primitives/dialog.tsx",
+    "Select": "src/primitives/select.tsx",
+    "Checkbox": "src/primitives/checkbox.tsx",
+    "Popover": "src/primitives/popover.tsx",
+    "Calendar": "src/primitives/calendar.tsx",
+    "TimePicker": "src/primitives/time-picker.tsx",
+    "DateTimePicker": "src/primitives/datetime-picker.tsx",
+    "Combobox": "src/primitives/combobox.tsx"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,71 @@
+# Building with OpenSaas Stack UI
+
+A composable React admin-UI library (Tailwind CSS v4 + Radix primitives). Every component here is
+the real shipped component — import it from `@opensaas/stack-ui` and compose with realistic props.
+
+## Setup — no provider needed for styling
+
+Components carry their own token-based classes, so they render on-brand as soon as the design system's
+stylesheet is loaded (it already is, in this environment). There is **no ThemeProvider to wrap** — just
+render the components. Dark mode is driven by `data-theme="dark"` on a root element (tokens use CSS
+`light-dark()`); default is light. (The admin *composites* — `AdminUI`, `Dashboard`, `ListView`,
+`ItemForm`, `SingletonView` — are the exception: they need a live server `context` + `config` and are
+data-fetching, so build screens from the primitives/fields/standalone components, not these.)
+
+## Styling idiom — Tailwind v4 utilities backed by design tokens
+
+Style your own layout/glue with **Tailwind utility classes that resolve to the theme tokens** — never
+hardcode hex colors, radii, or shadows. Use these token-backed families (real names from the compiled
+stylesheet):
+
+| Purpose | Utilities (use the token, not a raw value) |
+|---|---|
+| Surfaces | `bg-background` `bg-card` `bg-popover` `bg-muted` `bg-primary` `bg-secondary` `bg-accent` `bg-destructive` `bg-success` `bg-warning` |
+| Text | `text-foreground` `text-muted-foreground` `text-card-foreground` `text-primary` `text-primary-foreground` `text-destructive` `text-secondary-foreground` `text-accent-foreground` |
+| Borders | `border` `border-border` `border-input` `border-primary` `border-destructive` (+ `border-dashed`) |
+| Radius | `rounded-sm` `rounded-md` `rounded-lg` `rounded-xl` `rounded-full` |
+| Elevation | `shadow-sm` `shadow-md` `shadow-lg` `shadow-2xl` |
+| Type | `font-sans` (body) `font-heading` (titles) `font-mono`; weights `font-medium` `font-semibold` `font-bold` |
+
+Each token has a paired `-foreground` for accessible text (e.g. `bg-primary text-primary-foreground`,
+`bg-destructive text-destructive-foreground`). Semantic status colors: `success`, `warning`,
+`destructive` (used by `Badge` variants and field error/warning text). A signature gradient
+(`gradient-from`/`gradient-to`, via `bg-gradient-to-br`) is reserved for dashboard headers
+(`PageHeader gradient`).
+
+## Where the truth lives
+
+- **Tokens & stylesheet**: `_ds/<folder>/styles.css` and its `@import` closure (the `@theme` block
+  defines every `--color-*`, `--radius-*`, `--font-*`). Read it before inventing any class.
+- **Per-component API**: each component's `.d.ts` (`<Name>Props`) is the exact contract; its
+  `.prompt.md` shows usage. Prefer named props over ad-hoc styling — e.g. `Button` has
+  `variant="default|secondary|destructive|outline|ghost|link"` and `size="sm|default|lg|icon"`;
+  fields (`TextField`, `SelectField`, …) are controlled (`value`/`onChange`) with `label`, `error`,
+  `disabled`, `required`, `mode="edit|read"`, `helpText`.
+
+## Idiomatic example
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Badge } from '@opensaas/stack-ui'
+
+export function InvoiceCard() {
+  return (
+    <Card className="max-w-sm">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Invoice #1042</CardTitle>
+          <Badge variant="success">Paid</Badge>
+        </div>
+        <CardDescription>Billed to Ada Lovelace · Mar 2026</CardDescription>
+      </CardHeader>
+      <CardContent className="flex items-center justify-between">
+        <span className="text-2xl font-heading font-semibold">$1,240.00</span>
+        <Button variant="outline" size="sm">Download</Button>
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+The library component (`Card`, `Button`, `Badge`) carries the design language; your `className` glue
+uses only token-backed utilities (`flex`, `text-2xl`, `font-heading`, `max-w-sm`).

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -7,10 +7,18 @@ the real shipped component — import it from `@opensaas/stack-ui` and compose w
 
 Components carry their own token-based classes, so they render on-brand as soon as the design system's
 stylesheet is loaded (it already is, in this environment). There is **no ThemeProvider to wrap** — just
-render the components. Dark mode is driven by `data-theme="dark"` on a root element (tokens use CSS
-`light-dark()`); default is light. (The admin *composites* — `AdminUI`, `Dashboard`, `ListView`,
-`ItemForm`, `SingletonView` — are the exception: they need a live server `context` + `config` and are
-data-fetching, so build screens from the primitives/fields/standalone components, not these.)
+render the components.
+
+**Pin a color scheme on the root.** The tokens use CSS `light-dark()`, driven by `color-scheme`. Set
+`data-theme="light"` (or `"dark"`) on the root/`<html>` so text stays readable — e.g. `text-foreground`
+resolves to dark-on-light under `light`. If you leave it unpinned it follows the viewer's OS preference
+(`:root { color-scheme: light dark }`), which can put near-white `text-foreground` on a light surface for
+a dark-mode viewer. For a fixed light layout, wrap the screen root in
+`<div data-theme="light" style={{ colorScheme: 'light' }}>…</div>`.
+
+(The admin *composites* — `AdminUI`, `Dashboard`, `ListView`, `ItemForm`, `SingletonView` — are the
+exception to "just render": they need a live server `context` + `config` and are data-fetching, so build
+screens from the primitives/fields/standalone components, not these.)
 
 ## Styling idiom — Tailwind v4 utilities backed by design tokens
 

--- a/.design-sync/next-stub-tsconfig.json
+++ b/.design-sync/next-stub-tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "paths": {
+      "next/link.js": ["./stubs/next/link.tsx"],
+      "next/navigation.js": ["./stubs/next/navigation.tsx"],
+      "next/image.js": ["./stubs/next/image.tsx"],
+      "@/*": ["../packages/ui/src/*"]
+    }
+  }
+}

--- a/.design-sync/preview-theme.tsx
+++ b/.design-sync/preview-theme.tsx
@@ -1,0 +1,14 @@
+// Preview-only wrapper (wired via cfg.provider). The DS's tokens use CSS
+// `light-dark()` driven by `color-scheme`; with no pinned `data-theme` the
+// default `:root { color-scheme: light dark }` follows the VIEWER's OS
+// preference. The claude.ai/design pane draws every card on a white canvas,
+// so a dark-mode viewer would get near-white `text-foreground` on white
+// (unreadable). Pinning the preview root to `light` keeps cards readable on
+// that white canvas regardless of the viewer's OS theme. This wraps ONLY the
+// preview cards — it does not change the shipped bundle or how real designs
+// render (those should pin their own theme; see the README conventions).
+import * as React from 'react'
+
+export function DsPreviewLight({ children }: { children?: React.ReactNode }) {
+  return React.createElement('div', { style: { colorScheme: 'light' } }, children)
+}

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,12 @@
+import { Badge } from '@opensaas/stack-ui'
+
+export const Variants = () => (
+  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+    <Badge>Active</Badge>
+    <Badge variant="secondary">Draft</Badge>
+    <Badge variant="success">Published</Badge>
+    <Badge variant="warning">Pending</Badge>
+    <Badge variant="destructive">Failed</Badge>
+    <Badge variant="outline">Archived</Badge>
+  </div>
+)

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@opensaas/stack-ui'
+
+export const Variants = () => (
+  <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+    <Button>Save changes</Button>
+    <Button variant="secondary">Cancel</Button>
+    <Button variant="destructive">Delete</Button>
+    <Button variant="outline">Export</Button>
+    <Button variant="ghost">Dismiss</Button>
+    <Button variant="link">Learn more</Button>
+  </div>
+)
+
+export const Sizes = () => (
+  <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+    <Button size="sm">Small</Button>
+    <Button size="default">Default</Button>
+    <Button size="lg">Large</Button>
+  </div>
+)
+
+export const States = () => (
+  <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+    <Button>Enabled</Button>
+    <Button disabled>Disabled</Button>
+  </div>
+)

--- a/.design-sync/previews/Calendar.tsx
+++ b/.design-sync/previews/Calendar.tsx
@@ -1,0 +1,9 @@
+import { Calendar } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const SingleSelect = () => (
+  <div style={{ maxWidth: 320, border: '1px solid var(--color-border)', borderRadius: 8 }}>
+    <Calendar mode="single" selected={new Date(2026, 6, 18)} onSelect={noop} />
+  </div>
+)

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,42 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  Button,
+  Badge,
+} from '@opensaas/stack-ui'
+
+export const WithHeaderAndFooter = () => (
+  <Card style={{ maxWidth: 380 }}>
+    <CardHeader>
+      <CardTitle>Project settings</CardTitle>
+      <CardDescription>Manage how your workspace behaves and who can access it.</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p style={{ fontSize: 14, lineHeight: 1.6, margin: 0 }}>
+        Changes apply immediately across every environment. Members are notified by email whenever
+        their access level changes.
+      </p>
+    </CardContent>
+    <CardFooter style={{ display: 'flex', gap: 8 }}>
+      <Button>Save changes</Button>
+      <Button variant="outline">Cancel</Button>
+    </CardFooter>
+  </Card>
+)
+
+export const StatCard = () => (
+  <Card style={{ maxWidth: 260 }}>
+    <CardHeader>
+      <CardDescription>Monthly revenue</CardDescription>
+      <CardTitle>$48,120</CardTitle>
+    </CardHeader>
+    <CardContent style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Badge variant="success">+12.5%</Badge>
+      <span style={{ fontSize: 13, color: 'var(--color-muted-foreground)' }}>vs last month</span>
+    </CardContent>
+  </Card>
+)

--- a/.design-sync/previews/Checkbox.tsx
+++ b/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,35 @@
+import { Checkbox, Label } from '@opensaas/stack-ui'
+
+export const WithLabels = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="terms" defaultChecked />
+      <Label htmlFor="terms">I accept the terms and conditions</Label>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="newsletter" />
+      <Label htmlFor="newsletter">Send me product updates by email</Label>
+    </div>
+  </div>
+)
+
+export const States = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="checked" defaultChecked />
+      <Label htmlFor="checked">Checked</Label>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="unchecked" />
+      <Label htmlFor="unchecked">Unchecked</Label>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="disabled-on" defaultChecked disabled />
+      <Label htmlFor="disabled-on">Disabled (locked on)</Label>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Checkbox id="disabled-off" disabled />
+      <Label htmlFor="disabled-off">Disabled (unavailable)</Label>
+    </div>
+  </div>
+)

--- a/.design-sync/previews/CheckboxField.tsx
+++ b/.design-sync/previews/CheckboxField.tsx
@@ -1,0 +1,56 @@
+import { CheckboxField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <CheckboxField
+      name="featured"
+      label="Feature this post on the homepage"
+      value={true}
+      onChange={noop}
+      helpText="Featured posts appear in the hero carousel."
+    />
+  </div>
+)
+
+export const Unchecked = () => (
+  <div style={{ maxWidth: 360 }}>
+    <CheckboxField
+      name="sendNewsletter"
+      label="Send to newsletter subscribers"
+      value={false}
+      onChange={noop}
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <CheckboxField
+      name="acceptTerms"
+      label="I accept the terms of service"
+      value={false}
+      onChange={noop}
+      error="You must accept the terms to continue."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <CheckboxField
+      name="verified"
+      label="Email verified"
+      value={true}
+      onChange={noop}
+      disabled
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <CheckboxField name="featured" label="Featured post" value={true} onChange={noop} mode="read" />
+  </div>
+)

--- a/.design-sync/previews/Combobox.tsx
+++ b/.design-sync/previews/Combobox.tsx
@@ -1,0 +1,39 @@
+import {
+  Combobox,
+  ComboboxTrigger,
+  ComboboxContent,
+  ComboboxSearch,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxEmpty,
+} from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Open = () => (
+  <Combobox defaultOpen>
+    <ComboboxTrigger style={{ width: 260 }}>Assign reviewer…</ComboboxTrigger>
+    <ComboboxContent style={{ width: 260 }}>
+      <ComboboxSearch placeholder="Search people…" value="" onChange={noop} />
+      <ComboboxList>
+        <ComboboxItem selected>Jordan Lee</ComboboxItem>
+        <ComboboxItem>Priya Nair</ComboboxItem>
+        <ComboboxItem>Marcus Chen</ComboboxItem>
+        <ComboboxItem>Sofia Alvarez</ComboboxItem>
+        <ComboboxItem>Diego Fernandez</ComboboxItem>
+      </ComboboxList>
+    </ComboboxContent>
+  </Combobox>
+)
+
+export const Empty = () => (
+  <Combobox defaultOpen>
+    <ComboboxTrigger style={{ width: 260 }}>Search frameworks…</ComboboxTrigger>
+    <ComboboxContent style={{ width: 260 }}>
+      <ComboboxSearch placeholder="Search frameworks…" value="qwerty" onChange={noop} />
+      <ComboboxList>
+        <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+      </ComboboxList>
+    </ComboboxContent>
+  </Combobox>
+)

--- a/.design-sync/previews/ConfirmDialog.tsx
+++ b/.design-sync/previews/ConfirmDialog.tsx
@@ -1,0 +1,29 @@
+import { ConfirmDialog } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Danger = () => (
+  <ConfirmDialog
+    isOpen={true}
+    variant="danger"
+    title="Delete post"
+    message="This will permanently delete “Getting started with OpenSaaS” and cannot be undone."
+    confirmLabel="Delete post"
+    cancelLabel="Cancel"
+    onConfirm={noop}
+    onCancel={noop}
+  />
+)
+
+export const Warning = () => (
+  <ConfirmDialog
+    isOpen={true}
+    variant="warning"
+    title="Discard changes?"
+    message="You have unsaved edits on this post. Leaving now will discard them."
+    confirmLabel="Discard changes"
+    cancelLabel="Keep editing"
+    onConfirm={noop}
+    onCancel={noop}
+  />
+)

--- a/.design-sync/previews/DateTimePicker.tsx
+++ b/.design-sync/previews/DateTimePicker.tsx
@@ -1,0 +1,15 @@
+import { DateTimePicker } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const WithValue = () => (
+  <div style={{ maxWidth: 320 }}>
+    <DateTimePicker value={new Date(2026, 6, 18, 9, 30)} onChange={noop} />
+  </div>
+)
+
+export const Placeholder = () => (
+  <div style={{ maxWidth: 320 }}>
+    <DateTimePicker onChange={noop} placeholder="Schedule publish time" />
+  </div>
+)

--- a/.design-sync/previews/DeleteButton.tsx
+++ b/.design-sync/previews/DeleteButton.tsx
@@ -1,0 +1,26 @@
+import { DeleteButton } from '@opensaas/stack-ui'
+
+const submit = async () => ({ success: true })
+
+export const Default = () => (
+  <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+    <DeleteButton onDelete={submit} itemName="post" buttonLabel="Delete post" />
+  </div>
+)
+
+export const Outline = () => (
+  <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+    <DeleteButton
+      onDelete={submit}
+      itemName="post"
+      buttonLabel="Remove"
+      buttonVariant="outline"
+    />
+  </div>
+)
+
+export const Small = () => (
+  <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+    <DeleteButton onDelete={submit} itemName="comment" buttonLabel="Delete" size="sm" />
+  </div>
+)

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,55 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  Button,
+  Label,
+  Input,
+} from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Confirmation = () => (
+  <Dialog defaultOpen>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Delete project</DialogTitle>
+        <DialogDescription>
+          This permanently removes the project and all of its environments. This action cannot be
+          undone.
+        </DialogDescription>
+      </DialogHeader>
+      <div style={{ fontSize: 14, lineHeight: 1.6, color: 'var(--color-muted-foreground)' }}>
+        Members will lose access immediately and any running deployments will be stopped.
+      </div>
+      <DialogFooter style={{ display: 'flex', gap: 8 }}>
+        <Button variant="outline">Cancel</Button>
+        <Button variant="destructive">Delete project</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+)
+
+export const FormDialog = () => (
+  <Dialog defaultOpen>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Invite teammate</DialogTitle>
+        <DialogDescription>Send an invitation to join this workspace.</DialogDescription>
+      </DialogHeader>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <Label htmlFor="invite-email">Email address</Label>
+          <Input id="invite-email" type="email" value="alex@acme.com" onChange={noop} />
+        </div>
+      </div>
+      <DialogFooter style={{ display: 'flex', gap: 8 }}>
+        <Button variant="outline">Cancel</Button>
+        <Button>Send invite</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+)

--- a/.design-sync/previews/EmptyState.tsx
+++ b/.design-sync/previews/EmptyState.tsx
@@ -1,0 +1,22 @@
+import { EmptyState, Button } from '@opensaas/stack-ui'
+
+export const WithAction = () => (
+  <div style={{ maxWidth: 480 }}>
+    <EmptyState
+      icon={<span aria-hidden="true">📝</span>}
+      title="No posts yet"
+      description="Your blog is empty. Create your first post to start publishing to your readers."
+      actions={<Button>Create post</Button>}
+    />
+  </div>
+)
+
+export const NoAction = () => (
+  <div style={{ maxWidth: 480 }}>
+    <EmptyState
+      icon={<span aria-hidden="true">🔍</span>}
+      title="No results found"
+      description="No records match your current filters. Try broadening your search criteria."
+    />
+  </div>
+)

--- a/.design-sync/previews/FieldError.tsx
+++ b/.design-sync/previews/FieldError.tsx
@@ -1,0 +1,23 @@
+import { FieldRoot, FieldLabel, FieldError, Input } from '@opensaas/stack-ui'
+
+export const InvalidSlug = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="slug">Slug</FieldLabel>
+      <Input id="slug" defaultValue="My First Post!" aria-invalid />
+      <FieldError>Slug can only contain lowercase letters, numbers and hyphens.</FieldError>
+    </FieldRoot>
+  </div>
+)
+
+export const RequiredMissing = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="title" required>
+        Post title
+      </FieldLabel>
+      <Input id="title" defaultValue="" placeholder="Enter a descriptive title" aria-invalid />
+      <FieldError>Title is required.</FieldError>
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/FieldHelp.tsx
+++ b/.design-sync/previews/FieldHelp.tsx
@@ -1,0 +1,23 @@
+import { FieldRoot, FieldLabel, FieldHelp, Input } from '@opensaas/stack-ui'
+
+export const BelowInput = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="email">Email address</FieldLabel>
+      <Input id="email" defaultValue="ada@example.com" />
+      <FieldHelp>We'll never share your email with anyone else.</FieldHelp>
+    </FieldRoot>
+  </div>
+)
+
+export const WithRequiredLabel = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="slug" required>
+        Slug
+      </FieldLabel>
+      <Input id="slug" defaultValue="my-first-post" />
+      <FieldHelp>URL-friendly identifier — lowercase letters, numbers and hyphens only.</FieldHelp>
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/FieldLabel.tsx
+++ b/.design-sync/previews/FieldLabel.tsx
@@ -1,0 +1,30 @@
+import { FieldRoot, FieldLabel, Input } from '@opensaas/stack-ui'
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="email">Email address</FieldLabel>
+      <Input id="email" defaultValue="ada@example.com" />
+    </FieldRoot>
+  </div>
+)
+
+export const Required = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="title" required>
+        Post title
+      </FieldLabel>
+      <Input id="title" placeholder="Enter a descriptive title" />
+    </FieldRoot>
+  </div>
+)
+
+export const Muted = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Role</FieldLabel>
+      <Input defaultValue="Administrator" disabled />
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/FieldReadValue.tsx
+++ b/.design-sync/previews/FieldReadValue.tsx
@@ -1,0 +1,32 @@
+import { FieldRoot, FieldLabel, FieldReadValue } from '@opensaas/stack-ui'
+
+export const ScalarValue = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Email address</FieldLabel>
+      <FieldReadValue>ada@example.com</FieldReadValue>
+    </FieldRoot>
+  </div>
+)
+
+export const LongText = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Bio</FieldLabel>
+      <FieldReadValue>Building admin tools that stay out of the way.</FieldReadValue>
+    </FieldRoot>
+  </div>
+)
+
+export const Stacked = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 360 }}>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Status</FieldLabel>
+      <FieldReadValue>Published</FieldReadValue>
+    </FieldRoot>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Created</FieldLabel>
+      <FieldReadValue>18 July 2026, 9:42 AM</FieldReadValue>
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/FieldRenderer.tsx
+++ b/.design-sync/previews/FieldRenderer.tsx
@@ -1,0 +1,62 @@
+import { FieldRenderer } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const TextConfig = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRenderer
+      fieldName="title"
+      fieldConfig={{
+        type: 'text',
+        label: 'Post title',
+        validation: { isRequired: true },
+        ui: { description: 'Shown as the headline on the post page.' },
+      }}
+      value="Designing admin tools that stay out of the way"
+      onChange={noop}
+    />
+  </div>
+)
+
+export const SelectConfig = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRenderer
+      fieldName="status"
+      fieldConfig={{
+        type: 'select',
+        label: 'Status',
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+          { label: 'Archived', value: 'archived' },
+        ],
+      }}
+      value="published"
+      onChange={noop}
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRenderer
+      fieldName="slug"
+      fieldConfig={{ type: 'text', label: 'Slug' }}
+      value="My First Post!"
+      onChange={noop}
+      error="Slug can only contain lowercase letters, numbers and hyphens."
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRenderer
+      fieldName="email"
+      fieldConfig={{ type: 'text', label: 'Email address' }}
+      value="ada@example.com"
+      onChange={noop}
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/FieldRoot.tsx
+++ b/.design-sync/previews/FieldRoot.tsx
@@ -1,0 +1,20 @@
+import { FieldRoot, FieldLabel, FieldHelp, FieldReadValue, Input } from '@opensaas/stack-ui'
+
+export const EditField = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="workspace">Workspace name</FieldLabel>
+      <Input id="workspace" defaultValue="Acme Analytics" placeholder="Enter a workspace name" />
+      <FieldHelp>Shown to every member in the workspace switcher.</FieldHelp>
+    </FieldRoot>
+  </div>
+)
+
+export const ReadField = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot mode="read">
+      <FieldLabel muted>Workspace name</FieldLabel>
+      <FieldReadValue>Acme Analytics</FieldReadValue>
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/FieldWarning.tsx
+++ b/.design-sync/previews/FieldWarning.tsx
@@ -1,0 +1,21 @@
+import { FieldRoot, FieldLabel, FieldWarning, Input } from '@opensaas/stack-ui'
+
+export const InProgressJson = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="metadata">Metadata</FieldLabel>
+      <Input id="metadata" defaultValue='{ "featured": true,' />
+      <FieldWarning>Incomplete JSON — changes won't be saved until this parses.</FieldWarning>
+    </FieldRoot>
+  </div>
+)
+
+export const DeprecatedValue = () => (
+  <div style={{ maxWidth: 360 }}>
+    <FieldRoot>
+      <FieldLabel htmlFor="region">Region</FieldLabel>
+      <Input id="region" defaultValue="us-west-1" />
+      <FieldWarning>This region is being retired — migrate to us-west-2 before December.</FieldWarning>
+    </FieldRoot>
+  </div>
+)

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,21 @@
+import { Input, Label } from '@opensaas/stack-ui'
+
+export const WithValueAndPlaceholder = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 360 }}>
+    <Input defaultValue="ada@example.com" />
+    <Input placeholder="Search posts, users and settings…" />
+  </div>
+)
+
+export const Labelled = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxWidth: 360 }}>
+    <Label htmlFor="workspace">Workspace name</Label>
+    <Input id="workspace" defaultValue="Acme Analytics" placeholder="Enter a workspace name" />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <Input defaultValue="usr_8f2a1c9d" disabled />
+  </div>
+)

--- a/.design-sync/previews/IntegerField.tsx
+++ b/.design-sync/previews/IntegerField.tsx
@@ -1,0 +1,55 @@
+import { IntegerField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <IntegerField
+      name="readingTime"
+      label="Reading time (minutes)"
+      value={7}
+      onChange={noop}
+      helpText="Estimated time to read this post."
+    />
+  </div>
+)
+
+export const Required = () => (
+  <div style={{ maxWidth: 360 }}>
+    <IntegerField
+      name="stock"
+      label="Units in stock"
+      value={0}
+      onChange={noop}
+      required
+      min={0}
+      placeholder="0"
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <IntegerField
+      name="price"
+      label="Price (cents)"
+      value={-50}
+      onChange={noop}
+      min={0}
+      max={100000}
+      error="Price must be zero or greater."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <IntegerField name="version" label="Schema version" value={12} onChange={noop} disabled />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <IntegerField name="views" label="Total views" value={4821} onChange={noop} mode="read" />
+  </div>
+)

--- a/.design-sync/previews/ItemCreateForm.tsx
+++ b/.design-sync/previews/ItemCreateForm.tsx
@@ -1,0 +1,42 @@
+import { ItemCreateForm } from '@opensaas/stack-ui'
+
+const submit = async () => ({ success: true })
+
+const postFields = {
+  title: {
+    type: 'text',
+    label: 'Title',
+    validation: { isRequired: true },
+  },
+  status: {
+    type: 'select',
+    label: 'Status',
+    options: [
+      { label: 'Draft', value: 'draft' },
+      { label: 'Published', value: 'published' },
+      { label: 'Archived', value: 'archived' },
+    ],
+  },
+  publishedAt: {
+    type: 'timestamp',
+    label: 'Published at',
+  },
+}
+
+export const Default = () => (
+  <div style={{ maxWidth: 480 }}>
+    <ItemCreateForm fields={postFields} onSubmit={submit} submitLabel="Create post" />
+  </div>
+)
+
+export const WithCancel = () => (
+  <div style={{ maxWidth: 480 }}>
+    <ItemCreateForm
+      fields={postFields}
+      onSubmit={submit}
+      onCancel={() => {}}
+      submitLabel="Create post"
+      cancelLabel="Discard"
+    />
+  </div>
+)

--- a/.design-sync/previews/ItemEditForm.tsx
+++ b/.design-sync/previews/ItemEditForm.tsx
@@ -1,0 +1,54 @@
+import { ItemEditForm } from '@opensaas/stack-ui'
+
+const submit = async () => ({ success: true })
+
+const postFields = {
+  title: {
+    type: 'text',
+    label: 'Title',
+    validation: { isRequired: true },
+  },
+  status: {
+    type: 'select',
+    label: 'Status',
+    options: [
+      { label: 'Draft', value: 'draft' },
+      { label: 'Published', value: 'published' },
+      { label: 'Archived', value: 'archived' },
+    ],
+  },
+  publishedAt: {
+    type: 'timestamp',
+    label: 'Published at',
+  },
+}
+
+const post = {
+  title: 'Launching the new dashboard',
+  status: 'published',
+  publishedAt: '2026-02-14T09:30:00Z',
+}
+
+export const Default = () => (
+  <div style={{ maxWidth: 480 }}>
+    <ItemEditForm
+      fields={postFields}
+      initialData={post}
+      onSubmit={submit}
+      submitLabel="Save changes"
+    />
+  </div>
+)
+
+export const WithCancel = () => (
+  <div style={{ maxWidth: 480 }}>
+    <ItemEditForm
+      fields={postFields}
+      initialData={post}
+      onSubmit={submit}
+      onCancel={() => {}}
+      submitLabel="Save changes"
+      cancelLabel="Cancel"
+    />
+  </div>
+)

--- a/.design-sync/previews/Label.tsx
+++ b/.design-sync/previews/Label.tsx
@@ -1,0 +1,15 @@
+import { Label, Input, Checkbox } from '@opensaas/stack-ui'
+
+export const WithInput = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxWidth: 360 }}>
+    <Label htmlFor="email">Email address</Label>
+    <Input id="email" type="email" defaultValue="ada@example.com" placeholder="you@example.com" />
+  </div>
+)
+
+export const WithCheckbox = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <Checkbox id="marketing" defaultChecked />
+    <Label htmlFor="marketing">Subscribe to the monthly newsletter</Label>
+  </div>
+)

--- a/.design-sync/previews/ListTable.tsx
+++ b/.design-sync/previews/ListTable.tsx
@@ -1,0 +1,36 @@
+import { ListTable } from '@opensaas/stack-ui'
+
+const posts: Record<string, unknown>[] = [
+  { id: '1', title: 'Launching the new dashboard', author: 'Ada Lovelace', status: 'Published', views: 1240 },
+  { id: '2', title: 'Access control, explained', author: 'Grace Hopper', status: 'Published', views: 862 },
+  { id: '3', title: 'Draft: migrating from Keystone', author: 'Alan Turing', status: 'Draft', views: 0 },
+  { id: '4', title: 'Field-level hooks in practice', author: 'Katherine Johnson', status: 'Review', views: 315 },
+]
+
+const fieldTypes = {
+  title: 'text',
+  author: 'text',
+  status: 'text',
+  views: 'integer',
+}
+
+export const Populated = () => (
+  <div style={{ maxWidth: 720 }}>
+    <ListTable
+      items={posts}
+      fieldTypes={fieldTypes}
+      columns={['title', 'author', 'status', 'views']}
+    />
+  </div>
+)
+
+export const Empty = () => (
+  <div style={{ maxWidth: 720 }}>
+    <ListTable
+      items={[]}
+      fieldTypes={fieldTypes}
+      columns={['title', 'author', 'status', 'views']}
+      emptyMessage="No posts yet — create your first post to get started."
+    />
+  </div>
+)

--- a/.design-sync/previews/LoadingSpinner.tsx
+++ b/.design-sync/previews/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from '@opensaas/stack-ui'
+
+export const Sizes = () => (
+  <div style={{ display: 'flex', gap: 32, alignItems: 'center' }}>
+    <LoadingSpinner size="sm" />
+    <LoadingSpinner size="md" />
+    <LoadingSpinner size="lg" />
+  </div>
+)

--- a/.design-sync/previews/PageHeader.tsx
+++ b/.design-sync/previews/PageHeader.tsx
@@ -1,0 +1,34 @@
+import { PageHeader, Button } from '@opensaas/stack-ui'
+
+export const Default = () => (
+  <div style={{ maxWidth: 640 }}>
+    <PageHeader
+      title="Posts"
+      description="Manage the articles published to your blog."
+      actions={<Button>Create post</Button>}
+    />
+  </div>
+)
+
+export const WithBackLink = () => (
+  <div style={{ maxWidth: 640 }}>
+    <PageHeader
+      title="Edit post"
+      description="Update the title, body, and publication status of this article."
+      backHref="/admin/post"
+      backLabel="Back to posts"
+      actions={<Button variant="outline">Save changes</Button>}
+    />
+  </div>
+)
+
+export const Gradient = () => (
+  <div style={{ maxWidth: 640 }}>
+    <PageHeader
+      gradient
+      title="Dashboard"
+      description="An overview of activity across your workspace."
+      actions={<Button>New report</Button>}
+    />
+  </div>
+)

--- a/.design-sync/previews/PasswordField.tsx
+++ b/.design-sync/previews/PasswordField.tsx
@@ -1,0 +1,66 @@
+import { PasswordField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <PasswordField
+      name="password"
+      label="Password"
+      value=""
+      onChange={noop}
+      placeholder="Enter a new password"
+      helpText="Use at least 12 characters with a mix of letters and numbers."
+    />
+  </div>
+)
+
+export const AlreadySet = () => (
+  <div style={{ maxWidth: 360 }}>
+    <PasswordField
+      name="password"
+      label="Password"
+      value={{ isSet: true }}
+      onChange={noop}
+      helpText="A password is already set for this account."
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <PasswordField
+      name="password"
+      label="Password"
+      value=""
+      onChange={noop}
+      required
+      error="Password must be at least 12 characters long."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <PasswordField
+      name="password"
+      label="Password"
+      value=""
+      onChange={noop}
+      placeholder="Managed by your SSO provider"
+      disabled
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <PasswordField
+      name="password"
+      label="Password"
+      value={{ isSet: true }}
+      onChange={noop}
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/Popover.tsx
+++ b/.design-sync/previews/Popover.tsx
@@ -1,0 +1,65 @@
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Button,
+  Label,
+  Input,
+} from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Settings = () => (
+  <Popover defaultOpen>
+    <PopoverTrigger asChild>
+      <Button variant="outline">Dimensions</Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <p style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Dimensions</p>
+          <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--color-muted-foreground)' }}>
+            Set the size for the container.
+          </p>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Label htmlFor="pop-width" style={{ width: 72 }}>
+            Width
+          </Label>
+          <Input id="pop-width" value="480px" onChange={noop} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Label htmlFor="pop-height" style={{ width: 72 }}>
+            Height
+          </Label>
+          <Input id="pop-height" value="320px" onChange={noop} />
+        </div>
+      </div>
+    </PopoverContent>
+  </Popover>
+)
+
+export const AccountMenu = () => (
+  <Popover defaultOpen>
+    <PopoverTrigger asChild>
+      <Button variant="outline">Account</Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <p style={{ margin: '0 0 4px', fontSize: 14, fontWeight: 600 }}>Jordan Lee</p>
+        <p style={{ margin: '0 0 8px', fontSize: 13, color: 'var(--color-muted-foreground)' }}>
+          jordan@acme.com
+        </p>
+        <Button variant="ghost" style={{ justifyContent: 'flex-start' }}>
+          Profile settings
+        </Button>
+        <Button variant="ghost" style={{ justifyContent: 'flex-start' }}>
+          Billing
+        </Button>
+        <Button variant="ghost" style={{ justifyContent: 'flex-start' }}>
+          Sign out
+        </Button>
+      </div>
+    </PopoverContent>
+  </Popover>
+)

--- a/.design-sync/previews/RelationshipField.tsx
+++ b/.design-sync/previews/RelationshipField.tsx
@@ -1,0 +1,83 @@
+import { RelationshipField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+const authors = [
+  { id: 'usr_ada', label: 'Ada Lovelace' },
+  { id: 'usr_grace', label: 'Grace Hopper' },
+  { id: 'usr_alan', label: 'Alan Turing' },
+]
+
+const tags = [
+  { id: 'tag_eng', label: 'Engineering' },
+  { id: 'tag_design', label: 'Design' },
+  { id: 'tag_product', label: 'Product' },
+  { id: 'tag_ops', label: 'Operations' },
+]
+
+export const Single = () => (
+  <div style={{ maxWidth: 360 }}>
+    <RelationshipField
+      name="author"
+      label="Author"
+      value="usr_grace"
+      onChange={noop}
+      items={authors}
+    />
+  </div>
+)
+
+export const ManyConnected = () => (
+  <div style={{ maxWidth: 420 }}>
+    <RelationshipField
+      name="tags"
+      label="Tags"
+      value={['tag_eng', 'tag_product']}
+      onChange={noop}
+      items={tags}
+      many
+    />
+  </div>
+)
+
+export const ManyEmpty = () => (
+  <div style={{ maxWidth: 420 }}>
+    <RelationshipField
+      name="tags"
+      label="Tags"
+      value={[]}
+      onChange={noop}
+      items={tags}
+      many
+      required
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <RelationshipField
+      name="author"
+      label="Author"
+      value=""
+      onChange={noop}
+      items={authors}
+      required
+      error="Please select an author for this post."
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 420 }}>
+    <RelationshipField
+      name="tags"
+      label="Tags"
+      value={['tag_eng', 'tag_design']}
+      onChange={noop}
+      items={tags}
+      many
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/SearchBar.tsx
+++ b/.design-sync/previews/SearchBar.tsx
@@ -1,0 +1,26 @@
+import { SearchBar } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 520 }}>
+    <SearchBar
+      onSearch={noop}
+      onClear={noop}
+      placeholder="Search posts by title or author..."
+      searchLabel="Search"
+    />
+  </div>
+)
+
+export const WithValue = () => (
+  <div style={{ maxWidth: 520 }}>
+    <SearchBar
+      onSearch={noop}
+      onClear={noop}
+      placeholder="Search posts..."
+      defaultValue="release notes"
+      searchLabel="Search"
+    />
+  </div>
+)

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,62 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectGroup,
+  SelectLabel,
+  SelectSeparator,
+} from '@opensaas/stack-ui'
+
+export const Open = () => (
+  <Select defaultOpen defaultValue="published">
+    <SelectTrigger style={{ width: 220 }}>
+      <SelectValue placeholder="Status" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectGroup>
+        <SelectLabel>Publication status</SelectLabel>
+        <SelectItem value="draft">Draft</SelectItem>
+        <SelectItem value="in-review">In review</SelectItem>
+        <SelectItem value="published">Published</SelectItem>
+        <SelectItem value="archived">Archived</SelectItem>
+      </SelectGroup>
+    </SelectContent>
+  </Select>
+)
+
+export const Selected = () => (
+  <Select defaultValue="published">
+    <SelectTrigger style={{ width: 220 }}>
+      <SelectValue placeholder="Status" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="draft">Draft</SelectItem>
+      <SelectItem value="in-review">In review</SelectItem>
+      <SelectItem value="published">Published</SelectItem>
+      <SelectItem value="archived">Archived</SelectItem>
+    </SelectContent>
+  </Select>
+)
+
+export const WithSeparator = () => (
+  <Select defaultValue="us-east-1">
+    <SelectTrigger style={{ width: 240 }}>
+      <SelectValue placeholder="Region" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectGroup>
+        <SelectLabel>Americas</SelectLabel>
+        <SelectItem value="us-east-1">US East (N. Virginia)</SelectItem>
+        <SelectItem value="us-west-2">US West (Oregon)</SelectItem>
+      </SelectGroup>
+      <SelectSeparator />
+      <SelectGroup>
+        <SelectLabel>Europe</SelectLabel>
+        <SelectItem value="eu-west-1">EU West (Ireland)</SelectItem>
+        <SelectItem value="eu-central-1">EU Central (Frankfurt)</SelectItem>
+      </SelectGroup>
+    </SelectContent>
+  </Select>
+)

--- a/.design-sync/previews/SelectField.tsx
+++ b/.design-sync/previews/SelectField.tsx
@@ -1,0 +1,80 @@
+import { SelectField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+const statusOptions = [
+  { label: 'Draft', value: 'draft' },
+  { label: 'Published', value: 'published' },
+  { label: 'Archived', value: 'archived' },
+]
+
+const roleOptions = [
+  { label: 'Admin', value: 'admin' },
+  { label: 'Editor', value: 'editor' },
+  { label: 'Viewer', value: 'viewer' },
+]
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <SelectField
+      name="status"
+      label="Post status"
+      value="published"
+      onChange={noop}
+      options={statusOptions}
+      helpText="Controls whether the post is visible to readers."
+    />
+  </div>
+)
+
+export const Required = () => (
+  <div style={{ maxWidth: 360 }}>
+    <SelectField
+      name="role"
+      label="User role"
+      value=""
+      onChange={noop}
+      required
+      options={roleOptions}
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <SelectField
+      name="status"
+      label="Post status"
+      value=""
+      onChange={noop}
+      options={statusOptions}
+      error="Please choose a status before saving."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <SelectField
+      name="role"
+      label="User role"
+      value="admin"
+      onChange={noop}
+      options={roleOptions}
+      disabled
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <SelectField
+      name="status"
+      label="Post status"
+      value="archived"
+      onChange={noop}
+      options={statusOptions}
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/SkeletonLoader.tsx
+++ b/.design-sync/previews/SkeletonLoader.tsx
@@ -1,0 +1,28 @@
+import { SkeletonLoader } from '@opensaas/stack-ui'
+
+const labelStyle = {
+  fontSize: 12,
+  color: 'var(--color-muted-foreground)',
+  marginBottom: 8,
+} as const
+
+export const Variants = () => (
+  <div style={{ display: 'flex', gap: 32, alignItems: 'flex-start' }}>
+    <div>
+      <div style={labelStyle}>text</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: 200 }}>
+        <SkeletonLoader variant="text" className="w-full" />
+        <SkeletonLoader variant="text" className="w-48" />
+        <SkeletonLoader variant="text" className="w-32" />
+      </div>
+    </div>
+    <div>
+      <div style={labelStyle}>circular</div>
+      <SkeletonLoader variant="circular" className="h-12 w-12" />
+    </div>
+    <div>
+      <div style={labelStyle}>rectangular</div>
+      <SkeletonLoader variant="rectangular" className="h-16 w-64" />
+    </div>
+  </div>
+)

--- a/.design-sync/previews/Table.tsx
+++ b/.design-sync/previews/Table.tsx
@@ -1,0 +1,73 @@
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+  Badge,
+} from '@opensaas/stack-ui'
+
+const users = [
+  { name: 'Ada Lovelace', email: 'ada@opensaas.au', role: 'Owner', status: 'Active' },
+  { name: 'Grace Hopper', email: 'grace@opensaas.au', role: 'Admin', status: 'Active' },
+  { name: 'Alan Turing', email: 'alan@opensaas.au', role: 'Editor', status: 'Invited' },
+  { name: 'Katherine Johnson', email: 'kj@opensaas.au', role: 'Viewer', status: 'Suspended' },
+]
+
+const statusVariant = (status: string) =>
+  status === 'Active' ? 'success' : status === 'Invited' ? 'warning' : 'destructive'
+
+export const UsersTable = () => (
+  <div style={{ maxWidth: 640 }}>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {users.map((user) => (
+          <TableRow key={user.email}>
+            <TableCell style={{ fontWeight: 500 }}>{user.name}</TableCell>
+            <TableCell style={{ color: 'var(--color-muted-foreground)' }}>{user.email}</TableCell>
+            <TableCell>{user.role}</TableCell>
+            <TableCell>
+              <Badge variant={statusVariant(user.status)}>{user.status}</Badge>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </div>
+)
+
+export const WithCaption = () => (
+  <div style={{ maxWidth: 640 }}>
+    <Table>
+      <TableCaption>Team members with access to the Marketing workspace.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {users.slice(0, 3).map((user) => (
+          <TableRow key={user.email}>
+            <TableCell style={{ fontWeight: 500 }}>{user.name}</TableCell>
+            <TableCell>{user.role}</TableCell>
+            <TableCell>
+              <Badge variant={statusVariant(user.status)}>{user.status}</Badge>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </div>
+)

--- a/.design-sync/previews/TextField.tsx
+++ b/.design-sync/previews/TextField.tsx
@@ -1,0 +1,59 @@
+import { TextField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TextField
+      name="email"
+      label="Email address"
+      value="ada@example.com"
+      onChange={noop}
+      placeholder="you@example.com"
+      helpText="We'll never share your email."
+    />
+  </div>
+)
+
+export const Required = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TextField
+      name="title"
+      label="Post title"
+      value=""
+      onChange={noop}
+      required
+      placeholder="Enter a descriptive title"
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TextField
+      name="slug"
+      label="Slug"
+      value="My First Post!"
+      onChange={noop}
+      error="Slug can only contain lowercase letters, numbers and hyphens."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TextField name="id" label="Identifier" value="usr_8f2a1c" onChange={noop} disabled />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TextField
+      name="bio"
+      label="Bio"
+      value="Building admin tools that stay out of the way."
+      onChange={noop}
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/Textarea.tsx
+++ b/.design-sync/previews/Textarea.tsx
@@ -1,0 +1,30 @@
+import { Textarea, Label } from '@opensaas/stack-ui'
+
+export const WithValue = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxWidth: 420 }}>
+    <Label htmlFor="bio">Bio</Label>
+    <Textarea
+      id="bio"
+      rows={4}
+      defaultValue={
+        'Product engineer building admin tools that stay out of the way.\n\nPreviously led platform teams at two SaaS startups.'
+      }
+    />
+  </div>
+)
+
+export const Placeholder = () => (
+  <div style={{ maxWidth: 420 }}>
+    <Textarea rows={4} placeholder="Write release notes for this deployment…" />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 420 }}>
+    <Textarea
+      rows={4}
+      disabled
+      defaultValue="This changelog entry has been published and can no longer be edited."
+    />
+  </div>
+)

--- a/.design-sync/previews/ThemeToggle.tsx
+++ b/.design-sync/previews/ThemeToggle.tsx
@@ -1,0 +1,7 @@
+import { ThemeToggle } from '@opensaas/stack-ui'
+
+export const Default = () => (
+  <div style={{ display: 'inline-flex' }}>
+    <ThemeToggle />
+  </div>
+)

--- a/.design-sync/previews/TimePicker.tsx
+++ b/.design-sync/previews/TimePicker.tsx
@@ -1,0 +1,11 @@
+import { TimePicker } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const WithValue = () => (
+  <TimePicker value={new Date(2026, 6, 18, 9, 30)} onChange={noop} />
+)
+
+export const Disabled = () => (
+  <TimePicker value={new Date(2026, 6, 18, 14, 5)} onChange={noop} disabled />
+)

--- a/.design-sync/previews/TimestampField.tsx
+++ b/.design-sync/previews/TimestampField.tsx
@@ -1,0 +1,63 @@
+import { TimestampField } from '@opensaas/stack-ui'
+
+const noop = () => {}
+
+export const Default = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TimestampField
+      name="publishedAt"
+      label="Publish date"
+      value="2026-03-14T09:30:00.000Z"
+      onChange={noop}
+      helpText="When this post should go live."
+    />
+  </div>
+)
+
+export const Required = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TimestampField
+      name="startsAt"
+      label="Event starts at"
+      value="2026-06-01T18:00:00.000Z"
+      onChange={noop}
+      required
+    />
+  </div>
+)
+
+export const WithError = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TimestampField
+      name="expiresAt"
+      label="Expires at"
+      value="2026-01-01T00:00:00.000Z"
+      onChange={noop}
+      error="Expiry date must be in the future."
+    />
+  </div>
+)
+
+export const Disabled = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TimestampField
+      name="createdAt"
+      label="Created at"
+      value="2025-11-02T14:12:00.000Z"
+      onChange={noop}
+      disabled
+    />
+  </div>
+)
+
+export const ReadMode = () => (
+  <div style={{ maxWidth: 360 }}>
+    <TimestampField
+      name="publishedAt"
+      label="Published"
+      value="2026-03-14T09:30:00.000Z"
+      onChange={noop}
+      mode="read"
+    />
+  </div>
+)

--- a/.design-sync/previews/UserMenu.tsx
+++ b/.design-sync/previews/UserMenu.tsx
@@ -1,0 +1,9 @@
+import { UserMenu } from '@opensaas/stack-ui'
+
+const asyncNoop = async () => {}
+
+export const Default = () => (
+  <div style={{ width: 280 }}>
+    <UserMenu userName="Ada Lovelace" userEmail="ada@example.com" onSignOut={asyncNoop} />
+  </div>
+)

--- a/.design-sync/stubs/next/image.tsx
+++ b/.design-sync/stubs/next/image.tsx
@@ -1,0 +1,28 @@
+// Browser-safe stub for `next/image`, used only when bundling @opensaas/stack-ui
+// for claude.ai/design previews. Renders a plain <img> so ImageField displays
+// outside a Next app (no image optimization pipeline).
+import * as React from 'react'
+
+type ImageProps = Omit<React.ComponentPropsWithoutRef<'img'>, 'src' | 'width' | 'height'> & {
+  src?: string | { src?: string }
+  alt?: string
+  width?: number | string
+  height?: number | string
+  fill?: boolean
+  priority?: boolean
+  quality?: number
+  placeholder?: string
+  blurDataURL?: string
+  sizes?: string
+  loader?: unknown
+}
+
+const Image = React.forwardRef<HTMLImageElement, ImageProps>(function Image(
+  { src, alt, width, height, fill, priority, quality, placeholder, blurDataURL, sizes, loader, ...rest },
+  ref,
+) {
+  const resolved = typeof src === 'string' ? src : (src?.src ?? '')
+  return React.createElement('img', { ref, src: resolved, alt: alt ?? '', width, height, ...rest })
+})
+
+export default Image

--- a/.design-sync/stubs/next/link.tsx
+++ b/.design-sync/stubs/next/link.tsx
@@ -1,0 +1,24 @@
+// Browser-safe stub for `next/link`, used only when bundling @opensaas/stack-ui
+// for claude.ai/design previews (wired via cfg.tsconfig → next-stub-tsconfig.json).
+// Renders a plain anchor so Link-using components display outside a Next app.
+import * as React from 'react'
+
+type LinkProps = Omit<React.ComponentPropsWithoutRef<'a'>, 'href'> & {
+  href?: string | { pathname?: string }
+  prefetch?: boolean | null
+  replace?: boolean
+  scroll?: boolean
+  shallow?: boolean
+  passHref?: boolean
+  locale?: string | false
+}
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { href, prefetch, replace, scroll, shallow, passHref, locale, children, ...rest },
+  ref,
+) {
+  const resolved = typeof href === 'string' ? href : (href?.pathname ?? '#')
+  return React.createElement('a', { ref, href: resolved, ...rest }, children)
+})
+
+export default Link

--- a/.design-sync/stubs/next/navigation.tsx
+++ b/.design-sync/stubs/next/navigation.tsx
@@ -1,0 +1,35 @@
+// Browser-safe stub for `next/navigation`, used only when bundling
+// @opensaas/stack-ui for claude.ai/design previews. Router methods are no-ops
+// (navigation happens in event handlers, so components render fine).
+type Router = {
+  push: (href: string) => void
+  replace: (href: string) => void
+  refresh: () => void
+  back: () => void
+  forward: () => void
+  prefetch: (href: string) => void
+}
+
+const noop = (): void => {}
+
+export function useRouter(): Router {
+  return { push: noop, replace: noop, refresh: noop, back: noop, forward: noop, prefetch: noop }
+}
+
+export function usePathname(): string {
+  return '/'
+}
+
+export function useSearchParams(): URLSearchParams {
+  return new URLSearchParams()
+}
+
+export function useParams(): Record<string, string> {
+  return {}
+}
+
+export function redirect(_href: string): void {}
+
+export function permanentRedirect(_href: string): void {}
+
+export function notFound(): void {}

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ pnpm-debug.log*
 
 # Background agent worktrees (transient, auto-cleaned)
 .claude/worktrees/
+
+# design-sync (staged scripts, build output, machine state)
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,8 @@ next-env.d.ts
 *.log
 pnpm-lock.yaml
 .agents
+
+# design-sync (tooling inputs + gitignored build artifacts)
+.design-sync/
+ds-bundle/
+.ds-sync/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default [
       '**/next.config.*',
       '**/next-env.d.ts',
       '**/__generated__/**',
+      '**/.design-sync/**',
     ],
   },
   js.configs.recommended,


### PR DESCRIPTION
Syncs `@opensaas/stack-ui` to a Claude Design project so the design agent builds with the real components. This PR commits only the **reproducible sync inputs** under `.design-sync/` (build artifacts stay gitignored); no package code changes, so no changeset is needed.

**Project:** https://claude.ai/design/p/08206dc2-60c0-4681-969c-a12af2587f76

## What's in the project
- **56 components** imported, each with its exact `.d.ts` (`<Name>Props`) contract + `.prompt.md` usage doc.
- **41 authored preview cards**, all graded styled/complete/plausible — every primitive, field, field-shell part, presentational component, and standalone CRUD component.
- **5 floor cards** by design: `Dashboard`, `ListView`, `ItemForm`, `SingletonView` (need a live Prisma `context`+`config`, can't render statically) and `ThemeScript` (non-visual). The agent still gets their real API contract.
- Conventions header baked into the README, the token-backed `styles.css`, and the compiled bundle. `package-validate` exits clean (56/56 render, 0 broken).

## Committed inputs
| File | Purpose |
|---|---|
| `.design-sync/config.json` | package shape; primitives merged via `extraEntries` + `componentSrcMap`; `cssEntry`, `readmeHeader`, overlay `cardMode` overrides |
| `.design-sync/next-stub-tsconfig.json` + `stubs/next/*.tsx` | browser-safe `next/link` / `next/navigation` / `next/image` stubs — Next's module-scope `process.env` reads otherwise blank the whole bundle in a bare browser |
| `.design-sync/previews/*.tsx` (41) | authored preview compositions of the real components |
| `.design-sync/conventions.md` | README header for the design agent (Tailwind v4 token vocabulary, no-provider setup, idiomatic example) |
| `.design-sync/NOTES.md` | re-sync gotchas + risks |

## Notes
- The main entry only re-exports `Badge` from primitives, so Button/Card/Input/etc. are merged onto the bundle global via `extraEntries` (`./dist/primitives/index.js`) + `componentSrcMap` for discovery.
- Re-sync reuses these inputs plus the uploaded `_ds_sync.json` anchor and runs mostly deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AePRRdMzxAV8mLujGevFCH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AePRRdMzxAV8mLujGevFCH)_