### PR TITLE
Align Claude plugins and MCP with current stack APIs

### DIFF
--- a/.changeset/mellow-rivers-align.md
+++ b/.changeset/mellow-rivers-align.md
@@ -1,0 +1,28 @@
+---
+'@opensaas/stack-core': minor
+---
+
+MCP runtime: serve plugin-registered tools, support Zod input schemas, and pass custom session fields through to access control
+
+- Tools registered by plugins via `registerMcpTool` (e.g. the RAG plugin's `semantic_search_*` tools) are now listed by `tools/list` and callable via `tools/call` — previously they were stored but never served.
+- Custom tool `inputSchema` may now be a Zod schema or a plain JSON Schema object. Zod schemas are converted to JSON Schema for `tools/list` and validated on `tools/call` (invalid input returns a JSON-RPC `-32602` error):
+
+```typescript
+mcp: {
+  customTools: [
+    {
+      name: 'publish_post',
+      description: 'Publish a draft post',
+      inputSchema: z.object({ id: z.string() }),
+      handler: async ({ input, context }) => {
+        return context.db.post.update({
+          where: { id: input.id },
+          data: { status: 'published' },
+        })
+      },
+    },
+  ]
+}
+```
+
+- MCP sessions now pass custom fields through to access control. Transport fields (`accessToken`, `expiresAt`, `scopes`) are stripped; everything else — `userId` plus any fields your session provider attaches (email, role, ...) — reaches `context.session`, so session-based access rules behave consistently over MCP.

--- a/.changeset/quiet-maps-mend.md
+++ b/.changeset/quiet-maps-mend.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+Fix stale `withMcpAuth` JSDoc example that imported a nonexistent generated module

--- a/.changeset/steady-owls-focus.md
+++ b/.changeset/steady-owls-focus.md
@@ -1,0 +1,11 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+MCP feature wizards now generate current-API code for all five features
+
+- `comments`, `file-upload`, and `semantic-search` wizards previously returned "coming soon" stubs — they now generate real config (Comment list with moderation/threading, storage config with local/S3/R2/Vercel Blob providers, ragPlugin with OpenAI or Ollama embeddings and `searchable()` fields).
+- The `authentication` wizard output was rewritten to the current API: `authPlugin` with `socialProviders`/`extendUserList`/`access` (ADR-0013), the required `prismaClientConstructor`, `SignInForm`/`SignUpForm` with the `authClient` prop, and `lib/auth.ts` wiring via `createAuth(config, rawOpensaasContext)`.
+- The `blog` wizard now emits valid `select()` options, wires Category/Tag relationships on both sides, and uses filter-based query access.
+- `opensaas mcp start` no longer prints its startup banner to stdout, which corrupted the MCP stdio JSON-RPC stream.
+- Removed unsupported options from wizard catalogs (Cohere/Anthropic embeddings, magic links) and fixed the docs provider's field-type guidance (`json()` mapping, `getPrismaType` modifiers).

--- a/.claude-plugin/MARKETPLACE.md
+++ b/.claude-plugin/MARKETPLACE.md
@@ -89,9 +89,12 @@ This allows testing plugin changes before publishing.
 ## Marketplace Structure
 
 ```
-claude-plugins/
+.claude-plugin/
 ├── marketplace.json          # Marketplace manifest
-├── MARKETPLACE.md            # This file
+└── MARKETPLACE.md            # This file
+
+claude-plugins/
+├── README.md                 # Plugins directory overview
 ├── opensaas-stack/
 │   ├── .claude-plugin/
 │   │   └── plugin.json       # opensaas-stack plugin manifest

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official OpenSaaS Stack plugin marketplace for development and migration tools",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "homepage": "https://stack.opensaas.au/"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "opensaas-stack",
       "source": "./claude-plugins/opensaas-stack",
       "description": "Feature-driven development assistant for OpenSaaS Stack. Build complete applications by describing what you want to build instead of configuring infrastructure.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "OpenSaaS",
         "url": "https://opensaas.au"

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,7 +6,7 @@ This directory contains Claude Code settings for OpenSaaS Stack contributors.
 
 ### `settings.json`
 
-Automatically connects to the `@opensaas/stack-mcp` MCP server, giving contributors access to:
+Automatically connects to the OpenSaaS Stack MCP server (`opensaas mcp start`, from `@opensaas/stack-cli`), giving contributors access to:
 
 - Feature implementation wizards
 - Live documentation search
@@ -45,7 +45,13 @@ Just trust the repository folder in Claude Code and everything works automatical
 Install the MCP server and plugin separately:
 
 ```bash
-npx @opensaas/stack-mcp install
+npx @opensaas/stack-cli mcp install
 ```
 
-Then optionally install the plugin from a marketplace.
+Or install the plugins from the marketplace (which bundle the MCP server):
+
+```bash
+# In Claude Code
+/plugin marketplace add OpenSaasAU/stack
+/plugin install opensaas-stack@opensaas-stack-marketplace
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,14 @@ OpenSaas Stack is a Next.js-based stack for building admin-heavy applications wi
 This is a pnpm monorepo with:
 
 - `packages/core`: Core stack (config system, access control, generators)
-- `packages/cli`: CLI tools (generators via bin scripts)
+- `packages/cli`: CLI tools (generators, migration, MCP server via bin scripts)
 - `packages/ui`: Admin UI components (composable React components)
 - `packages/auth`: Better-auth integration (authentication & sessions)
-- `packages/mcp`: **DEPRECATED** - MCP functionality moved to core and auth packages
+- `packages/create-opensaas-app`: Project scaffolding (`npm create opensaas-app`)
+- `packages/rag`: RAG plugin (embeddings + semantic search)
+- `packages/storage`: File/image fields + local storage provider
+- `packages/storage-s3`: S3-compatible storage provider
+- `packages/storage-vercel`: Vercel Blob storage provider
 - `packages/tiptap`: Rich text editor integration (third-party field example)
 - `examples/blog`: Basic blog example
 - `examples/custom-field`: Custom field types demonstration
@@ -29,6 +33,13 @@ This is a pnpm monorepo with:
 - `examples/auth-demo`: Authentication integration
 - `examples/mcp-demo`: MCP server integration
 - `examples/tiptap-demo`: Tiptap rich text editor integration
+- `examples/file-upload-demo`: File/image fields with storage providers
+- `examples/json-demo`: JSON field usage
+- `examples/plain-css-theming`: Admin UI theming without Tailwind
+- `examples/rag-ollama-demo`: Semantic search with local Ollama embeddings
+- `examples/rag-openai-chatbot`: RAG chatbot with OpenAI embeddings
+- `examples/starter`: Minimal starter (template for create-opensaas-app)
+- `examples/starter-auth`: Starter with auth (template for create-opensaas-app)
 - `specs/`: Design documents and specifications
 
 ## Common Commands
@@ -563,11 +574,11 @@ The stack provides Model Context Protocol server integration through `@opensaas/
 
 **How it works:**
 
-1. Enable MCP in config with `mcp: { enabled: true, auth: { type: 'better-auth', loginPage: '/sign-in' } }`
-2. Core runtime generates CRUD tools for each list (query, create, update, delete)
-3. Auth adapter provides session from Better-auth OAuth flow with AI assistants
+1. Enable MCP in config with `mcp: { enabled: true }` (the runtime reads `enabled`/`basePath`/`defaultTools`)
+2. Core runtime derives CRUD tools for each list (query, create, update, delete) at request time
+3. OAuth with AI assistants is wired through Better-auth's `mcp` plugin (`authPlugin({ betterAuthPlugins: [mcp({ loginPage: '/sign-in' })] })`) and the `createBetterAuthMcpAdapter` session provider
 4. All tools respect existing access control rules
-5. Custom tools can be added per-list for specialized operations
+5. Custom tools can be added per-list via `mcp.customTools` (Zod or JSON Schema inputSchema); plugins can register global tools via `registerMcpTool`
 
 **Migration Note:** The `@opensaas/stack-mcp` package is deprecated. Use `@opensaas/stack-core/mcp` for MCP handlers and `@opensaas/stack-auth/mcp` for Better-auth integration.
 

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -1,124 +1,38 @@
-# OpenSaaS Migration Assistant Plugin
+# OpenSaaS Stack Claude Code Plugins
 
-A Claude Code plugin that provides AI-guided migration assistance for converting existing Prisma, KeystoneJS, or Next.js projects to OpenSaaS Stack.
+This directory contains the Claude Code plugins distributed through the OpenSaaS Stack marketplace (defined in `../.claude-plugin/marketplace.json`).
 
-## Features
+## Plugins
 
-- **Migration Assistant Agent**: Contextual agent that guides you through the migration process
-- **Interactive Commands**: Slash commands for schema analysis, config generation, and validation
-- **Migration Skill**: Expert knowledge about migration patterns and best practices
-- **MCP Integration**: Works with the OpenSaaS MCP server for advanced tooling
+### [opensaas-stack](./opensaas-stack/)
+
+Feature-driven development assistant for building OpenSaaS Stack applications. Describe what you want to build and the plugin's agent, skill, and MCP feature wizards implement it — authentication, blog, comments, file uploads, semantic search, or fully custom features.
+
+### [opensaas-migration](./opensaas-migration/)
+
+Migration assistant for converting existing Prisma, KeystoneJS, or Next.js projects to OpenSaaS Stack. Includes a migration agent, slash commands for schema analysis and config generation, and eight skills covering context calls, imports, document/image/virtual fields, and admin UI setup.
 
 ## Installation
-
-This plugin is automatically set up when you run:
-
-```bash
-npx @opensaas/stack-cli migrate --with-ai
-```
-
-The CLI will:
-
-1. Add the OpenSaaS Stack marketplace to your project
-2. Install this plugin from the marketplace
-3. Create `.claude/opensaas-project.json` with your project metadata
-4. Configure `.claude/settings.json` with marketplace and plugin settings
-
-The plugin automatically sets up MCP server integration for migration tools.
-
-### Manual Installation
-
-You can also install this plugin manually by adding the marketplace:
 
 ```bash
 # In Claude Code
 /plugin marketplace add OpenSaasAU/stack
+/plugin install opensaas-stack@opensaas-stack-marketplace
 /plugin install opensaas-migration@opensaas-stack-marketplace
 ```
 
-## What's Included
+Or let the tooling set things up for you:
 
-### Migration Assistant Agent
+```bash
+# New projects — prompts "Enable AI development tools?"
+npm create opensaas-app@latest my-app
 
-A specialized agent that:
-
-- Reads your project metadata from `.claude/opensaas-project.json`
-- Guides you through the migration wizard
-- Explains access control patterns
-- Generates `opensaas.config.ts`
-
-### Slash Commands
-
-- `/analyze-schema` - Detailed schema analysis with recommendations
-- `/generate-config` - Generate opensaas.config.ts
-- `/validate-migration` - Validate generated configuration
-
-### Migration Skill
-
-Expert knowledge including:
-
-- Access control patterns
-- Field type mappings
-- Database configuration examples
-- Common challenges and solutions
-
-## Usage
-
-Once installed, simply ask Claude:
-
-```
-Help me migrate to OpenSaaS Stack
+# Existing projects — sets up the migration plugin
+npx @opensaas/stack-cli migrate --with-ai
 ```
 
-The migration assistant will:
+Both plugins bundle the OpenSaaS Stack MCP server from `@opensaas/stack-cli` (feature wizards, documentation search, schema introspection, and migration tooling).
 
-1. Read your project details
-2. Start the interactive wizard
-3. Guide you through configuration
-4. Generate your opensaas.config.ts
+## Versioning
 
-## Project Metadata
-
-The CLI creates `.claude/opensaas-project.json` with information about your project:
-
-```json
-{
-  "projectTypes": ["prisma"],
-  "provider": "sqlite",
-  "models": [
-    { "name": "User", "fieldCount": 5 },
-    { "name": "Post", "fieldCount": 7 }
-  ],
-  "hasAuth": true
-}
-```
-
-The plugin reads this file to provide contextual assistance.
-
-## Development
-
-This plugin is part of the `@opensaas/stack-cli` package and is distributed with it.
-
-**Directory structure:**
-
-```
-plugin/
-├── .claude-plugin/
-│   └── plugin.json          # Plugin manifest
-├── agents/
-│   └── migration-assistant.md   # Migration agent
-├── commands/
-│   ├── analyze-schema.md
-│   ├── generate-config.md
-│   └── validate-migration.md
-├── skills/
-│   └── opensaas-migration/
-│       └── SKILL.md
-└── README.md
-```
-
-## Links
-
-- [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
-- [Migration Guide](https://stack.opensaas.au/docs/how-to/migrate-from-keystone)
-- [GitHub Repository](https://github.com/OpenSaasAU/stack)
+Plugin versions are managed directly in each plugin's `.claude-plugin/plugin.json` and the marketplace entry in `../.claude-plugin/marketplace.json` — see the `plugin-version` skill in the monorepo.

--- a/claude-plugins/opensaas-migration/README.md
+++ b/claude-plugins/opensaas-migration/README.md
@@ -1,0 +1,134 @@
+# OpenSaaS Migration Assistant Plugin
+
+A Claude Code plugin that provides AI-guided migration assistance for converting existing Prisma, KeystoneJS, or Next.js projects to OpenSaaS Stack.
+
+## Features
+
+- **Migration Assistant Agent**: Contextual agent that guides you through the migration process
+- **Interactive Commands**: Slash commands for schema analysis, config generation, and validation
+- **Migration Skills**: Expert knowledge about migration patterns and best practices
+- **MCP Integration**: Bundles the OpenSaaS Stack MCP server for schema introspection and wizard tooling
+
+## Installation
+
+This plugin is automatically set up when you run:
+
+```bash
+npx @opensaas/stack-cli migrate --with-ai
+```
+
+The CLI will:
+
+1. Add the OpenSaaS Stack marketplace to your project
+2. Enable this plugin from the marketplace
+3. Create `.claude/opensaas-project.json` with your project metadata
+4. Configure `.claude/settings.json` with marketplace and plugin settings
+
+The plugin's manifest declares the MCP server, so migration tools are available as soon as the plugin is enabled.
+
+### Manual Installation
+
+You can also install this plugin manually by adding the marketplace:
+
+```bash
+# In Claude Code
+/plugin marketplace add OpenSaasAU/stack
+/plugin install opensaas-migration@opensaas-stack-marketplace
+```
+
+## What's Included
+
+### Migration Assistant Agent
+
+A specialized agent that:
+
+- Reads your project metadata from `.claude/opensaas-project.json`
+- Guides you through the migration wizard
+- Explains access control patterns
+- Generates `opensaas.config.ts`
+
+### Slash Commands
+
+- `/analyze-schema` - Detailed schema analysis with recommendations
+- `/generate-config` - Generate opensaas.config.ts
+- `/validate-migration` - Validate generated configuration
+
+### Migration Skills
+
+Expert knowledge covering:
+
+- The end-to-end migration process (`opensaas-migration`)
+- Rewriting `context.query`/`context.graphql` calls (`migrate-context-calls`)
+- Import path migration (`migrate-imports`)
+- Keystone `document` fields → `richText` (`migrate-document-fields`)
+- Keystone `image` fields → storage fields, non-destructively (`migrate-image-fields`)
+- Keystone `virtual` fields → `virtual()` with `resolveOutput` (`migrate-virtual-fields`, `keystone-virtual-fields-context`)
+- Setting up the admin UI (`setup-admin-ui`)
+
+## Usage
+
+Once installed, simply ask Claude:
+
+```
+Help me migrate to OpenSaaS Stack
+```
+
+The migration assistant will:
+
+1. Read your project details
+2. Start the interactive wizard
+3. Guide you through configuration
+4. Generate your opensaas.config.ts
+
+## Project Metadata
+
+The CLI creates `.claude/opensaas-project.json` with information about your project:
+
+```json
+{
+  "projectTypes": ["prisma"],
+  "provider": "sqlite",
+  "models": [
+    { "name": "User", "fieldCount": 5 },
+    { "name": "Post", "fieldCount": 7 }
+  ],
+  "hasAuth": true
+}
+```
+
+The plugin reads this file to provide contextual assistance.
+
+## Development
+
+This plugin lives in the OpenSaaS Stack monorepo at `claude-plugins/opensaas-migration/` and is distributed via the Claude Code marketplace (`OpenSaasAU/stack`).
+
+**Directory structure:**
+
+```
+claude-plugins/opensaas-migration/
+├── .claude-plugin/
+│   └── plugin.json              # Plugin manifest (declares the MCP server)
+├── agents/
+│   ├── migration-assistant.md
+│   └── github-issue-creator.md
+├── commands/
+│   ├── analyze-schema.md
+│   ├── generate-config.md
+│   └── validate-migration.md
+├── skills/
+│   ├── keystone-virtual-fields-context/
+│   ├── migrate-context-calls/
+│   ├── migrate-document-fields/
+│   ├── migrate-image-fields/
+│   ├── migrate-imports/
+│   ├── migrate-virtual-fields/
+│   ├── opensaas-migration/
+│   └── setup-admin-ui/
+└── README.md
+```
+
+## Links
+
+- [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
+- [Migration Guide](https://stack.opensaas.au/docs/how-to/migrate-from-keystone)
+- [GitHub Repository](https://github.com/OpenSaasAU/stack)

--- a/claude-plugins/opensaas-migration/agents/migration-assistant.md
+++ b/claude-plugins/opensaas-migration/agents/migration-assistant.md
@@ -322,6 +322,7 @@ Add OpenSaaS packages:
 
 ```bash
 pnpm add @opensaas/stack-core @opensaas/stack-ui
+pnpm add -D @opensaas/stack-cli
 # If using auth:
 pnpm add @opensaas/stack-auth better-auth
 # SQLite adapter:
@@ -538,4 +539,4 @@ Guide them through:
 3. Run `npx prisma db push`
 4. Start dev server: `pnpm dev`
 5. If Admin UI was set up: visit `http://localhost:3000/{adminPath}` (e.g. `http://localhost:3000/admin`)
-6. If Admin UI was skipped: mention that they can set it up any time — see https://stack.opensaas.au/admin-ui
+6. If Admin UI was skipped: mention that they can set it up any time — see https://stack.opensaas.au/docs/reference/ui

--- a/claude-plugins/opensaas-migration/skills/keystone-virtual-fields-context/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/keystone-virtual-fields-context/SKILL.md
@@ -267,7 +267,7 @@ const count = await context.db.post.count({
 
 ### Related data
 
-Keystone returns nested GraphQL results in a single query. OpenSaaS Stack uses separate `context.db` calls per list:
+Keystone returns nested GraphQL results in a single query. OpenSaaS Stack does the same in one call with a fragment (`defineFragment` + the `query` param) — see the `migrate-context-calls` skill for the full pattern:
 
 ```typescript
 // Keystone — nested in one query
@@ -282,11 +282,21 @@ const { post } = await context.graphql.run({
   variables: { id: postId },
 })
 
-// OpenSaaS Stack — separate calls
-const post = await context.db.post.findUnique({ where: { id: postId } })
-const author = post?.authorId
-  ? await context.db.user.findUnique({ where: { id: post.authorId } })
-  : null
+// OpenSaaS Stack — one call with a fragment
+import type { User, Post, Tag } from '@/.opensaas/prisma-client/client'
+import { defineFragment } from '@opensaas/stack-core'
+
+const postFragment = defineFragment<Post>()({
+  id: true,
+  title: true,
+  author: defineFragment<User>()({ id: true, name: true, email: true } as const),
+  tags: defineFragment<Tag>()({ id: true, name: true } as const),
+} as const)
+
+const post = await context.db.post.findUnique({
+  where: { id: postId },
+  query: postFragment,
+})
 ```
 
 ### Bypassing access control (sudo)

--- a/claude-plugins/opensaas-migration/skills/migrate-context-calls/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/migrate-context-calls/SKILL.md
@@ -15,8 +15,8 @@ $ARGUMENTS
 | ------------------------------------------- | ----------------------------------- |
 | `context.graphql.run({ query, variables })` | `context.db.{list}.{method}(args)`  |
 | `context.graphql.raw({ query, variables })` | `context.db.{list}.{method}(args)`  |
-| `context.query.PostList.findMany(...)`      | `context.db.post.findMany(...)`     |
-| `context.query.PostList.count(...)`         | `context.db.post.count(...)`        |
+| `context.query.Post.findMany(...)`          | `context.db.post.findMany(...)`     |
+| `context.query.Post.count(...)`             | `context.db.post.count(...)`        |
 | `context.sudo().graphql.run(...)`           | `context.sudo().db.post.findMany()` |
 
 **List names are camelCase**: `Post` → `context.db.post`, `BlogPost` → `context.db.blogPost`, `AuthUser` → `context.db.authUser`.
@@ -133,7 +133,7 @@ const { posts } = await context.graphql.run({
 })
 
 // After — define fragments once, compose and reuse them
-import type { User, Post, Tag } from '.prisma/client'
+import type { User, Post, Tag } from '@/.opensaas/prisma-client/client'
 import { defineFragment, type ResultOf } from '@opensaas/stack-core'
 
 const authorFragment = defineFragment<User>()({ id: true, name: true } as const)
@@ -392,7 +392,7 @@ async function getPosts(vars: PostsVars) {
 
 ```typescript
 // After — defineFragment + ResultOf (no GraphQL schema, no codegen)
-import type { Post, User } from '.prisma/client'
+import type { Post, User } from '@/.opensaas/prisma-client/client'
 import { defineFragment, type ResultOf } from '@opensaas/stack-core'
 
 const authorFragment = defineFragment<User>()({ id: true, name: true } as const)
@@ -449,7 +449,7 @@ A `defineFragment` selection maps directly onto a Prisma query under the hood, a
 - **Relationship fields selected with a nested fragment / `RelationSelector`** generate a Prisma `include` entry (recursively). The fragment walker emits `{ include: { author: { include: { … } } } }`; nested `where` / `orderBy` / `take` / `skip` from a `RelationSelector` are attached to that include entry.
 
 ```typescript
-import type { Post, User, Comment } from '.prisma/client'
+import type { Post, User, Comment } from '@/.opensaas/prisma-client/client'
 import { defineFragment, type ResultOf } from '@opensaas/stack-core'
 
 const authorFragment = defineFragment<User>()({ id: true, name: true } as const)

--- a/claude-plugins/opensaas-migration/skills/migrate-document-fields/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/migrate-document-fields/SKILL.md
@@ -72,9 +72,9 @@ In the admin page (`app/admin/[[...admin]]/page.tsx` or similar):
 'use client'
 
 import { registerFieldComponent } from '@opensaas/stack-ui'
-import { RichTextFieldComponent } from '@opensaas/stack-tiptap'
+import { TiptapField } from '@opensaas/stack-tiptap'
 
-registerFieldComponent('richText', RichTextFieldComponent)
+registerFieldComponent('richText', TiptapField)
 ```
 
 Then import it in the admin page as a side effect:

--- a/claude-plugins/opensaas-migration/skills/migrate-image-fields/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/migrate-image-fields/SKILL.md
@@ -212,6 +212,8 @@ storage: {
 
 Because the multi-column mode reads existing stored URLs in place, you can adopt any of these providers without re-uploading the assets already referenced by the live columns. The provider only handles new uploads.
 
+**Provider registration (S3 / Vercel Blob)**: only the `'local'` provider is built in. For new uploads to work with S3 or Vercel Blob, register the provider at startup via `registerStorageProvider(...)` from `@opensaas/stack-storage/runtime` (an unregistered type throws `Unknown storage provider type` on upload). Reads of existing assets need no provider.
+
 ---
 
 ## Destructive alternative (opt-in): consolidate to a single JSON column

--- a/claude-plugins/opensaas-migration/skills/migrate-imports/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/migrate-imports/SKILL.md
@@ -15,10 +15,12 @@ $ARGUMENTS
 | ---------------------------------------- | ------------------------------------------ |
 | `@keystone-6/core`                       | `@opensaas/stack-core`                     |
 | `@keystone-6/core/fields`                | `@opensaas/stack-core/fields`              |
-| `@keystone-6/auth`                       | `@opensaas/stack-auth`                     |
+| `@keystone-6/auth`                       | `@opensaas/stack-auth` (see note)          |
 | `@keystone-6/fields-document`            | `@opensaas/stack-tiptap/fields` (see note) |
 | `.keystone/types` or `'.keystone/types'` | `@opensaas/stack-core`                     |
 | `@keystone-6/core/session`               | Remove entirely (handled by authPlugin)    |
+
+**Note on `@keystone-6/auth`**: This is NOT a pure find-and-replace. Keystone's `createAuth`/`withAuth` have no equivalent export on `@opensaas/stack-auth` — replace the whole pattern with `authPlugin(...)` in the config's `plugins` array. (The stack's `createAuth` on `@opensaas/stack-auth/server` is a different function — it builds the Better-auth server instance for `lib/auth.ts`.)
 
 **Note on `@keystone-6/fields-document`**: Replace with `@opensaas/stack-tiptap/fields` and change `document()` → `richText()`. If document field migration is complex, note it for the user and leave a `// TODO: migrate document field` comment.
 
@@ -32,7 +34,10 @@ import type { Lists } from '.keystone/types'
 
 // After
 import type { AccessControl } from '@opensaas/stack-core'
-// KeystoneContext and Lists are no longer needed — use context from getContext()
+import type { Lists } from '@/.opensaas/lists'
+// KeystoneContext is no longer needed — use the context from getContext().
+// Keystone's `Lists` types have a direct successor: the generated
+// `@/.opensaas/lists` namespace, used as list<Lists.Post.TypeInfo>({ ... }).
 ```
 
 ## Config File Rename

--- a/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/opensaas-migration/SKILL.md
@@ -121,11 +121,11 @@ operation: {
   delete: ({ session }) => session?.role === 'admin',
 }
 
-// Filter-based access
+// Filter-based access — return the Prisma filter DIRECTLY (no `where` wrapper);
+// the engine merges it into the query's where clause
 operation: {
-  query: ({ session }) => ({
-    where: { authorId: { equals: session?.userId } }
-  }),
+  query: ({ session }) =>
+    session ? { authorId: { equals: session.userId } } : false,
 }
 ```
 
@@ -139,6 +139,8 @@ operation: {
 | `Int`       | `integer()`                    |
 | `Boolean`   | `checkbox()`                   |
 | `DateTime`  | `timestamp()`                  |
+| `Decimal`   | `decimal()`                    |
+| `Json`      | `json()`                       |
 | `Enum`      | `select({ options: [...] })`   |
 | `Relation`  | `relationship({ ref: '...' })` |
 
@@ -153,6 +155,9 @@ operation: {
 | `select`         | `select()`                                                                 |
 | `relationship`   | `relationship()`                                                           |
 | `password`       | `password()`                                                               |
+| `decimal`        | `decimal()`                                                                |
+| `calendarDay`    | `calendarDay()`                                                            |
+| `json`           | `json()`                                                                   |
 | `virtual`        | `virtual()` — **requires changes** (no GraphQL, use `hooks.resolveOutput`) |
 
 ### 6. Database Configuration
@@ -292,7 +297,7 @@ export default config({
     Post: list({
       fields: {
         title: text({ validation: { isRequired: true } }),
-        content: text(), // Note: OpenSaaS text() doesn't have ui.displayMode
+        content: text({ ui: { displayMode: 'textarea' } }), // ui.displayMode carries over from Keystone
         author: relationship({ ref: 'User.posts' }),
         publishedAt: timestamp(),
       },
@@ -423,7 +428,7 @@ const { posts } = await context.graphql.run({
 })
 
 // OpenSaaS Stack — defineFragment + context.db (no codegen, no GraphQL)
-import type { User, Post } from '.prisma/client'
+import type { User, Post } from '@/.opensaas/prisma-client/client'
 import { defineFragment, type ResultOf } from '@opensaas/stack-core'
 
 const authorFragment = defineFragment<User>()({ id: true, name: true } as const)
@@ -552,5 +557,5 @@ The agent will create a detailed GitHub issue with reproduction steps and propos
 
 - [OpenSaaS Stack Documentation](https://stack.opensaas.au/)
 - [Migration Guide](https://stack.opensaas.au/docs/how-to/migrate-from-keystone)
-- [Access Control Guide](https://stack.opensaas.au/core-concepts/access-control)
-- [Field Types](https://stack.opensaas.au/core-concepts/field-types)
+- [Access Control Guide](https://stack.opensaas.au/docs/concepts/access-control)
+- [Field Types](https://stack.opensaas.au/docs/concepts/field-types)

--- a/claude-plugins/opensaas-migration/skills/setup-admin-ui/SKILL.md
+++ b/claude-plugins/opensaas-migration/skills/setup-admin-ui/SKILL.md
@@ -100,7 +100,8 @@ import { getSession } from '@/lib/auth'
 
 async function serverAction(props: ServerActionInput) {
   'use server'
-  const context = await getContext({ session: await getSession() })
+  const session = await getSession()
+  const context = await getContext(session ?? undefined)
   return await context.serverAction(props)
 }
 
@@ -162,7 +163,7 @@ Next steps:
 2. Run `pnpm dev` to start the dev server
 3. Visit http://localhost:3000{adminPath} to access the admin UI
 
-Docs: https://stack.opensaas.au/admin-ui
+Docs: https://stack.opensaas.au/docs/reference/ui
 ```
 
 ## Notes
@@ -171,4 +172,4 @@ Docs: https://stack.opensaas.au/admin-ui
 - The `basePath` prop must match exactly the URL path where the admin is mounted.
 - The `serverAction` wrapper function is required — it provides the server action bridge between the client-side admin UI components and the database context.
 - If the user is using a custom `getSession` approach (not from `@opensaas/stack-auth`), the auth template still works — just update the import path and the session shape passed to `getContext`.
-- If Tailwind CSS is not configured in the project, mention that `@opensaas/stack-ui` uses Tailwind for styling and link to the docs for setup: https://stack.opensaas.au/admin-ui#tailwind
+- If Tailwind CSS is not configured in the project, mention that `@opensaas/stack-ui` uses Tailwind for styling and link to the docs for setup: https://stack.opensaas.au/docs/reference/ui

--- a/claude-plugins/opensaas-stack/.claude-plugin/plugin.json
+++ b/claude-plugins/opensaas-stack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opensaas-stack",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Feature-driven development assistant for OpenSaaS Stack. Build complete applications by describing what you want to build instead of configuring infrastructure.",
   "author": {
     "name": "OpenSaaS",

--- a/claude-plugins/opensaas-stack/README.md
+++ b/claude-plugins/opensaas-stack/README.md
@@ -21,11 +21,24 @@ Feature-driven development assistant for building OpenSaaS Stack applications.
 
 This plugin works with the MCP server built into `@opensaas/stack-cli` which provides:
 
+**Feature wizards:**
+
 - `opensaas_implement_feature` - Interactive feature implementation wizards
-- `opensaas_feature_docs` - Live documentation search
+- `opensaas_answer_feature` / `opensaas_answer_followup` - Progress through wizard questions
 - `opensaas_list_features` - Browse available features
 - `opensaas_suggest_features` - Get personalized recommendations
 - `opensaas_validate_feature` - Validate implementations
+
+**Documentation:**
+
+- `opensaas_feature_docs` - Live documentation search
+- `opensaas_get_example` - Example code for common patterns
+
+**Migration (shared with the opensaas-migration plugin):**
+
+- `opensaas_start_migration` / `opensaas_answer_migration` - Migration wizard
+- `opensaas_introspect_prisma` / `opensaas_introspect_keystone` - Schema analysis
+- `opensaas_search_migration_docs` - Migration documentation search
 
 ## Installation
 
@@ -136,7 +149,7 @@ Agent will:
 ## What Makes This Different
 
 1. **App-level thinking** - Describe goals, not infrastructure
-2. **Complete solutions** - Config + UI + access control + docs + tests
+2. **Complete solutions** - Config + UI + access control + docs
 3. **Conversational wizards** - Natural Q&A, not configuration files
 4. **Smart suggestions** - Recommends next features based on context
 5. **Live documentation** - Always current with production docs
@@ -186,14 +199,14 @@ Each wizard generates:
 
 ## Links
 
-- [MCP Server Package](../packages/stack-mcp/) - Implementation details
+- [MCP Server Implementation](../../packages/cli/src/mcp/) - Ships inside `@opensaas/stack-cli`
 - [OpenSaaS Stack Docs](https://stack.opensaas.au/) - Full documentation
 - [GitHub Repository](https://github.com/OpenSaasAU/stack)
-- [Examples](../examples/) - Reference implementations
+- [Examples](../../examples/) - Reference implementations
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](../CONTRIBUTING.md).
+We welcome contributions! Please see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## License
 

--- a/claude-plugins/opensaas-stack/agents/opensaas-helper.md
+++ b/claude-plugins/opensaas-stack/agents/opensaas-helper.md
@@ -1,3 +1,8 @@
+---
+name: opensaas-helper
+description: OpenSaaS Stack expert that maps application requirements to stack features and implements them using the MCP feature wizards. Use when a developer describes an app idea, asks how to build a feature on OpenSaaS Stack, or needs guidance on stack patterns (access control, hooks, fields, plugins).
+---
+
 You are an OpenSaaS Stack expert that helps developers build applications by understanding their goals and implementing the right features.
 
 ## Your Approach
@@ -73,8 +78,12 @@ When implementing features, ensure proper access control:
 ```typescript
 // Common patterns
 const isAuthenticated: AccessControl = ({ session }) => !!session?.userId
-const isOwner: AccessControl = ({ session, item }) => session?.userId === item.userId
+const isOwner: AccessControl = ({ session, item }) => session?.userId === item?.userId
 const isAdmin: AccessControl = ({ session }) => session?.role === 'admin'
+
+// Filter-based access: return a Prisma filter directly to scope queries
+const ownOnly: AccessControl = ({ session }) =>
+  session ? { userId: { equals: session.userId } } : false
 ```
 
 ## Response Strategy

--- a/docs/content/concepts/config.md
+++ b/docs/content/concepts/config.md
@@ -5,7 +5,7 @@ The config system is the heart of Stack. Define your entire schema, access contr
 ## Basic Config
 
 ```typescript
-import { config, list } from '@opensaas/stack-core/config'
+import { config, list } from '@opensaas/stack-core'
 import { text, relationship } from '@opensaas/stack-core/fields'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 

--- a/docs/content/concepts/queries.md
+++ b/docs/content/concepts/queries.md
@@ -25,7 +25,7 @@ Each key in the selection maps to:
 - A `RelationSelector` — include a relationship with optional Prisma `where`/`orderBy`/`take`/`skip`.
 
 ```typescript
-import type { User, Post } from '.prisma/client'
+import type { User, Post } from '@/.opensaas/prisma-client/client'
 import { defineFragment } from '@opensaas/stack-core'
 
 export const userFragment = defineFragment<User>()({
@@ -125,7 +125,7 @@ Both forms produce the same result and enforce the same access control.
 To filter, sort, or paginate a nested relationship **within the same query**, use a `RelationSelector` object — `{ query, where?, orderBy?, take?, skip? }` — instead of a plain fragment:
 
 ```typescript
-import type { Post, Comment } from '.prisma/client'
+import type { Post, Comment } from '@/.opensaas/prisma-client/client'
 import { defineFragment, type ResultOf } from '@opensaas/stack-core'
 
 const commentFragment = defineFragment<Comment>()({ id: true, body: true } as const)

--- a/docs/content/how-to/claude-code.md
+++ b/docs/content/how-to/claude-code.md
@@ -35,11 +35,24 @@ The Stack Claude Code plugin enables **feature-driven development**:
 
 When the MCP server is installed, Claude has access to:
 
+**Feature wizards:**
+
 - `opensaas_implement_feature` - Start feature implementation wizards
-- `opensaas_feature_docs` - Search live documentation
+- `opensaas_answer_feature` / `opensaas_answer_followup` - Progress through wizard questions
 - `opensaas_list_features` - Browse available features
 - `opensaas_suggest_features` - Get personalized recommendations
 - `opensaas_validate_feature` - Validate implementations
+
+**Documentation:**
+
+- `opensaas_feature_docs` - Search live documentation
+- `opensaas_get_example` - Example code for common patterns
+
+**Migration:**
+
+- `opensaas_start_migration` / `opensaas_answer_migration` - Migration wizard
+- `opensaas_introspect_prisma` / `opensaas_introspect_keystone` - Schema analysis
+- `opensaas_search_migration_docs` - Migration documentation search
 
 ## Installation
 
@@ -72,7 +85,7 @@ Add the OpenSaaS repository as a plugin marketplace:
 Install the plugin:
 
 ```shell
-/plugin install opensaas-stack@OpenSaasAU/stack
+/plugin install opensaas-stack@opensaas-stack-marketplace
 ```
 
 ### For Stack Contributors
@@ -93,7 +106,13 @@ This command updates your Claude Code configuration automatically.
 
 ### Manual Configuration
 
-If you prefer manual setup, add to your Claude Code MCP configuration:
+If you prefer manual setup in Claude Code, register the server directly:
+
+```bash
+claude mcp add opensaas-stack -- npx -y @opensaas/stack-cli mcp start
+```
+
+For **Claude Desktop**, add the server to its config file instead:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 
@@ -106,7 +125,7 @@ If you prefer manual setup, add to your Claude Code MCP configuration:
   "mcpServers": {
     "opensaas": {
       "command": "npx",
-      "args": ["@opensaas/stack-cli", "mcp", "serve"],
+      "args": ["-y", "@opensaas/stack-cli", "mcp", "start"],
       "env": {}
     }
   }

--- a/docs/content/how-to/installation.md
+++ b/docs/content/how-to/installation.md
@@ -54,6 +54,7 @@ Your schema lives in `opensaas.config.ts`. Running the generator (which the
 scaffolder did for you, and which you re-run with `pnpm generate`) produces:
 
 - **`prisma/schema.prisma`** — the Prisma schema
+- **`prisma.config.ts`** — Prisma CLI configuration (datasource URL for db push/migrations)
 - **`.opensaas/types.ts`** — TypeScript types for your lists
 - **`.opensaas/context.ts`** — the access-controlled context factory
 

--- a/docs/content/how-to/mcp.md
+++ b/docs/content/how-to/mcp.md
@@ -217,18 +217,11 @@ export async function GET() {
 }
 ```
 
-## Generate Schema
+## How Tools Are Built
 
-Run the generator to create your MCP tools:
+MCP tools are derived from your config **at request time** by `createMcpHandlers` — nothing MCP-specific is generated to disk. Every list gets CRUD tools automatically (unless disabled via `mcp.enabled: false` on the list), plus any custom tools you define and any tools registered by plugins.
 
-```bash
-pnpm generate
-```
-
-This creates:
-
-- `.opensaas/mcp/tools.json` - Tool metadata reference
-- `.opensaas/mcp/README.md` - Usage instructions
+You only need to run `pnpm generate` when your schema or lists change, to keep the Prisma schema and generated context in sync.
 
 ## Configure Claude Desktop
 
@@ -270,11 +263,11 @@ When Claude Desktop connects to your MCP server:
 
 ## Generated Tools
 
-The generator creates CRUD tools for each list:
+The MCP handler creates CRUD tools for each list. `{dbKey}` is the camelCase form of the list key (`Post` → `list_post_query`, `BlogPost` → `list_blogPost_query`):
 
 ### Query Tool
 
-**Tool Name:** `list_{listKey}_query`
+**Tool Name:** `list_{dbKey}_query`
 
 **Description:** Query records with filters, sorting, and pagination
 
@@ -301,7 +294,7 @@ The generator creates CRUD tools for each list:
 
 ### Create Tool
 
-**Tool Name:** `list_{listKey}_create`
+**Tool Name:** `list_{dbKey}_create`
 
 **Description:** Create a new record
 
@@ -328,7 +321,7 @@ The generator creates CRUD tools for each list:
 
 ### Update Tool
 
-**Tool Name:** `list_{listKey}_update`
+**Tool Name:** `list_{dbKey}_update`
 
 **Description:** Update an existing record
 
@@ -352,7 +345,7 @@ The generator creates CRUD tools for each list:
 
 ### Delete Tool
 
-**Tool Name:** `list_{listKey}_delete`
+**Tool Name:** `list_{dbKey}_delete`
 
 **Description:** Delete a record
 
@@ -424,7 +417,11 @@ fields: {
 
 ### Silent Failures
 
-When access is denied, tools return empty results rather than errors. This prevents information leakage about whether records exist.
+When access is denied, query tools return empty results rather than errors — this prevents information leakage about whether records exist. Create, update, and delete tools return a JSON-RPC error ("Access denied or record not found") that deliberately does not distinguish between a missing record and denied access.
+
+### Session Fields over MCP
+
+The Better Auth MCP adapter's session carries `userId` only. Access rules that rely on other session fields (e.g. `session.role`) will see them as `undefined` over MCP unless you use a custom session provider that loads and attaches those fields — any extra fields on the MCP session are passed through to access control.
 
 ## Testing MCP Tools
 
@@ -485,8 +482,8 @@ curl -X POST http://localhost:3000/api/mcp \
          │ Access Token
          ↓
 ┌─────────────────┐
-│   MCP Server    │ ← Generated Tools
-│ (.opensaas/mcp) │
+│   MCP Handler   │ ← Tools derived from
+│ (stack-core/mcp)│   config at runtime
 └────────┬────────┘
          │ context.db
          ↓
@@ -569,9 +566,9 @@ curl -X POST http://localhost:3000/api/mcp \
 
 **Solutions:**
 
-1. Run `pnpm generate` to regenerate tools
-2. Restart development server
-3. Verify Zod schema is valid
+1. Restart the development server — tools are read from config at runtime
+2. Check the tool is on a list's `mcp.customTools` (or registered by a plugin via `registerMcpTool`)
+3. Verify the input schema is valid (Zod schema or plain JSON Schema object)
 4. Check handler function returns correct format
 
 ## Example Project
@@ -581,7 +578,7 @@ See the complete working example at `examples/mcp-demo/` in the repository:
 - Full configuration with custom tools
 - OAuth setup with Better Auth
 - Access control patterns
-- Testing scripts
+- A `create-user.ts` script for seeding a test user
 
 ## Next Steps
 

--- a/docs/content/how-to/migrate-from-keystone.md
+++ b/docs/content/how-to/migrate-from-keystone.md
@@ -306,7 +306,7 @@ This is the largest API change. Stack has **no GraphQL layer** ([ADR-0005](https
 | `VariablesOf<typeof query>`                          | Plain function params / `where` args (or a fragment factory)       |
 | `context.graphql.run({ query, variables })` — list   | `context.db.post.findMany({ query: fragment, where?, … })`         |
 | `context.graphql.run({ query, variables })` — single | `context.db.post.findUnique({ where: { id }, query: fragment })`   |
-| `context.query.PostList.findMany(...)`               | `context.db.post.findMany(...)`                                    |
+| `context.query.Post.findMany(...)`                   | `context.db.post.findMany(...)`                                    |
 | `context.sudo().graphql.run(...)`                    | `context.sudo().db.post.findMany(...)`                             |
 | Nested relationship filtering                        | `RelationSelector`: `{ query: fragment, where?, orderBy?, take? }` |
 

--- a/docs/content/how-to/migrate.md
+++ b/docs/content/how-to/migrate.md
@@ -54,8 +54,9 @@ This command will:
    └─ Session (5 fields)
 ✔ Claude Code ready
    ├─ Created .claude directory
-   ├─ Generated migration assistant
-   └─ Registered MCP server
+   ├─ Added opensaas-stack-marketplace
+   ├─ Enabled opensaas-migration plugin (with MCP server)
+   └─ Wrote .claude/settings.json and .claude/opensaas-project.json
 
 ✅ Analysis complete!
 
@@ -65,7 +66,7 @@ This command will:
    2. Ask: "Help me migrate to Stack"
    3. Follow the interactive wizard
 
-📚 Documentation: https://stack.opensaas.au/guides/migration
+📚 Documentation: https://stack.opensaas.au/docs/guides/migrating-from-keystone
 ```
 
 ### Using Claude Code
@@ -196,7 +197,11 @@ export default config({
       },
       access: {
         operation: {
-          query: ({ session, item }) => item?.published || session?.userId === item?.authorId,
+          // Filter-based: anonymous users see published posts, authors see their own
+          query: ({ session }) =>
+            session
+              ? { OR: [{ published: { equals: true } }, { authorId: { equals: session.userId } }] }
+              : { published: { equals: true } },
           create: ({ session }) => !!session,
           update: ({ session, item }) => session?.userId === item?.authorId,
           delete: ({ session, item }) => session?.userId === item?.authorId,
@@ -358,7 +363,8 @@ Options:
   ```typescript
   access: {
     operation: {
-      query: ({ session, item }) => session?.userId === item?.userId,
+      // Filter-based: users only ever see their own records
+      query: ({ session }) => (session ? { userId: { equals: session.userId } } : false),
       create: ({ session }) => !!session,
       update: ({ session, item }) => session?.userId === item?.userId,
       delete: ({ session, item }) => session?.userId === item?.userId,
@@ -431,24 +437,16 @@ The migration system provides these MCP tools to Claude:
 
 - **`opensaas_introspect_prisma`** - Detailed Prisma schema analysis
 - **`opensaas_introspect_keystone`** - KeystoneJS config analysis
-- **`opensaas_introspect_nextjs`** - Next.js project structure
 
 #### Migration Wizard
 
 - **`opensaas_start_migration`** - Begin interactive migration
 - **`opensaas_answer_migration`** - Answer wizard questions
-- **`opensaas_get_migration_status`** - Check wizard progress
 
 #### Documentation
 
 - **`opensaas_search_migration_docs`** - Search migration docs
-- **`opensaas_get_migration_example`** - Get code examples
-- **`opensaas_list_field_types`** - Available field types
-
-#### Validation
-
-- **`opensaas_validate_migration`** - Validate generated config
-- **`opensaas_generate_config_file`** - Write config to disk
+- **`opensaas_get_example`** - Get code examples for common patterns
 
 ### Available Slash Commands
 
@@ -460,7 +458,7 @@ After running `migrate --with-ai`, you get these commands:
 
 ### Migration Assistant Agent
 
-The migration creates a specialized agent (`.claude/agents/migration-assistant.md`) that:
+The opensaas-migration plugin ships a specialized agent (`migration-assistant`) that:
 
 - Understands your project context
 - Guides you through the wizard
@@ -500,6 +498,7 @@ model Post {
 import { config, list } from '@opensaas/stack-core'
 import { text, checkbox, relationship } from '@opensaas/stack-core/fields'
 import { authPlugin } from '@opensaas/stack-auth'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 export default config({
   plugins: [
@@ -508,7 +507,14 @@ export default config({
       sessionFields: ['userId', 'email', 'name'],
     }),
   ],
-  db: { provider: 'sqlite', url: 'file:./dev.db' },
+  db: {
+    provider: 'sqlite',
+    url: 'file:./dev.db',
+    prismaClientConstructor: (PrismaClient) => {
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
+      return new PrismaClient({ adapter })
+    },
+  },
   lists: {
     Post: list({
       fields: {
@@ -519,7 +525,8 @@ export default config({
       },
       access: {
         operation: {
-          query: ({ item }) => item?.published || !!session,
+          // Anonymous visitors only see published posts (filter-based access)
+          query: ({ session }) => (session ? true : { published: { equals: true } }),
           create: ({ session }) => !!session,
           update: ({ session, item }) => session?.userId === item?.authorId,
           delete: ({ session, item }) => session?.userId === item?.authorId,
@@ -564,9 +571,13 @@ Product: list({
 Order: list({
   access: {
     operation: {
-      query: ({ session, item }) =>
-        session?.userId === item?.userId ||
-        session?.role === 'admin',
+      // Filter-based: admins see everything, users see their own orders
+      query: ({ session }) =>
+        session?.role === 'admin'
+          ? true
+          : session
+            ? { userId: { equals: session.userId } }
+            : false,
       create: ({ session }) => !!session,
       update: ({ session }) => session?.role === 'admin',
       delete: ({ session }) => session?.role === 'admin',
@@ -716,19 +727,21 @@ MCP server not responding
 
 **Solutions:**
 
-1. Check `.claude/settings.json` was created
-2. Restart Claude Code
-3. Verify MCP server registration:
+1. Check `.claude/settings.json` was created and enables the plugin:
    ```json
    {
-     "mcpServers": {
-       "opensaas-migration": {
-         "command": "npx",
-         "args": ["@opensaas/stack-cli", "mcp", "start"]
+     "extraKnownMarketplaces": {
+       "opensaas-stack-marketplace": {
+         "source": { "source": "github", "repo": "OpenSaasAU/stack" }
        }
+     },
+     "enabledPlugins": {
+       "opensaas-migration@opensaas-stack-marketplace": true
      }
    }
    ```
+2. Restart Claude Code
+3. The MCP server (named `opensaas-stack`) is declared by the plugin's own manifest — no `mcpServers` entry is written to settings.json
 4. Check for errors in Claude Code console
 
 ### Generated Config Errors
@@ -1044,11 +1057,13 @@ Add comments to your config:
 ```typescript
 lists: {
   Post: list({
-    // Public read for published posts, author-only for drafts
+    // Public read for published posts, author-only for drafts (filter-based)
     access: {
       operation: {
-        query: ({ session, item }) =>
-          item?.published || session?.userId === item?.authorId,
+        query: ({ session }) =>
+          session
+            ? { OR: [{ published: { equals: true } }, { authorId: { equals: session.userId } }] }
+            : { published: { equals: true } },
       },
     },
   }),

--- a/docs/content/how-to/migrate.md
+++ b/docs/content/how-to/migrate.md
@@ -66,7 +66,7 @@ This command will:
    2. Ask: "Help me migrate to Stack"
    3. Follow the interactive wizard
 
-📚 Documentation: https://stack.opensaas.au/docs/guides/migrating-from-keystone
+📚 Documentation: https://stack.opensaas.au/docs/how-to/migrate-from-keystone
 ```
 
 ### Using Claude Code

--- a/docs/content/reference/config-api.md
+++ b/docs/content/reference/config-api.md
@@ -933,7 +933,7 @@ Base path for MCP API routes.
 
 ##### `auth`
 
-Authentication metadata (optional, currently informational). The MCP runtime authenticates via the session provider passed to `createMcpHandlers` — for Better Auth, the OAuth flow is wired through the `mcp` plugin in `authPlugin`'s `betterAuthPlugins` plus `createBetterAuthMcpAdapter`. See the [MCP Setup Guide](/docs/guides/mcp-setup).
+Authentication metadata (optional, currently informational). The MCP runtime authenticates via the session provider passed to `createMcpHandlers` — for Better Auth, the OAuth flow is wired through the `mcp` plugin in `authPlugin`'s `betterAuthPlugins` plus `createBetterAuthMcpAdapter`. See the [MCP Setup Guide](/docs/how-to/mcp).
 
 **Type:** [`McpAuthConfig`](#mcpauthconfig)
 

--- a/docs/content/reference/config-api.md
+++ b/docs/content/reference/config-api.md
@@ -933,7 +933,7 @@ Base path for MCP API routes.
 
 ##### `auth`
 
-Authentication configuration (required when MCP is enabled).
+Authentication metadata (optional, currently informational). The MCP runtime authenticates via the session provider passed to `createMcpHandlers` — for Better Auth, the OAuth flow is wired through the `mcp` plugin in `authPlugin`'s `betterAuthPlugins` plus `createBetterAuthMcpAdapter`. See the [MCP Setup Guide](/docs/guides/mcp-setup).
 
 **Type:** [`McpAuthConfig`](#mcpauthconfig)
 
@@ -945,10 +945,9 @@ Default CRUD tool configuration for all lists.
 
 ##### `resource`
 
-OAuth resource identifier for protected resource metadata.
+OAuth resource identifier for protected resource metadata (optional, currently informational — the `.well-known/oauth-protected-resource` route you create serves this metadata).
 
 **Type:** `string`
-**Default:** `"https://yourdomain.com"`
 
 ---
 
@@ -1074,7 +1073,9 @@ Custom MCP tool definition for specialized operations.
 type McpCustomTool = {
   name: string
   description: string
-  inputSchema: ZodSchema
+  // Zod schema (validated on tools/call, converted to JSON Schema for
+  // tools/list) or a plain JSON Schema object
+  inputSchema: ZodSchema | Record<string, unknown>
   handler: (args) => Promise<unknown>
 }
 ```

--- a/docs/content/tutorials/quick-start.md
+++ b/docs/content/tutorials/quick-start.md
@@ -68,7 +68,7 @@ pnpm add -D prisma
 Create `opensaas.config.ts` in your project root:
 
 ```typescript
-import { config, list } from '@opensaas/stack-core/config'
+import { config, list } from '@opensaas/stack-core'
 import { text, timestamp, relationship } from '@opensaas/stack-core/fields'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
@@ -121,6 +121,7 @@ pnpm generate
 This creates:
 
 - `prisma/schema.prisma` - Database schema
+- `prisma.config.ts` - Prisma CLI configuration (datasource URL for db push/migrations)
 - `.opensaas/types.ts` - TypeScript types
 - `.opensaas/context.ts` - Context factory
 

--- a/examples/mcp-demo/README.md
+++ b/examples/mcp-demo/README.md
@@ -34,10 +34,11 @@ pnpm generate
 This generates:
 
 - `prisma/schema.prisma` - Prisma schema
+- `prisma.config.ts` - Prisma CLI configuration
 - `.opensaas/types.ts` - TypeScript types
 - `.opensaas/context.ts` - Context factory
-- `.opensaas/mcp/tools.json` - MCP tool reference (metadata only)
-- `.opensaas/mcp/README.md` - Usage instructions
+
+(MCP tools are not generated to disk — they are derived from the config at request time by `createMcpHandlers`.)
 
 ### 4. Push Schema to Database
 
@@ -167,7 +168,9 @@ Post: list({
 - **list_user_query** - Query users
 - **list_user_create** - Create a new user
 - **list_user_update** - Update user information
-- (delete disabled for safety)
+- **list_user_delete** - Delete a user (enabled by this example's `defaultTools`)
+
+The auth-injected lists (Session, Account, Verification) also get CRUD tools; all of them are governed by the access control rules in `opensaas.config.ts`. Disable tools per list with `mcp: { enabled: false }` or `mcp: { tools: { delete: false } }`.
 
 ## Claude Desktop Integration
 
@@ -269,8 +272,8 @@ curl -X POST http://localhost:3000/api/mcp \
          │ Access Token
          ↓
 ┌─────────────────┐
-│   MCP Server    │ ← Generated Tools
-│ (.opensaas/mcp) │
+│   MCP Handler   │ ← Tools derived from
+│ (stack-core/mcp)│   config at runtime
 └────────┬────────┘
          │ context.db
          ↓
@@ -304,16 +307,13 @@ examples/mcp-demo/
 │           └── route.ts         # Resource metadata
 └── .opensaas/                   # Generated
     ├── types.ts
-    ├── context.ts
-    └── mcp/
-        ├── tools.json           # Tool reference (metadata)
-        └── README.md            # Usage instructions
+    └── context.ts
 ```
 
 ## Next Steps
 
-1. **Add Authentication UI** - Create sign-in/sign-up pages
-2. **Customize Access Control** - Add more granular rules
+1. **Customize Access Control** - Add more granular rules (a sign-in page ships at `app/sign-in/`)
+2. **Seed a Test User** - Run `npx tsx create-user.ts`
 3. **Add More Custom Tools** - Extend MCP capabilities
 4. **Deploy** - Deploy to production with proper OAuth setup
 

--- a/packages/auth/src/mcp/better-auth.ts
+++ b/packages/auth/src/mcp/better-auth.ts
@@ -51,11 +51,10 @@ export function createBetterAuthMcpAdapter(auth: BetterAuthInstance): McpSession
  * ```typescript
  * import { withMcpAuth } from '@opensaas/stack-auth/mcp'
  * import { auth } from '@/lib/auth'
- * import { createMcpServer } from '@/.opensaas/mcp/server'
  *
  * const handler = withMcpAuth(auth, async (req, session) => {
- *   const server = createMcpServer(session)
- *   return server.handleRequest(req)
+ *   // session.userId is authenticated — handle the MCP request
+ *   return new Response(JSON.stringify({ ok: true }))
  * })
  *
  * export { handler as GET, handler as POST, handler as DELETE }

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -16,15 +16,18 @@ Entry point exposing `opensaas` CLI command
 
 - `generate.ts` - One-time generation
 - `dev.ts` - Watch mode with automatic regeneration
-- `init.ts` - Project scaffolding (future)
+- `init.ts` - Project scaffolding (delegates to `create-opensaas-app`)
+- `mcp.ts` - MCP server management (`mcp install`/`uninstall`/`start`)
+- `migrate.ts` - Migration from Prisma/KeystoneJS/Next.js projects
 
 ### Generators (`src/generator/`)
 
 - `prisma.ts` - Generates `prisma/schema.prisma` from config
+- `prisma-config.ts` - Generates `prisma.config.ts` (Prisma CLI configuration)
 - `types.ts` - Generates `.opensaas/types.ts` TypeScript types
 - `context.ts` - Generates `.opensaas/context.ts` context factory
-- `mcp.ts` - Generates MCP tools metadata
-- `type-patcher.ts` - Patches Prisma types for relationships
+- `lists.ts` - Generates the `.opensaas/lists` type namespace
+- Supporting modules: `extension.ts`, `node-build.ts`, `output-paths.ts`, `plugin-types.ts`, `prisma-extensions.ts`
 
 ## Architecture
 
@@ -41,9 +44,11 @@ const config = jiti('./opensaas.config.ts').default
 
 1. Load config from `opensaas.config.ts`
 2. Generate Prisma schema → `prisma/schema.prisma`
-3. Generate TypeScript types → `.opensaas/types.ts`
-4. Generate context factory → `.opensaas/context.ts`
-5. Generate MCP tools (if enabled) → `.opensaas/mcp-tools.json`
+3. Generate Prisma CLI config → `prisma.config.ts`
+4. Generate TypeScript types → `.opensaas/types.ts`
+5. Generate context factory → `.opensaas/context.ts`
+
+(No MCP files are generated — MCP tools are derived at request time by `@opensaas/stack-core/mcp`.)
 
 ### Watch Mode
 
@@ -181,8 +186,8 @@ export function getContext(session?: any) {
 
 ### With MCP (Model Context Protocol)
 
-- Generates MCP tools metadata when MCP enabled in config
-- MCP functionality is now in `@opensaas/stack-core/mcp` (runtime) and `@opensaas/stack-auth/mcp` (adapter)
+- Ships the dev-assistant MCP server (`src/mcp/`) exposed via `opensaas mcp start` — feature wizards, docs search, migration tools
+- Runtime MCP for applications lives in `@opensaas/stack-core/mcp` (handlers) and `@opensaas/stack-auth/mcp` (Better-auth adapter); the generator emits no MCP files
 
 ### With Prisma
 
@@ -347,20 +352,13 @@ opensaas migrate --with-ai
 
 Includes basic mode steps plus:
 
-4. **Setup Claude Code integration**:
+4. **Setup Claude Code integration** (`setupClaudeCode` in `migrate.ts`):
    - Create `.claude/` directory
-   - Generate `settings.json` with MCP server config
-   - Generate `README.md` with project summary
-   - Generate `.claude/agents/migration-assistant.md` agent
-   - Generate slash commands:
-     - `/analyze-schema` - Detailed schema analysis
-     - `/generate-config` - Generate config file
-     - `/validate-migration` - Validate configuration
+   - Write `.claude/opensaas-project.json` (project metadata: projectTypes, provider, models, hasAuth)
+   - Write `.claude/settings.json` registering `opensaas-stack-marketplace` (`extraKnownMarketplaces`) and enabling `opensaas-migration@opensaas-stack-marketplace` (`enabledPlugins`)
+   - Write `.claude/README.md` with a project summary
 
-5. **Template system**:
-   - All generated files use template placeholders
-   - `{{PROJECT_TYPES}}`, `{{PROVIDER}}`, `{{MODEL_COUNT}}`, etc.
-   - Templates populated from `ProjectAnalysis` data
+The migration agent, slash commands (`/analyze-schema`, `/generate-config`, `/validate-migration`), and skills are NOT generated — they ship statically in `claude-plugins/opensaas-migration/` and arrive via the enabled plugin. The MCP server comes from the plugin's `plugin.json` `mcpServers` entry.
 
 ### Migration Types
 
@@ -531,21 +529,23 @@ interface MigrationOutput {
 
 ### MCP Integration
 
-**New MCP Tools:**
+**Registered MCP Tools:**
 
-Registered in `src/mcp/server/stack-mcp-server.ts`:
+Declared in the `TOOLS` array and dispatched in `src/mcp/server/index.ts` (implementations live in `stack-mcp-server.ts`):
 
-1. **opensaas_introspect_prisma** - Analyze Prisma schema
-2. **opensaas_introspect_keystone** - Analyze Keystone config
-3. **opensaas_introspect_nextjs** - Analyze Next.js project
-4. **opensaas_start_migration** - Begin wizard
-5. **opensaas_answer_migration** - Answer wizard question
-6. **opensaas_get_migration_status** - Check wizard progress
-7. **opensaas_search_migration_docs** - Search migration docs
-8. **opensaas_get_migration_example** - Get code examples
-9. **opensaas_list_field_types** - List available field types
-10. **opensaas_validate_migration** - Validate config
-11. **opensaas_generate_config_file** - Write config to disk
+1. **opensaas_implement_feature** - Start a feature wizard (authentication, blog, comments, file-upload, semantic-search, custom)
+2. **opensaas_answer_feature** - Answer a feature wizard question
+3. **opensaas_answer_followup** - Answer a wizard follow-up question
+4. **opensaas_feature_docs** - Search hosted documentation
+5. **opensaas_list_features** - List available features
+6. **opensaas_suggest_features** - Suggest complementary features
+7. **opensaas_validate_feature** - Feature validation checklist
+8. **opensaas_start_migration** - Begin migration wizard
+9. **opensaas_answer_migration** - Answer migration wizard question
+10. **opensaas_introspect_prisma** - Analyze Prisma schema
+11. **opensaas_introspect_keystone** - Analyze Keystone config
+12. **opensaas_search_migration_docs** - Search migration docs (local CLAUDE.md + hosted)
+13. **opensaas_get_example** - Get example code for common patterns
 
 **MCP Response Format:**
 
@@ -562,21 +562,9 @@ All tools return standardized format:
 }
 ```
 
-### Claude Code Templates
+### Claude Code Plugin Integration
 
-**Generated Agent:** `.claude/agents/migration-assistant.md`
-
-**Purpose:** Contextual agent that knows project details
-
-**Template Variables:**
-
-- `{{PROJECT_TYPES}}` - Detected types (e.g., "prisma, nextjs")
-- `{{PROVIDER}}` - Database provider (e.g., "postgresql")
-- `{{MODEL_COUNT}}` - Number of models
-- `{{MODEL_DETAILS}}` - Formatted model list
-- `{{PROJECT_TYPE}}` - Primary type (e.g., "Prisma")
-- `{{PROJECT_TYPE_LOWER}}` - Lowercase type (e.g., "prisma")
-- `{{HAS_AUTH}}` - Whether auth detected
+The migration agent (`migration-assistant`), slash commands (`/analyze-schema`, `/generate-config`, `/validate-migration`), and skills ship statically in `claude-plugins/opensaas-migration/` — `migrate --with-ai` enables that plugin rather than generating files. The agent reads `.claude/opensaas-project.json` (written by `migrate --with-ai`) for project context.
 
 **Agent Behavior:**
 
@@ -586,45 +574,6 @@ All tools return standardized format:
 4. Show progress throughout
 5. Generate and explain config
 6. Provide validation and next steps
-
-**Generated Slash Commands:**
-
-`.claude/commands/analyze-schema.md`:
-
-```markdown
-Analyze the current project schema and provide a detailed breakdown.
-
-## Instructions
-
-1. Use `opensaas_introspect_prisma` or `opensaas_introspect_keystone`
-2. Present results in clear format
-3. Highlight models, relations, potential access patterns
-```
-
-`.claude/commands/generate-config.md`:
-
-```markdown
-Generate the opensaas.config.ts file for this project.
-
-## Instructions
-
-1. Start migration wizard if not started
-2. Guide through questions
-3. Display generated config and dependencies
-```
-
-`.claude/commands/validate-migration.md`:
-
-```markdown
-Validate the generated opensaas.config.ts file.
-
-## Instructions
-
-1. Check file exists
-2. Verify syntax and imports
-3. Try running `opensaas generate`
-4. Report errors and suggest fixes
-```
 
 ### Common Patterns
 
@@ -674,21 +623,6 @@ async function analyzePrismaSchema(cwd: string) {
   const provider = providerMatch?.[1] || 'unknown'
 
   return { models, provider }
-}
-```
-
-**Template Rendering:**
-
-```typescript
-function generateTemplateContent(template: string, data: ProjectAnalysis): string {
-  return template
-    .replace(/\{\{PROJECT_TYPES\}\}/g, data.projectTypes.join(', '))
-    .replace(/\{\{PROVIDER\}\}/g, data.provider || 'sqlite')
-    .replace(/\{\{MODEL_COUNT\}\}/g, String(data.models?.length || 0))
-    .replace(
-      /\{\{MODEL_LIST\}\}/g,
-      data.models?.map((m) => `- ${m.name} (${m.fieldCount} fields)`).join('\n'),
-    )
 }
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,7 @@
   },
   "files": [
     "dist",
-    "bin",
-    "plugin"
+    "bin"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -33,11 +33,17 @@ function installMCPServer(): Promise<void> {
       if (code === 0) {
         console.log('\n✅ OpenSaaS Stack MCP server installed successfully!')
         console.log('\n📖 Available tools:')
+        console.log('  Feature wizards:')
         console.log('  - opensaas_implement_feature')
-        console.log('  - opensaas_feature_docs')
-        console.log('  - opensaas_list_features')
-        console.log('  - opensaas_suggest_features')
+        console.log('  - opensaas_answer_feature / opensaas_answer_followup')
+        console.log('  - opensaas_list_features / opensaas_suggest_features')
         console.log('  - opensaas_validate_feature')
+        console.log('  Documentation:')
+        console.log('  - opensaas_feature_docs / opensaas_get_example')
+        console.log('  Migration:')
+        console.log('  - opensaas_start_migration / opensaas_answer_migration')
+        console.log('  - opensaas_introspect_prisma / opensaas_introspect_keystone')
+        console.log('  - opensaas_search_migration_docs')
         console.log('\n🚀 Restart Claude Code to use the MCP tools.')
         resolve()
       } else {
@@ -82,7 +88,8 @@ function uninstallMCPServer(): Promise<void> {
 }
 
 function startMCPServer(): void {
-  console.log('🚀 Starting OpenSaaS Stack MCP server...\n')
+  // stdout carries the MCP stdio JSON-RPC stream — status output must go to stderr
+  console.error('🚀 Starting OpenSaaS Stack MCP server...\n')
 
   const serverPath = getServerPath()
 

--- a/packages/cli/src/mcp/lib/features/catalog.ts
+++ b/packages/cli/src/mcp/lib/features/catalog.ts
@@ -23,7 +23,7 @@ export const AUTHENTICATION_FEATURE: Feature = {
       text: 'Which authentication methods do you want to support?',
       type: 'multiselect',
       required: true,
-      options: ['Email & Password', 'Google OAuth', 'GitHub OAuth', 'Magic Links'],
+      options: ['Email & Password', 'Google OAuth', 'GitHub OAuth'],
       defaultValue: ['Email & Password'],
     },
     {
@@ -247,7 +247,7 @@ export const SEMANTIC_SEARCH_FEATURE: Feature = {
       text: 'Which embedding provider?',
       type: 'select',
       required: true,
-      options: ['OpenAI (text-embedding-3-small)', 'Cohere', 'Anthropic'],
+      options: ['OpenAI (text-embedding-3-small)', 'Ollama (local, self-hosted)'],
       defaultValue: 'OpenAI (text-embedding-3-small)',
     },
     {

--- a/packages/cli/src/mcp/lib/generators/feature-generator.ts
+++ b/packages/cli/src/mcp/lib/generators/feature-generator.ts
@@ -1,8 +1,30 @@
 /**
  * Feature generator - Generates code, config, and documentation for features
+ *
+ * Emitted code must match the current stack APIs. Canonical references:
+ * - examples/starter-auth (authPlugin, access helpers, lib/auth wiring)
+ * - examples/file-upload-demo (storage config, file/image fields)
+ * - examples/rag-openai-chatbot and examples/rag-ollama-demo (ragPlugin, searchable)
  */
 
 import type { Feature, FeatureImplementation, GeneratedFile } from '../types.js'
+
+const SQLITE_DB_BLOCK = `db: {
+    provider: 'sqlite',
+    prismaClientConstructor: (PrismaClient) => {
+      const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL || 'file:./dev.db' })
+      return new PrismaClient({ adapter })
+    },
+  }`
+
+const POSTGRES_DB_BLOCK = `db: {
+    provider: 'postgresql',
+    prismaClientConstructor: (PrismaClient) => {
+      const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+      const adapter = new PrismaPg(pool)
+      return new PrismaClient({ adapter })
+    },
+  }`
 
 export class FeatureGenerator {
   constructor(
@@ -47,134 +69,206 @@ export class FeatureGenerator {
     const userFields = (this.answers['user-fields'] as string[]) || []
     const emailVerification = this.answers['email-verification'] as boolean
 
-    const hasOAuth = authMethods.some((m) => ['Google OAuth', 'GitHub OAuth'].includes(m))
+    const hasGoogle = authMethods.includes('Google OAuth')
+    const hasGithub = authMethods.includes('GitHub OAuth')
+    const hasOAuth = hasGoogle || hasGithub
     const hasPassword = authMethods.includes('Email & Password')
-    const hasMagicLink = authMethods.includes('Magic Links')
 
-    // Build User list fields
-    const fields = ['email: text({ validation: { isRequired: true } })']
-
-    if (hasPassword) {
-      fields.push('password: password({ validation: { isRequired: true } })')
-    }
-
-    fields.push('name: text()')
+    // Custom User fields go through authPlugin's extendUserList — the plugin
+    // auto-generates the User/Session/Account/Verification lists. Passwords
+    // live on the Account list managed by Better-auth; never add a password
+    // field to User.
+    const extendFields: string[] = []
 
     if (hasRoles && roles) {
-      fields.push(
-        `role: select({ options: [${roles.map((r) => `'${r}'`).join(', ')}], defaultValue: '${roles[roles.length - 1]}' })`,
+      const options = roles.map(
+        (r) => `{ label: '${r[0].toUpperCase()}${r.slice(1)}', value: '${r}' }`,
+      )
+      extendFields.push(
+        `role: select({ options: [${options.join(', ')}], defaultValue: '${roles[roles.length - 1]}' })`,
       )
     }
-
     if (userFields.includes('Avatar')) {
-      fields.push('avatar: text()')
+      extendFields.push(`avatar: text() // or an image() field — see the file-upload feature`)
     }
     if (userFields.includes('Bio')) {
-      fields.push('bio: text({ ui: { displayMode: "textarea" } })')
+      extendFields.push(`bio: text({ ui: { displayMode: 'textarea' } })`)
     }
     if (userFields.includes('Phone')) {
-      fields.push('phone: text()')
+      extendFields.push(`phone: text()`)
     }
     if (userFields.includes('Location')) {
-      fields.push('location: text()')
+      extendFields.push(`location: text()`)
     }
     if (userFields.includes('Website')) {
-      fields.push('website: text()')
+      extendFields.push(`website: text()`)
     }
 
-    // Config updates
-    const configUpdates = `import { config, list } from '@opensaas/stack-core';
-import { text, password, select } from '@opensaas/stack-core/fields';
-import { authPlugin } from '@opensaas/stack-auth';
+    const fieldImports = ['text']
+    if (hasRoles) fieldImports.push('select')
+
+    const socialProvidersBlock = hasOAuth
+      ? `
+      socialProviders: {
+        ${hasGoogle ? `google: {\n          clientId: process.env.GOOGLE_CLIENT_ID!,\n          clientSecret: process.env.GOOGLE_CLIENT_SECRET!,\n        },` : ''}
+        ${hasGithub ? `github: {\n          clientId: process.env.GITHUB_CLIENT_ID!,\n          clientSecret: process.env.GITHUB_CLIENT_SECRET!,\n        },` : ''}
+      },`
+      : ''
+
+    const configUpdates = `import { config, list } from '@opensaas/stack-core'
+import type { AccessControl } from '@opensaas/stack-core'
+import { ${fieldImports.join(', ')} } from '@opensaas/stack-core/fields'
+import { authPlugin } from '@opensaas/stack-auth'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+
+// Access control helpers (see lib/access-control.ts for the full set)
+const isSignedIn: AccessControl = ({ session }) => !!session
 
 export default config({
   plugins: [
     authPlugin({
-      emailAndPassword: { enabled: ${hasPassword} },
+      emailAndPassword: { enabled: ${hasPassword} },${socialProvidersBlock}
+      ${emailVerification ? `emailVerification: { enabled: true },` : ''}
+      sessionFields: ['userId', 'email', 'name'${hasRoles ? ", 'role'" : ''}],
       ${
-        hasOAuth
-          ? `oauth: {
-        google: { enabled: ${authMethods.includes('Google OAuth')} },
-        github: { enabled: ${authMethods.includes('GitHub OAuth')} },
+        extendFields.length > 0
+          ? `// Custom fields on the auto-generated User list
+      extendUserList: {
+        fields: {
+          ${extendFields.join(',\n          ')},
+        },
       },`
           : ''
       }
-      ${hasMagicLink ? `magicLink: { enabled: true },` : ''}
-      ${emailVerification ? `emailVerification: { enabled: true },` : ''}
-      sessionFields: ['userId', 'email', 'name'${hasRoles ? ", 'role'" : ''}],
-    }),
-  ],
-  db: {
-    provider: 'postgresql', // or 'sqlite'
-    url: process.env.DATABASE_URL,
-  },
-  lists: {
-    User: list({
-      fields: {
-        ${fields.join(',\n        ')}
-      },
+      // The auth lists ship closed (deny-by-default) — grant the access your
+      // app needs here (ADR-0013).
       access: {
-        operation: {
-          query: () => true,
-          create: () => true, // Public sign-up
-          update: ({ session, item }) => session?.userId === item.id,
-          delete: ({ session }) => session?.role === 'admin',
+        user: {
+          operation: {
+            query: isSignedIn,
+            update: ({ session, item }) => session?.userId === item?.id,
+            delete: ({ session, item }) => ${hasRoles ? `session?.role === 'admin' || session?.userId === item?.id` : `session?.userId === item?.id`},
+          },
         },
       },
     }),
-    // Add your other lists here
+  ],
+  ${SQLITE_DB_BLOCK},
+  // For PostgreSQL use @prisma/adapter-pg instead:
+  // ${POSTGRES_DB_BLOCK.replace(/\n/g, '\n  // ')}
+  lists: {
+    // Your app lists go here. User, Session, Account, and Verification are
+    // added automatically by authPlugin.
   },
-});`
+  ui: {
+    basePath: '/admin',
+  },
+})`
 
-    // Generated files
     const files: GeneratedFile[] = []
 
+    // Better-auth server instance
+    files.push({
+      path: 'lib/auth.ts',
+      language: 'typescript',
+      description: 'Better-auth server instance and session helper',
+      content: `import { createAuth } from '@opensaas/stack-auth/server'
+import { headers } from 'next/headers'
+import config from '../opensaas.config'
+import { rawOpensaasContext } from '@/.opensaas/context'
+
+export const auth = createAuth(config, rawOpensaasContext)
+
+/**
+ * Get the current session in OpenSaas format (the configured sessionFields).
+ */
+export async function getSession() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session || !session.user) return null
+  return {
+    userId: session.user.id,
+    email: session.user.email,
+    name: session.user.name,${hasRoles ? `\n    role: (session.user as { role?: string }).role,` : ''}
+  }
+}
+
+export const GET = auth.handler
+export const POST = auth.handler`,
+    })
+
+    // Auth API route
+    files.push({
+      path: 'app/api/auth/[...all]/route.ts',
+      language: 'typescript',
+      description: 'Better-auth API route (handles all /api/auth/* endpoints)',
+      content: `export { GET, POST } from '@/lib/auth'`,
+    })
+
+    // Auth client
+    files.push({
+      path: 'lib/auth-client.ts',
+      language: 'typescript',
+      description: 'Client-side Better-auth instance for React components',
+      content: `'use client'
+
+import { createClient } from '@opensaas/stack-auth/client'
+
+export const authClient = createClient({
+  baseURL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
+})`,
+    })
+
     // Sign-in page
-    if (hasPassword || hasOAuth) {
-      files.push({
-        path: 'app/sign-in/page.tsx',
-        language: 'tsx',
-        description: 'Sign-in page with form and OAuth buttons',
-        content: `import { SignInForm } from '@opensaas/stack-auth/ui';
+    files.push({
+      path: 'app/sign-in/page.tsx',
+      language: 'tsx',
+      description: 'Sign-in page using the pre-built SignInForm',
+      content: `import { SignInForm } from '@opensaas/stack-auth/ui'
+import { authClient } from '@/lib/auth-client'
+import Link from 'next/link'
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <h1 className="text-2xl font-bold mb-6">Sign In</h1>
         <SignInForm
-          ${hasPassword ? 'emailAndPassword' : ''}
-          ${hasOAuth ? `oauth={[${authMethods.includes('Google OAuth') ? "'google'" : ''}${authMethods.includes('GitHub OAuth') ? ", 'github'" : ''}]}` : ''}
-          redirectTo="/dashboard"
+          authClient={authClient}
+          redirectTo="/admin"
+          showSocialProviders={${hasOAuth}}
         />
+        ${
+          hasPassword
+            ? `<div className="mt-4 text-center text-sm">
+          Don&apos;t have an account?{' '}
+          <Link href="/sign-up" className="underline">Sign up</Link>
+        </div>`
+            : ''
+        }
       </div>
     </div>
-  );
+  )
 }`,
-      })
-    }
+    })
 
     // Sign-up page
     if (hasPassword) {
       files.push({
         path: 'app/sign-up/page.tsx',
         language: 'tsx',
-        description: 'Sign-up page with registration form',
-        content: `import { SignUpForm } from '@opensaas/stack-auth/ui';
+        description: 'Sign-up page using the pre-built SignUpForm',
+        content: `import { SignUpForm } from '@opensaas/stack-auth/ui'
+import { authClient } from '@/lib/auth-client'
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center">
+    <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <h1 className="text-2xl font-bold mb-6">Create Account</h1>
-        <SignUpForm
-          fields={['email', 'password', 'name']}
-          redirectTo="/dashboard"
-          ${emailVerification ? 'requireEmailVerification' : ''}
-        />
+        <SignUpForm authClient={authClient} redirectTo="/admin" />
       </div>
     </div>
-  );
+  )
 }`,
       })
     }
@@ -184,60 +278,55 @@ export default function SignUpPage() {
       path: 'lib/access-control.ts',
       language: 'typescript',
       description: 'Reusable access control functions',
-      content: `import type { AccessControl } from '@opensaas/stack-core';
+      content: `import type { AccessControl } from '@opensaas/stack-core'
 
-export const isAuthenticated: AccessControl = ({ session }) => {
-  return !!session?.userId;
-};
-
+export const isSignedIn: AccessControl = ({ session }) => !!session
 ${
   hasRoles
-    ? `export const isAdmin: AccessControl = ({ session }) => {
-  return session?.role === 'admin';
-};
+    ? `
+export const isAdmin: AccessControl = ({ session }) => session?.role === 'admin'
 
-export const isOwner: AccessControl = ({ session, item }) => {
-  return session?.userId === item.id;
-};
+export const isSelf: AccessControl = ({ session, item }) => session?.userId === item?.id
 
-export const isAdminOrOwner: AccessControl = ({ session, item }) => {
-  return session?.role === 'admin' || session?.userId === item.id;
-};`
-    : ''
+export const isAdminOrSelf: AccessControl = ({ session, item }) =>
+  session?.role === 'admin' || session?.userId === item?.id
+`
+    : `
+export const isSelf: AccessControl = ({ session, item }) => session?.userId === item?.id
+`
 }
-
-export const requireAuth: AccessControl = ({ session }) => {
-  if (!session?.userId) {
-    throw new Error('Authentication required');
-  }
-  return true;
-};`,
+// Filter-based access: scope queries to rows the user owns.
+// Returning a Prisma filter (instead of a boolean) narrows results silently.
+export const ownRecordsOnly: AccessControl = ({ session }) =>
+  session ? { userId: { equals: session.userId } } : false`,
     })
 
     // Environment variables
     const envVars: Record<string, string> = {
-      DATABASE_URL: 'postgresql://user:password@localhost:5432/mydb',
+      DATABASE_URL: 'file:./dev.db',
       BETTER_AUTH_SECRET: '<generate-with-openssl-rand-base64-32>',
       BETTER_AUTH_URL: 'http://localhost:3000',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
     }
 
-    if (authMethods.includes('Google OAuth')) {
+    if (hasGoogle) {
       envVars.GOOGLE_CLIENT_ID = '<your-google-client-id>'
       envVars.GOOGLE_CLIENT_SECRET = '<your-google-client-secret>'
     }
 
-    if (authMethods.includes('GitHub OAuth')) {
+    if (hasGithub) {
       envVars.GITHUB_CLIENT_ID = '<your-github-client-id>'
       envVars.GITHUB_CLIENT_SECRET = '<your-github-client-secret>'
     }
 
     // Next steps
     const nextSteps = [
-      'Copy the config updates to your `opensaas.config.ts`',
+      'Install dependencies: `pnpm add @opensaas/stack-auth @prisma/adapter-better-sqlite3`',
+      'Merge the config updates into your `opensaas.config.ts`',
       'Create the files shown above in your project',
       'Add environment variables to your `.env` file',
       hasOAuth ? 'Set up OAuth applications in Google/GitHub developer consoles' : null,
-      'Run `pnpm generate` to update Prisma schema',
+      'Run `pnpm generate` to update the Prisma schema and generated context',
       'Run `pnpm db:push` to update your database',
       'Start your dev server: `pnpm dev`',
       `Visit http://localhost:3000/${hasPassword ? 'sign-up' : 'sign-in'} to test authentication`,
@@ -246,44 +335,44 @@ export const requireAuth: AccessControl = ({ session }) => {
     // Dev guide section
     const devGuideSection = `## Authentication Feature
 
-This project uses Better-auth for authentication with the following configuration:
+This project uses Better-auth (via \`@opensaas/stack-auth\`) with:
 
 ${authMethods.map((m) => `- ${m}`).join('\n')}
 ${hasRoles ? `\n**User Roles**: ${roles?.join(', ')}` : ''}
 
+The User, Session, Account, and Verification lists are auto-generated by
+\`authPlugin\`. They ship closed (deny-by-default) — access is granted through
+the plugin's \`access\` option in \`opensaas.config.ts\`.
+
 ### Access Control Helpers
 
-Use these functions in your list configurations:
-
 \`\`\`typescript
-import { isAuthenticated${hasRoles ? ', isAdmin, isOwner' : ''} } from './lib/access-control';
+import { isSignedIn${hasRoles ? ', isAdmin, isSelf' : ', isSelf'} } from './lib/access-control'
 
 // In your list config:
 access: {
   operation: {
     query: () => true,
-    create: isAuthenticated,
-    update: isOwner,
-    delete: ${hasRoles ? 'isAdmin' : 'isOwner'},
-  }
+    create: isSignedIn,
+    update: ({ session, item }) => session?.userId === item?.authorId,
+    delete: ${hasRoles ? 'isAdmin' : '({ session, item }) => session?.userId === item?.authorId'},
+  },
 }
 \`\`\`
 
 ### Protected Routes
 
-To protect a route, check the session in your server components:
+Check the session in server components:
 
 \`\`\`typescript
-import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation'
+import { getSession } from '@/lib/auth'
 
 export default async function ProtectedPage() {
-  const session = await auth();
+  const session = await getSession()
+  if (!session) redirect('/sign-in')
 
-  if (!session) {
-    redirect('/sign-in');
-  }
-
-  return <div>Protected content for {session.user.name}</div>;
+  return <div>Signed in as {session.name}</div>
 }
 \`\`\`
 
@@ -292,12 +381,14 @@ export default async function ProtectedPage() {
 In server actions or API routes:
 
 \`\`\`typescript
-import { getContext } from '@/.opensaas/context';
+import { getSession } from '@/lib/auth'
+import { getContext } from '@/.opensaas/context'
 
-const context = await getContext();
-const currentUser = await context.db.user.findUnique({
-  where: { id: context.session?.userId }
-});
+const session = await getSession()
+const context = await getContext(session)
+const currentUser = session
+  ? await context.db.user.findUnique({ where: { id: session.userId } })
+  : null
 \`\`\``
 
     return {
@@ -320,38 +411,44 @@ const currentUser = await context.db.user.findUnique({
     const postFields = (this.answers['post-fields'] as string[]) || []
 
     const useTiptap = contentEditor === 'Rich text editor (Tiptap)'
-    const useMarkdown = contentEditor === 'Markdown'
+    const hasCategories = taxonomy.includes('Categories')
+    const hasTags = taxonomy.includes('Tags')
 
     // Build Post fields
     const fields = [
       'title: text({ validation: { isRequired: true } })',
-      'slug: text({ validation: { isRequired: true } })',
+      "slug: text({ validation: { isRequired: true }, isIndexed: 'unique' })",
     ]
 
     if (useTiptap) {
       fields.push('content: richText({ validation: { isRequired: true } })')
-    } else if (useMarkdown) {
-      fields.push(
-        'content: text({ ui: { displayMode: "textarea" }, validation: { isRequired: true } })',
-      )
     } else {
       fields.push(
-        'content: text({ ui: { displayMode: "textarea" }, validation: { isRequired: true } })',
+        "content: text({ ui: { displayMode: 'textarea' }, validation: { isRequired: true } })",
       )
     }
 
-    fields.push('author: relationship({ ref: "User.posts" })')
+    fields.push("author: relationship({ ref: 'User.posts' })")
 
     if (hasStatus) {
-      fields.push("status: select({ options: ['draft', 'published'], defaultValue: 'draft' })")
+      fields.push(
+        "status: select({ options: [{ label: 'Draft', value: 'draft' }, { label: 'Published', value: 'published' }], defaultValue: 'draft' })",
+      )
       fields.push('publishedAt: timestamp()')
     }
 
+    if (hasCategories) {
+      fields.push("category: relationship({ ref: 'Category.posts' })")
+    }
+    if (hasTags) {
+      fields.push("tags: relationship({ ref: 'Tag.posts', many: true })")
+    }
+
     if (postFields.includes('Featured image')) {
-      fields.push('featuredImage: text()')
+      fields.push('featuredImage: text() // URL — or an image() field, see the file-upload feature')
     }
     if (postFields.includes('Excerpt/summary')) {
-      fields.push('excerpt: text({ ui: { displayMode: "textarea" } })')
+      fields.push("excerpt: text({ ui: { displayMode: 'textarea' } })")
     }
     if (postFields.includes('SEO metadata (title, description)')) {
       fields.push('seoTitle: text()')
@@ -361,65 +458,103 @@ const currentUser = await context.db.user.findUnique({
       fields.push('readingTime: integer()')
     }
 
-    const configUpdates = `import { config, list } from '@opensaas/stack-core';
-import { text, select, relationship, timestamp${useTiptap ? '' : ', integer'} } from '@opensaas/stack-core/fields';
-${useTiptap ? "import { richText } from '@opensaas/stack-tiptap/fields';" : ''}
+    const fieldImports = ['text', 'relationship']
+    if (hasStatus) fieldImports.push('select', 'timestamp')
+    if (postFields.includes('Reading time estimate')) fieldImports.push('integer')
 
-export default config({
-  lists: {
+    const configUpdates = `// Add these imports and lists to your existing opensaas.config.ts
+import { ${fieldImports.join(', ')} } from '@opensaas/stack-core/fields'
+${useTiptap ? "import { richText } from '@opensaas/stack-tiptap/fields'" : ''}
+
+// Inside config({ lists: { ... } }):
     Post: list({
       fields: {
         ${fields.join(',\n        ')},
       },
       access: {
         operation: {
-          query: ({ session }) => {
-            ${hasStatus ? "if (!session) return { status: { equals: 'published' } };" : ''}
-            return true;
-          },
-          create: ({ session }) => !!session?.userId,
-          update: ({ session, item }) => session?.userId === item.authorId,
+          ${
+            hasStatus
+              ? `// Anonymous visitors only see published posts (filter-based access)
+          query: ({ session }) => (session ? true : { status: { equals: 'published' } }),`
+              : 'query: () => true,'
+          }
+          create: ({ session }) => !!session,
+          update: ({ session, item }) => session?.userId === item?.authorId,
           delete: ({ session, item }) =>
-            session?.role === 'admin' || session?.userId === item.authorId,
+            session?.role === 'admin' || session?.userId === item?.authorId,
         },
       },
       hooks: {
-        ${
-          hasStatus
-            ? `resolveInput: async ({ resolvedData, operation }) => {
-          // Auto-set publishedAt when publishing
-          if (operation === 'update' && resolvedData.status === 'published' && !resolvedData.publishedAt) {
-            resolvedData.publishedAt = new Date();
+        resolveInput: async ({ operation, resolvedData, item, context }) => {
+          const data = { ...resolvedData }
+          // Auto-connect the author on create
+          if (operation === 'create' && !data.author && context.session?.userId) {
+            data.author = { connect: { id: context.session.userId } }
           }
-          return resolvedData;
-        },`
-            : ''
-        }
+          ${
+            hasStatus
+              ? `// Auto-set publishedAt when publishing
+          if (operation === 'create' && data.status === 'published') {
+            data.publishedAt = new Date()
+          } else if (operation === 'update' && data.status === 'published' && !item?.publishedAt) {
+            data.publishedAt = new Date()
+          }`
+              : ''
+          }
+          return data
+        },
       },
     }),
     ${
-      taxonomy.includes('Categories')
+      hasCategories
         ? `Category: list({
       fields: {
         name: text({ validation: { isRequired: true } }),
-        slug: text({ validation: { isRequired: true } }),
+        slug: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
         posts: relationship({ ref: 'Post.category', many: true }),
+      },
+      access: {
+        operation: {
+          query: () => true,
+          create: ({ session }) => session?.role === 'admin',
+          update: ({ session }) => session?.role === 'admin',
+          delete: ({ session }) => session?.role === 'admin',
+        },
       },
     }),`
         : ''
     }
     ${
-      taxonomy.includes('Tags')
+      hasTags
         ? `Tag: list({
       fields: {
         name: text({ validation: { isRequired: true } }),
         posts: relationship({ ref: 'Post.tags', many: true }),
       },
+      access: {
+        operation: {
+          query: () => true,
+          create: ({ session }) => !!session,
+          update: ({ session }) => session?.role === 'admin',
+          delete: ({ session }) => session?.role === 'admin',
+        },
+      },
     }),`
         : ''
     }
-  },
-});`
+
+// If you use authPlugin, give the auto-generated User list the other side of
+// the author relationship via extendUserList:
+//
+//   authPlugin({
+//     ...,
+//     extendUserList: {
+//       fields: {
+//         posts: relationship({ ref: 'Post.author', many: true }),
+//       },
+//     },
+//   })`
 
     const files: GeneratedFile[] = []
 
@@ -428,17 +563,17 @@ export default config({
       path: 'app/blog/page.tsx',
       language: 'tsx',
       description: 'Blog listing page',
-      content: `import { getContext } from '@/.opensaas/context';
-import Link from 'next/link';
+      content: `import { getContext } from '@/.opensaas/context'
+import Link from 'next/link'
 
 export default async function BlogPage() {
-  const context = await getContext();
+  const context = await getContext()
 
   const posts = await context.db.post.findMany({
-    ${hasStatus ? "where: { status: 'published' }," : ''}
+    ${hasStatus ? "where: { status: { equals: 'published' } }," : ''}
     orderBy: { ${hasStatus ? 'publishedAt' : 'createdAt'}: 'desc' },
     include: { author: true },
-  });
+  })
 
   return (
     <div className="container mx-auto py-8">
@@ -447,19 +582,17 @@ export default async function BlogPage() {
         {posts.map((post) => (
           <article key={post.id} className="border rounded-lg p-6">
             <Link href={\`/blog/\${post.slug}\`}>
-              <h2 className="text-2xl font-bold hover:underline">
-                {post.title}
-              </h2>
+              <h2 className="text-2xl font-bold hover:underline">{post.title}</h2>
             </Link>
             ${postFields.includes('Excerpt/summary') ? '<p className="mt-2 text-gray-600">{post.excerpt}</p>' : ''}
             <div className="mt-4 text-sm text-gray-500">
-              By {post.author.name} · ${hasStatus ? '{post.publishedAt?.toLocaleDateString()}' : '{post.createdAt.toLocaleDateString()}'}
+              By {post.author?.name ?? 'Unknown'} · ${hasStatus ? '{post.publishedAt?.toLocaleDateString()}' : '{post.createdAt.toLocaleDateString()}'}
             </div>
           </article>
         ))}
       </div>
     </div>
-  );
+  )
 }`,
     })
 
@@ -468,48 +601,59 @@ export default async function BlogPage() {
       path: 'app/blog/[slug]/page.tsx',
       language: 'tsx',
       description: 'Individual blog post page',
-      content: `import { getContext } from '@/.opensaas/context';
-import { notFound } from 'next/navigation';
+      content: `import { getContext } from '@/.opensaas/context'
+import { notFound } from 'next/navigation'
 
 export default async function BlogPostPage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>
 }) {
-  const context = await getContext();
+  const { slug } = await params
+  const context = await getContext()
 
   const post = await context.db.post.findFirst({
     where: {
-      slug: params.slug,
-      ${hasStatus ? "status: 'published'," : ''}
+      slug: { equals: slug },
+      ${hasStatus ? "status: { equals: 'published' }," : ''}
     },
     include: { author: true },
-  });
+  })
 
   if (!post) {
-    notFound();
+    notFound()
   }
 
   return (
     <article className="container mx-auto py-8 max-w-3xl">
       <h1 className="text-4xl font-bold mb-4">{post.title}</h1>
       <div className="text-gray-600 mb-8">
-        By {post.author.name} · ${hasStatus ? '{post.publishedAt?.toLocaleDateString()}' : '{post.createdAt.toLocaleDateString()}'}
+        By {post.author?.name ?? 'Unknown'} · ${hasStatus ? '{post.publishedAt?.toLocaleDateString()}' : '{post.createdAt.toLocaleDateString()}'}
       </div>
-      ${useTiptap ? '<div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: post.content }} />' : useMarkdown ? '<div className="prose max-w-none">{/* Render markdown here */}{post.content}</div>' : '<div className="prose max-w-none whitespace-pre-wrap">{post.content}</div>'}
+      ${
+        useTiptap
+          ? `{/* richText stores Tiptap JSON. Render it to HTML with
+          generateHTML(post.content, [StarterKit]) from '@tiptap/html' +
+          '@tiptap/starter-kit', or build a custom renderer. */}
+      <div className="prose max-w-none">{JSON.stringify(post.content)}</div>`
+          : '<div className="prose max-w-none whitespace-pre-wrap">{post.content}</div>'
+      }
     </article>
-  );
+  )
 }`,
     })
 
     const nextSteps = [
-      'Copy the config updates to your `opensaas.config.ts`',
-      'Add the `posts` relationship field to your User list',
-      useTiptap ? 'Install Tiptap package: `pnpm add @opensaas/stack-tiptap`' : null,
+      'Merge the config updates into your `opensaas.config.ts`',
+      'Add the `posts` relationship to the User list (via authPlugin `extendUserList` shown above)',
+      useTiptap ? 'Install the Tiptap package: `pnpm add @opensaas/stack-tiptap`' : null,
+      useTiptap
+        ? 'For public rendering of rich text, add `@tiptap/html` and `@tiptap/starter-kit`'
+        : null,
       'Create the blog pages in your `app/` directory',
-      'Run `pnpm generate` to update Prisma schema',
-      'Run `pnpm db:push` to update database',
-      'Create your first blog post in the admin UI',
+      'Run `pnpm generate` to update the Prisma schema',
+      'Run `pnpm db:push` to update the database',
+      'Create your first blog post in the admin UI at /admin',
     ].filter(Boolean) as string[]
 
     const devGuideSection = `## Blog Feature
@@ -517,33 +661,13 @@ export default async function BlogPostPage({
 This project includes a blog system with:
 
 - ${contentEditor} for writing posts
-${hasStatus ? '- Draft/publish workflow' : ''}
+${hasStatus ? '- Draft/publish workflow (publishedAt is set automatically by a resolveInput hook)' : ''}
 ${taxonomy.length > 0 ? `- ${taxonomy.join(' and ')} for organization` : ''}
-
-### Creating a Post
-
-${
-  hasStatus
-    ? `Posts start as drafts and can be published when ready:
-
-\`\`\`typescript
-const post = await context.db.post.create({
-  data: {
-    title: 'My Post',
-    slug: 'my-post',
-    content: '...',
-    authorId: session.userId,
-    status: 'draft', // or 'published'
-  }
-});
-\`\`\``
-    : ''
-}
 
 ### Access Control
 
-- Anyone can read ${hasStatus ? 'published posts' : 'posts'}
-- Only authenticated users can create posts
+- Anyone can read ${hasStatus ? 'published posts; signed-in users see drafts too (filter-based access)' : 'posts'}
+- Only authenticated users can create posts (author is auto-connected from the session)
 - Only authors can update their own posts
 - Admins and authors can delete posts`
 
@@ -552,47 +676,370 @@ const post = await context.db.post.create({
       files,
       instructions: nextSteps,
       devGuideSection,
-      envVars: useTiptap ? {} : undefined,
+      envVars: undefined,
       nextSteps,
     }
   }
 
   /**
-   * Generate comments feature (stub - to be implemented)
+   * Generate comments feature
    */
   private generateComments(): FeatureImplementation {
+    const targets = (this.answers['comment-targets'] as string[]) || ['Posts']
+    const nestedReplies = this.answers['nested-replies'] as boolean
+    const moderation = this.answers['moderation'] as string
+    const requiresApproval = moderation === 'Require admin approval'
+
+    // Build one relationship per commentable list (Posts → Post, Products → Product)
+    const targetLists = targets
+      .filter((t) => t !== 'Other')
+      .map((t) => (t.endsWith('s') ? t.slice(0, -1) : t))
+
+    const fields = [
+      "content: text({ validation: { isRequired: true }, ui: { displayMode: 'textarea' } })",
+      "author: relationship({ ref: 'User.comments' })",
+      ...targetLists.map(
+        (target) => `${target.toLowerCase()}: relationship({ ref: '${target}.comments' })`,
+      ),
+    ]
+
+    if (nestedReplies) {
+      fields.push("parent: relationship({ ref: 'Comment.replies' })")
+      fields.push("replies: relationship({ ref: 'Comment.parent', many: true })")
+    }
+
+    if (requiresApproval) {
+      fields.push(
+        "status: select({ options: [{ label: 'Pending', value: 'pending' }, { label: 'Approved', value: 'approved' }], defaultValue: 'pending' })",
+      )
+    }
+
+    const fieldImports = ['text', 'relationship']
+    if (requiresApproval) fieldImports.push('select')
+
+    const configUpdates = `// Add these imports and lists to your existing opensaas.config.ts
+import { ${fieldImports.join(', ')} } from '@opensaas/stack-core/fields'
+
+// Inside config({ lists: { ... } }):
+    Comment: list({
+      fields: {
+        ${fields.join(',\n        ')},
+      },
+      access: {
+        operation: {
+          ${
+            requiresApproval
+              ? `// Everyone sees approved comments; authors see their own pending
+          // ones; admins see everything (filter-based access).
+          query: ({ session }) => {
+            if (session?.role === 'admin') return true
+            if (session) {
+              return {
+                OR: [
+                  { status: { equals: 'approved' } },
+                  { authorId: { equals: session.userId } },
+                ],
+              }
+            }
+            return { status: { equals: 'approved' } }
+          },`
+              : 'query: () => true,'
+          }
+          create: ({ session }) => !!session,
+          update: ({ session, item }) =>
+            session?.role === 'admin' || session?.userId === item?.authorId,
+          delete: ({ session, item }) =>
+            session?.role === 'admin' || session?.userId === item?.authorId,
+        },
+      },
+      hooks: {
+        resolveInput: async ({ operation, resolvedData, context }) => {
+          const data = { ...resolvedData }
+          // Auto-connect the author on create
+          if (operation === 'create' && !data.author && context.session?.userId) {
+            data.author = { connect: { id: context.session.userId } }
+          }
+          return data
+        },
+      },
+    }),
+
+// Add the other side of each relationship:
+${targetLists
+  .map(
+    (target) =>
+      `// - On the ${target} list: comments: relationship({ ref: 'Comment.${target.toLowerCase()}', many: true })`,
+  )
+  .join('\n')}
+// - On the User list (via authPlugin extendUserList):
+//     comments: relationship({ ref: 'Comment.author', many: true })`
+
+    const nextSteps = [
+      'Merge the config updates into your `opensaas.config.ts`',
+      ...targetLists.map(
+        (target) => `Add the \`comments\` relationship field to your ${target} list`,
+      ),
+      'Add the `comments` relationship to the User list (via authPlugin `extendUserList`)',
+      'Run `pnpm generate` to update the Prisma schema',
+      'Run `pnpm db:push` to update the database',
+      requiresApproval
+        ? 'Moderate comments in the admin UI at /admin/comment (flip status to approved)'
+        : 'View comments in the admin UI at /admin/comment',
+    ]
+
+    const devGuideSection = `## Comments Feature
+
+Threaded comments on: ${targetLists.join(', ')}
+
+- ${nestedReplies ? 'Nested replies via a self-referential parent/replies relationship' : 'Flat comment threads'}
+- ${moderation}
+- Authors are auto-connected from the session by a resolveInput hook
+- Authors can edit/delete their own comments; admins can moderate everything${
+      requiresApproval
+        ? '\n- Anonymous visitors only see approved comments (filter-based access)'
+        : ''
+    }`
+
     return {
-      configUpdates: '// Comments feature implementation coming soon',
+      configUpdates,
       files: [],
-      instructions: ['Feature implementation in progress'],
-      devGuideSection: '## Comments Feature\n\nComing soon...',
-      nextSteps: ['Feature implementation in progress'],
+      instructions: nextSteps,
+      devGuideSection,
+      nextSteps,
     }
   }
 
   /**
-   * Generate file upload feature (stub - to be implemented)
+   * Generate file upload feature
    */
   private generateFileUpload(): FeatureImplementation {
+    const provider = this.answers['storage-provider'] as string
+    const associations = (this.answers['file-associations'] as string[]) || []
+    const fileTypes = (this.answers['file-types'] as string[]) || []
+
+    const imagesOnly = fileTypes.length === 1 && fileTypes.includes('Images (jpg, png, webp)')
+
+    let storageImport: string
+    let storageBlock: string
+    let extraDependency: string | null = null
+    const envVars: Record<string, string> = {}
+
+    if (provider === 'AWS S3' || provider === 'Cloudflare R2') {
+      const isR2 = provider === 'Cloudflare R2'
+      storageImport = "import { s3Storage } from '@opensaas/stack-storage-s3'"
+      extraDependency = '@opensaas/stack-storage-s3'
+      storageBlock = `storage: {
+    uploads: s3Storage({
+      bucket: process.env.S3_BUCKET!,
+      region: process.env.S3_REGION${isR2 ? " || 'auto'" : '!'},
+      accessKeyId: process.env.S3_ACCESS_KEY_ID,
+      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,${
+        isR2
+          ? `\n      // R2 is S3-compatible — point the endpoint at your account
+      endpoint: process.env.S3_ENDPOINT, // https://<account-id>.r2.cloudflarestorage.com`
+          : ''
+      }
+    }),
+  },`
+      envVars.S3_BUCKET = '<your-bucket>'
+      envVars.S3_REGION = isR2 ? 'auto' : 'us-east-1'
+      envVars.S3_ACCESS_KEY_ID = '<access-key-id>'
+      envVars.S3_SECRET_ACCESS_KEY = '<secret-access-key>'
+      if (isR2) envVars.S3_ENDPOINT = 'https://<account-id>.r2.cloudflarestorage.com'
+    } else if (provider === 'Vercel Blob') {
+      storageImport = "import { vercelBlobStorage } from '@opensaas/stack-storage-vercel'"
+      extraDependency = '@opensaas/stack-storage-vercel'
+      storageBlock = `storage: {
+    uploads: vercelBlobStorage({
+      token: process.env.BLOB_READ_WRITE_TOKEN,
+    }),
+  },`
+      envVars.BLOB_READ_WRITE_TOKEN = '<vercel-blob-read-write-token>'
+    } else {
+      storageImport = "import { localStorage } from '@opensaas/stack-storage'"
+      storageBlock = `storage: {
+    uploads: localStorage({
+      uploadDir: './public/uploads',
+      serveUrl: '/uploads',
+    }),
+  },`
+    }
+
+    const imageFieldExample = `image({
+          storage: 'uploads',
+          transformations: {
+            thumbnail: { width: 100, height: 100, fit: 'cover', format: 'webp' },
+          },
+          validation: {
+            maxFileSize: 5 * 1024 * 1024, // 5MB
+            acceptedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+          },
+        })`
+
+    const fileFieldExample = `file({
+          storage: 'uploads',
+          validation: {
+            maxFileSize: 25 * 1024 * 1024, // 25MB
+          },
+        })`
+
+    const fieldExamples: string[] = []
+    if (associations.includes('User avatars')) {
+      fieldExamples.push(`// On the User list (via authPlugin extendUserList):
+        avatar: ${imageFieldExample},`)
+    }
+    if (associations.includes('Post featured images') || associations.includes('Product images')) {
+      const listName = associations.includes('Post featured images') ? 'Post' : 'Product'
+      fieldExamples.push(`// On the ${listName} list:
+        ${associations.includes('Post featured images') ? 'featuredImage' : 'images'}: ${imageFieldExample},`)
+    }
+    if (associations.includes('General attachments') || !imagesOnly) {
+      fieldExamples.push(`// General attachments on any list:
+        attachment: ${fileFieldExample},`)
+    }
+
+    const configUpdates = `// Add these imports to your opensaas.config.ts
+${storageImport}
+import { file, image } from '@opensaas/stack-storage/fields'
+
+// Add a top-level storage config alongside db and lists:
+export default config({
+  ${storageBlock}
+  // ...
+  lists: {
+    // Use file()/image() fields, referencing the storage key by name:
+        ${fieldExamples.join('\n        ')}
+  },
+})`
+
+    const nextSteps = [
+      `Install dependencies: \`pnpm add @opensaas/stack-storage${extraDependency ? ` ${extraDependency}` : ''}\``,
+      'Merge the storage config and fields into your `opensaas.config.ts`',
+      Object.keys(envVars).length > 0 ? 'Add environment variables to your `.env` file' : null,
+      'Run `pnpm generate` to update the Prisma schema',
+      'Run `pnpm db:push` to update the database',
+      'Upload files through the admin UI — the image/file fields render an upload widget automatically',
+    ].filter(Boolean) as string[]
+
+    const devGuideSection = `## File Upload Feature
+
+Storage provider: ${provider}
+
+- Files are stored via the \`storage\` config block; fields reference a storage
+  key by name (\`storage: 'uploads'\`)
+- \`image()\` fields support transformations (resize/format) and validation
+- \`file()\` fields handle any file type with size validation
+- Access control on the owning list applies to the field like any other field`
+
     return {
-      configUpdates: '// File upload feature implementation coming soon',
+      configUpdates,
       files: [],
-      instructions: ['Feature implementation in progress'],
-      devGuideSection: '## File Upload Feature\n\nComing soon...',
-      nextSteps: ['Feature implementation in progress'],
+      instructions: nextSteps,
+      devGuideSection,
+      envVars: Object.keys(envVars).length > 0 ? envVars : undefined,
+      nextSteps,
     }
   }
 
   /**
-   * Generate semantic search feature (stub - to be implemented)
+   * Generate semantic search feature
    */
   private generateSemanticSearch(): FeatureImplementation {
+    const searchableContent = (this.answers['searchable-content'] as string[]) || ['Posts']
+    const embeddingProvider = this.answers['embedding-provider'] as string
+    const searchFields = (this.answers['search-fields'] as string[]) || ['Title', 'Content/body']
+
+    const useOllama = embeddingProvider?.startsWith('Ollama')
+
+    const providerBlock = useOllama
+      ? `provider: ollamaEmbeddings({
+        baseURL: process.env.OLLAMA_BASE_URL || 'http://localhost:11434',
+        model: 'nomic-embed-text',
+      }),
+      storage: sqliteVssStorage({
+        distanceFunction: 'cosine',
+      }),`
+      : `provider: openaiEmbeddings({
+        apiKey: process.env.OPENAI_API_KEY!,
+        model: 'text-embedding-3-small',
+      }),
+      // pgvectorStorage requires the postgresql db provider.
+      // On SQLite, use sqliteVssStorage from '@opensaas/stack-rag' instead.
+      storage: pgvectorStorage({
+        distanceFunction: 'cosine',
+      }),`
+
+    const ragImports = useOllama
+      ? "import { ragPlugin, ollamaEmbeddings, sqliteVssStorage } from '@opensaas/stack-rag'"
+      : "import { ragPlugin, openaiEmbeddings, pgvectorStorage } from '@opensaas/stack-rag'"
+
+    const targetList = searchableContent[0]?.endsWith('s')
+      ? searchableContent[0].slice(0, -1)
+      : searchableContent[0] || 'Post'
+
+    const envVars: Record<string, string> = useOllama
+      ? { OLLAMA_BASE_URL: 'http://localhost:11434' }
+      : { OPENAI_API_KEY: '<your-openai-api-key>' }
+
+    const configUpdates = `// Add these imports to your opensaas.config.ts
+${ragImports}
+import { searchable } from '@opensaas/stack-rag/fields'
+
+// Add the RAG plugin alongside your other plugins:
+export default config({
+  plugins: [
+    ragPlugin({
+      ${providerBlock}
+    }),
+    // ...your other plugins
+  ],
+  // ...
+  lists: {
+    ${targetList}: list({
+      fields: {
+        // Wrap the fields you want indexed with searchable() —
+        // embeddings update automatically when the content changes.
+        ${searchFields.includes('Title') ? `title: searchable(text({ validation: { isRequired: true } })),` : ''}
+        ${
+          searchFields.includes('Content/body')
+            ? `content: searchable(
+          text({ validation: { isRequired: true }, ui: { displayMode: 'textarea' } }),
+        ),`
+            : ''
+        }
+        // ...your other fields
+      },
+    }),
+  },
+})`
+
+    const nextSteps = [
+      'Install the RAG package: `pnpm add @opensaas/stack-rag`',
+      useOllama
+        ? 'Install and start Ollama, then pull the embedding model: `ollama pull nomic-embed-text`'
+        : 'Set OPENAI_API_KEY in your `.env` file (pgvector storage requires PostgreSQL)',
+      'Merge the plugin and searchable() fields into your `opensaas.config.ts`',
+      'Run `pnpm generate` to update the Prisma schema',
+      'Run `pnpm db:push` to update the database',
+      `Query with the RAG runtime — see the ${useOllama ? 'rag-ollama-demo' : 'rag-openai-chatbot'} example for a full search API route`,
+    ]
+
+    const devGuideSection = `## Semantic Search Feature
+
+AI-powered search over: ${searchableContent.join(', ')}
+
+- Embedding provider: ${embeddingProvider}
+- Fields wrapped in \`searchable()\` are embedded automatically on create/update
+- Search respects the list's access control — users only find what they can read
+- See the ${useOllama ? 'rag-ollama-demo' : 'rag-openai-chatbot'} example in the stack repo for a complete search UI`
+
     return {
-      configUpdates: '// Semantic search feature implementation coming soon',
+      configUpdates,
       files: [],
-      instructions: ['Feature implementation in progress'],
-      devGuideSection: '## Semantic Search Feature\n\nComing soon...',
-      nextSteps: ['Feature implementation in progress'],
+      instructions: nextSteps,
+      devGuideSection,
+      envVars,
+      nextSteps,
     }
   }
 }

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -273,10 +273,10 @@ const context = createContext<typeof prisma>(config, prisma, session)
 ### With MCP (Model Context Protocol)
 
 - Core provides auth-agnostic MCP runtime via `@opensaas/stack-core/mcp`
-- MCP handler reads config to generate tools
-- Uses context for all operations (access control enforced)
-- Zod schemas from fields validate tool inputs
-- Auth adapters (like `@opensaas/stack-auth/mcp`) provide session integration
+- MCP handler reads config to derive tools at request time (CRUD per list, list `mcp.customTools`, plugin-registered tools)
+- Uses context for all operations (access control enforced); writes are validated by the normal `context.db` pipeline (field Zod schemas, hooks, access control)
+- Custom tools may declare a Zod `inputSchema` — validated on `tools/call`, converted to JSON Schema for `tools/list` — or a plain JSON Schema object
+- Auth adapters (like `@opensaas/stack-auth/mcp`) provide session integration; custom session fields pass through to access control
 
 ### With Third-Party Field Packages
 

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -3,10 +3,66 @@
  * Creates MCP API handlers from OpenSaaS config at runtime
  */
 
-import type { OpenSaasConfig, FieldConfig } from '../config/types.js'
+import * as z from 'zod'
+import type { OpenSaasConfig, FieldConfig, McpCustomTool } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { McpSession, McpSessionProvider } from './types.js'
+
+/**
+ * Context session type accepted by the generated getContext factory.
+ * userId is always present; auth adapters may pass additional session fields
+ * (email, role, ...) through for access control.
+ */
+type ContextSession = { userId: string; [key: string]: unknown }
+
+/**
+ * Convert an MCP session into a context session.
+ * Transport-level fields (accessToken, expiresAt, scopes) are stripped;
+ * everything else — userId plus any custom fields the session provider
+ * attached (email, role, ...) — flows through to access control.
+ */
+function toContextSession(session: McpSession): ContextSession {
+  const { accessToken: _accessToken, expiresAt: _expiresAt, scopes: _scopes, ...rest } = session
+  return rest as ContextSession
+}
+
+/**
+ * MCP tools registered globally by plugins via `registerMcpTool`
+ * (stored by the plugin engine under `_pluginData.__mcpTools`).
+ */
+function getPluginMcpTools(config: OpenSaasConfig): McpCustomTool[] {
+  return (config._pluginData?.__mcpTools as McpCustomTool[] | undefined) ?? []
+}
+
+/**
+ * Whether a custom tool's inputSchema is a Zod schema (as opposed to a plain
+ * JSON Schema object). Duck-typed so it works across zod module instances.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- duck-typing across zod instances
+function isZodSchema(schema: any): schema is z.ZodType {
+  return !!schema && typeof schema.safeParse === 'function'
+}
+
+/**
+ * Normalize a custom tool's inputSchema for the tools/list response.
+ * Zod schemas are converted to JSON Schema (the MCP wire format); plain
+ * objects are passed through as-is.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- inputSchema is user-supplied
+function toolInputSchemaToJson(inputSchema: any): McpTool['inputSchema'] {
+  if (isZodSchema(inputSchema)) {
+    try {
+      const { $schema: _$schema, ...jsonSchema } = z.toJSONSchema(inputSchema)
+      return jsonSchema as McpTool['inputSchema']
+    } catch {
+      // Unconvertible schema (transforms, custom types) — advertise a
+      // permissive object schema; runtime validation still applies.
+      return { type: 'object', properties: {} }
+    }
+  }
+  return inputSchema as McpTool['inputSchema']
+}
 
 /**
  * Create MCP route handlers
@@ -32,7 +88,7 @@ import type { McpSession, McpSessionProvider } from './types.js'
 export function createMcpHandlers(options: {
   config: OpenSaasConfig
   getSession: McpSessionProvider
-  getContext: (session?: { userId: string }) => Promise<AccessContext>
+  getContext: (session?: ContextSession) => Promise<AccessContext>
 }): {
   GET: (req: Request) => Promise<Response>
   POST: (req: Request) => Promise<Response>
@@ -378,10 +434,19 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
         tools.push({
           name: customTool.name,
           description: customTool.description,
-          inputSchema: customTool.inputSchema,
+          inputSchema: toolInputSchemaToJson(customTool.inputSchema),
         })
       }
     }
+  }
+
+  // Tools registered globally by plugins (e.g. the RAG plugin's semantic search)
+  for (const pluginTool of getPluginMcpTools(config)) {
+    tools.push({
+      name: pluginTool.name,
+      description: pluginTool.description,
+      inputSchema: toolInputSchemaToJson(pluginTool.inputSchema),
+    })
   }
 
   return new Response(
@@ -404,7 +469,7 @@ async function handleToolsCall(
   params: any,
   session: McpSession,
   config: OpenSaasConfig,
-  getContext: (session?: { userId: string }) => Promise<AccessContext>,
+  getContext: (session?: ContextSession) => Promise<AccessContext>,
   id?: number | string,
 ): Promise<Response> {
   const toolName = params?.name
@@ -446,11 +511,11 @@ async function handleCrudTool(
   args: any,
   session: McpSession,
   config: OpenSaasConfig,
-  getContext: (session?: { userId: string }) => Promise<AccessContext>,
+  getContext: (session?: ContextSession) => Promise<AccessContext>,
   id?: number | string,
 ): Promise<Response> {
-  // Create context with user session
-  const context = await getContext({ userId: session.userId })
+  // Create context with the user session (custom session fields pass through)
+  const context = await getContext(toContextSession(session))
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Result type varies by Prisma operation
@@ -529,34 +594,59 @@ async function handleCustomTool(
   args: any,
   session: McpSession,
   config: OpenSaasConfig,
-  getContext: (session?: { userId: string }) => Promise<AccessContext>,
+  getContext: (session?: ContextSession) => Promise<AccessContext>,
   id?: number | string,
 ): Promise<Response> {
-  // Find custom tool in config
-  for (const [_listKey, listConfig] of Object.entries(config.lists)) {
-    const customTool = listConfig.mcp?.customTools?.find((t) => t.name === toolName)
+  // Find the tool: list-level custom tools first, then plugin-registered tools
+  let customTool: McpCustomTool | undefined
+  for (const listConfig of Object.values(config.lists)) {
+    customTool = listConfig.mcp?.customTools?.find((t) => t.name === toolName)
+    if (customTool) break
+  }
+  customTool ??= getPluginMcpTools(config).find((t) => t.name === toolName)
 
-    if (customTool) {
-      const context = await getContext({ userId: session.userId })
-
-      try {
-        const result = await customTool.handler({
-          input: args,
-          context,
-        })
-
-        return createSuccessResponse(result, id)
-      } catch (error) {
-        return createErrorResponse(
-          'Custom tool execution failed: ' +
-            (error instanceof Error ? error.message : 'Unknown error'),
-          id,
-        )
-      }
-    }
+  if (!customTool) {
+    return createErrorResponse(`Unknown tool: ${toolName}`, id)
   }
 
-  return createErrorResponse(`Unknown tool: ${toolName}`, id)
+  // Validate input when the tool declares a Zod schema
+  let input = args
+  if (isZodSchema(customTool.inputSchema)) {
+    const parsed = customTool.inputSchema.safeParse(args)
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: id ?? null,
+          error: {
+            code: -32602,
+            message: `Invalid params: ${parsed.error.message}`,
+          },
+        }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+    input = parsed.data
+  }
+
+  const context = await getContext(toContextSession(session))
+
+  try {
+    const result = await customTool.handler({
+      input,
+      context,
+    })
+
+    return createSuccessResponse(result, id)
+  } catch (error) {
+    return createErrorResponse(
+      'Custom tool execution failed: ' + (error instanceof Error ? error.message : 'Unknown error'),
+      id,
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
Full alignment review of the Claude plugins, the MCP integration (dev-assistant server in `@opensaas/stack-cli` and runtime handlers in `@opensaas/stack-core/mcp`), and the docs — verifying every claim against the actual code and fixing what had drifted. Goal: the "describe an app, build it with AI" flow produces working, secure applications instead of code that references APIs that don't exist.

## MCP runtime (`@opensaas/stack-core`) — functional fixes

- **Plugin-registered tools are now served.** Tools registered via `registerMcpTool` (e.g. the RAG plugin's `semantic_search_*`) were stored in `_pluginData.__mcpTools` but never listed or dispatched — they now appear in `tools/list` and are callable.
- **Zod `inputSchema` support for custom tools.** Zod schemas were previously advertised verbatim (invalid JSON Schema on the wire) and never validated. They are now converted to JSON Schema for `tools/list` and validated on `tools/call` (invalid input → JSON-RPC `-32602`). Plain JSON Schema objects still pass through, so both in-repo conventions work.
- **Custom session fields pass through to access control.** The handler narrowed every MCP session to `{ userId }`, so `session.role`-style access rules silently evaluated with `undefined` over MCP. Transport fields (`accessToken`, `expiresAt`, `scopes`) are stripped; everything else reaches `context.session`.

## Dev-assistant MCP server (`@opensaas/stack-cli`)

- **`opensaas mcp start` no longer prints its banner to stdout**, which corrupted the stdio JSON-RPC stream the plugin's declared MCP server relies on.
- **Three of the five advertised feature wizards were "coming soon" stubs** (`comments`, `file-upload`, `semantic-search`). They now generate real config against the actual storage and RAG plugin APIs (local/S3/R2/Vercel Blob providers, `ragPlugin` with OpenAI or Ollama embeddings, `searchable()` fields).
- **The `authentication` and `blog` wizards emitted invented or obsolete API**: nonexistent `authPlugin({ oauth, magicLink })` options, a hand-rolled User list with a `password` field (Better-auth stores credentials on Account), missing Prisma 7 `prismaClientConstructor`, `SignInForm`/`SignUpForm` props that don't exist (they require `authClient`), string-array `select()` options, and taxonomy lists referencing a `Post.category` field that was never generated. Rewritten to mirror the canonical `starter-auth` / `file-upload-demo` / `rag-*` examples, including ADR-0013 (auth lists ship closed; access granted via the plugin's `access` option).
- Removed unsupported wizard options (Cohere/Anthropic embeddings, magic links) and fixed stale docs-provider examples (`json()` mapping, `getPrismaType` modifiers).

## Claude plugins

- **opensaas-stack** (0.2.2 → 0.2.3): the `opensaas-helper` agent had no YAML frontmatter so it wouldn't register; README had dead links (`../packages/stack-mcp/` never existed) and listed 5 of the 13 MCP tools.
- **opensaas-migration** (0.4.0 → 0.4.1): 13 verified inaccuracies fixed, including two that silently defeat access control in migrated apps — a filter-based access sample wrapped in `{ where: ... }` (treated as a field filter, breaking every query) and a `getContext({ session })` call shape that makes owner checks see an anonymous session. Also: nonexistent `RichTextFieldComponent` export → `TiptapField`, stale `.prisma/client` imports → `.opensaas/prisma-client/client`, broken doc URLs, missing `decimal`/`calendarDay`/`json` field mappings, `registerStorageProvider` requirement for S3/Vercel uploads, fragment-based nested reads instead of N+1 guidance, `@opensaas/stack-cli` added to the agent's install list.
- Restructured the `claude-plugins/` READMEs (directory overview + per-plugin README, which `MARKETPLACE.md`'s diagram expected but didn't exist) and bumped marketplace metadata (1.1.1 → 1.1.2).

## Documentation

- **Removed phantom-behavior claims**: `pnpm generate` does not create `.opensaas/mcp/tools.json` / `mcp-tools.json` — tools are derived at request time; fixed architecture diagrams, troubleshooting steps, and `packages/cli/CLAUDE.md`'s fictional generator files (`mcp.ts`, `type-patcher.ts`) and template system.
- **Fixed copy-paste-breaking commands**: nonexistent `mcp serve` subcommand, wrong plugin install id (`opensaas-stack@OpenSaasAU/stack`), invalid `@opensaas/stack-core/config` import subpath.
- **Corrected the MCP tool inventory** everywhere (six documented tools were never registered; eight registered tools were undocumented) and tool naming (`list_{dbKey}_…` camelCase, not PascalCase).
- **Corrected access/behavior descriptions**: denied writes return a JSON-RPC error (only queries return empty results); `query` access never receives `item` — replaced query-with-item samples with filter-based patterns; documented the session-fields-over-MCP caveat; marked `mcp.auth`/`resource` config as informational (runtime reads `enabled`/`basePath`/`defaultTools`).
- **`migrate --with-ai` docs** now describe the marketplace-plugin flow (settings.json `extraKnownMarketplaces`/`enabledPlugins`, plugin-manifest MCP server) instead of the removed template-generation system.
- Root `CLAUDE.md`: removed the deleted `packages/mcp`, added 5 missing packages and 7 missing examples.
- Branch is rebased on #741's docs restructure; links point at the new `how-to`/`concepts`/`reference` paths, including one fresh drift fix the restructure introduced (`concepts/config.md`'s invalid import subpath).

## Not addressed (flagged for follow-up)

- `fieldToJsonSchema` in the core MCP handler uses a field-type `switch` (violates the field-self-containment rule; third-party fields degrade to `string` schemas).
- The `mcp.auth`/`resource` config keys remain inert — now documented honestly; wiring or removing them is a design decision.
- The Better-auth MCP adapter still supplies `userId` only; role-based rules over MCP need a custom session provider (now documented, and custom fields now pass through).

## Testing

- `packages/core`: 774 tests pass; `packages/cli`: 323 tests pass (re-run after rebasing onto #741)
- `pnpm build` clean for core, cli, auth; `pnpm lint` 0 errors (3 pre-existing warnings); `pnpm format` + `manypkg fix` applied
- Changesets included: core (minor), cli (minor), auth (patch); plugin versions bumped via the plugin-version flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132CnFrMV13e3T2Nx9gECdQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0132CnFrMV13e3T2Nx9gECdQ)_