### PR TITLE
Admin UI: Cell registry with default cells for core field types

### DIFF
--- a/.changeset/rich-cells-registry.md
+++ b/.changeset/rich-cells-registry.md
@@ -1,0 +1,40 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add a Cell registry with default cells for core field types
+
+List tables now render every value through a **Cell** resolved by a
+cell-component registry that mirrors the form-field registry's priority chain:
+per-field override → custom type registry → field-type registry → plain-text
+fallback. Each core field type ships a default Cell — text (plain), integer
+(tabular figures), select (coloured Badge), timestamp (formatted date), checkbox
+(mark), and to-one relationship (Item label link). Unknown/third-party types
+without a registered Cell fall back to plain text.
+
+Select options gain optional, additive per-option UI metadata mapping a value to
+a badge variant. Existing options keep working unchanged; unmapped options render
+the neutral badge.
+
+```typescript
+// opensaas.config.ts — colour a status value in list-table cells
+status: select({
+  options: [
+    { label: 'Draft', value: 'draft', ui: { variant: 'secondary' } },
+    { label: 'Published', value: 'published', ui: { variant: 'success' } },
+  ],
+})
+```
+
+Register a Cell for a custom/third-party field exactly as you register its form
+component, or override a single field's Cell:
+
+```typescript
+'use client'
+import { registerCellComponent } from '@opensaas/stack-ui'
+registerCellComponent('myField', MyCell)
+
+// or per-field override (highest priority)
+price: integer({ ui: { cell: CurrencyCell } })
+```

--- a/e2e/starter-auth/03-admin-ui.spec.ts
+++ b/e2e/starter-auth/03-admin-ui.spec.ts
@@ -110,6 +110,32 @@ test.describe('Admin UI', () => {
         page.getByRole('row', { name: /Full Post/ }).getByRole('cell', { name: 'published' }),
       ).toBeVisible()
     })
+
+    test('should render the select column value as a coloured status badge', async ({ page }) => {
+      // Create a published post so the status column has a value to badge.
+      await page.goto('/admin/post')
+      await page.waitForLoadState('networkidle')
+
+      await page.click('text=/create|new/i')
+      await page.waitForLoadState('networkidle')
+      await page.fill('input[name="title"]', 'Badged Post')
+      await page.fill('input[name="slug"]', 'badged-post')
+      await page.fill('textarea[name="content"]', 'Content here')
+      await page.getByLabel('Status').click()
+      await page.getByRole('option', { name: 'published' }).click()
+      await page.click('button[type="submit"]')
+      await page.waitForURL(/admin\/post/, { timeout: 10000 })
+
+      // The status cell renders through the select Cell → a Badge (Slot
+      // `cell-select`) coloured by the option's `ui.variant` (success → the
+      // success token class), not raw text.
+      const badge = page
+        .getByRole('row', { name: /Badged Post/ })
+        .locator('[data-slot="cell-select"]')
+      await expect(badge).toBeVisible()
+      await expect(badge).toHaveText('Published')
+      await expect(badge).toHaveClass(/text-success/)
+    })
   })
 
   test.describe('Create Form', () => {

--- a/examples/starter-auth/opensaas.config.ts
+++ b/examples/starter-auth/opensaas.config.ts
@@ -127,8 +127,8 @@ export default config({
         }),
         status: select({
           options: [
-            { label: 'Draft', value: 'draft' },
-            { label: 'Published', value: 'published' },
+            { label: 'Draft', value: 'draft', ui: { variant: 'secondary' } },
+            { label: 'Published', value: 'published', ui: { variant: 'success' } },
           ],
           defaultValue: 'draft',
           ui: { displayMode: 'segmented-control' },

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -814,9 +814,34 @@ export type PasswordField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConf
   }
 }
 
+/**
+ * Badge-variant vocabulary a select option can map its value to for status-Cell
+ * rendering in the admin UI (issue #729). Mirrors the admin UI Badge primitive's
+ * variants; `secondary` is the neutral fallback used for unmapped options.
+ */
+export type SelectOptionVariant =
+  'default' | 'secondary' | 'success' | 'warning' | 'destructive' | 'outline'
+
+/**
+ * A single choice in a `select` field.
+ *
+ * `label`/`value` are the long-standing shape; `ui` is additive, optional
+ * metadata (issue #729). `ui.variant` lets a value render as a coloured status
+ * badge in list-table Cells — an option without it renders with the neutral
+ * badge, so existing options keep working unchanged.
+ */
+export type SelectOption = {
+  label: string
+  value: string
+  ui?: {
+    /** Badge variant used when this option's value renders as a status Cell. */
+    variant?: SelectOptionVariant
+  }
+}
+
 export type SelectField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<TTypeInfo> & {
   type: 'select'
-  options: Array<{ label: string; value: string }>
+  options: Array<SelectOption>
   defaultValue?: string
   db?: {
     /**

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -30,6 +30,8 @@ export type {
   CalendarDayField,
   PasswordField,
   SelectField,
+  SelectOption,
+  SelectOptionVariant,
   RelationshipField,
   JsonField,
   VirtualField,

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link.js'
 import { Plus } from 'lucide-react'
 import { ListViewClient } from './ListViewClient.js'
 import { formatListName } from '../lib/utils.js'
+import { serializeFieldConfigs } from '../lib/serializeFieldConfig.js'
 import { PageHeader } from './PageHeader.js'
 import { Button } from '../primitives/button.js'
 import {
@@ -207,6 +208,7 @@ export async function ListView({
             (field as { type: string }).type,
           ]),
         )}
+        fields={serializeFieldConfigs(listConfig.fields)}
         relationshipRefs={relationshipRefs}
         columns={columns}
         initialSort={activeSort}

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Link from 'next/link.js'
 import { Inbox, Plus, SearchX } from 'lucide-react'
 import { useRouter } from 'next/navigation.js'
-import { cn, formatFieldName, getFieldDisplayValue, isNumericField } from '../lib/utils.js'
+import { cn, formatFieldName, isNumericField } from '../lib/utils.js'
 import {
   Table,
   TableBody,
@@ -17,24 +17,19 @@ import { Input } from '../primitives/input.js'
 import { Button } from '../primitives/button.js'
 import { Card } from '../primitives/card.js'
 import { EmptyState } from './EmptyState.js'
-import { getUrlKey } from '@opensaas/stack-core'
-
-/**
- * A relationship value after the server has resolved its label via the
- * shared label seam (`getItemLabel`) — see `ListView.tsx`.
- */
-interface RelationshipLabelValue {
-  id: string
-  label: string
-}
-
-function isRelationshipLabelValue(value: unknown): value is RelationshipLabelValue {
-  return !!value && typeof value === 'object' && 'id' in value && 'label' in value
-}
+import { CellRenderer } from './cells/CellRenderer.js'
+import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
 
 export interface ListViewClientProps {
   items: Array<Record<string, unknown>>
   fieldTypes: Record<string, string>
+  /**
+   * Serialised per-field config, keyed by field name. Drives Cell resolution
+   * (per-field override, select option variants, relationship ref). Optional so
+   * callers that only have `fieldTypes` still render via the field-type
+   * registry; a minimal config is synthesised from `fieldTypes` when absent.
+   */
+  fields?: Record<string, SerializableFieldConfig>
   relationshipRefs: Record<string, string>
   columns?: string[]
   /**
@@ -59,6 +54,7 @@ export interface ListViewClientProps {
 export function ListViewClient({
   items,
   fieldTypes,
+  fields,
   relationshipRefs,
   columns,
   initialSort,
@@ -132,64 +128,17 @@ export function ListViewClient({
   }
 
   /**
-   * Render a relationship field as a clickable link or links.
-   *
-   * `value` has already been resolved server-side (`ListView.tsx`) into
-   * `{ id, label }` pairs via the shared label seam (`getItemLabel`), so no
-   * label derivation happens here.
+   * The serialised field config for a column. Prefer the explicit `fields`
+   * prop; otherwise synthesise a minimal config from `fieldTypes` (and the
+   * relationship ref) so Cells still resolve via the field-type registry.
    */
-  const renderRelationshipCell = (value: unknown, fieldName: string) => {
-    if (!value) {
-      return <span className="text-muted-foreground">-</span>
+  const columnField = (column: string): SerializableFieldConfig => {
+    if (fields?.[column]) return fields[column]
+    const ref = relationshipRefs[column]
+    return {
+      type: fieldTypes[column],
+      ...(ref ? { ref } : {}),
     }
-
-    const ref = relationshipRefs[fieldName]
-    const relatedUrlKey = ref ? getUrlKey(ref.split('.')[0]) : undefined
-
-    // Handle array of relationships (many: true)
-    if (Array.isArray(value)) {
-      const relatedItems = value.filter(isRelationshipLabelValue)
-      if (relatedItems.length === 0) return <span className="text-muted-foreground">-</span>
-      return (
-        <span className="flex flex-wrap gap-1">
-          {relatedItems.map((item, idx) => (
-            <React.Fragment key={item.id}>
-              {idx > 0 && <span className="text-muted-foreground">, </span>}
-              {relatedUrlKey ? (
-                <Link
-                  href={`${basePath}/${relatedUrlKey}/${item.id}`}
-                  className="text-primary hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {item.label}
-                </Link>
-              ) : (
-                item.label
-              )}
-            </React.Fragment>
-          ))}
-        </span>
-      )
-    }
-
-    // Handle single relationship
-    if (!isRelationshipLabelValue(value)) {
-      return <span className="text-muted-foreground">-</span>
-    }
-
-    if (!relatedUrlKey) {
-      return value.label
-    }
-
-    return (
-      <Link
-        href={`${basePath}/${relatedUrlKey}/${value.id}`}
-        className="text-primary hover:underline"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {value.label}
-      </Link>
-    )
   }
 
   return (
@@ -295,9 +244,12 @@ export function ListViewClient({
                       key={column}
                       className={cn(isNumericField(fieldTypes[column]) && 'text-right')}
                     >
-                      {fieldTypes[column] === 'relationship'
-                        ? renderRelationshipCell(item[column], column)
-                        : getFieldDisplayValue(item[column], fieldTypes[column])}
+                      <CellRenderer
+                        value={item[column]}
+                        field={columnField(column)}
+                        fieldName={column}
+                        basePath={basePath}
+                      />
                     </TableCell>
                   ))}
                   <TableCell className="text-right">

--- a/packages/ui/src/components/cells/CellRenderer.tsx
+++ b/packages/ui/src/components/cells/CellRenderer.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import * as React from 'react'
+import { getCellComponent, type CellComponent, type CellComponentProps } from './registry.js'
+import { TextCell } from './TextCell.js'
+
+/**
+ * Internal component that renders the already-resolved Cell. Resolving in the
+ * outer factory and rendering here (Cell arrives as a prop) mirrors
+ * `FieldRenderer`, keeping the resolved component out of this scope's render.
+ */
+function CellRendererInner({
+  Component,
+  ...props
+}: CellComponentProps & { Component: CellComponent }) {
+  return <Component {...props} />
+}
+
+/**
+ * Resolves and renders the Cell for one field value, mirroring `FieldRenderer`'s
+ * form-component resolution priority exactly:
+ *
+ * 1. `field.ui.cell` — per-field override (highest priority)
+ * 2. `field.ui.fieldType` — custom type lookup in the cell registry
+ * 3. `field.type` — default field-type lookup in the cell registry
+ * 4. {@link TextCell} — plain-text fallback (unknown/third-party types)
+ *
+ * The resolution delegates to each field type's registered Cell — there is no
+ * switch on field type here, matching the field-builder self-containment rule.
+ */
+export function CellRenderer(props: CellComponentProps) {
+  const { field } = props
+
+  const Component: CellComponent =
+    field.ui?.cell ||
+    (field.ui?.fieldType ? getCellComponent(field.ui.fieldType) : getCellComponent(field.type)) ||
+    TextCell
+
+  return <CellRendererInner {...props} Component={Component} />
+}

--- a/packages/ui/src/components/cells/CheckboxCell.tsx
+++ b/packages/ui/src/components/cells/CheckboxCell.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import * as React from 'react'
+import { Check, Minus } from 'lucide-react'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * Checkbox Cell — renders a mark rather than raw text: a check for `true`, a
+ * muted dash for `false`. The boolean is preserved as an accessible name
+ * (`Yes`/`No`) so screen readers and tests can read the state. Slot:
+ * `cell-checkbox`.
+ */
+export function CheckboxCell({ value }: CellComponentProps) {
+  if (value) {
+    return (
+      <Check
+        data-slot="cell-checkbox"
+        role="img"
+        aria-label="Yes"
+        className="h-4 w-4 text-success"
+      />
+    )
+  }
+  return (
+    <Minus
+      data-slot="cell-checkbox"
+      role="img"
+      aria-label="No"
+      className="h-4 w-4 text-muted-foreground"
+    />
+  )
+}

--- a/packages/ui/src/components/cells/IntegerCell.tsx
+++ b/packages/ui/src/components/cells/IntegerCell.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '../../lib/utils.js'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * Numeric Cell — renders in tabular figures so digits line up down the column.
+ * Right alignment is applied by the table cell (the numeric column). Slot:
+ * `cell-integer`.
+ */
+export function IntegerCell({ value }: CellComponentProps) {
+  if (value === null || value === undefined) {
+    return (
+      <span data-slot="cell-integer" className="tabular-nums text-muted-foreground">
+        -
+      </span>
+    )
+  }
+  return (
+    <span data-slot="cell-integer" className={cn('tabular-nums')}>
+      {String(value)}
+    </span>
+  )
+}

--- a/packages/ui/src/components/cells/RelationshipCell.tsx
+++ b/packages/ui/src/components/cells/RelationshipCell.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link.js'
+import { getUrlKey } from '@opensaas/stack-core'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * One related row's `{ id, label }`. The label is normally resolved server-side
+ * via the shared label seam (`getItemLabel`); the raw-record fallback
+ * (`name` → `title` → `label` → `id`) covers callers that pass unresolved rows.
+ */
+interface RelatedRef {
+  id: string | null
+  label: string
+}
+
+function toRelatedRef(value: unknown): RelatedRef | null {
+  if (!value || typeof value !== 'object') return null
+  const row = value as Record<string, unknown>
+  const id = 'id' in row && row.id != null ? String(row.id) : null
+  let label: string | undefined
+  if (typeof row.label === 'string') label = row.label
+  else if (typeof row.name === 'string') label = row.name
+  else if (typeof row.title === 'string') label = row.title
+  else if (id !== null) label = id
+  if (label === undefined) return null
+  return { id, label }
+}
+
+function EmptyDash() {
+  return <span className="text-muted-foreground">-</span>
+}
+
+/**
+ * To-one relationship Cell — renders the related row's Item label, linked to
+ * its edit page when the field's `ref` (and `basePath`) resolve a URL. Arrays
+ * (to-many) render as comma-separated labels, preserving the list view's
+ * long-standing behaviour. Slot: `cell-relationship`.
+ */
+export function RelationshipCell({ value, field, basePath = '/admin' }: CellComponentProps) {
+  const relatedUrlKey = field.ref ? getUrlKey(field.ref.split('.')[0] ?? '') : undefined
+
+  const renderRef = (ref: RelatedRef, key: React.Key) => {
+    if (relatedUrlKey && ref.id !== null) {
+      return (
+        <Link
+          key={key}
+          href={`${basePath}/${relatedUrlKey}/${ref.id}`}
+          className="text-primary hover:underline"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {ref.label}
+        </Link>
+      )
+    }
+    return <React.Fragment key={key}>{ref.label}</React.Fragment>
+  }
+
+  if (Array.isArray(value)) {
+    const refs = value.map(toRelatedRef).filter((ref): ref is RelatedRef => ref !== null)
+    if (refs.length === 0) return <EmptyDash />
+    return (
+      <span data-slot="cell-relationship" className="flex flex-wrap gap-1">
+        {refs.map((ref, index) => (
+          <React.Fragment key={ref.id ?? index}>
+            {index > 0 && <span className="text-muted-foreground">, </span>}
+            {renderRef(ref, ref.id ?? index)}
+          </React.Fragment>
+        ))}
+      </span>
+    )
+  }
+
+  const ref = toRelatedRef(value)
+  if (ref === null) return <EmptyDash />
+  return <span data-slot="cell-relationship">{renderRef(ref, ref.id ?? 'single')}</span>
+}

--- a/packages/ui/src/components/cells/SelectCell.tsx
+++ b/packages/ui/src/components/cells/SelectCell.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import * as React from 'react'
+import type { SelectOptionVariant } from '@opensaas/stack-core/fields'
+import { Badge } from '../../primitives/badge.js'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * Neutral badge variant used when an option carries no `ui.variant` metadata.
+ * State stays scannable even before a project colours its options.
+ */
+const NEUTRAL_VARIANT: SelectOptionVariant = 'secondary'
+
+/**
+ * Select Cell — renders a value as a coloured status Badge. The colour comes
+ * from the matched option's additive `ui.variant` metadata (issue #729);
+ * unmapped options (and unknown values) fall back to the neutral badge. The
+ * option's `label` is shown, matching the field's read-mode rendering. Slot:
+ * `cell-select`.
+ */
+export function SelectCell({ value, field }: CellComponentProps) {
+  if (value === null || value === undefined || value === '') {
+    return (
+      <span data-slot="cell-select" className="text-muted-foreground">
+        -
+      </span>
+    )
+  }
+
+  const stringValue = String(value)
+  const option = field.options?.find((opt) => opt.value === stringValue)
+  const label = option?.label ?? stringValue
+  const variant = option?.ui?.variant ?? NEUTRAL_VARIANT
+
+  return (
+    <Badge data-slot="cell-select" variant={variant}>
+      {label}
+    </Badge>
+  )
+}

--- a/packages/ui/src/components/cells/TextCell.tsx
+++ b/packages/ui/src/components/cells/TextCell.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import * as React from 'react'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * Plain-text Cell — the default rendering for text fields and the fallback for
+ * any field type without a registered Cell. Renders a muted dash for
+ * empty values. Slot: `cell-text`.
+ */
+export function TextCell({ value }: CellComponentProps) {
+  if (value === null || value === undefined || value === '') {
+    return (
+      <span data-slot="cell-text" className="text-muted-foreground">
+        -
+      </span>
+    )
+  }
+  return <span data-slot="cell-text">{String(value)}</span>
+}

--- a/packages/ui/src/components/cells/TimestampCell.tsx
+++ b/packages/ui/src/components/cells/TimestampCell.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import * as React from 'react'
+import type { CellComponentProps } from './registry.js'
+
+/**
+ * Narrow an unknown value to a valid `Date`, or `null`. Timestamps arrive as
+ * ISO strings across the server/client boundary, but epoch numbers and `Date`
+ * instances are handled too — no casting.
+ */
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+  return null
+}
+
+/**
+ * Timestamp Cell — renders a humanly-formatted local date/time. Slot:
+ * `cell-timestamp`.
+ */
+export function TimestampCell({ value }: CellComponentProps) {
+  const date = toDate(value)
+  if (date === null) {
+    return (
+      <span data-slot="cell-timestamp" className="text-muted-foreground">
+        -
+      </span>
+    )
+  }
+  return <span data-slot="cell-timestamp">{date.toLocaleString()}</span>
+}

--- a/packages/ui/src/components/cells/index.ts
+++ b/packages/ui/src/components/cells/index.ts
@@ -1,0 +1,13 @@
+// Cell components — the list-table rendering of a field's value
+export { TextCell } from './TextCell.js'
+export { IntegerCell } from './IntegerCell.js'
+export { CheckboxCell } from './CheckboxCell.js'
+export { SelectCell } from './SelectCell.js'
+export { TimestampCell } from './TimestampCell.js'
+export { RelationshipCell } from './RelationshipCell.js'
+export { CellRenderer } from './CellRenderer.js'
+
+// Registry for custom / third-party Cell components
+export { cellComponentRegistry, registerCellComponent, getCellComponent } from './registry.js'
+
+export type { CellComponent, CellComponentProps } from './registry.js'

--- a/packages/ui/src/components/cells/registry.ts
+++ b/packages/ui/src/components/cells/registry.ts
@@ -1,0 +1,70 @@
+import type { ComponentType } from 'react'
+import type { SerializableFieldConfig } from '../../lib/serializeFieldConfig.js'
+import { TextCell } from './TextCell.js'
+import { IntegerCell } from './IntegerCell.js'
+import { CheckboxCell } from './CheckboxCell.js'
+import { SelectCell } from './SelectCell.js'
+import { TimestampCell } from './TimestampCell.js'
+import { RelationshipCell } from './RelationshipCell.js'
+
+/**
+ * Props every Cell component receives. A Cell is the list-table rendering of
+ * one field's value (see `CONTEXT.md` — "Cell"). Props are deliberately
+ * serialisable — `value` is the JSON-safe, access-filtered field value and
+ * `field` is the serialised field config — so Cells stay drop-in for the
+ * server-driven list view.
+ */
+export type CellComponentProps = {
+  /** The access-filtered, JSON-serialisable field value for this row. */
+  value: unknown
+  /** Serialised config for this column's field — drives options, ref, etc. */
+  field: SerializableFieldConfig
+  /** Raw field/column key. */
+  fieldName: string
+  /** Admin base path, used by relationship Cells to build links. */
+  basePath?: string
+}
+
+/**
+ * A Cell component. Unlike form-field components (which have per-type prop
+ * shapes and so widen to `ComponentType<any>` in their registry), every Cell
+ * shares one prop contract, so this stays strongly typed.
+ */
+export type CellComponent = ComponentType<CellComponentProps>
+
+/**
+ * Registry mapping field types to their default Cell components — the
+ * field-type layer of the resolution chain. Mirrors `fieldComponentRegistry`
+ * for form fields; extend it with {@link registerCellComponent} exactly the
+ * same way a third-party field registers its form component.
+ */
+const cellComponentRegistry: Record<string, CellComponent> = {
+  text: TextCell,
+  integer: IntegerCell,
+  checkbox: CheckboxCell,
+  select: SelectCell,
+  timestamp: TimestampCell,
+  relationship: RelationshipCell,
+}
+
+/**
+ * Register a default Cell component for a field type. A third-party field
+ * package calls this to make its values render correctly in tables, exactly as
+ * it calls `registerFieldComponent` for its form component.
+ *
+ * @param fieldType - The field type identifier
+ * @param component - A Cell component accepting {@link CellComponentProps}
+ */
+export function registerCellComponent(fieldType: string, component: CellComponent): void {
+  cellComponentRegistry[fieldType] = component
+}
+
+/**
+ * Get the Cell component registered for a field type, or `undefined` when none
+ * is registered (the caller falls back to plain text).
+ */
+export function getCellComponent(fieldType: string): CellComponent | undefined {
+  return cellComponentRegistry[fieldType]
+}
+
+export { cellComponentRegistry }

--- a/packages/ui/src/components/standalone/ListTable.tsx
+++ b/packages/ui/src/components/standalone/ListTable.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useState } from 'react'
 import Link from 'next/link.js'
 import { Inbox } from 'lucide-react'
-import { cn, formatFieldName, getFieldDisplayValue, isNumericField } from '../../lib/utils.js'
+import { cn, formatFieldName, isNumericField } from '../../lib/utils.js'
 import { getUrlKey } from '@opensaas/stack-core'
 import {
   Table,
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from '../../primitives/table.js'
 import { EmptyState } from '../EmptyState.js'
+import { CellRenderer } from '../cells/CellRenderer.js'
 
 /**
  * Per-part `classNames` slots for `ListTable` (issue #709). Each slot is merged
@@ -284,9 +285,16 @@ export function ListTable({
                         classNames?.cell,
                       )}
                     >
-                      {fieldTypes[column] === 'relationship'
-                        ? renderRelationshipCell(item[column], column)
-                        : getFieldDisplayValue(item[column], fieldTypes[column])}
+                      {fieldTypes[column] === 'relationship' ? (
+                        renderRelationshipCell(item[column], column)
+                      ) : (
+                        <CellRenderer
+                          value={item[column]}
+                          field={{ type: fieldTypes[column] }}
+                          fieldName={column}
+                          basePath={basePath}
+                        />
+                      )}
                     </TableCell>
                   ))}
                   {renderActions && (

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,6 +49,21 @@ export {
   FieldReadValue,
 } from './components/fields/index.js'
 
+// Cell components + registry (list-table rendering of field values)
+export {
+  TextCell,
+  IntegerCell,
+  CheckboxCell,
+  SelectCell,
+  TimestampCell,
+  RelationshipCell,
+  CellRenderer,
+  cellComponentRegistry,
+  registerCellComponent,
+  getCellComponent,
+} from './components/cells/index.js'
+export type { CellComponent, CellComponentProps } from './components/cells/index.js'
+
 // Types
 export type { AdminUIProps } from './components/AdminUI.js'
 export type { DashboardProps } from './components/Dashboard.js'

--- a/packages/ui/src/lib/serializeFieldConfig.ts
+++ b/packages/ui/src/lib/serializeFieldConfig.ts
@@ -1,5 +1,7 @@
 import type { FieldConfig } from '@opensaas/stack-core'
+import type { SelectOption } from '@opensaas/stack-core/fields'
 import type { ComponentType } from 'react'
+import type { CellComponent } from '../components/cells/registry.js'
 
 /**
  * Serializable field config for client components
@@ -14,12 +16,21 @@ export type SerializableFieldConfig = {
     min?: number
     max?: number
   }
-  options?: Array<{ label: string; value: string }>
+  /**
+   * Select options. Carries the additive per-option `ui.variant` metadata
+   * (issue #729) so list-table select Cells can colour their badge.
+   */
+  options?: Array<SelectOption>
   many?: boolean
   ref?: string
   ui?: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     component?: ComponentType<any>
+    /**
+     * Per-field Cell override — the highest-priority entry in the cell
+     * resolution chain, mirroring `component` for form fields (issue #729).
+     */
+    cell?: CellComponent
     fieldType?: string
     /** Help / description text surfaced to the field component as `helpText`. */
     description?: string
@@ -54,9 +65,9 @@ export function serializeFieldConfig(fieldConfig: FieldConfig): SerializableFiel
     config.validation = fieldConfig.validation as SerializableFieldConfig['validation']
   }
 
-  // Extract options for select fields
+  // Extract options for select fields (including additive per-option ui.variant)
   if ('options' in fieldConfig && fieldConfig.options !== undefined) {
-    config.options = fieldConfig.options as Array<{ label: string; value: string }>
+    config.options = fieldConfig.options as Array<SelectOption>
   }
 
   // Extract many for relationship fields

--- a/packages/ui/tests/components/CellRenderer.test.tsx
+++ b/packages/ui/tests/components/CellRenderer.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CellRenderer } from '../../src/components/cells/CellRenderer.js'
+import {
+  registerCellComponent,
+  type CellComponentProps,
+} from '../../src/components/cells/registry.js'
+import type { SerializableFieldConfig } from '../../src/lib/serializeFieldConfig.js'
+
+/**
+ * The cell registry must resolve a Cell through the SAME priority chain as the
+ * form-field registry: per-field override → custom type registry → field-type
+ * registry → plain-text fallback.
+ */
+describe('CellRenderer resolution priority', () => {
+  function OverrideCell({ value }: CellComponentProps) {
+    return <span>override:{String(value)}</span>
+  }
+
+  function CustomTypeCell({ value }: CellComponentProps) {
+    return <span>custom-type:{String(value)}</span>
+  }
+
+  // Register a Cell for a made-up custom type used via `ui.fieldType`.
+  registerCellComponent('cellTestCustom', CustomTypeCell)
+
+  it('1. per-field override (ui.cell) wins over every registry', () => {
+    const field: SerializableFieldConfig = {
+      // Even though `select` and the custom type both resolve, the override wins.
+      type: 'select',
+      ui: { cell: OverrideCell, fieldType: 'cellTestCustom' },
+    }
+    render(<CellRenderer value="X" field={field} fieldName="f" />)
+    expect(screen.getByText('override:X')).toBeInTheDocument()
+  })
+
+  it('2. custom type registry (ui.fieldType) resolves next', () => {
+    const field: SerializableFieldConfig = {
+      type: 'select',
+      ui: { fieldType: 'cellTestCustom' },
+    }
+    render(<CellRenderer value="Y" field={field} fieldName="f" />)
+    expect(screen.getByText('custom-type:Y')).toBeInTheDocument()
+  })
+
+  it('3. field-type registry resolves the default Cell', () => {
+    const field: SerializableFieldConfig = {
+      type: 'select',
+      options: [{ label: 'Published', value: 'published' }],
+    }
+    render(<CellRenderer value="published" field={field} fieldName="status" />)
+    // The select default Cell renders a Badge showing the option label.
+    const badge = screen.getByText('Published')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveAttribute('data-slot', 'cell-select')
+  })
+
+  it('4. unknown / third-party types without a registered Cell fall back to plain text', () => {
+    const field: SerializableFieldConfig = { type: 'someUnregisteredThirdPartyType' }
+    render(<CellRenderer value="raw value" field={field} fieldName="f" />)
+    const cell = screen.getByText('raw value')
+    expect(cell).toBeInTheDocument()
+    expect(cell).toHaveAttribute('data-slot', 'cell-text')
+  })
+})

--- a/packages/ui/tests/components/Cells.test.tsx
+++ b/packages/ui/tests/components/Cells.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SelectCell } from '../../src/components/cells/SelectCell.js'
+import { IntegerCell } from '../../src/components/cells/IntegerCell.js'
+import { TimestampCell } from '../../src/components/cells/TimestampCell.js'
+import { CheckboxCell } from '../../src/components/cells/CheckboxCell.js'
+import { RelationshipCell } from '../../src/components/cells/RelationshipCell.js'
+import { TextCell } from '../../src/components/cells/TextCell.js'
+import type { SerializableFieldConfig } from '../../src/lib/serializeFieldConfig.js'
+
+const statusField: SerializableFieldConfig = {
+  type: 'select',
+  options: [
+    { label: 'Draft', value: 'draft', ui: { variant: 'secondary' } },
+    { label: 'Published', value: 'published', ui: { variant: 'success' } },
+    // No `ui.variant` — must fall back to the neutral badge.
+    { label: 'Archived', value: 'archived' },
+  ],
+}
+
+describe('SelectCell', () => {
+  it('colours the badge from the matched option ui.variant', () => {
+    render(<SelectCell value="published" field={statusField} fieldName="status" />)
+    const badge = screen.getByText('Published')
+    expect(badge).toHaveAttribute('data-slot', 'cell-select')
+    // `success` variant maps to the success token class.
+    expect(badge.className).toContain('text-success')
+  })
+
+  it('renders the neutral badge for an option without variant metadata', () => {
+    render(<SelectCell value="archived" field={statusField} fieldName="status" />)
+    const badge = screen.getByText('Archived')
+    // Neutral = secondary variant.
+    expect(badge.className).toContain('bg-secondary')
+    expect(badge.className).not.toContain('text-success')
+  })
+
+  it('renders the neutral badge for an unmapped value not in options', () => {
+    render(<SelectCell value="mystery" field={statusField} fieldName="status" />)
+    const badge = screen.getByText('mystery')
+    expect(badge.className).toContain('bg-secondary')
+  })
+
+  it('renders a dash for an empty value', () => {
+    render(<SelectCell value={null} field={statusField} fieldName="status" />)
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+})
+
+describe('IntegerCell', () => {
+  it('renders numbers with tabular figures', () => {
+    render(<IntegerCell value={42} field={{ type: 'integer' }} fieldName="views" />)
+    const cell = screen.getByText('42')
+    expect(cell).toHaveAttribute('data-slot', 'cell-integer')
+    expect(cell.className).toContain('tabular-nums')
+  })
+})
+
+describe('TimestampCell', () => {
+  it('formats a valid timestamp', () => {
+    render(
+      <TimestampCell value="2024-01-01T12:00:00Z" field={{ type: 'timestamp' }} fieldName="at" />,
+    )
+    expect(screen.getByText(/2024/)).toBeInTheDocument()
+  })
+
+  it('renders a dash for an invalid/empty value', () => {
+    render(<TimestampCell value={null} field={{ type: 'timestamp' }} fieldName="at" />)
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+})
+
+describe('CheckboxCell', () => {
+  it('renders a mark with an accessible name for true/false', () => {
+    const { rerender } = render(
+      <CheckboxCell value={true} field={{ type: 'checkbox' }} fieldName="done" />,
+    )
+    expect(screen.getByLabelText('Yes')).toBeInTheDocument()
+
+    rerender(<CheckboxCell value={false} field={{ type: 'checkbox' }} fieldName="done" />)
+    expect(screen.getByLabelText('No')).toBeInTheDocument()
+  })
+})
+
+describe('RelationshipCell', () => {
+  const field: SerializableFieldConfig = { type: 'relationship', ref: 'User.posts' }
+
+  it('renders a to-one relationship as a linked Item label', () => {
+    render(
+      <RelationshipCell
+        value={{ id: 'user-1', label: 'Ada Lovelace' }}
+        field={field}
+        fieldName="author"
+        basePath="/admin"
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Ada Lovelace' })
+    expect(link).toHaveAttribute('href', '/admin/user/user-1')
+  })
+
+  it('falls back to a raw record label when not pre-resolved', () => {
+    render(
+      <RelationshipCell
+        value={{ id: 'user-2', name: 'Grace Hopper' }}
+        field={field}
+        fieldName="author"
+        basePath="/admin"
+      />,
+    )
+    expect(screen.getByRole('link', { name: 'Grace Hopper' })).toBeInTheDocument()
+  })
+
+  it('renders a dash for an empty relationship', () => {
+    render(<RelationshipCell value={null} field={field} fieldName="author" />)
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+})
+
+describe('TextCell', () => {
+  it('renders a dash for empty values', () => {
+    render(<TextCell value="" field={{ type: 'text' }} fieldName="t" />)
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/tests/components/ListTable.test.tsx
+++ b/packages/ui/tests/components/ListTable.test.tsx
@@ -347,7 +347,7 @@ describe('ListTable', () => {
   })
 
   describe('field display values', () => {
-    it('should display checkbox values as Yes/No', () => {
+    it('should display checkbox values as accessible marks (Yes/No)', () => {
       const items = [
         { id: '1', title: 'Post 1', published: true },
         { id: '2', title: 'Post 2', published: false },
@@ -361,8 +361,9 @@ describe('ListTable', () => {
         />,
       )
 
-      expect(screen.getByText('Yes')).toBeInTheDocument()
-      expect(screen.getByText('No')).toBeInTheDocument()
+      // Checkbox Cells render a mark; the boolean survives as the accessible name.
+      expect(screen.getByLabelText('Yes')).toBeInTheDocument()
+      expect(screen.getByLabelText('No')).toBeInTheDocument()
     })
 
     it('should display timestamp values as formatted dates', () => {

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -474,7 +474,7 @@ describe('ListViewClient', () => {
   })
 
   describe('field display values', () => {
-    it('should display checkbox values as Yes/No', () => {
+    it('should display checkbox values as accessible marks (Yes/No)', () => {
       const items = [
         { id: '1', title: 'Post 1', published: true },
         { id: '2', title: 'Post 2', published: false },
@@ -489,8 +489,9 @@ describe('ListViewClient', () => {
         />,
       )
 
-      expect(screen.getByText('Yes')).toBeInTheDocument()
-      expect(screen.getByText('No')).toBeInTheDocument()
+      // Checkbox Cells render a mark; the boolean survives as the accessible name.
+      expect(screen.getByLabelText('Yes')).toBeInTheDocument()
+      expect(screen.getByLabelText('No')).toBeInTheDocument()
     })
 
     it('should display timestamp values as formatted dates', () => {


### PR DESCRIPTION
Implements #729
Part of #728

## What this does

List tables now render every value through a **Cell** resolved by a cell-component registry that **exactly mirrors the form-field registry's** resolution chain and registration mechanism:

1. **per-field override** — `field.ui.cell` (mirrors `ui.component` for forms)
2. **custom type registry** — `field.ui.fieldType` (shared with forms)
3. **field-type registry** — `field.type`
4. **plain-text fallback** — `TextCell` for unknown/third-party types

`registerCellComponent(type, Cell)` is the peer of `registerFieldComponent`, and `CellRenderer` is the peer of `FieldRenderer` (same inner-component pattern so the resolution stays out of the render scope). There is **no switch on field type** anywhere — each field type provides its own default Cell and the renderer delegates, per the field-builder self-containment rule.

### Default cells (core field types)

- **text** — plain text (also the fallback for unregistered types)
- **integer** — tabular figures (right alignment stays on the numeric column)
- **select** — `Badge`, coloured by the new option-level UI metadata; neutral badge when unmapped
- **timestamp** — formatted local date/time
- **checkbox** — accessible mark (`Yes`/`No` preserved as the accessible name)
- **relationship (to-one)** — Item label link; arrays keep the existing comma-separated links

All new components consume **only Theme tokens** and ship named **Slots** (`data-slot="cell-*"`).

### Additive option-shape change (core)

`SelectOption` gains an optional, additive `ui.variant`:

```typescript
status: select({
  options: [
    { label: 'Draft', value: 'draft', ui: { variant: 'secondary' } },
    { label: 'Published', value: 'published', ui: { variant: 'success' } },
  ],
})
```

This is purely additive to the shared `{ value, label }` shape — existing consumers are untouched, options without `ui.variant` render the neutral badge, and unmapped values still render. `SelectOptionVariant` mirrors the UI `Badge` primitive's variants and is exported from `@opensaas/stack-core/fields`.

## How existing pages stay working

`ListView` (server) now passes serialized field configs to `ListViewClient`, which routes each cell through `CellRenderer`. `ListViewClient` synthesizes a minimal field config from `fieldTypes` when no serialized `fields` prop is supplied, so all existing call sites and tests render unchanged. `ListTable` routes scalar cells through the registry while keeping its own relationship rendering (`stopPropagation` for row clicks). Zero config changes required.

## Tests

- **Component** — `CellRenderer.test.tsx` locks down the four-step resolution priority (override wins over both registries; custom-type registry; field-type registry; plain-text fallback). `Cells.test.tsx` covers select badge variants (mapped `success`, neutral fallback for both unmapped-option and unknown-value), integer tabular figures, timestamp formatting, checkbox marks, and relationship link resolution.
- **e2e** — `03-admin-ui.spec.ts` asserts the select column renders a `data-slot="cell-select"` Badge with the `text-success` token class for a published post.
- Existing UI (387) and core (774) suites pass unchanged (two checkbox assertions updated from visible `Yes`/`No` text to the accessible mark's name).

## Verification

- `pnpm --filter @opensaas/stack-core build` + `@opensaas/stack-ui build` — pass (tsc clean)
- core vitest 774 passed; ui vitest 387 passed (+ new cell tests)
- `pnpm lint` — 0 errors (3 pre-existing warnings in untouched core files); `pnpm manypkg fix`; `pnpm format`
- Changeset included (`minor` for `@opensaas/stack-core` and `@opensaas/stack-ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_