### PR TITLE
Filter engine: Filter spec contract and URL-driven server filtering

### DIFF
--- a/.changeset/filter-engine-filter-spec.md
+++ b/.changeset/filter-engine-filter-spec.md
@@ -1,0 +1,30 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add the admin UI filter engine: a Filter spec field-builder contract and URL-driven server-side list filtering (ADR-0017).
+
+Fields now declare their filtering capability through a new optional `getFilterSpec` method — a peer of `getPrismaType`/`getTypeScriptType` on the field-builder contract. It reports the operators a field supports, a pure token→condition mapper, and serializable suggestion metadata. Core field types implement it (text contains + free text, integer/decimal/timestamp/calendarDay comparisons, select/checkbox equality against enumerated values, relationship by label lookup). A field without a spec — `password`, `json`, `virtual`, or any third-party field that hasn't adopted one — is simply not filterable, so the addition degrades gracefully everywhere.
+
+The admin list view now parses the URL filter query (the list's `search` param) through the engine and merges the result into the access-controlled query via the secured context, so filtering runs server-side and can only ever narrow — never widen — what a session may see. This replaces the previous hard-coded `type === 'text'` search; free-text behavior is now driven by each text field's Filter spec.
+
+Grammar (ADR-0017): implicit-AND tokens, quoted multi-word values, `>`/`>=`/`<`/`<=` comparisons on numeric/date fields, and bare words as free text. Unknown syntax degrades to free text, never errors.
+
+New exports from `@opensaas/stack-core`:
+
+```typescript
+import {
+  parseFilterQuery, // (query) => FilterToken[]  — pure
+  buildFilterWhere, // (tokens, specs) => where   — pure
+  collectFilterSpecs, // (listConfig, listKey, config) => specs
+  buildListFilterWhere, // (query, listConfig, listKey, config) => where
+  collectFilterSuggestions, // serializable autocomplete metadata
+} from '@opensaas/stack-core'
+
+// e.g. "status:Published views:>10 author:\"Ada Lovelace\" beta"
+const where = buildListFilterWhere(query, listConfig, listKey, config)
+const rows = await context.db.post.findMany({ where }) // ANDed with the access filter
+```
+
+Third-party field authors can implement `FilterSpec` (exported from `@opensaas/stack-core/extend`) to make their field filterable.

--- a/.changeset/filter-engine-filter-spec.md
+++ b/.changeset/filter-engine-filter-spec.md
@@ -11,6 +11,8 @@ The admin list view now parses the URL filter query (the list's `search` param) 
 
 Grammar (ADR-0017): implicit-AND tokens, quoted multi-word values, `>`/`>=`/`<`/`<=` comparisons on numeric/date fields, and bare words as free text. Unknown syntax degrades to free text, never errors.
 
+Multi-word free-text UX shift (intentional, per ADR-0017): bare words now combine with AND, so `hello world` requires each word to match separately (not the literal substring `hello world`). To match a contiguous phrase, quote it: `"hello world"`. A pasted URL such as `http://x` is treated as a single free-text token and searched verbatim — the `http:` prefix is not parsed as a field.
+
 New exports from `@opensaas/stack-core`:
 
 ```typescript

--- a/e2e/starter-auth/05-filter.spec.ts
+++ b/e2e/starter-auth/05-filter.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * Filter engine (issue #730 / ADR-0017).
+ *
+ * A URL-typed filter query narrows the list server-side through the secured
+ * context: field-scoped tokens, bare-word free text, and graceful degradation
+ * of unknown syntax. These specs type the query into the URL (`?search=`) — the
+ * same param the Filter builder input writes — and assert the table shows
+ * exactly the matching, access-scoped rows.
+ */
+test.describe('List filtering (URL-driven, server-side)', () => {
+  let testUser: ReturnType<typeof generateTestUser>
+
+  test.beforeEach(async ({ page }) => {
+    testUser = generateTestUser()
+    await signUp(page, testUser)
+  })
+
+  // Content is a fixed string that never collides with a post title, so a cell
+  // selector for a title matches the title column only.
+  async function createPost(
+    page: Page,
+    { title, slug, status }: { title: string; slug: string; status: 'draft' | 'published' },
+  ) {
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    await page.click('text=/create|new/i')
+    await page.waitForLoadState('networkidle')
+    await page.fill('input[name="title"]', title)
+    await page.fill('input[name="slug"]', slug)
+    await page.fill('textarea[name="content"]', 'Body content for the post.')
+    if (status === 'published') {
+      await page.getByLabel('Status').click()
+      await page.getByRole('option', { name: 'published' }).click()
+    }
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/admin\/post/, { timeout: 10000 })
+  }
+
+  /** A table cell whose exact text is the given title (the title column). */
+  function titleCell(page: Page, title: string) {
+    return page.getByRole('cell', { name: title, exact: true })
+  }
+
+  test('bare-word free text narrows the table to matching rows', async ({ page }) => {
+    await createPost(page, { title: 'Apples are red', slug: 'apples', status: 'published' })
+    await createPost(page, { title: 'Bananas are yellow', slug: 'bananas', status: 'published' })
+
+    // Free-text query typed into the URL.
+    await page.goto('/admin/post?search=Apples')
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Apples are red')).toBeVisible()
+    await expect(titleCell(page, 'Bananas are yellow')).toHaveCount(0)
+  })
+
+  test('a field-scoped select token filters by status', async ({ page }) => {
+    await createPost(page, { title: 'Draft One', slug: 'draft-one', status: 'draft' })
+    await createPost(page, { title: 'Published One', slug: 'published-one', status: 'published' })
+
+    // `status:Published` — matched against the select option label/value.
+    await page.goto('/admin/post?search=status%3APublished')
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Published One')).toBeVisible()
+    await expect(titleCell(page, 'Draft One')).toHaveCount(0)
+  })
+
+  test('unknown syntax degrades to free text and never errors', async ({ page }) => {
+    await createPost(page, { title: 'Findable Title', slug: 'findable', status: 'published' })
+
+    // `nosuchfield:Findable` — the field has no Filter spec, so the token
+    // degrades to a free-text search for "Findable" rather than 500-ing.
+    await page.goto('/admin/post?search=nosuchfield%3AFindable')
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Findable Title')).toBeVisible()
+  })
+})

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,4 +1,5 @@
 import type { AccessControl, FieldAccess } from '../access/types.js'
+import type { FilterSpec } from '../filter/types.js'
 import type { z } from 'zod'
 
 /**
@@ -663,6 +664,29 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
     type: string
     optional: boolean
   }
+  /**
+   * Declare this field's filtering capability — its {@link FilterSpec} — for the
+   * admin UI's Filter builder (ADR-0017). Optional and additive: a field that
+   * omits it (like `password`, `json`, `virtual`, or a third-party field that
+   * hasn't adopted filtering) is simply not filterable and never suggested, so
+   * absence degrades gracefully everywhere.
+   *
+   * Self-contained, like {@link getPrismaType} and friends — the filter engine
+   * delegates to each field's spec rather than switching on field type. The
+   * returned `toCondition` mapper must stay pure (no DB/Prisma imports); its
+   * output is ANDed with the access filter through the secured context.
+   *
+   * @param fieldName The field's config key (closed over by the mapper).
+   * @param listKey   The owning list's key.
+   * @param config    The full config (e.g. relationship specs resolve their
+   *   target list's label field from it).
+   * @returns The field's Filter spec, or `undefined` when not filterable.
+   */
+  getFilterSpec?: (
+    fieldName: string,
+    listKey: string,
+    config: OpenSaasConfig,
+  ) => FilterSpec | undefined
   /**
    * Get TypeScript imports needed for this field's type
    * @returns Array of import statements needed for the generated types file

--- a/packages/core/src/extend.ts
+++ b/packages/core/src/extend.ts
@@ -17,3 +17,12 @@ export type {
   TypeDescriptor,
   MultiColumnPrismaResult,
 } from './config/index.js'
+
+// Filter spec authoring — a field's optional `getFilterSpec` returns these
+// (ADR-0017). Additive: a field without one is simply not filterable.
+export type {
+  FilterSpec,
+  FilterOperator,
+  FilterCondition,
+  FilterValueSource,
+} from './filter/index.js'

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -17,6 +17,19 @@ import type {
 } from '../config/types.js'
 import { hashPassword, isHashedPassword, HashedPassword } from '../utils/password.js'
 import { formatPrismaDefault } from './format-prisma-default.js'
+import { getLabelFieldName } from '../config/label.js'
+import type { FilterOperator, FilterSpec } from '../filter/types.js'
+
+/**
+ * Operators shared by numeric/date fields: plain equality plus the four
+ * comparisons. `eq` maps to Prisma's `equals`; the comparisons pass through.
+ */
+const COMPARISON_OPERATORS: FilterOperator[] = ['eq', 'gt', 'gte', 'lt', 'lte']
+
+/** Map a Filter operator to its Prisma condition key (`eq` → `equals`). */
+function prismaComparisonKey(operator: FilterOperator): string {
+  return operator === 'eq' ? 'equals' : operator
+}
 
 // Field-config types live here, alongside the builders that produce them.
 // (The umbrella `FieldConfig` and authoring `BaseFieldConfig` stay on the root
@@ -154,6 +167,16 @@ export function text<
         optional: !isRequired,
       }
     },
+    // Text fields drive free-text search: a bare word (or a `field:value`) maps
+    // to a case-preserving `contains`. This is what replaces the old hard-coded
+    // `type === 'text'` search in the admin list view.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: ['eq'],
+      freeText: true,
+      toCondition: (operator, value) =>
+        operator === 'eq' ? { [fieldName]: { contains: value } } : null,
+      suggestions: { valueSource: { kind: 'none' } },
+    }),
   }
 }
 
@@ -231,6 +254,17 @@ export function integer<
         optional: !isRequired,
       }
     },
+    // Integers support equality and comparisons (`orders:>5`). A non-integer
+    // value can't be interpreted, so its token degrades to free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: COMPARISON_OPERATORS,
+      toCondition: (operator, value) => {
+        const trimmed = value.trim()
+        if (!/^-?\d+$/.test(trimmed)) return null
+        return { [fieldName]: { [prismaComparisonKey(operator)]: Number(trimmed) } }
+      },
+      suggestions: { valueSource: { kind: 'none' } },
+    }),
   }
 }
 
@@ -397,6 +431,17 @@ export function decimal<
         },
       ]
     },
+    // Decimals compare like integers, but the value stays a string so Prisma's
+    // Decimal keeps full precision. A non-numeric value degrades to free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: COMPARISON_OPERATORS,
+      toCondition: (operator, value) => {
+        const trimmed = value.trim()
+        if (!/^-?\d+(\.\d+)?$/.test(trimmed)) return null
+        return { [fieldName]: { [prismaComparisonKey(operator)]: trimmed } }
+      },
+      suggestions: { valueSource: { kind: 'none' } },
+    }),
   }
 }
 
@@ -443,6 +488,27 @@ export function checkbox<
         optional: options?.defaultValue === undefined,
       }
     },
+    // Checkboxes filter by equality against the two enumerated values. Anything
+    // other than true/false can't be interpreted and degrades to free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: ['eq'],
+      toCondition: (operator, value) => {
+        if (operator !== 'eq') return null
+        const normalized = value.trim().toLowerCase()
+        if (normalized === 'true') return { [fieldName]: { equals: true } }
+        if (normalized === 'false') return { [fieldName]: { equals: false } }
+        return null
+      },
+      suggestions: {
+        valueSource: {
+          kind: 'enum',
+          options: [
+            { value: 'true', label: 'True' },
+            { value: 'false', label: 'False' },
+          ],
+        },
+      },
+    }),
   }
 }
 
@@ -508,6 +574,17 @@ export function timestamp<
         optional: !hasDefault,
       }
     },
+    // Timestamps support equality and comparisons (`joined:>2024-01-01`). An
+    // unparseable date degrades to free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: COMPARISON_OPERATORS,
+      toCondition: (operator, value) => {
+        const date = new Date(value.trim())
+        if (Number.isNaN(date.getTime())) return null
+        return { [fieldName]: { [prismaComparisonKey(operator)]: date } }
+      },
+      suggestions: { valueSource: { kind: 'none' } },
+    }),
   }
 }
 
@@ -696,6 +773,20 @@ export function calendarDay<
         optional: isNullable,
       }
     },
+    // Calendar days compare on the `YYYY-MM-DD` value (coerced to a UTC-midnight
+    // Date so it matches the `@db.Date` column). A malformed value degrades to
+    // free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: COMPARISON_OPERATORS,
+      toCondition: (operator, value) => {
+        const trimmed = value.trim()
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null
+        const date = new Date(`${trimmed}T00:00:00.000Z`)
+        if (Number.isNaN(date.getTime())) return null
+        return { [fieldName]: { [prismaComparisonKey(operator)]: date } }
+      },
+      suggestions: { valueSource: { kind: 'none' } },
+    }),
   }
 }
 
@@ -1014,6 +1105,28 @@ export function select<
         optional: !options.validation?.isRequired || options.defaultValue !== undefined,
       }
     },
+    // Selects filter by equality against their enumerated options. The token
+    // value is matched (case-insensitively) against option value or label and
+    // resolved to the canonical stored value; an unknown option degrades to
+    // free text.
+    getFilterSpec: (fieldName: string): FilterSpec => ({
+      operators: ['eq'],
+      toCondition: (operator, value) => {
+        if (operator !== 'eq') return null
+        const needle = value.trim().toLowerCase()
+        const match = options.options.find(
+          (opt) => opt.value.toLowerCase() === needle || opt.label.toLowerCase() === needle,
+        )
+        if (!match) return null
+        return { [fieldName]: { equals: match.value } }
+      },
+      suggestions: {
+        valueSource: {
+          kind: 'enum',
+          options: options.options.map((opt) => ({ value: opt.value, label: opt.label })),
+        },
+      },
+    }),
   }
 }
 
@@ -1343,6 +1456,38 @@ export function relationship<
     listKey: string,
     config: OpenSaasConfig,
   ) => getPrismaRelation(field as RelationshipField, fieldName, listKey, config)
+
+  // Relationships filter by the related Item's label — `author:"Ada Lovelace"`
+  // becomes a nested `contains` on the target list's Label field (`is` for a
+  // to-one, `some` for a to-many). The mapper stays pure: it emits a Prisma
+  // nested filter, no DB lookup. Suggestions point the client at the target
+  // list so it can use the existing access-controlled label lookup.
+  field.getFilterSpec = (
+    _fieldName: string,
+    _listKey: string,
+    config: OpenSaasConfig,
+  ): FilterSpec | undefined => {
+    const { list: targetList } = parseRelationshipRef(field.ref)
+    const relatedListConfig = config.lists[targetList]
+    if (!relatedListConfig) return undefined
+
+    const labelField = getLabelFieldName(relatedListConfig)
+    const labelFieldConfig = relatedListConfig.fields[labelField]
+    // A virtual label field has no queryable column, so `contains` can't run
+    // against it — the relationship is then not filterable.
+    if (labelFieldConfig?.virtual === true) return undefined
+
+    const many = field.many === true
+    return {
+      operators: ['eq'],
+      toCondition: (operator, value) => {
+        if (operator !== 'eq') return null
+        const inner = { [labelField]: { contains: value } }
+        return many ? { [_fieldName]: { some: inner } } : { [_fieldName]: { is: inner } }
+      },
+      suggestions: { valueSource: { kind: 'relationship', listKey: targetList, many } },
+    }
+  }
 
   return field
 }

--- a/packages/core/src/filter/collect.ts
+++ b/packages/core/src/filter/collect.ts
@@ -1,0 +1,72 @@
+import type { ListConfig, OpenSaasConfig } from '../config/types.js'
+import { parseFilterQuery } from './parse.js'
+import { buildFilterWhere } from './map.js'
+import type { FilterCondition, FilterFieldSuggestion, FilterSpec } from './types.js'
+
+/**
+ * Resolve every field's {@link FilterSpec} for a list by delegating to each
+ * field's optional `getFilterSpec` method. A field without the method (or one
+ * whose method returns `undefined`) is simply not filterable — the absence
+ * degrades gracefully so third-party fields keep working.
+ *
+ * @param listConfig The list whose fields to inspect.
+ * @param listKey    The list's key (passed through to each field's spec).
+ * @param config     The full config (relationship specs resolve their target
+ *   list's label field from it).
+ */
+export function collectFilterSpecs(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listKey: string,
+  config: OpenSaasConfig,
+): Record<string, FilterSpec> {
+  const specs: Record<string, FilterSpec> = {}
+  for (const [fieldName, field] of Object.entries(listConfig.fields)) {
+    if (typeof field.getFilterSpec !== 'function') continue
+    const spec = field.getFilterSpec(fieldName, listKey, config)
+    if (spec) specs[fieldName] = spec
+  }
+  return specs
+}
+
+/**
+ * End-to-end helper for the list view: parse a raw URL query, collect the
+ * list's Filter specs, and build the merged Prisma `where` fragment. The
+ * fragment is meant to be handed to `context.db.<list>.findMany`/`count`, where
+ * the secured context ANDs it with the access filter — so the filter can only
+ * ever narrow, never widen, what a session may see.
+ *
+ * @returns A `where` fragment, or `undefined` when the query filters nothing.
+ */
+export function buildListFilterWhere(
+  query: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listKey: string,
+  config: OpenSaasConfig,
+): FilterCondition | undefined {
+  const specs = collectFilterSpecs(listConfig, listKey, config)
+  const tokens = parseFilterQuery(query)
+  return buildFilterWhere(tokens, specs)
+}
+
+/**
+ * Collect the client-serializable suggestion metadata for a list's filterable
+ * fields (field names, operators, enumerated values / relationship label
+ * search). Carries no functions, so it can cross the server/client boundary to
+ * drive the Filter builder's autocomplete.
+ */
+export function collectFilterSuggestions(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listKey: string,
+  config: OpenSaasConfig,
+): FilterFieldSuggestion[] {
+  const specs = collectFilterSpecs(listConfig, listKey, config)
+  return Object.entries(specs).map(([field, spec]) => ({
+    field,
+    operators: spec.operators,
+    freeText: spec.freeText ?? false,
+    valueSource: spec.suggestions.valueSource,
+  }))
+}

--- a/packages/core/src/filter/filter.test.ts
+++ b/packages/core/src/filter/filter.test.ts
@@ -70,6 +70,23 @@ describe('parseFilterQuery', () => {
       { field: null, operator: 'eq', value: '>5', raw: '>5' },
     ])
   })
+
+  it('treats a URL scheme (`http://…`) as whole free text, not a field prefix', () => {
+    // `http:` must NOT be parsed as a `field:` prefix — the `//` after the
+    // colon marks a URL scheme, so the entire URL stays a free-text token.
+    expect(() => parseFilterQuery('http://x')).not.toThrow()
+    expect(parseFilterQuery('http://x')).toEqual([
+      { field: null, operator: 'eq', value: 'http://x', raw: 'http://x' },
+    ])
+    expect(parseFilterQuery('https://example.com/path?q=1')).toEqual([
+      {
+        field: null,
+        operator: 'eq',
+        value: 'https://example.com/path?q=1',
+        raw: 'https://example.com/path?q=1',
+      },
+    ])
+  })
 })
 
 // ─────────────────────────────────────────────────────────────
@@ -187,6 +204,17 @@ describe('buildFilterWhere', () => {
   it('drops a degraded token entirely when there are no free-text fields', () => {
     const noFreeText = { orders: ordersSpec }
     expect(buildFilterWhere(parseFilterQuery('role:Editor'), noFreeText)).toBeUndefined()
+  })
+
+  it('searches a pasted URL as whole free text (scheme not dropped)', () => {
+    // `http://x` must be searched in full, not mangled to `//x` by a spurious
+    // `http:` field prefix.
+    expect(buildFilterWhere(parseFilterQuery('http://x'), specs)).toEqual({
+      name: { contains: 'http://x' },
+    })
+    expect(buildFilterWhere(parseFilterQuery('https://example.com'), specs)).toEqual({
+      name: { contains: 'https://example.com' },
+    })
   })
 })
 

--- a/packages/core/src/filter/filter.test.ts
+++ b/packages/core/src/filter/filter.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest'
+import { parseFilterQuery } from './parse.js'
+import { buildFilterWhere } from './map.js'
+import { buildListFilterWhere, collectFilterSpecs, collectFilterSuggestions } from './collect.js'
+import type { FilterSpec } from './types.js'
+import { list } from '../config/index.js'
+import { text, integer, select, checkbox, timestamp, relationship } from '../fields/index.js'
+import type { OpenSaasConfig } from '../config/types.js'
+
+// ─────────────────────────────────────────────────────────────
+// parseFilterQuery — the pure query-string → tokens boundary (ADR-0017)
+// ─────────────────────────────────────────────────────────────
+
+describe('parseFilterQuery', () => {
+  it('parses a bare word as a free-text token (field: null)', () => {
+    expect(parseFilterQuery('beta')).toEqual([
+      { field: null, operator: 'eq', value: 'beta', raw: 'beta' },
+    ])
+  })
+
+  it('parses a field:value token with the default eq operator', () => {
+    expect(parseFilterQuery('role:Editor')).toEqual([
+      { field: 'role', operator: 'eq', value: 'Editor', raw: 'role:Editor' },
+    ])
+  })
+
+  it('parses comparison operators on a field token', () => {
+    expect(parseFilterQuery('orders:>5')).toEqual([
+      { field: 'orders', operator: 'gt', value: '5', raw: 'orders:>5' },
+    ])
+    expect(parseFilterQuery('orders:>=5')[0].operator).toBe('gte')
+    expect(parseFilterQuery('orders:<5')[0].operator).toBe('lt')
+    expect(parseFilterQuery('orders:<=5')[0].operator).toBe('lte')
+  })
+
+  it('keeps spaces inside a quoted value', () => {
+    expect(parseFilterQuery('name:"Ada Lovelace"')).toEqual([
+      { field: 'name', operator: 'eq', value: 'Ada Lovelace', raw: 'name:"Ada Lovelace"' },
+    ])
+  })
+
+  it('parses a bare quoted phrase as a single free-text token', () => {
+    expect(parseFilterQuery('"multi word"')).toEqual([
+      { field: null, operator: 'eq', value: 'multi word', raw: '"multi word"' },
+    ])
+  })
+
+  it('parses implicit-AND: multiple whitespace-separated tokens', () => {
+    const tokens = parseFilterQuery('role:Editor status:Active orders:>5 name:"Ada Lovelace" beta')
+    expect(tokens.map((t) => ({ field: t.field, operator: t.operator, value: t.value }))).toEqual([
+      { field: 'role', operator: 'eq', value: 'Editor' },
+      { field: 'status', operator: 'eq', value: 'Active' },
+      { field: 'orders', operator: 'gt', value: '5' },
+      { field: 'name', operator: 'eq', value: 'Ada Lovelace' },
+      { field: null, operator: 'eq', value: 'beta' },
+    ])
+  })
+
+  it('collapses surrounding / repeated whitespace', () => {
+    expect(parseFilterQuery('   a    b  ').map((t) => t.value)).toEqual(['a', 'b'])
+  })
+
+  it('returns no tokens for an empty query', () => {
+    expect(parseFilterQuery('')).toEqual([])
+    expect(parseFilterQuery('   ')).toEqual([])
+  })
+
+  it('never throws on odd input — a leading comparison on a bare word stays free text', () => {
+    expect(parseFilterQuery('>5')).toEqual([
+      { field: null, operator: 'eq', value: '>5', raw: '>5' },
+    ])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// buildFilterWhere — tokens + specs → Prisma where (the mapping seam)
+// ─────────────────────────────────────────────────────────────
+
+// Small hand-rolled specs so the mapping is tested independently of the field
+// builders.
+const nameSpec: FilterSpec = {
+  operators: ['eq'],
+  freeText: true,
+  toCondition: (op, value) => (op === 'eq' ? { name: { contains: value } } : null),
+  suggestions: { valueSource: { kind: 'none' } },
+}
+const ordersSpec: FilterSpec = {
+  operators: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  toCondition: (op, value) => {
+    if (!/^-?\d+$/.test(value)) return null
+    return { orders: { [op === 'eq' ? 'equals' : op]: Number(value) } }
+  },
+  suggestions: { valueSource: { kind: 'none' } },
+}
+const statusSpec: FilterSpec = {
+  operators: ['eq'],
+  toCondition: (op, value) =>
+    op === 'eq' && ['active', 'inactive'].includes(value.toLowerCase())
+      ? { status: { equals: value.toLowerCase() } }
+      : null,
+  suggestions: {
+    valueSource: {
+      kind: 'enum',
+      options: [
+        { value: 'active', label: 'Active' },
+        { value: 'inactive', label: 'Inactive' },
+      ],
+    },
+  },
+}
+const specs = { name: nameSpec, orders: ordersSpec, status: statusSpec }
+
+describe('buildFilterWhere', () => {
+  it('returns undefined when nothing filters', () => {
+    expect(buildFilterWhere([], specs)).toBeUndefined()
+  })
+
+  it('maps a single field token to its condition (no AND wrapper)', () => {
+    expect(buildFilterWhere(parseFilterQuery('orders:>5'), specs)).toEqual({
+      orders: { gt: 5 },
+    })
+  })
+
+  it('maps eq on a numeric field to `equals`', () => {
+    expect(buildFilterWhere(parseFilterQuery('orders:5'), specs)).toEqual({
+      orders: { equals: 5 },
+    })
+  })
+
+  it('ANDs multiple field tokens (implicit AND)', () => {
+    expect(buildFilterWhere(parseFilterQuery('status:Active orders:>5'), specs)).toEqual({
+      AND: [{ status: { equals: 'active' } }, { orders: { gt: 5 } }],
+    })
+  })
+
+  it('maps a bare word to an OR across free-text fields', () => {
+    // Only `name` is free-text here.
+    expect(buildFilterWhere(parseFilterQuery('beta'), specs)).toEqual({
+      name: { contains: 'beta' },
+    })
+  })
+
+  it('ANDs multiple bare words (each word must match)', () => {
+    const multiFreeText = {
+      name: nameSpec,
+      title: {
+        ...nameSpec,
+        toCondition: (op: 'eq' | 'gt' | 'gte' | 'lt' | 'lte', v: string) =>
+          op === 'eq' ? { title: { contains: v } } : null,
+      } as FilterSpec,
+    }
+    expect(buildFilterWhere(parseFilterQuery('beta gamma'), multiFreeText)).toEqual({
+      AND: [
+        { OR: [{ name: { contains: 'beta' } }, { title: { contains: 'beta' } }] },
+        { OR: [{ name: { contains: 'gamma' } }, { title: { contains: 'gamma' } }] },
+      ],
+    })
+  })
+
+  // ─── Graceful degradation (ADR-0017): unknown syntax → free text, never error
+  it('degrades an unknown field to free text', () => {
+    // `role` has no spec → search "Editor" across free-text fields.
+    expect(buildFilterWhere(parseFilterQuery('role:Editor'), specs)).toEqual({
+      name: { contains: 'Editor' },
+    })
+  })
+
+  it('degrades an unsupported operator to free text', () => {
+    // `status` supports only eq → `status:>x` degrades, searching "x".
+    expect(buildFilterWhere(parseFilterQuery('status:>x'), specs)).toEqual({
+      name: { contains: 'x' },
+    })
+  })
+
+  it('degrades an unmappable value (non-numeric on a numeric field) to free text', () => {
+    expect(buildFilterWhere(parseFilterQuery('orders:abc'), specs)).toEqual({
+      name: { contains: 'abc' },
+    })
+  })
+
+  it('degrades an unknown enum value to free text', () => {
+    expect(buildFilterWhere(parseFilterQuery('status:pending'), specs)).toEqual({
+      name: { contains: 'pending' },
+    })
+  })
+
+  it('drops a degraded token entirely when there are no free-text fields', () => {
+    const noFreeText = { orders: ordersSpec }
+    expect(buildFilterWhere(parseFilterQuery('role:Editor'), noFreeText)).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Field-builder Filter specs + collect helpers (config-aware layer)
+// ─────────────────────────────────────────────────────────────
+
+function makeConfig(): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+    lists: {
+      User: list({ fields: { name: text() } }),
+      Post: list({
+        fields: {
+          title: text(),
+          views: integer(),
+          status: select({
+            options: [
+              { label: 'Draft', value: 'draft' },
+              { label: 'Published', value: 'published' },
+            ],
+          }),
+          featured: checkbox(),
+          publishedAt: timestamp(),
+          author: relationship({ ref: 'User.posts' }),
+        },
+      }),
+    },
+  }
+}
+
+describe('core field Filter specs', () => {
+  const config = makeConfig()
+  const postConfig = config.lists.Post
+
+  it('collectFilterSpecs resolves a spec for every filterable core field', () => {
+    const collected = collectFilterSpecs(postConfig, 'Post', config)
+    expect(Object.keys(collected).sort()).toEqual(
+      ['author', 'featured', 'publishedAt', 'status', 'title', 'views'].sort(),
+    )
+  })
+
+  it('text is free-text and maps to contains', () => {
+    const spec = postConfig.fields.title.getFilterSpec!('title', 'Post', config)!
+    expect(spec.freeText).toBe(true)
+    expect(spec.toCondition('eq', 'hello')).toEqual({ title: { contains: 'hello' } })
+  })
+
+  it('integer supports comparisons and rejects non-integers', () => {
+    const spec = postConfig.fields.views.getFilterSpec!('views', 'Post', config)!
+    expect(spec.toCondition('gt', '5')).toEqual({ views: { gt: 5 } })
+    expect(spec.toCondition('eq', '5')).toEqual({ views: { equals: 5 } })
+    expect(spec.toCondition('eq', 'abc')).toBeNull()
+  })
+
+  it('select matches by value or label and resolves to the stored value', () => {
+    const spec = postConfig.fields.status.getFilterSpec!('status', 'Post', config)!
+    expect(spec.toCondition('eq', 'Published')).toEqual({ status: { equals: 'published' } })
+    expect(spec.toCondition('eq', 'published')).toEqual({ status: { equals: 'published' } })
+    expect(spec.toCondition('eq', 'archived')).toBeNull()
+    expect(spec.suggestions.valueSource).toEqual({
+      kind: 'enum',
+      options: [
+        { value: 'draft', label: 'Draft' },
+        { value: 'published', label: 'Published' },
+      ],
+    })
+  })
+
+  it('checkbox maps true/false and rejects anything else', () => {
+    const spec = postConfig.fields.featured.getFilterSpec!('featured', 'Post', config)!
+    expect(spec.toCondition('eq', 'true')).toEqual({ featured: { equals: true } })
+    expect(spec.toCondition('eq', 'False')).toEqual({ featured: { equals: false } })
+    expect(spec.toCondition('eq', 'yes')).toBeNull()
+  })
+
+  it('timestamp compares parsed dates and rejects unparseable values', () => {
+    const spec = postConfig.fields.publishedAt.getFilterSpec!('publishedAt', 'Post', config)!
+    const condition = spec.toCondition('gt', '2024-01-01') as { publishedAt: { gt: Date } }
+    expect(condition.publishedAt.gt).toBeInstanceOf(Date)
+    expect(spec.toCondition('gt', 'not-a-date')).toBeNull()
+  })
+
+  it('relationship maps to a nested label filter (is for to-one)', () => {
+    const spec = postConfig.fields.author.getFilterSpec!('author', 'Post', config)!
+    // User's label field falls back to `name`.
+    expect(spec.toCondition('eq', 'Ada')).toEqual({ author: { is: { name: { contains: 'Ada' } } } })
+    expect(spec.suggestions.valueSource).toEqual({
+      kind: 'relationship',
+      listKey: 'User',
+      many: false,
+    })
+  })
+
+  it('does not produce specs for password/json/virtual (absence degrades gracefully)', () => {
+    // A list of non-filterable fields yields no specs at all.
+    const specsForUser = collectFilterSpecs(config.lists.User, 'User', config)
+    // User only has `name` (text) → exactly one spec, proving non-text absence.
+    expect(Object.keys(specsForUser)).toEqual(['name'])
+  })
+})
+
+describe('buildListFilterWhere (end-to-end over a real list config)', () => {
+  const config = makeConfig()
+
+  it('composes parse + specs into a merged where', () => {
+    const where = buildListFilterWhere(
+      'status:Published views:>10 author:"Ada" hello',
+      config.lists.Post,
+      'Post',
+      config,
+    )
+    expect(where).toEqual({
+      AND: [
+        { status: { equals: 'published' } },
+        { views: { gt: 10 } },
+        { author: { is: { name: { contains: 'Ada' } } } },
+        // `hello` is free text over the two text fields (title only — status is
+        // not free-text) → but title is the only free-text field here.
+        { title: { contains: 'hello' } },
+      ],
+    })
+  })
+
+  it('returns undefined for an all-whitespace query', () => {
+    expect(buildListFilterWhere('   ', config.lists.Post, 'Post', config)).toBeUndefined()
+  })
+})
+
+describe('collectFilterSuggestions', () => {
+  it('returns serializable, function-free suggestion metadata', () => {
+    const config = makeConfig()
+    const suggestions = collectFilterSuggestions(config.lists.Post, 'Post', config)
+    // No functions anywhere → JSON round-trips cleanly.
+    expect(JSON.parse(JSON.stringify(suggestions))).toEqual(suggestions)
+    const status = suggestions.find((s) => s.field === 'status')!
+    expect(status.valueSource.kind).toBe('enum')
+    const author = suggestions.find((s) => s.field === 'author')!
+    expect(author.valueSource).toEqual({ kind: 'relationship', listKey: 'User', many: false })
+  })
+})

--- a/packages/core/src/filter/index.ts
+++ b/packages/core/src/filter/index.ts
@@ -1,0 +1,22 @@
+// ───────────────────────────────────────────────────────────────
+// Filter engine (ADR-0017)
+//
+// The pure boundary behind the admin UI's Filter builder:
+//   • parseFilterQuery  — query string → Filter tokens
+//   • buildFilterWhere  — tokens + Filter specs → Prisma where fragment
+// plus config-aware helpers that collect each field's Filter spec and compose
+// the two steps for a list. All of this stays free of DB/Prisma imports so the
+// grammar contract (including graceful degradation) is unit-testable.
+// ───────────────────────────────────────────────────────────────
+
+export { parseFilterQuery } from './parse.js'
+export { buildFilterWhere } from './map.js'
+export { collectFilterSpecs, buildListFilterWhere, collectFilterSuggestions } from './collect.js'
+export type {
+  FilterOperator,
+  FilterToken,
+  FilterCondition,
+  FilterSpec,
+  FilterValueSource,
+  FilterFieldSuggestion,
+} from './types.js'

--- a/packages/core/src/filter/map.ts
+++ b/packages/core/src/filter/map.ts
@@ -1,0 +1,68 @@
+import type { FilterCondition, FilterSpec, FilterToken } from './types.js'
+
+/**
+ * Map parsed {@link FilterToken}s to a single Prisma `where` fragment, given the
+ * fields' {@link FilterSpec}s (ADR-0017).
+ *
+ * Pure — no DB/Prisma imports. This is the unit-tested half of the filter seam.
+ * Tokens combine with implicit AND. A token degrades to free text (never an
+ * error) when its field is unknown, has no spec, uses an unsupported operator,
+ * has an empty value, or maps to `null`. Bare words (and degraded tokens) are
+ * OR-matched across every free-text field, and each such word is ANDed with the
+ * rest — so `beta gamma` requires both.
+ *
+ * @param tokens Parsed tokens from {@link parseFilterQuery}.
+ * @param specs  Field-name → Filter spec (from {@link collectFilterSpecs}).
+ * @returns A Prisma `where` fragment, or `undefined` when nothing filters.
+ */
+export function buildFilterWhere(
+  tokens: FilterToken[],
+  specs: Record<string, FilterSpec>,
+): FilterCondition | undefined {
+  const andConditions: FilterCondition[] = []
+  const freeTextWords: string[] = []
+
+  const freeTextFields = Object.keys(specs).filter((field) => specs[field].freeText)
+
+  for (const token of tokens) {
+    // Bare free-text word.
+    if (token.field === null) {
+      if (token.value) freeTextWords.push(token.value)
+      continue
+    }
+
+    const spec = specs[token.field]
+
+    // Unknown field / no spec / unsupported operator / empty value →
+    // degrade to free text (search the value across free-text fields).
+    if (!spec || !spec.operators.includes(token.operator) || token.value === '') {
+      if (token.value) freeTextWords.push(token.value)
+      continue
+    }
+
+    const condition = spec.toCondition(token.operator, token.value)
+    if (condition === null) {
+      // Value couldn't be interpreted for this field → free text.
+      freeTextWords.push(token.value)
+      continue
+    }
+
+    andConditions.push(condition)
+  }
+
+  // Each free-text word: OR across every free-text field's `eq` mapping.
+  if (freeTextFields.length > 0) {
+    for (const word of freeTextWords) {
+      const orConditions = freeTextFields
+        .map((field) => specs[field].toCondition('eq', word))
+        .filter((condition): condition is FilterCondition => condition !== null)
+      if (orConditions.length > 0) {
+        andConditions.push(orConditions.length === 1 ? orConditions[0] : { OR: orConditions })
+      }
+    }
+  }
+
+  if (andConditions.length === 0) return undefined
+  if (andConditions.length === 1) return andConditions[0]
+  return { AND: andConditions }
+}

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -1,0 +1,100 @@
+import type { FilterOperator, FilterToken } from './types.js'
+
+/**
+ * A field prefix is an identifier (letter/underscore, then word chars)
+ * immediately followed by a colon, e.g. `role:` or `orders:`.
+ */
+const FIELD_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_]*):/
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r'
+}
+
+/**
+ * Parse a filter query string into {@link FilterToken}s (ADR-0017 grammar).
+ *
+ * Pure and field-agnostic: it recognises the *syntax* (field prefix, comparison
+ * operator, quoted value, bare word) but never validates field names or values
+ * — that is the mapping step's job, where unknown/unmappable tokens degrade to
+ * free text. This parser therefore never throws; malformed input simply parses
+ * as bare free-text words.
+ *
+ * Grammar:
+ * - `field:value` → a field token with the `eq` operator.
+ * - `field:>value`, `field:>=value`, `field:<value`, `field:<=value` →
+ *   comparison operators.
+ * - `field:"multi word"` / bare `"multi word"` → quoted values keep spaces.
+ * - anything else (`beta`, `>5`, `http://x`) → a bare free-text token
+ *   (`field: null`).
+ *
+ * @example
+ * parseFilterQuery('role:Editor orders:>5 name:"Ada Lovelace" beta')
+ * // [
+ * //   { field: 'role',   operator: 'eq',  value: 'Editor',       raw: 'role:Editor' },
+ * //   { field: 'orders', operator: 'gt',  value: '5',            raw: 'orders:>5' },
+ * //   { field: 'name',   operator: 'eq',  value: 'Ada Lovelace', raw: 'name:"Ada Lovelace"' },
+ * //   { field: null,     operator: 'eq',  value: 'beta',         raw: 'beta' },
+ * // ]
+ */
+export function parseFilterQuery(query: string): FilterToken[] {
+  const tokens: FilterToken[] = []
+  if (!query) return tokens
+
+  const n = query.length
+  let i = 0
+
+  while (i < n) {
+    // Skip leading whitespace between tokens.
+    while (i < n && isWhitespace(query[i])) i++
+    if (i >= n) break
+
+    const start = i
+
+    // Optional `field:` prefix.
+    let field: string | null = null
+    const prefixMatch = FIELD_PREFIX_RE.exec(query.slice(i))
+    if (prefixMatch) {
+      field = prefixMatch[1]
+      i += prefixMatch[0].length
+    }
+
+    // Comparison operator prefix — only meaningful once a field is present.
+    // A leading `>`/`<` on a bare word is left as part of the free-text value.
+    let operator: FilterOperator = 'eq'
+    if (field) {
+      if (query.startsWith('>=', i)) {
+        operator = 'gte'
+        i += 2
+      } else if (query.startsWith('<=', i)) {
+        operator = 'lte'
+        i += 2
+      } else if (query[i] === '>') {
+        operator = 'gt'
+        i += 1
+      } else if (query[i] === '<') {
+        operator = 'lt'
+        i += 1
+      }
+    }
+
+    // Value: quoted (spaces kept) or a run up to the next whitespace.
+    let value = ''
+    if (query[i] === '"') {
+      i++ // opening quote
+      while (i < n && query[i] !== '"') {
+        value += query[i]
+        i++
+      }
+      if (i < n) i++ // closing quote
+    } else {
+      while (i < n && !isWhitespace(query[i])) {
+        value += query[i]
+        i++
+      }
+    }
+
+    tokens.push({ field, operator, value, raw: query.slice(start, i) })
+  }
+
+  return tokens
+}

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -24,8 +24,12 @@ function isWhitespace(ch: string): boolean {
  * - `field:>value`, `field:>=value`, `field:<value`, `field:<=value` →
  *   comparison operators.
  * - `field:"multi word"` / bare `"multi word"` → quoted values keep spaces.
- * - anything else (`beta`, `>5`, `http://x`) → a bare free-text token
- *   (`field: null`).
+ * - anything else (`beta`, `>5`) → a bare free-text token (`field: null`).
+ *
+ * A `word:` is *not* treated as a field prefix when the colon is immediately
+ * followed by `//` (a URL scheme like `http://x` or `https://…`); the whole
+ * token stays free text so a pasted URL is searched verbatim rather than
+ * mangled into `{ field: 'http', value: '//x' }`.
  *
  * @example
  * parseFilterQuery('role:Editor orders:>5 name:"Ada Lovelace" beta')
@@ -50,10 +54,12 @@ export function parseFilterQuery(query: string): FilterToken[] {
 
     const start = i
 
-    // Optional `field:` prefix.
+    // Optional `field:` prefix. A URL scheme (`http://…`) is not a field
+    // prefix: when the colon is immediately followed by `//`, keep the whole
+    // token as free text so pasted URLs are searched verbatim.
     let field: string | null = null
     const prefixMatch = FIELD_PREFIX_RE.exec(query.slice(i))
-    if (prefixMatch) {
+    if (prefixMatch && !query.startsWith('//', i + prefixMatch[0].length)) {
       field = prefixMatch[1]
       i += prefixMatch[0].length
     }

--- a/packages/core/src/filter/types.ts
+++ b/packages/core/src/filter/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Filter engine types (ADR-0017).
+ *
+ * The admin UI's Filter builder turns a URL query string into scoped,
+ * server-executed filtering. The grammar is an AND-only URL contract:
+ * implicit-AND tokens, quoted multi-word values, comparison operators on
+ * numeric/date fields, and bare words as free text. Fields participate by
+ * declaring a {@link FilterSpec} (a self-contained field-builder method, peer
+ * of `getPrismaType` et al.); a field without one is not filterable.
+ *
+ * These types are the pure boundary — no Prisma / DB imports — so the
+ * `parse → tokens` and `tokens + specs → conditions` seam is unit-testable.
+ */
+
+/**
+ * A Filter operator. `eq` is the default operator for a plain `field:value`
+ * token (each field's spec decides what equality means — `contains` for text,
+ * `equals` for a select); the comparisons are produced by the `>`/`>=`/`<`/`<=`
+ * prefixes on numeric and date tokens.
+ */
+export type FilterOperator = 'eq' | 'gt' | 'gte' | 'lt' | 'lte'
+
+/**
+ * One parsed unit of a filter query — a field, an operator, and a value.
+ *
+ * A bare free-text word parses to a token with `field: null`. `raw` is the
+ * original source substring, retained so a token that can't map to a condition
+ * degrades to free text without re-tokenising.
+ */
+export interface FilterToken {
+  /** Field key the token targets, or `null` for a bare free-text word. */
+  field: string | null
+  /** The operator; `eq` for a plain `field:value`, comparisons for prefixed values. */
+  operator: FilterOperator
+  /** The unquoted value. */
+  value: string
+  /** The original source substring for this token (used when degrading to free text). */
+  raw: string
+}
+
+/**
+ * A Prisma `where` fragment produced by a Filter spec's `toCondition` mapper.
+ * Kept as an opaque record so this module carries no Prisma type dependency;
+ * the secured context ANDs it with the access filter when the fragment reaches
+ * `context.db.*`.
+ */
+export type FilterCondition = Record<string, unknown>
+
+/**
+ * Serializable description of what the suggestion dropdown may offer for a
+ * field's values. Structure only — never data-derived values for unbounded
+ * fields (ADR-0017): `none` for text/number/date, enumerated `options` for
+ * select/checkbox, and `relationship` for label search via the existing
+ * access-controlled lookup.
+ */
+export type FilterValueSource =
+  | { kind: 'none' }
+  | { kind: 'enum'; options: Array<{ value: string; label: string }> }
+  | { kind: 'relationship'; listKey: string; many: boolean }
+
+/**
+ * A field's self-declared filtering capability. Returned by the optional
+ * `getFilterSpec` field-builder method.
+ */
+export interface FilterSpec {
+  /** Operators this field supports. A token using any other operator degrades to free text. */
+  operators: FilterOperator[]
+  /**
+   * Whether this field participates in bare-word free-text search. Bare words
+   * are OR-matched across every free-text field via each field's `eq` mapping.
+   */
+  freeText?: boolean
+  /**
+   * Pure map from a supported `(operator, value)` to a Prisma `where` fragment,
+   * or `null` when the value can't be interpreted (e.g. a non-numeric value on
+   * a numeric field, or an unknown select option) — in which case the token
+   * degrades to free text. MUST stay free of DB/Prisma imports.
+   */
+  toCondition: (operator: FilterOperator, value: string) => FilterCondition | null
+  /** Serializable suggestion metadata for the client. */
+  suggestions: {
+    valueSource: FilterValueSource
+  }
+}
+
+/**
+ * Collected, client-serializable suggestion metadata for one filterable field.
+ * The union of every list field's Filter spec suggestions; carries no
+ * functions, so it crosses the server/client boundary.
+ */
+export interface FilterFieldSuggestion {
+  /** The field key. */
+  field: string
+  /** Operators the field supports. */
+  operators: FilterOperator[]
+  /** Whether the field participates in bare-word free-text search. */
+  freeText: boolean
+  /** How the suggestion dropdown may offer values for this field. */
+  valueSource: FilterValueSource
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,3 +72,24 @@ export type { ResultOf, RelationSelector, QueryArgs } from './query/index.js'
 // op; also callable directly wherever a full context is already in hand.
 export { getRelationshipOptions } from './query/relationship-options.js'
 export type { RelationshipOption, RelationshipOptionsArgs } from './query/relationship-options.js'
+
+// Filter engine (ADR-0017) — the admin UI's Filter builder. The pure seam
+// (`parseFilterQuery`, `buildFilterWhere`) plus config-aware helpers that
+// collect each field's Filter spec and compose a list's server-side `where`.
+// The produced fragment is ANDed with the access filter through the secured
+// context, so the filter can only ever narrow visibility.
+export {
+  parseFilterQuery,
+  buildFilterWhere,
+  collectFilterSpecs,
+  buildListFilterWhere,
+  collectFilterSuggestions,
+} from './filter/index.js'
+export type {
+  FilterOperator,
+  FilterToken,
+  FilterCondition,
+  FilterSpec,
+  FilterValueSource,
+  FilterFieldSuggestion,
+} from './filter/index.js'

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from './PageHeader.js'
 import { Button } from '../primitives/button.js'
 import {
   type AccessContext,
+  buildListFilterWhere,
   getDbKey,
   getItemLabel,
   getUrlKey,
@@ -105,24 +106,16 @@ export async function ListView({
       throw new Error(`Context for ${listKey} not found`)
     }
 
-    // Build search filter if search term provided
-    let where: Record<string, unknown> | undefined = undefined
-    if (search && search.trim()) {
-      // Find all text fields to search across
-      const searchableFields = Object.entries(listConfig.fields)
-        .filter(([_, field]) => (field as { type: string }).type === 'text')
-        .map(([fieldName]) => fieldName)
-
-      if (searchableFields.length > 0) {
-        where = {
-          OR: searchableFields.map((fieldName) => ({
-            [fieldName]: {
-              contains: search.trim(),
-            },
-          })),
-        }
-      }
-    }
+    // Parse the URL filter query into a server-side `where` fragment via the
+    // filter engine (ADR-0017). Field-scoped tokens, comparisons, quoted values
+    // and bare-word free text are all driven by each field's Filter spec — no
+    // hard-coded `type === 'text'` search here. The fragment is handed to the
+    // secured `context.db` below, which ANDs it with the access filter, so the
+    // filter can only ever narrow (never widen) what this session may see.
+    const where =
+      search && search.trim()
+        ? buildListFilterWhere(search, listConfig, listKey, config)
+        : undefined
 
     // Build include object for relationship fields
     const include: Record<string, boolean> = {}

--- a/packages/ui/tests/components/ListView.test.tsx
+++ b/packages/ui/tests/components/ListView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import * as React from 'react'
 import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
 import { list } from '@opensaas/stack-core'
-import { text, relationship } from '@opensaas/stack-core/fields'
+import { text, relationship, select } from '@opensaas/stack-core/fields'
 import { ListView } from '../../src/components/ListView.js'
 import { ListViewClient, type ListViewClientProps } from '../../src/components/ListViewClient.js'
 
@@ -208,5 +208,69 @@ describe('ListView relationship label resolution (shared label seam)', () => {
     const props = findListViewClientProps(tree)
 
     expect(props.items[0].author).toBeNull()
+  })
+})
+
+describe('ListView server-side filtering (filter engine, secured context)', () => {
+  const config: OpenSaasConfig = {
+    db: { provider: 'sqlite', url: 'file:./test.db' },
+    lists: {
+      Post: list({
+        fields: {
+          title: text(),
+          status: select({
+            options: [
+              { label: 'Draft', value: 'draft' },
+              { label: 'Published', value: 'published' },
+            ],
+          }),
+        },
+      }),
+    },
+  }
+
+  it('passes a field-token filter (status:Published) to context.db.findMany/count as a where', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ post: { findMany, count } })
+
+    // The URL filter query is the ListView `search` prop.
+    await ListView({
+      context,
+      config,
+      listKey: 'Post',
+      basePath: '/admin',
+      search: 'status:Published',
+    })
+
+    // Filtering runs through the secured context.db (never client-side); the
+    // engine mapped the select token to an equality on the stored value.
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { status: { equals: 'published' } } }),
+    )
+    expect(count).toHaveBeenCalledWith({ where: { status: { equals: 'published' } } })
+  })
+
+  it('maps a bare word to a free-text contains over text fields', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ post: { findMany, count } })
+
+    await ListView({ context, config, listKey: 'Post', basePath: '/admin', search: 'hello' })
+
+    // Only `title` is a text (free-text) field → a single contains condition.
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { title: { contains: 'hello' } } }),
+    )
+  })
+
+  it('passes where: undefined when there is no filter query', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ post: { findMany, count } })
+
+    await ListView({ context, config, listKey: 'Post', basePath: '/admin' })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: undefined }))
   })
 })


### PR DESCRIPTION
Implements #730. Part of #728.

## What this adds

The admin UI's **filter engine** (ADR-0017). An admin can put a filter query in the list URL (e.g. `role:Editor status:Active orders:>5 name:"Ada Lovelace" beta`) and the list shows exactly the matching, access-scoped rows — filtering runs server-side through the secured context.

### Filter spec — an additive field-builder method
Fields declare their filtering capability through a new **optional** `getFilterSpec` method on the field-builder contract, a peer of `getPrismaType`/`getTypeScriptType`. A spec reports:
- the **operators** it supports,
- a pure **token → condition** mapper, and
- serializable **suggestion** metadata (enumerated values for select/checkbox, relationship label search, structure-only for unbounded fields).

All core field types implement it: text (`contains` + free text), integer/decimal/timestamp/calendarDay (comparisons), select/checkbox (equality against enumerated values), relationship (nested label lookup). A field **without** a spec — `password`, `json`, `virtual`, or any third-party field that hasn't adopted one — is simply not filterable, so the addition degrades gracefully everywhere. `FilterSpec` is exported from `@opensaas/stack-core/extend` for third-party field authors.

### The pure seam (unit-tested)
Kept free of any DB/Prisma imports:
- `parseFilterQuery(query) → FilterToken[]`
- `buildFilterWhere(tokens, specs) → where`

Grammar per ADR-0017: implicit AND, quoted multi-word values, `>`/`>=`/`<`/`<=` comparisons, bare-word free text. **Unknown syntax degrades to free text, never errors** (unknown field, unsupported operator, or unmappable value all fall back to a free-text search across text-searchable fields).

### Merged through the secured context
`ListView` composes the two steps via `buildListFilterWhere` and hands the `where` to `context.db.<list>.findMany`/`count`. The access engine ANDs it with the operation-level access filter, so the filter UI can only ever **narrow**, never widen, visibility. The hard-coded `type === 'text'` search is removed; free-text behavior is now driven by each text field's Filter spec (preserving prior behavior).

## Acceptance criteria
- [x] Filter spec is an optional, additive method on the field contract; all core field types implement it
- [x] URL query param filters the list server-side, merged with access control via the secured context — never client-side
- [x] ADR-0017 grammar: implicit AND, quoted values, numeric/date comparisons, bare-word free text; malformed tokens degrade to free text
- [x] Hard-coded `type === 'text'` search removed; free-text driven by Filter specs
- [x] Unit tests lock down the parse and mapping seam, including graceful degradation
- [x] E2e: a URL-typed query returns the filtered, access-scoped table; changeset included (core + ui)

## Verification
- `pnpm build` (full workspace): green
- core vitest: **805 passed** (incl. new `src/filter/filter.test.ts` — parser, mapper, per-field specs, collect helpers, degradation)
- ui vitest: **374 passed** (incl. new `ListView` tests asserting the filter `where` reaches the secured `context.db`)
- e2e `05-filter.spec.ts`: **3 passed** against the real starter-auth app (free text, select token, unknown-syntax degradation)
- `pnpm lint` (0 errors), `pnpm manypkg fix`, `pnpm format`
- changeset: `minor` for `@opensaas/stack-core` and `@opensaas/stack-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_