### PR TITLE
Admin UI: row selection and built-in bulk delete

### DIFF
--- a/.changeset/bulk-delete-server-action.md
+++ b/.changeset/bulk-delete-server-action.md
@@ -1,0 +1,23 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Add a `bulkDelete` server action for list-level bulk deletion
+
+`context.serverAction` now accepts `{ listKey, action: 'bulkDelete', ids }`. It
+deletes each id row-by-row through the secured context, honouring Silent failure
+(a denied or missing row returns `null` and is not counted; one row's error does
+not abort the rest), and returns `{ deleted, total }`.
+
+The result is deliberately a count shape rather than the single-op `{ success }`
+shape, so a UI `serverAction` wrapper that redirects on a single-item success
+(the item-form pattern) does not hijack a list-level bulk operation.
+
+```ts
+const result = await context.serverAction({
+  listKey: 'Post',
+  action: 'bulkDelete',
+  ids: ['a', 'b', 'c'],
+})
+// result: { deleted: 2, total: 3 }  // one row was denied/missing
+```

--- a/.changeset/row-selection-bulk-delete.md
+++ b/.changeset/row-selection-bulk-delete.md
@@ -1,0 +1,35 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Add row selection and a built-in Bulk action Delete to the admin list view
+
+The list table now renders a selection checkbox column when the list's delete
+access is not statically false. The header checkbox toggles the visible page,
+per-row checkboxes accumulate an explicit id set across pages, and the selection
+clears when the filter changes. A selection bar shows the count, a Clear action,
+a named `data-slot="selection-actions"` seam for future custom bulk actions, and
+— only when delete access allows — a Delete that confirms first, deletes each
+selected row through the secured context honouring Silent failure, and reports
+"N of M deleted" (partial access denials are visible without revealing which or
+why).
+
+The admin list view also honours an optional `?pageSize=` URL param, preserved
+across sorting, searching and paging.
+
+New exports: `RowSelectionBar` (with `RowSelectionBarProps` /
+`RowSelectionBarClassNames`) and the `useRowSelection` hook plus the pure
+`isPageFullySelected` / `getPageCheckboxState` helpers.
+
+```tsx
+import { RowSelectionBar, useRowSelection } from '@opensaas/stack-ui'
+
+const selection = useRowSelection('Post', filterKey)
+<RowSelectionBar
+  count={selection.selectedCount}
+  onClear={selection.clear}
+  onDelete={async () => {
+    /* delete the selected ids through the secured context */
+  }}
+/>
+```

--- a/e2e/starter-auth/05-bulk-delete.spec.ts
+++ b/e2e/starter-auth/05-bulk-delete.spec.ts
@@ -42,8 +42,9 @@ test.describe('Bulk delete', () => {
     // Narrow to these three via search, two per page → page 1 has two, page 2
     // has one. The search (the filter) is kept across page nav, so the selection
     // persists.
-    await page.goto(`/admin/post?search=${stamp}&pageSize=2`)
-    await page.waitForLoadState('networkidle')
+    // Sort by title so pagination is deterministic: page 1 = [A, B], page 2 = [C].
+    await page.goto(`/admin/post?search=${stamp}&pageSize=2&sort=title:asc`)
+    await expect(page.getByText(titles[0])).toBeVisible()
 
     const toolbar = page.getByRole('toolbar', { name: /selection/i })
 
@@ -51,9 +52,15 @@ test.describe('Bulk delete', () => {
     await page.getByRole('checkbox', { name: /select all rows on this page/i }).click()
     await expect(toolbar).toContainText('2 selected')
 
-    // Page 2: the page-1 selection persists across the navigation…
+    // Go to page 2 and wait for its (distinct) row to load before interacting —
+    // the selection persists on both pages, so a content wait is what proves the
+    // navigation actually landed on page 2.
     await page.getByRole('button', { name: /next/i }).click()
-    await page.waitForLoadState('networkidle')
+    await page.waitForURL(/[?&]page=2\b/)
+    await expect(page.getByText(titles[2])).toBeVisible()
+    await expect(page.getByText(titles[0])).toHaveCount(0)
+
+    // The page-1 selection persisted across the navigation…
     await expect(toolbar).toContainText('2 selected')
 
     // …and adding the remaining row accumulates to three.
@@ -64,8 +71,10 @@ test.describe('Bulk delete', () => {
     await toolbar.getByRole('button', { name: 'Delete' }).click()
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
 
-    // All three were the author's own → "3 of 3 deleted", table refreshed.
-    await expect(page.getByRole('status')).toContainText('3 of 3 deleted')
+    // All three were the author's own → "3 of 3 deleted", table refreshed. Target
+    // the report by its Slot (the Delete button's spinner also uses role="status")
+    // and because it must survive the router.refresh() that reloads the table.
+    await expect(page.locator('[data-slot="selection-status"]')).toContainText('3 of 3 deleted')
     for (const title of titles) {
       await expect(page.getByText(title)).toHaveCount(0)
     }

--- a/e2e/starter-auth/05-bulk-delete.spec.ts
+++ b/e2e/starter-auth/05-bulk-delete.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * Row selection + built-in Bulk action Delete (issue #733).
+ *
+ * Exercises the whole flow against the real access-controlled context: select
+ * across pages, delete row-by-row through the secured context, and see the
+ * "N of M deleted" report with the table refreshed. The list's `Post` delete
+ * access is `isAuthor` (a function), so the built-in Delete is offered and the
+ * signed-in author can delete their own posts.
+ */
+test.describe('Bulk delete', () => {
+  test.beforeEach(async ({ page }) => {
+    await signUp(page, generateTestUser())
+  })
+
+  async function createPost(page: Page, title: string, slug: string) {
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    await page.click('text=/create|new/i')
+    await page.waitForLoadState('networkidle')
+    await page.fill('input[name="title"]', title)
+    await page.fill('input[name="slug"]', slug)
+    await page.fill('textarea[name="content"]', 'content')
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/admin\/post/, { timeout: 10000 })
+  }
+
+  test('select across pages, delete, and report N of M with a refreshed table', async ({
+    page,
+  }) => {
+    // Unique stamp so a search narrows the (shared) list to exactly these three
+    // posts — signed-in query access shows every author's posts, so pagination
+    // counts must not depend on the whole table.
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1000)}`
+    const titles = [`Bulk A ${stamp}`, `Bulk B ${stamp}`, `Bulk C ${stamp}`]
+    for (let i = 0; i < titles.length; i++) {
+      await createPost(page, titles[i], `bulk-${stamp}-${i}`)
+    }
+
+    // Narrow to these three via search, two per page → page 1 has two, page 2
+    // has one. The search (the filter) is kept across page nav, so the selection
+    // persists.
+    await page.goto(`/admin/post?search=${stamp}&pageSize=2`)
+    await page.waitForLoadState('networkidle')
+
+    const toolbar = page.getByRole('toolbar', { name: /selection/i })
+
+    // Page 1: header checkbox toggles the visible page → two selected.
+    await page.getByRole('checkbox', { name: /select all rows on this page/i }).click()
+    await expect(toolbar).toContainText('2 selected')
+
+    // Page 2: the page-1 selection persists across the navigation…
+    await page.getByRole('button', { name: /next/i }).click()
+    await page.waitForLoadState('networkidle')
+    await expect(toolbar).toContainText('2 selected')
+
+    // …and adding the remaining row accumulates to three.
+    await page.getByRole('checkbox', { name: /select all rows on this page/i }).click()
+    await expect(toolbar).toContainText('3 selected')
+
+    // Confirm and delete.
+    await toolbar.getByRole('button', { name: 'Delete' }).click()
+    await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
+
+    // All three were the author's own → "3 of 3 deleted", table refreshed.
+    await expect(page.getByRole('status')).toContainText('3 of 3 deleted')
+    for (const title of titles) {
+      await expect(page.getByText(title)).toHaveCount(0)
+    }
+  })
+})

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -24,6 +24,7 @@ export type ServerActionProps =
   | { listKey: string; action: 'create'; data: Record<string, unknown> }
   | { listKey: string; action: 'update'; id: string; data: Record<string, unknown> }
   | { listKey: string; action: 'delete'; id: string }
+  | { listKey: string; action: 'bulkDelete'; ids: string[] }
   | {
       listKey: string
       action: 'relationshipOptions'
@@ -409,11 +410,14 @@ export function getContext<
 
   // Generic server action handler with discriminated union for type safety
   // Returns a result object instead of throwing to work properly in Next.js production
-  async function serverAction(
-    props: ServerActionProps,
-  ): Promise<
+  async function serverAction(props: ServerActionProps): Promise<
     | { success: true; data: unknown }
     | { success: false; error: string; fieldErrors?: Record<string, string> }
+    // Bulk actions report a count rather than a single-op `success` flag: the
+    // shape is deliberately distinct so a UI wrapper that redirects on a
+    // single-item `success` (the item-form pattern) does not hijack a
+    // list-level bulk operation.
+    | { deleted: number; total: number }
   > {
     const dbKey = getDbKey(props.listKey)
     const listConfig = config.lists[props.listKey]
@@ -429,6 +433,24 @@ export function getContext<
       create: (args: { data: Record<string, unknown> }) => Promise<unknown>
       update: (args: { where: { id: string }; data: Record<string, unknown> }) => Promise<unknown>
       delete: (args: { where: { id: string } }) => Promise<unknown>
+    }
+
+    // Bulk delete: remove each id row-by-row through the secured context,
+    // honouring Silent failure — a denied (or missing) row returns `null` and is
+    // simply not counted. Returns "N of M" so partial denials are visible without
+    // revealing which rows were denied or why. One row's error never aborts the
+    // rest.
+    if (props.action === 'bulkDelete') {
+      let deleted = 0
+      for (const id of props.ids) {
+        try {
+          const result = await model.delete({ where: { id } })
+          if (result !== null && result !== undefined) deleted++
+        } catch {
+          // Skip this row (e.g. a DB constraint error); it is not counted.
+        }
+      }
+      return { deleted, total: props.ids.length }
     }
 
     try {

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -108,6 +108,14 @@ export function AdminUI({
     // List view
     const search = typeof searchParams.search === 'string' ? searchParams.search : undefined
     const page = typeof searchParams.page === 'string' ? parseInt(searchParams.page, 10) : 1
+    // Optional `?pageSize=` override (Keystone-style). When absent, ListView's
+    // own default applies.
+    const pageSizeParam =
+      typeof searchParams.pageSize === 'string' ? parseInt(searchParams.pageSize, 10) : undefined
+    const pageSize =
+      pageSizeParam !== undefined && Number.isFinite(pageSizeParam) && pageSizeParam > 0
+        ? pageSizeParam
+        : undefined
 
     // Read list-view defaults (column selection/order + default sort) from the
     // list-level `ui.listView` config (mirrors Keystone). When absent, the
@@ -137,9 +145,11 @@ export function AdminUI({
         basePath={basePath}
         search={search}
         page={page}
+        pageSize={pageSize}
         columns={listView?.initialColumns}
         initialSort={listView?.initialSort}
         sort={urlSort}
+        serverAction={serverAction}
       />
     )
   }

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -5,14 +5,31 @@ import { formatListName } from '../lib/utils.js'
 import { serializeFieldConfigs } from '../lib/serializeFieldConfig.js'
 import { PageHeader } from './PageHeader.js'
 import { Button } from '../primitives/button.js'
+import type { ServerActionInput } from '../server/types.js'
 import {
   type AccessContext,
+  type AccessControl,
   buildListFilterWhere,
   getDbKey,
   getItemLabel,
   getUrlKey,
   OpenSaasConfig,
 } from '@opensaas/stack-core'
+
+/**
+ * Whether the list's delete access is NOT statically false (issue #733).
+ *
+ * "Statically false" means we can prove no session can ever delete without
+ * running a session-dependent function: delete access is absent (deny by
+ * default) or the literal boolean `false`. A function — or `true` — can't be
+ * evaluated up front, so Delete is offered and per-row Silent failure absorbs
+ * any denials into the "N of M deleted" report.
+ */
+function canDeleteList(deleteAccess: AccessControl | boolean | undefined): boolean {
+  if (deleteAccess === undefined) return false
+  if (typeof deleteAccess === 'boolean') return deleteAccess
+  return true
+}
 
 /**
  * Resolve a fetched relationship value (the full related record, or `null`)
@@ -58,6 +75,12 @@ export interface ListViewProps {
    * Takes precedence over `initialSort`.
    */
   sort?: ListViewSort
+  /**
+   * The generic server action (rebuilds the session context server-side).
+   * Threaded to the client table for the built-in Bulk action Delete. When
+   * omitted, no bulk delete is offered.
+   */
+  serverAction?: (input: ServerActionInput) => Promise<unknown>
 }
 
 /**
@@ -75,6 +98,7 @@ export async function ListView({
   search,
   initialSort,
   sort,
+  serverAction,
 }: ListViewProps) {
   const key = getDbKey(listKey)
   const urlKey = getUrlKey(listKey)
@@ -212,6 +236,8 @@ export async function ListView({
         pageSize={pageSize}
         total={total || 0}
         search={search}
+        serverAction={serverAction}
+        canDelete={canDeleteList(listConfig.access?.operation?.delete)}
       />
     </div>
   )

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -16,9 +16,27 @@ import {
 import { Input } from '../primitives/input.js'
 import { Button } from '../primitives/button.js'
 import { Card } from '../primitives/card.js'
+import { Checkbox } from '../primitives/checkbox.js'
 import { EmptyState } from './EmptyState.js'
 import { CellRenderer } from './cells/CellRenderer.js'
+import { RowSelectionBar } from './RowSelectionBar.js'
+import { useRowSelection, getPageCheckboxState } from '../lib/useRowSelection.js'
 import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
+import type { ServerActionInput } from '../server/types.js'
+
+/**
+ * Narrow a `serverAction` result to a success without leaking a shape onto the
+ * external API. A denied delete comes back `{ success: false }` (Silent
+ * failure) and is simply not counted.
+ */
+function isServerActionSuccess(result: unknown): boolean {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'success' in result &&
+    (result as { success: unknown }).success === true
+  )
+}
 
 export interface ListViewClientProps {
   items: Array<Record<string, unknown>>
@@ -45,6 +63,20 @@ export interface ListViewClientProps {
   pageSize: number
   total: number
   search?: string
+  /**
+   * The generic server action (rebuilds the session context server-side). Used
+   * by the built-in Bulk action Delete to remove each selected row through the
+   * secured context. When omitted, no bulk delete is offered.
+   */
+  serverAction?: (input: ServerActionInput) => Promise<unknown>
+  /**
+   * Whether the list's delete access is NOT statically false — evaluated up
+   * front on the server (see `ListView`). Gates both the selection affordance
+   * and the built-in Delete: when `false`, no session can ever delete, so
+   * neither is shown. When `true`, Delete is offered and per-row denials are
+   * absorbed by Silent failure into the "N of M deleted" report.
+   */
+  canDelete?: boolean
 }
 
 /**
@@ -58,17 +90,59 @@ export function ListViewClient({
   relationshipRefs,
   columns,
   initialSort,
+  listKey,
   urlKey,
   basePath,
   page,
   pageSize,
   total,
   search: initialSearch,
+  serverAction,
+  canDelete = false,
 }: ListViewClientProps) {
   const router = useRouter()
   const sortBy = initialSort?.field ?? null
   const sortOrder = initialSort?.direction ?? 'asc'
   const [searchInput, setSearchInput] = React.useState(initialSearch || '')
+
+  // Row selection (issue #733). The filter identity is the active search — page
+  // and sort changes keep it stable (selection persists while paging) while a
+  // filter change resets it. When the Filter builder lands this becomes the full
+  // filter query string.
+  const filterKey = initialSearch ?? ''
+  const selection = useRowSelection(listKey, filterKey)
+
+  // Selection is offered only when a Bulk action exists. Today that is the
+  // built-in Delete (gated by static delete access); #736 will widen this to
+  // `canDelete || hasCustomBulkActions`.
+  const selectionEnabled = canDelete
+  const canBulkDelete = canDelete && !!serverAction
+
+  // The "N of M deleted" report persists after the selection clears, so it lives
+  // here (always mounted) rather than in the selection bar (which unmounts once
+  // the selection empties).
+  const [bulkStatus, setBulkStatus] = React.useState<string | null>(null)
+
+  const pageIds = items.map((item) => String(item.id))
+
+  const handleBulkDelete = async () => {
+    if (!serverAction) return
+    const ids = [...selection.selectedIds]
+    setBulkStatus(null)
+
+    // Row-by-row through the secured context. A denied row returns a Silent
+    // failure (`{ success: false }`) and is simply not counted — the report
+    // never reveals which rows were denied or why.
+    let deleted = 0
+    for (const id of ids) {
+      const result = await serverAction({ listKey, action: 'delete', id })
+      if (isServerActionSuccess(result)) deleted++
+    }
+
+    selection.clear()
+    setBulkStatus(`${deleted} of ${ids.length} deleted`)
+    router.refresh()
+  }
 
   // Determine which columns to show
   const displayColumns =
@@ -81,6 +155,14 @@ export function ListViewClient({
   const hasNextPage = page < totalPages
   const hasPrevPage = page > 1
 
+  // Echo a non-default page size into nav URLs so an active `?pageSize=` survives
+  // sorting/searching/paging. DEFAULT_PAGE_SIZE mirrors ListView's own default.
+  const DEFAULT_PAGE_SIZE = 50
+  const withPageSize = (params: URLSearchParams) => {
+    if (pageSize !== DEFAULT_PAGE_SIZE) params.set('pageSize', String(pageSize))
+    return params
+  }
+
   const handleSort = (column: string) => {
     const newDirection = sortBy === column ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'asc'
     const params = new URLSearchParams()
@@ -89,7 +171,7 @@ export function ListViewClient({
     }
     params.set('sort', `${column}:${newDirection}`)
     params.set('page', '1')
-    router.push(`${basePath}/${urlKey}?${params.toString()}`)
+    router.push(`${basePath}/${urlKey}?${withPageSize(params).toString()}`)
   }
 
   const handleSearch = (e: React.FormEvent) => {
@@ -102,7 +184,7 @@ export function ListViewClient({
       params.set('sort', `${sortBy}:${sortOrder}`)
     }
     params.set('page', '1') // Reset to page 1 on new search
-    router.push(`${basePath}/${urlKey}?${params.toString()}`)
+    router.push(`${basePath}/${urlKey}?${withPageSize(params).toString()}`)
   }
 
   const handleClearSearch = () => {
@@ -111,7 +193,7 @@ export function ListViewClient({
     if (sortBy) {
       params.set('sort', `${sortBy}:${sortOrder}`)
     }
-    const qs = params.toString()
+    const qs = withPageSize(params).toString()
     router.push(`${basePath}/${urlKey}${qs ? `?${qs}` : ''}`)
   }
 
@@ -124,7 +206,7 @@ export function ListViewClient({
       params.set('sort', `${sortBy}:${sortOrder}`)
     }
     params.set('page', newPage.toString())
-    return `${basePath}/${urlKey}?${params.toString()}`
+    return `${basePath}/${urlKey}?${withPageSize(params).toString()}`
   }
 
   /**
@@ -168,11 +250,43 @@ export function ListViewClient({
         </form>
       </Card>
 
+      {/* Bulk-action result ("N of M deleted"). Lives here (always mounted) so
+          it survives the selection clearing after a delete. */}
+      {bulkStatus && (
+        <div
+          data-slot="selection-status"
+          role="status"
+          className="rounded-lg border bg-muted/50 px-4 py-2 text-sm text-foreground"
+        >
+          {bulkStatus}
+        </div>
+      )}
+
+      {/* Selection bar — visible only while rows are selected. */}
+      {selectionEnabled && (
+        <RowSelectionBar
+          count={selection.selectedCount}
+          onClear={selection.clear}
+          onDelete={canBulkDelete ? handleBulkDelete : undefined}
+          itemName={formatFieldName(listKey).toLowerCase()}
+        />
+      )}
+
       {/* Table */}
       <div className="rounded-lg border">
         <Table>
           <TableHeader>
             <TableRow>
+              {selectionEnabled && (
+                <TableHead data-slot="selection-header" className="w-10">
+                  <Checkbox
+                    aria-label="Select all rows on this page"
+                    checked={getPageCheckboxState(selection.selectedIds, pageIds)}
+                    onCheckedChange={() => selection.togglePage(pageIds)}
+                    disabled={pageIds.length === 0}
+                  />
+                </TableHead>
+              )}
               {displayColumns.map((column) => {
                 const numeric = isNumericField(fieldTypes[column])
                 return (
@@ -203,7 +317,7 @@ export function ListViewClient({
               <TableRow>
                 <TableCell
                   data-slot="list-view-empty"
-                  colSpan={displayColumns.length + 1}
+                  colSpan={displayColumns.length + 1 + (selectionEnabled ? 1 : 0)}
                   className="p-0"
                 >
                   {initialSearch ? (
@@ -237,31 +351,46 @@ export function ListViewClient({
                 </TableCell>
               </TableRow>
             ) : (
-              items.map((item) => (
-                <TableRow key={String(item.id)}>
-                  {displayColumns.map((column) => (
-                    <TableCell
-                      key={column}
-                      className={cn(isNumericField(fieldTypes[column]) && 'text-right')}
-                    >
-                      <CellRenderer
-                        value={item[column]}
-                        field={columnField(column)}
-                        fieldName={column}
-                        basePath={basePath}
-                      />
+              items.map((item) => {
+                const rowId = String(item.id)
+                return (
+                  <TableRow
+                    key={rowId}
+                    data-state={selection.isSelected(rowId) ? 'selected' : undefined}
+                  >
+                    {selectionEnabled && (
+                      <TableCell data-slot="selection-cell" className="w-10">
+                        <Checkbox
+                          aria-label={`Select row ${rowId}`}
+                          checked={selection.isSelected(rowId)}
+                          onCheckedChange={() => selection.toggle(rowId)}
+                        />
+                      </TableCell>
+                    )}
+                    {displayColumns.map((column) => (
+                      <TableCell
+                        key={column}
+                        className={cn(isNumericField(fieldTypes[column]) && 'text-right')}
+                      >
+                        <CellRenderer
+                          value={item[column]}
+                          field={columnField(column)}
+                          fieldName={column}
+                          basePath={basePath}
+                        />
+                      </TableCell>
+                    ))}
+                    <TableCell className="text-right">
+                      <Link
+                        href={`${basePath}/${urlKey}/${item.id}`}
+                        className="text-primary hover:underline"
+                      >
+                        Edit
+                      </Link>
                     </TableCell>
-                  ))}
-                  <TableCell className="text-right">
-                    <Link
-                      href={`${basePath}/${urlKey}/${item.id}`}
-                      className="text-primary hover:underline"
-                    >
-                      Edit
-                    </Link>
-                  </TableCell>
-                </TableRow>
-              ))
+                  </TableRow>
+                )
+              })
             )}
           </TableBody>
         </Table>

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -21,21 +21,25 @@ import { EmptyState } from './EmptyState.js'
 import { CellRenderer } from './cells/CellRenderer.js'
 import { RowSelectionBar } from './RowSelectionBar.js'
 import { useRowSelection, getPageCheckboxState } from '../lib/useRowSelection.js'
+import { useBulkStatus } from '../lib/useBulkStatus.js'
 import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
 import type { ServerActionInput } from '../server/types.js'
 
 /**
- * Narrow a `serverAction` result to a success without leaking a shape onto the
- * external API. A denied delete comes back `{ success: false }` (Silent
- * failure) and is simply not counted.
+ * Read the `{ deleted, total }` count a bulk-delete server action returns. The
+ * deletion runs row-by-row through the secured context server-side, so denied
+ * rows (Silent failure) are already absent from `deleted`; `total` falls back to
+ * the number attempted if the result shape is unexpected.
  */
-function isServerActionSuccess(result: unknown): boolean {
-  return (
-    typeof result === 'object' &&
-    result !== null &&
-    'success' in result &&
-    (result as { success: unknown }).success === true
-  )
+function parseBulkDeleteResult(
+  result: unknown,
+  attempted: number,
+): { deleted: number; total: number } {
+  if (typeof result === 'object' && result !== null && 'deleted' in result && 'total' in result) {
+    const { deleted, total } = result as { deleted: unknown; total: unknown }
+    if (typeof deleted === 'number' && typeof total === 'number') return { deleted, total }
+  }
+  return { deleted: 0, total: attempted }
 }
 
 export interface ListViewClientProps {
@@ -105,10 +109,12 @@ export function ListViewClient({
   const sortOrder = initialSort?.direction ?? 'asc'
   const [searchInput, setSearchInput] = React.useState(initialSearch || '')
 
-  // Row selection (issue #733). The filter identity is the active search — page
-  // and sort changes keep it stable (selection persists while paging) while a
-  // filter change resets it. When the Filter builder lands this becomes the full
-  // filter query string.
+  // Row selection (issue #733). The selection is keyed on the ACTIVE FILTER
+  // STATE: the `search` param is the filter engine's URL filter query (#730 —
+  // field-scoped tokens, comparisons, quoted values, bare-word free text), so
+  // changing ANY filter token changes `filterKey` and clears the accumulated id
+  // set, while page and sort changes keep it stable (selection persists while
+  // paging). Reads back empty under a different filter.
   const filterKey = initialSearch ?? ''
   const selection = useRowSelection(listKey, filterKey)
 
@@ -118,30 +124,22 @@ export function ListViewClient({
   const selectionEnabled = canDelete
   const canBulkDelete = canDelete && !!serverAction
 
-  // The "N of M deleted" report persists after the selection clears, so it lives
-  // here (always mounted) rather than in the selection bar (which unmounts once
-  // the selection empties).
-  const [bulkStatus, setBulkStatus] = React.useState<string | null>(null)
+  // The "N of M deleted" report must outlive the table refresh: `router.refresh()`
+  // remounts this client component (the async ListView re-suspends), so the
+  // report is persisted (sessionStorage) rather than held in React state that
+  // the remount would discard.
+  const { status: bulkStatus, setStatus: setBulkStatus, clearStatus } = useBulkStatus(listKey)
 
   const pageIds = items.map((item) => String(item.id))
 
-  const handleBulkDelete = async () => {
-    if (!serverAction) return
-    const ids = [...selection.selectedIds]
-    setBulkStatus(null)
-
-    // Row-by-row through the secured context. A denied row returns a Silent
-    // failure (`{ success: false }`) and is simply not counted — the report
-    // never reveals which rows were denied or why.
-    let deleted = 0
-    for (const id of ids) {
-      const result = await serverAction({ listKey, action: 'delete', id })
-      if (isServerActionSuccess(result)) deleted++
-    }
-
-    selection.clear()
-    setBulkStatus(`${deleted} of ${ids.length} deleted`)
-    router.refresh()
+  // Starting a fresh selection dismisses any prior report.
+  const handleToggle = (id: string) => {
+    clearStatus()
+    selection.toggle(id)
+  }
+  const handleTogglePage = () => {
+    clearStatus()
+    selection.togglePage(pageIds)
   }
 
   // Determine which columns to show
@@ -207,6 +205,32 @@ export function ListViewClient({
     }
     params.set('page', newPage.toString())
     return `${basePath}/${urlKey}?${withPageSize(params).toString()}`
+  }
+
+  const handleBulkDelete = async () => {
+    if (!serverAction) return
+    const ids = [...selection.selectedIds]
+
+    // One server round-trip: the deletion runs row-by-row through the secured
+    // context server-side, honouring Silent failure (a denied row is not
+    // counted). A single call avoids a client loop of Server Actions — each of
+    // which would trigger its own route refresh/redirect — and yields the
+    // "N of M" count directly without revealing which rows were denied or why.
+    const result = await serverAction({ listKey, action: 'bulkDelete', ids })
+    const { deleted, total } = parseBulkDeleteResult(result, ids.length)
+
+    // Persist the report before mutating the view, so it survives the remount the
+    // navigation below triggers and renders against the fresh list.
+    setBulkStatus(`${deleted} of ${total} deleted`)
+    selection.clear()
+
+    // Reset to page 1 of the current filter: a bulk delete can remove the rows
+    // that made the current page exist (deleting across pages leaves the current
+    // page out of range). `router.refresh()` first invalidates the client Router
+    // Cache (so a previously-visited page 1 is not served stale), then the push
+    // lands on page 1 and fetches the now-shorter list fresh.
+    router.refresh()
+    router.push(buildPaginationUrl(1))
   }
 
   /**
@@ -282,7 +306,7 @@ export function ListViewClient({
                   <Checkbox
                     aria-label="Select all rows on this page"
                     checked={getPageCheckboxState(selection.selectedIds, pageIds)}
-                    onCheckedChange={() => selection.togglePage(pageIds)}
+                    onCheckedChange={handleTogglePage}
                     disabled={pageIds.length === 0}
                   />
                 </TableHead>
@@ -363,7 +387,7 @@ export function ListViewClient({
                         <Checkbox
                           aria-label={`Select row ${rowId}`}
                           checked={selection.isSelected(rowId)}
-                          onCheckedChange={() => selection.toggle(rowId)}
+                          onCheckedChange={() => handleToggle(rowId)}
                         />
                       </TableCell>
                     )}

--- a/packages/ui/src/components/RowSelectionBar.tsx
+++ b/packages/ui/src/components/RowSelectionBar.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import * as React from 'react'
+import { Button } from '../primitives/button.js'
+import { ConfirmDialog } from './ConfirmDialog.js'
+import { LoadingSpinner } from './LoadingSpinner.js'
+import { cn } from '../lib/utils.js'
+
+/**
+ * Per-part `classNames` Slots for {@link RowSelectionBar}. Each merges onto its
+ * `data-slot` part via `cn`/tailwind-merge, mirroring the other admin
+ * components. Slot names are part of the reviewed API surface (renaming a
+ * shipped Slot is a compatibility break).
+ */
+export interface RowSelectionBarClassNames {
+  /** The bar container (`data-slot="selection-bar"`). */
+  root?: string
+  /** The "N selected" count (`data-slot="selection-count"`). */
+  count?: string
+  /** The Clear button (`data-slot="selection-clear"`). */
+  clear?: string
+  /** The custom-actions region (`data-slot="selection-actions"`). */
+  actions?: string
+  /** The built-in Delete button (`data-slot="selection-delete"`). */
+  delete?: string
+}
+
+export interface RowSelectionBarProps {
+  /** Number of selected rows; the bar renders nothing when this is 0. */
+  count: number
+  /** Clear the whole selection. */
+  onClear: () => void
+  /**
+   * The built-in Bulk action Delete handler. When provided, a Delete button is
+   * shown (behind a {@link ConfirmDialog}); when omitted, no Delete is offered —
+   * the caller passes it only when the list's delete access is not statically
+   * false. The handler runs the deletion (row-by-row through the secured
+   * context) and resolves once done; the bar owns only the confirm + pending
+   * affordance.
+   */
+  onDelete?: () => Promise<void>
+  /** Noun for the confirm copy (e.g. "post"). Defaults to "item". */
+  itemName?: string
+  /**
+   * Seam for issue #736 (custom per-list Bulk actions): extra action controls
+   * render in the `data-slot="selection-actions"` region, to the left of the
+   * built-in Delete. This ships the named slot now so #736 can register
+   * additional actions without changing this component's shape.
+   */
+  actions?: React.ReactNode
+  className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: RowSelectionBarClassNames
+}
+
+/**
+ * The selection bar shown above the list table while rows are selected
+ * (issue #733). It reports the selection count, offers a Clear action and — when
+ * `onDelete` is provided (delete access is not statically false) — the built-in
+ * Bulk action Delete behind a confirmation.
+ *
+ * Styling uses Theme tokens only (no raw colours) and every part carries a named
+ * Slot, so custom themes/branding can target the bar without forking it.
+ */
+export function RowSelectionBar({
+  count,
+  onClear,
+  onDelete,
+  itemName = 'item',
+  actions,
+  className,
+  classNames,
+}: RowSelectionBarProps) {
+  const [showConfirm, setShowConfirm] = React.useState(false)
+  const [isPending, setIsPending] = React.useState(false)
+
+  if (count === 0) return null
+
+  const handleConfirm = async () => {
+    if (!onDelete) return
+    setShowConfirm(false)
+    setIsPending(true)
+    try {
+      await onDelete()
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div
+      data-slot="selection-bar"
+      role="toolbar"
+      aria-label="Selection actions"
+      className={cn(
+        'flex items-center justify-between gap-4 rounded-lg border bg-muted/50 px-4 py-2',
+        className,
+        classNames?.root,
+      )}
+    >
+      <span
+        data-slot="selection-count"
+        aria-live="polite"
+        className={cn('text-sm font-medium tabular-nums text-foreground', classNames?.count)}
+      >
+        {count} selected
+      </span>
+
+      <div className="flex items-center gap-2">
+        {/* Seam for #736: list-specific Bulk actions render here. */}
+        <div
+          data-slot="selection-actions"
+          className={cn('flex items-center gap-2', classNames?.actions)}
+        >
+          {actions}
+        </div>
+
+        {onDelete && (
+          <Button
+            type="button"
+            data-slot="selection-delete"
+            variant="destructive"
+            size="sm"
+            onClick={() => setShowConfirm(true)}
+            disabled={isPending}
+            className={classNames?.delete}
+          >
+            {isPending && (
+              <LoadingSpinner
+                size="sm"
+                className="border-primary-foreground border-t-transparent mr-2"
+              />
+            )}
+            Delete
+          </Button>
+        )}
+
+        <Button
+          type="button"
+          data-slot="selection-clear"
+          variant="outline"
+          size="sm"
+          onClick={onClear}
+          disabled={isPending}
+          className={classNames?.clear}
+        >
+          Clear
+        </Button>
+      </div>
+
+      {onDelete && (
+        <ConfirmDialog
+          isOpen={showConfirm}
+          title={`Delete ${count} ${itemName}${count === 1 ? '' : 's'}`}
+          message={`Are you sure you want to delete ${count} selected ${itemName}${
+            count === 1 ? '' : 's'
+          }? This action cannot be undone.`}
+          confirmLabel="Delete"
+          variant="danger"
+          onConfirm={handleConfirm}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export { ThemeToggle } from './components/ThemeToggle.js'
 export { ThemeScript } from './components/ThemeScript.js'
 export { ListView } from './components/ListView.js'
 export { ListViewClient } from './components/ListViewClient.js'
+export { RowSelectionBar } from './components/RowSelectionBar.js'
 export { ItemForm } from './components/ItemForm.js'
 export { ItemFormClient } from './components/ItemFormClient.js'
 export { SingletonView } from './components/SingletonView.js'
@@ -72,6 +73,10 @@ export type { UserMenuProps } from './components/UserMenu.js'
 export type { ThemeToggleProps } from './components/ThemeToggle.js'
 export type { ListViewProps } from './components/ListView.js'
 export type { ListViewClientProps } from './components/ListViewClient.js'
+export type {
+  RowSelectionBarProps,
+  RowSelectionBarClassNames,
+} from './components/RowSelectionBar.js'
 export type { ItemFormProps } from './components/ItemForm.js'
 export type { ItemFormClientProps } from './components/ItemFormClient.js'
 export type { SingletonViewProps } from './components/SingletonView.js'
@@ -127,6 +132,14 @@ export {
 // Relationship-options read primitive (re-exported from @opensaas/stack-core)
 export { getRelationshipOptions } from './lib/getRelationshipOptions.js'
 export type { RelationshipOption, RelationshipOptionsArgs } from './lib/getRelationshipOptions.js'
+
+// Row selection (list-table Bulk actions)
+export {
+  useRowSelection,
+  isPageFullySelected,
+  getPageCheckboxState,
+} from './lib/useRowSelection.js'
+export type { RowSelection } from './lib/useRowSelection.js'
 
 // Theme utilities
 export { compileTheme, presetThemes } from './lib/theme.js'

--- a/packages/ui/src/lib/useBulkStatus.ts
+++ b/packages/ui/src/lib/useBulkStatus.ts
@@ -1,0 +1,91 @@
+'use client'
+
+import * as React from 'react'
+
+/**
+ * The persisted "N of M deleted" report for a list's Bulk actions (issue #733).
+ *
+ * The report must outlive the table refresh a bulk delete triggers:
+ * `router.refresh()` re-runs the async `ListView` Server Component behind the
+ * admin `<Suspense>` boundary, which remounts `ListViewClient` and would discard
+ * plain React state. Persisting the message in `sessionStorage` (read back via
+ * `useSyncExternalStore`, the same store pattern as row selection) means the
+ * report survives that remount and is shown against the refreshed table.
+ */
+export interface BulkStatus {
+  /** The current report text, or `null` when there is none. */
+  status: string | null
+  /** Set (and persist) the report. */
+  setStatus: (status: string) => void
+  /** Clear the report (e.g. when the user starts a new selection). */
+  clearStatus: () => void
+}
+
+function storageKeyFor(listKey: string): string {
+  return `opensaas:bulk-status:${listKey}`
+}
+
+// Same-document change listeners per storage key (the `storage` event does not
+// fire for same-document `sessionStorage` writes).
+const listeners = new Map<string, Set<() => void>>()
+
+function readValue(storageKey: string): string | null {
+  try {
+    const raw = window.sessionStorage.getItem(storageKey)
+    return raw && raw.length > 0 ? raw : null
+  } catch {
+    return null
+  }
+}
+
+function writeValue(storageKey: string, value: string | null): void {
+  try {
+    if (value === null) window.sessionStorage.removeItem(storageKey)
+    else window.sessionStorage.setItem(storageKey, value)
+  } catch {
+    // Storage may be unavailable (private mode/quota) — notify anyway.
+  }
+  const set = listeners.get(storageKey)
+  if (set) for (const listener of set) listener()
+}
+
+/**
+ * Manage the persisted bulk-action report for one list. The value is a plain
+ * string, so `getSnapshot` is stable by value (no reference caching needed).
+ */
+export function useBulkStatus(listKey: string): BulkStatus {
+  const storageKey = storageKeyFor(listKey)
+
+  const subscribe = React.useCallback(
+    (onChange: () => void) => {
+      let set = listeners.get(storageKey)
+      if (!set) {
+        set = new Set()
+        listeners.set(storageKey, set)
+      }
+      set.add(onChange)
+      const onStorage = (event: StorageEvent) => {
+        if (event.key === storageKey) onChange()
+      }
+      window.addEventListener('storage', onStorage)
+      return () => {
+        set?.delete(onChange)
+        window.removeEventListener('storage', onStorage)
+      }
+    },
+    [storageKey],
+  )
+
+  const getSnapshot = React.useCallback(() => readValue(storageKey), [storageKey])
+  const getServerSnapshot = React.useCallback(() => null, [])
+
+  const status = React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  const setStatus = React.useCallback(
+    (value: string) => writeValue(storageKey, value),
+    [storageKey],
+  )
+  const clearStatus = React.useCallback(() => writeValue(storageKey, null), [storageKey])
+
+  return { status, setStatus, clearStatus }
+}

--- a/packages/ui/src/lib/useRowSelection.ts
+++ b/packages/ui/src/lib/useRowSelection.ts
@@ -1,0 +1,225 @@
+'use client'
+
+import * as React from 'react'
+
+/**
+ * Row selection for the list table (issue #733).
+ *
+ * Selection is an explicit **id set** — never "everything matching the filter"
+ * (that is deliberately out of scope, see the Bulk action glossary entry in
+ * `CONTEXT.md`). The set:
+ *
+ * - accumulates across pages (the header checkbox toggles the *visible page*,
+ *   per-row checkboxes add/remove one id), and
+ * - clears when the **filter changes** (a new `filterKey`), because a selection
+ *   is only meaningful against the result set it was made in.
+ *
+ * The set is persisted in `sessionStorage` keyed by list, tagged with the
+ * `filterKey` it was made under. Reading it back through `useSyncExternalStore`
+ * (the same store pattern `ThemeToggle` uses for the persisted theme) means the
+ * selection survives the soft navigation a page/sort change triggers — whether
+ * or not the client component remounts — without a setState-in-effect or a
+ * hydration mismatch. A stored set tagged with a different `filterKey` reads
+ * back as empty, so "clear on filter change" falls out of the read itself.
+ */
+export interface RowSelection {
+  /** The currently selected row ids (accumulated across pages). */
+  selectedIds: Set<string>
+  /** Number of selected rows. */
+  selectedCount: number
+  /** Whether a single row id is selected. */
+  isSelected: (id: string) => boolean
+  /** Toggle a single row id. */
+  toggle: (id: string) => void
+  /**
+   * Toggle the visible page: if every id on the page is already selected they
+   * are all removed, otherwise every page id is added (accumulating onto ids
+   * selected on other pages).
+   */
+  togglePage: (pageIds: string[]) => void
+  /** Clear the whole selection. */
+  clear: () => void
+}
+
+/**
+ * Whether every id on the visible page is in the selection. Empty pages are not
+ * "fully selected" (there is nothing to select). Pure so it can be unit-tested
+ * and reused by the header-checkbox rendering.
+ */
+export function isPageFullySelected(selected: Set<string>, pageIds: string[]): boolean {
+  return pageIds.length > 0 && pageIds.every((id) => selected.has(id))
+}
+
+/**
+ * The tri-state a header ("select visible page") checkbox should show for the
+ * given page: `true` when all page rows are selected, `'indeterminate'` when
+ * some are, `false` when none are.
+ */
+export function getPageCheckboxState(
+  selected: Set<string>,
+  pageIds: string[],
+): boolean | 'indeterminate' {
+  if (isPageFullySelected(selected, pageIds)) return true
+  if (pageIds.some((id) => selected.has(id))) return 'indeterminate'
+  return false
+}
+
+// Stable empty reference: `useSyncExternalStore` requires `getSnapshot` to
+// return the same reference when nothing changed.
+const EMPTY_IDS: readonly string[] = Object.freeze([])
+
+function storageKeyFor(listKey: string): string {
+  return `opensaas:selection:${listKey}`
+}
+
+// Same-document change listeners per storage key. The `storage` event does not
+// fire for same-document `sessionStorage` writes, so local writes notify here.
+const listeners = new Map<string, Set<() => void>>()
+
+// Cache the parsed value per storage key so `getSnapshot` returns a stable ids
+// reference until the underlying raw string changes.
+type ParsedSelection = { raw: string | null; filterKey: string | null; ids: readonly string[] }
+const snapshotCache = new Map<string, ParsedSelection>()
+
+function readRaw(storageKey: string): string | null {
+  try {
+    return window.sessionStorage.getItem(storageKey)
+  } catch {
+    return null
+  }
+}
+
+/** Parse a stored `{ filterKey, ids }` blob, tolerating anything malformed. */
+function parseStored(raw: string | null): { filterKey: string; ids: string[] } | null {
+  if (!raw) return null
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof value !== 'object' || value === null) return null
+  // Internal narrowing of a freshly-parsed JSON blob at the storage boundary.
+  const record = value as Record<string, unknown>
+  const { filterKey, ids } = record
+  if (typeof filterKey !== 'string' || !Array.isArray(ids)) return null
+  if (!ids.every((id): id is string => typeof id === 'string')) return null
+  return { filterKey, ids }
+}
+
+/** The parsed selection for `storageKey`, cached until its raw string changes. */
+function getParsed(storageKey: string): ParsedSelection {
+  const raw = readRaw(storageKey)
+  const cached = snapshotCache.get(storageKey)
+  if (cached && cached.raw === raw) return cached
+  const parsed = parseStored(raw)
+  const next: ParsedSelection = parsed
+    ? { raw, filterKey: parsed.filterKey, ids: parsed.ids }
+    : { raw, filterKey: null, ids: EMPTY_IDS }
+  snapshotCache.set(storageKey, next)
+  return next
+}
+
+/** The selected ids for `filterKey` (empty when the stored set is another filter's). */
+function readIds(storageKey: string, filterKey: string): readonly string[] {
+  const parsed = getParsed(storageKey)
+  return parsed.filterKey === filterKey ? parsed.ids : EMPTY_IDS
+}
+
+function writeIds(storageKey: string, filterKey: string, ids: readonly string[]): void {
+  try {
+    window.sessionStorage.setItem(storageKey, JSON.stringify({ filterKey, ids }))
+  } catch {
+    // Storage may be unavailable (private mode/quota); notify anyway so the
+    // in-memory subscribers still re-read (they will just read back nothing).
+  }
+  snapshotCache.delete(storageKey)
+  const set = listeners.get(storageKey)
+  if (set) for (const listener of set) listener()
+}
+
+/**
+ * Manage row selection for one list view, persisted per `filterKey`.
+ *
+ * @param listKey - The list being viewed (namespaces the persisted set).
+ * @param filterKey - A stable string identifying the active filter. Changing it
+ *   reads the selection back as empty; page and sort changes must NOT change it,
+ *   so the selection persists while paging.
+ */
+export function useRowSelection(listKey: string, filterKey: string): RowSelection {
+  const storageKey = storageKeyFor(listKey)
+
+  const subscribe = React.useCallback(
+    (onChange: () => void) => {
+      let set = listeners.get(storageKey)
+      if (!set) {
+        set = new Set()
+        listeners.set(storageKey, set)
+      }
+      set.add(onChange)
+      const onStorage = (event: StorageEvent) => {
+        if (event.key === storageKey) onChange()
+      }
+      window.addEventListener('storage', onStorage)
+      return () => {
+        set?.delete(onChange)
+        window.removeEventListener('storage', onStorage)
+      }
+    },
+    [storageKey],
+  )
+
+  const getSnapshot = React.useCallback(
+    () => readIds(storageKey, filterKey),
+    [storageKey, filterKey],
+  )
+  const getServerSnapshot = React.useCallback(() => EMPTY_IDS, [])
+
+  const ids = React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  const selectedIds = React.useMemo(() => new Set(ids), [ids])
+
+  const toggle = React.useCallback(
+    (id: string) => {
+      const current = readIds(storageKey, filterKey)
+      const next = current.includes(id) ? current.filter((x) => x !== id) : [...current, id]
+      writeIds(storageKey, filterKey, next)
+    },
+    [storageKey, filterKey],
+  )
+
+  const togglePage = React.useCallback(
+    (pageIds: string[]) => {
+      const current = readIds(storageKey, filterKey)
+      const currentSet = new Set(current)
+      if (isPageFullySelected(currentSet, pageIds)) {
+        const remove = new Set(pageIds)
+        writeIds(
+          storageKey,
+          filterKey,
+          current.filter((id) => !remove.has(id)),
+        )
+      } else {
+        const next = [...current]
+        for (const id of pageIds) if (!currentSet.has(id)) next.push(id)
+        writeIds(storageKey, filterKey, next)
+      }
+    },
+    [storageKey, filterKey],
+  )
+
+  const clear = React.useCallback(
+    () => writeIds(storageKey, filterKey, EMPTY_IDS),
+    [storageKey, filterKey],
+  )
+
+  const isSelected = React.useCallback((id: string) => selectedIds.has(id), [selectedIds])
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.size,
+    isSelected,
+    toggle,
+    togglePage,
+    clear,
+  }
+}

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -338,7 +338,8 @@ describe('ListViewClient', () => {
       const prevButton = screen.getByRole('button', { name: /previous/i })
       await user.click(prevButton)
 
-      expect(mockPush).toHaveBeenCalledWith('/admin/post?page=1')
+      // A non-default pageSize is echoed into nav URLs so it survives paging.
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?page=1&pageSize=10')
     })
 
     it('should navigate to next page when Next clicked', async () => {
@@ -348,7 +349,7 @@ describe('ListViewClient', () => {
       const nextButton = screen.getByRole('button', { name: /next/i })
       await user.click(nextButton)
 
-      expect(mockPush).toHaveBeenCalledWith('/admin/post?page=2')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?page=2&pageSize=10')
     })
 
     it('should preserve search in pagination URLs', async () => {
@@ -358,7 +359,7 @@ describe('ListViewClient', () => {
       const nextButton = screen.getByRole('button', { name: /next/i })
       await user.click(nextButton)
 
-      expect(mockPush).toHaveBeenCalledWith('/admin/post?search=test&page=2')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?search=test&page=2&pageSize=10')
     })
 
     it('should preserve sort in pagination URLs', async () => {
@@ -376,7 +377,7 @@ describe('ListViewClient', () => {
       const nextButton = screen.getByRole('button', { name: /next/i })
       await user.click(nextButton)
 
-      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc&page=2')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc&page=2&pageSize=10')
     })
   })
 

--- a/packages/ui/tests/components/RowSelection.test.tsx
+++ b/packages/ui/tests/components/RowSelection.test.tsx
@@ -127,9 +127,10 @@ describe('ListViewClient row selection', () => {
 describe('ListViewClient bulk delete', () => {
   it('reports "N of M deleted" and refreshes, absorbing per-row Silent failures', async () => {
     const user = userEvent.setup()
-    // Row 1 deletes; row 2 is denied (Silent failure → { success: false }).
-    const serverAction = vi.fn(async (input: { action: string; id?: string }) => {
-      if (input.action === 'delete' && input.id === '1') return { success: true, data: {} }
+    // One bulkDelete round-trip: the server deleted 1 of the 2 attempted (the
+    // other denied via Silent failure server-side) and reports the count.
+    const serverAction = vi.fn(async (input: { action: string; ids?: string[] }) => {
+      if (input.action === 'bulkDelete') return { deleted: 1, total: input.ids?.length ?? 0 }
       return { success: false, error: 'Access denied or operation failed' }
     })
 
@@ -143,12 +144,18 @@ describe('ListViewClient bulk delete', () => {
     const dialog = await screen.findByRole('dialog')
     await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
 
-    // Both rows attempted, only the allowed one counted; report never says which.
-    const status = await screen.findByRole('status')
-    expect(status).toHaveTextContent('1 of 2 deleted')
-    expect(serverAction).toHaveBeenCalledTimes(2)
-    expect(serverAction).toHaveBeenCalledWith({ listKey: 'Post', action: 'delete', id: '1' })
-    expect(serverAction).toHaveBeenCalledWith({ listKey: 'Post', action: 'delete', id: '2' })
+    // Only the allowed row counted; report never says which. Target the report by
+    // its Slot (the Delete button's spinner also uses role="status").
+    const status = await screen.findByText('1 of 2 deleted')
+    expect(status).toHaveAttribute('data-slot', 'selection-status')
+    // One secured server round-trip with both selected ids; denials are absorbed
+    // server-side into the count.
+    expect(serverAction).toHaveBeenCalledTimes(1)
+    expect(serverAction).toHaveBeenCalledWith({
+      listKey: 'Post',
+      action: 'bulkDelete',
+      ids: ['1', '2'],
+    })
     expect(mockRefresh).toHaveBeenCalled()
 
     // Selection is cleared after the delete.

--- a/packages/ui/tests/components/RowSelection.test.tsx
+++ b/packages/ui/tests/components/RowSelection.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ListViewClient } from '../../src/components/ListViewClient.js'
+import { isPageFullySelected, getPageCheckboxState } from '../../src/lib/useRowSelection.js'
+
+// Mock Next.js navigation — capture push/refresh so we can assert refresh after
+// a bulk delete without a real router.
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}))
+
+const page1 = [
+  { id: '1', title: 'First Post' },
+  { id: '2', title: 'Second Post' },
+]
+const page2 = [
+  { id: '3', title: 'Third Post' },
+  { id: '4', title: 'Fourth Post' },
+]
+
+const baseProps = {
+  fieldTypes: { title: 'text' },
+  relationshipRefs: {},
+  listKey: 'Post',
+  urlKey: 'post',
+  basePath: '/admin',
+  page: 1,
+  pageSize: 2,
+  total: 4,
+}
+
+beforeEach(() => {
+  mockPush.mockClear()
+  mockRefresh.mockClear()
+  window.sessionStorage.clear()
+})
+
+describe('selection helpers', () => {
+  it('isPageFullySelected is false for an empty page and true only when all present', () => {
+    expect(isPageFullySelected(new Set(['1']), [])).toBe(false)
+    expect(isPageFullySelected(new Set(['1']), ['1', '2'])).toBe(false)
+    expect(isPageFullySelected(new Set(['1', '2']), ['1', '2'])).toBe(true)
+  })
+
+  it('getPageCheckboxState reflects none / some / all selected', () => {
+    expect(getPageCheckboxState(new Set(), ['1', '2'])).toBe(false)
+    expect(getPageCheckboxState(new Set(['1']), ['1', '2'])).toBe('indeterminate')
+    expect(getPageCheckboxState(new Set(['1', '2']), ['1', '2'])).toBe(true)
+  })
+})
+
+describe('ListViewClient row selection', () => {
+  it('does not render selection checkboxes when canDelete is false', () => {
+    render(<ListViewClient {...baseProps} items={page1} canDelete={false} />)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('toolbar', { name: /selection/i })).not.toBeInTheDocument()
+  })
+
+  it('per-row checkbox selects one row and shows the count', async () => {
+    const user = userEvent.setup()
+    render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }))
+
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    expect(within(bar).getByText('1 selected')).toBeInTheDocument()
+  })
+
+  it('header checkbox toggles the whole visible page', async () => {
+    const user = userEvent.setup()
+    render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    const header = screen.getByRole('checkbox', { name: /select all rows on this page/i })
+    await user.click(header)
+
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    expect(within(bar).getByText('2 selected')).toBeInTheDocument()
+
+    // Clicking again clears the page.
+    await user.click(header)
+    expect(screen.queryByRole('toolbar', { name: /selection/i })).not.toBeInTheDocument()
+  })
+
+  it('Clear empties the selection', async () => {
+    const user = userEvent.setup()
+    render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }))
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    await user.click(within(bar).getByRole('button', { name: 'Clear' }))
+
+    expect(screen.queryByRole('toolbar', { name: /selection/i })).not.toBeInTheDocument()
+  })
+
+  it('accumulates selection across pages (persists on remount, same filter)', async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    // Select a row on page 1, then simulate navigating to page 2 (remount with
+    // the same list + filter but a different visible page).
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }))
+    unmount()
+    render(<ListViewClient {...baseProps} items={page2} page={2} canDelete />)
+
+    // The prior page-1 selection is restored, then a page-2 row is added.
+    await user.click(await screen.findByRole('checkbox', { name: 'Select row 4' }))
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    expect(within(bar).getByText('2 selected')).toBeInTheDocument()
+  })
+
+  it('clears the selection when the filter changes', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    // A new filter (search) resets the selection.
+    rerender(<ListViewClient {...baseProps} items={page1} search="query" canDelete />)
+    expect(screen.queryByRole('toolbar', { name: /selection/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('ListViewClient bulk delete', () => {
+  it('reports "N of M deleted" and refreshes, absorbing per-row Silent failures', async () => {
+    const user = userEvent.setup()
+    // Row 1 deletes; row 2 is denied (Silent failure → { success: false }).
+    const serverAction = vi.fn(async (input: { action: string; id?: string }) => {
+      if (input.action === 'delete' && input.id === '1') return { success: true, data: {} }
+      return { success: false, error: 'Access denied or operation failed' }
+    })
+
+    render(<ListViewClient {...baseProps} items={page1} canDelete serverAction={serverAction} />)
+
+    await user.click(screen.getByRole('checkbox', { name: /select all rows on this page/i }))
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    await user.click(within(bar).getByRole('button', { name: 'Delete' }))
+
+    // Confirm in the dialog.
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    // Both rows attempted, only the allowed one counted; report never says which.
+    const status = await screen.findByRole('status')
+    expect(status).toHaveTextContent('1 of 2 deleted')
+    expect(serverAction).toHaveBeenCalledTimes(2)
+    expect(serverAction).toHaveBeenCalledWith({ listKey: 'Post', action: 'delete', id: '1' })
+    expect(serverAction).toHaveBeenCalledWith({ listKey: 'Post', action: 'delete', id: '2' })
+    expect(mockRefresh).toHaveBeenCalled()
+
+    // Selection is cleared after the delete.
+    expect(screen.queryByRole('toolbar', { name: /selection/i })).not.toBeInTheDocument()
+  })
+
+  it('does not offer Delete when serverAction is absent', async () => {
+    const user = userEvent.setup()
+    render(<ListViewClient {...baseProps} items={page1} canDelete />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }))
+    const bar = screen.getByRole('toolbar', { name: /selection/i })
+    expect(within(bar).queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+    // Clear is still available.
+    expect(within(bar).getByRole('button', { name: 'Clear' })).toBeInTheDocument()
+    cleanup()
+  })
+})


### PR DESCRIPTION
Implements #733. Part of #728.

## What this adds

Row selection and a built-in **Bulk action** Delete on the admin list view, layered onto the existing `ListView`/`ListViewClient` table (and the #729 Cell registry / #730 filter engine already on `main`).

- **Selection semantics** — a checkbox column: the header checkbox toggles the **visible page**, per-row checkboxes accumulate an explicit **id set** that persists while paging and **clears when the filter changes**. Selection is persisted per-list, tagged with the active filter query, via `useSyncExternalStore` over `sessionStorage` — so it survives the soft navigation a page/sort change triggers (remount or not) without a setState-in-effect or hydration mismatch, and reads back empty under a different filter. There is no "select all matching the filter" (deliberately out of scope).
- **Selection bar** — shows the count, a **Clear** action, a named `data-slot="selection-actions"` **Slot** seam where #736 will register custom per-list bulk actions, and — only when delete access allows — the built-in **Delete**.
- **Bulk delete** — confirms first (`ConfirmDialog`), then performs a single `serverAction({ action: 'bulkDelete', ids })` round-trip. The `bulkDelete` action deletes **row-by-row through the secured context** and reports **"N of M deleted"**.

## The tricky bits

- **Silent failure → "N of M"**: `bulkDelete` (in `packages/core/src/context/index.ts`) loops the secured, access-controlled, hook-firing delegate (`db[dbKey].delete`), not raw `prisma.deleteMany`. A denied/missing row comes back as `null` (Silent failure) and is simply **not counted**; a per-row throw is caught and skipped so one row never aborts the rest. It returns `{ deleted, total: ids.length }` → `N` = successes, `M` = ids attempted; the report never reveals which rows were denied or why. The client uses a single `bulkDelete` round-trip (not a per-row `{action:'delete'}` loop, which the item-form `serverAction` wrapper would `redirect()` on and abort); the distinct `{deleted,total}` result shape is what stops that wrapper hijacking the bulk op. The status line lives in `ListViewClient` (always mounted) so it survives the selection clearing after the delete.
- **Post-delete refresh**: after a bulk delete the client calls `router.refresh()` (invalidate the Router Cache) then `router.push` to page 1 of the current filter — so an out-of-range page left after deleting a cross-page selection doesn't show stale rows. The active filter/sort/pageSize are preserved.
- **Static delete-access gating**: `ListView` evaluates the list's `access.operation.delete` up front. Delete (and the whole selection affordance) is hidden when it is **statically false** — absent (deny-by-default) or the literal `false`. A function or `true` can't be proven denied up front, so Delete is offered and per-row Silent failure handles real denials.
- **Filter-engine integration (#746)**: selection is keyed on the active filter query (`?search=`, which #746 repurposed as the URL filter query). Changing any filter token clears the accumulated id set (reads back empty), while page/sort keep it. The `?pageSize=` param coexists with the filter params without clobbering.
- **Seam for #736**: the `RowSelectionBar` ships an `actions` prop rendered in the `data-slot="selection-actions"` region; the selection-enabled gate is a single `selectionEnabled = canDelete` that #736 widens to `canDelete || hasCustomBulkActions`.

Also adds an optional `?pageSize=` URL param (preserved across sort/search/paging), which makes cross-page selection exercisable in e2e without seeding 50+ rows.

## Theming & API

- Bar and checkboxes use **Theme tokens only** (no raw colours) and ship named **Slots**: `selection-bar`, `selection-count`, `selection-actions`, `selection-delete`, `selection-clear`, `selection-status`, `selection-header`, `selection-cell`.
- New exports: `RowSelectionBar` (`RowSelectionBarProps` / `RowSelectionBarClassNames`), `useRowSelection`, and the pure `isPageFullySelected` / `getPageCheckboxState` helpers.
- Core: adds the `bulkDelete` action to the context/server-action surface (additive widening of the `serverAction` return union with `{ deleted, total }`).

## Tests

- **Component tests** (`RowSelection.test.tsx`): page-toggle header, per-row accumulation, Clear, cross-page accumulation on remount, clear-on-filter-change, "N of M deleted" absorbing a per-row denial via a single secured round-trip, Delete hidden without `serverAction`, `canDelete=false` hides everything, plus the pure selection helpers. Full UI suite green.
- **e2e** (`05-bulk-delete.spec.ts`): sign up → create 3 posts → `?search=…&pageSize=2` → select page 1, page to page 2 (selection persists) → select the rest → Delete → assert "3 of 3 deleted" and the rows gone from the refreshed table. Passing in CI.

Changesets: `minor` for `@opensaas/stack-core` (`bulkDelete` action) and `minor` for `@opensaas/stack-ui` (row selection + bulk delete UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_