### PR TITLE
feat(ui,core): derive item view layout with read-only Relationship tables and totals footer

### DIFF
--- a/.changeset/sharp-otters-drift.md
+++ b/.changeset/sharp-otters-drift.md
@@ -1,0 +1,52 @@
+---
+'@opensaas/stack-ui': minor
+'@opensaas/stack-core': minor
+---
+
+Derive the admin item view from the list shape, with read-only Relationship tables and a totals footer (#734)
+
+A record's edit page now derives its layout from the list's shape. Scalar and
+to-one fields stay in a details card (whole-form Save/Cancel, unchanged), and
+each to-many relationship renders as a read-only **Relationship table**: one
+to-many relationship gives a two-column split, none gives a single centered
+card, several stack. Table columns default to the related list's own column
+curation minus the back-reference to the parent, cells come from the cell
+registry, and a totals footer always shows the row count plus sums for any
+explicitly-configured numeric columns (each formatted by that column's Cell).
+Rows are fetched through the secured context, so only access-visible data shows.
+Rows are read-only here — a row click navigates to the related record.
+
+`@opensaas/stack-core` gains additive item-view config (no breaking changes):
+
+```typescript
+lists: {
+  User: list({
+    fields: {
+      posts: relationship({
+        ref: 'Post.author',
+        many: true,
+        ui: {
+          itemView: {
+            // Override the Relationship table's columns…
+            columns: ['title', 'status', 'viewCount'],
+            // …and sum numeric columns in the totals footer.
+            sum: ['viewCount'],
+            // Or demote it back to the compact picker in the details card:
+            // displayMode: 'picker',
+          },
+        },
+      }),
+    },
+    // Reorder the Relationship-table sections:
+    ui: { itemView: { order: ['posts'] } },
+  }),
+}
+```
+
+New `@opensaas/stack-ui` exports: `RelationshipTable`, `RelationshipTableClient`,
+and the pure `deriveItemViewLayout` helper (with `ItemViewLayout`,
+`ItemViewArrangement`, `RelationshipTableSection`). The Relationship table ships
+named Slots (`relationship-table`, `relationship-table-toolbar`,
+`relationship-table-row`, `relationship-table-cell`, `relationship-table-footer`)
+as extension seams for the follow-up inline-edit, create-drawer, and row-removal
+work.

--- a/e2e/starter-auth/05-item-view.spec.ts
+++ b/e2e/starter-auth/05-item-view.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * Item view layout (issue #734).
+ *
+ * The record edit page derives its layout from the list's shape: a User has one
+ * to-many relationship (`posts`) so its edit page is a two-column split — a
+ * details card beside a read-only Relationship table of the user's posts, with
+ * a totals footer (row count + summed `viewCount`). A Post has no to-many
+ * relationship, so its edit page is a single details card (no Relationship
+ * table). Rows shown come through the secured context, so only access-visible
+ * data appears.
+ */
+
+async function createPost(
+  page: Page,
+  { title, slug, viewCount }: { title: string; slug: string; viewCount: number },
+) {
+  await page.goto('/admin/post')
+  await page.waitForLoadState('networkidle')
+  await page.click('text=/create|new/i')
+  await page.waitForLoadState('networkidle')
+  await page.fill('input[name="title"]', title)
+  await page.fill('input[name="slug"]', slug)
+  await page.fill('textarea[name="content"]', `${title} content`)
+  await page.fill('input[name="viewCount"]', String(viewCount))
+  await page.click('button[type="submit"]')
+  await page.waitForURL(/admin\/post$/, { timeout: 10000 })
+}
+
+test.describe('Item view layout', () => {
+  test('renders a Relationship table with a totals footer on the User edit page', async ({
+    page,
+  }) => {
+    const testUser = generateTestUser()
+    await signUp(page, testUser)
+
+    // Two posts (auto-authored to the signed-in user) with known view counts.
+    await createPost(page, { title: 'View Post A', slug: 'view-post-a', viewCount: 5 })
+    await createPost(page, { title: 'View Post B', slug: 'view-post-b', viewCount: 10 })
+
+    // Open the current user's edit page via its row Edit link.
+    await page.goto('/admin/user')
+    await page.waitForLoadState('networkidle')
+    await page.locator('tr', { hasText: testUser.email }).locator('a:has-text("Edit")').click()
+    await page.waitForURL(/\/admin\/user\/[^/]+$/, { timeout: 10000 })
+
+    // The User has several to-many relationships (posts, sessions, accounts), so
+    // the derived layout stacks the Relationship-table sections.
+    await expect(page.locator('[data-slot="item-view-layout"]')).toBeVisible()
+    await expect(page.locator('[data-slot="relationship-table"]').first()).toBeVisible()
+
+    // The details card still hosts the whole-form Save (unchanged edit behaviour).
+    await expect(page.locator('[data-slot="item-view-details"]')).toBeVisible()
+    await expect(
+      page.locator('[data-slot="item-view-details"] button[type="submit"]'),
+    ).toBeVisible()
+
+    // Read-only Relationship table for `posts` (targeted by its heading).
+    const table = page.locator('[data-slot="relationship-table"]', {
+      has: page.getByRole('heading', { name: 'Posts', exact: true }),
+    })
+    await expect(table).toBeVisible()
+
+    // Curated columns: title, status, viewCount (the `author` back-reference removed).
+    await expect(table.getByRole('columnheader', { name: 'Title' })).toBeVisible()
+    await expect(table.getByRole('columnheader', { name: 'Status' })).toBeVisible()
+    await expect(table.getByRole('columnheader', { name: 'View Count' })).toBeVisible()
+
+    // Both access-visible rows appear.
+    await expect(table.getByText('View Post A')).toBeVisible()
+    await expect(table.getByText('View Post B')).toBeVisible()
+
+    // Footer: row count always, plus the summed numeric column (5 + 10 = 15).
+    const footer = table.locator('[data-slot="relationship-table-footer"]')
+    await expect(footer).toContainText('2 rows')
+    await expect(footer).toContainText('15')
+
+    // Rows show only access-visible data: the closed Session list (ADR-0013,
+    // ungranted here) renders its Relationship table empty rather than leaking.
+    const sessions = page.locator('[data-slot="relationship-table"]', {
+      has: page.getByRole('heading', { name: 'Sessions', exact: true }),
+    })
+    await expect(sessions.locator('[data-slot="relationship-table-empty"]')).toBeVisible()
+  })
+
+  test('clicking a Relationship-table row navigates to the related record', async ({ page }) => {
+    const testUser = generateTestUser()
+    await signUp(page, testUser)
+    await createPost(page, { title: 'Nav Post', slug: 'nav-post', viewCount: 1 })
+
+    await page.goto('/admin/user')
+    await page.waitForLoadState('networkidle')
+    await page.locator('tr', { hasText: testUser.email }).locator('a:has-text("Edit")').click()
+    await page.waitForURL(/\/admin\/user\/[^/]+$/, { timeout: 10000 })
+
+    await page.locator('[data-slot="relationship-table-row"]', { hasText: 'Nav Post' }).click()
+    await page.waitForURL(/\/admin\/post\/[^/]+$/, { timeout: 10000 })
+    await expect(page.locator('input[name="title"]')).toHaveValue('Nav Post')
+  })
+
+  test('a list with no to-many relationship renders a single details card', async ({ page }) => {
+    const testUser = generateTestUser()
+    await signUp(page, testUser)
+    await createPost(page, { title: 'Single Card Post', slug: 'single-card-post', viewCount: 2 })
+
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    await page.locator('tr', { hasText: 'Single Card Post' }).locator('a:has-text("Edit")').click()
+    await page.waitForURL(/\/admin\/post\/[^/]+$/, { timeout: 10000 })
+
+    // Post has no to-many relationship → no Relationship table, no split layout.
+    await expect(page.locator('[data-slot="relationship-table"]')).toHaveCount(0)
+    await expect(page.locator('[data-slot="item-view-layout"]')).toHaveCount(0)
+    // The details form still renders.
+    await expect(page.locator('input[name="title"]')).toHaveValue('Single Card Post')
+  })
+})

--- a/examples/starter-auth/opensaas.config.ts
+++ b/examples/starter-auth/opensaas.config.ts
@@ -1,5 +1,5 @@
 import { config, list } from '@opensaas/stack-core'
-import { text, relationship, select, timestamp } from '@opensaas/stack-core/fields'
+import { text, relationship, select, timestamp, integer } from '@opensaas/stack-core/fields'
 import { authPlugin } from '@opensaas/stack-auth'
 import type { AccessControl } from '@opensaas/stack-core'
 import type { Lists } from '@/.opensaas/lists'
@@ -61,10 +61,19 @@ export default config({
       // Extend User list with custom fields
       extendUserList: {
         fields: {
-          // Add a posts relationship
+          // Add a posts relationship. On the User item view this renders as a
+          // read-only Relationship table (issue #734): its columns default to
+          // Post's curation minus the `author` back-reference, and the totals
+          // footer sums the numeric `viewCount` column.
           posts: relationship({
             ref: 'Post.author',
             many: true,
+            ui: {
+              itemView: {
+                columns: ['title', 'status', 'viewCount'],
+                sum: ['viewCount'],
+              },
+            },
           }),
         },
       },
@@ -134,6 +143,8 @@ export default config({
           ui: { displayMode: 'segmented-control' },
         }),
         publishedAt: timestamp(),
+        // Numeric field summed by the User item view's Relationship-table footer.
+        viewCount: integer({ defaultValue: 0 }),
         author: relationship({
           ref: 'User.posts',
           access: {

--- a/examples/starter-auth/prisma/schema.prisma
+++ b/examples/starter-auth/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Post {
   internalNotes String?
   status        String    @default("draft")
   publishedAt   DateTime?
+  viewCount     Int?      @default(0)
   authorId      String?   @map("author")
   author        User?     @relation(fields: [authorId], references: [id])
 
@@ -43,11 +44,9 @@ model Session {
   ipAddress String?
   userAgent String?
   userId    String?   @map("user")
-  user      User?     @relation(fields: [userId], references: [id])
+  user      User?     @relation(onDelete: Cascade, fields: [userId], references: [id])
   createdAt DateTime  @default(now())
   updatedAt DateTime  @default(now()) @updatedAt
-
-  @@index([userId])
 }
 
 model Account {
@@ -62,11 +61,9 @@ model Account {
   idToken               String?
   password              String?
   userId                String?   @map("user")
-  user                  User?     @relation(fields: [userId], references: [id])
+  user                  User?     @relation(onDelete: Cascade, fields: [userId], references: [id])
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @default(now()) @updatedAt
-
-  @@index([userId])
 }
 
 model Verification {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -150,6 +150,8 @@ export type {
   UIConfig,
   ListUIConfig,
   ListViewUIConfig,
+  ItemViewUIConfig,
+  RelationshipItemViewConfig,
   ThemeConfig,
   ThemePreset,
   ThemeColors,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -929,6 +929,57 @@ export type SelectField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig
   }
 }
 
+/**
+ * Item-view configuration for a single to-many relationship field — the
+ * per-relationship overrides for the admin item view's Relationship table
+ * (issue #734). All values are plain, serialisable data so they can cross the
+ * server→client boundary via the existing field-config serialisation.
+ */
+export type RelationshipItemViewConfig = {
+  /**
+   * How this to-many relationship is presented on the owning record's item
+   * view:
+   * - `'table'` (default): a read-only Relationship table of related rows.
+   * - `'picker'`: demote it back to the compact relationship picker inside the
+   *   details card (the pre-#734 behaviour).
+   *
+   * @default 'table'
+   */
+  displayMode?: 'table' | 'picker'
+  /**
+   * The related list's fields to show as Relationship-table columns, in order.
+   *
+   * When omitted, the columns default to the related list's own column
+   * curation (`ui.listView.initialColumns`, else all non-system fields) minus
+   * the back-reference field that points at the parent record.
+   *
+   * @example
+   * ```typescript
+   * posts: relationship({
+   *   ref: 'Post.author',
+   *   many: true,
+   *   ui: { itemView: { columns: ['title', 'status'] } },
+   * })
+   * ```
+   */
+  columns?: string[]
+  /**
+   * The numeric columns whose values are summed in the Relationship table's
+   * totals footer. The row count is always shown; sums appear only for the
+   * columns listed here, each formatted by that column's Cell.
+   *
+   * @example
+   * ```typescript
+   * lineItems: relationship({
+   *   ref: 'LineItem.order',
+   *   many: true,
+   *   ui: { itemView: { sum: ['amount'] } },
+   * })
+   * ```
+   */
+  sum?: string[]
+}
+
 export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =
   BaseFieldConfig<TTypeInfo> & {
     type: 'relationship'
@@ -1055,6 +1106,13 @@ export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =
     }
     ui?: {
       displayMode?: 'select' | 'cards'
+      /**
+       * Item-view (Relationship table) overrides for this to-many relationship
+       * — columns, summed columns, and demotion to the compact picker (issue
+       * #734). Ignored for single (`many: false`) relationships, which always
+       * render inside the details card.
+       */
+      itemView?: RelationshipItemViewConfig
     }
     /**
      * Get the complete Prisma schema contribution for this relationship field.
@@ -1781,6 +1839,13 @@ export type ListUIConfig = {
    */
   listView?: ListViewUIConfig
   /**
+   * Item-view (record edit page) configuration for this list — controls the
+   * placement/order of the shape-derived Relationship-table sections (issue
+   * #734). When omitted, sections appear in field-declaration order and the
+   * layout is derived purely from the number of to-many relationships.
+   */
+  itemView?: ItemViewUIConfig
+  /**
    * The field used to represent a row as a single label — in relationship
    * cells, dropdown options, and page headings. Must reference a declared,
    * non-relationship field on this list.
@@ -1794,6 +1859,30 @@ export type ListUIConfig = {
    * ```
    */
   labelField?: string
+}
+
+/**
+ * Item-view (record edit page) configuration, mirroring the `ui.listView`
+ * shape but for the shape-derived item layout (issue #734).
+ *
+ * The layout itself — single card / two-column split / stacked — is derived
+ * from the number of to-many relationships rendered as Relationship tables and
+ * needs no configuration. This block only reorders those sections; the
+ * per-relationship column/sum/picker overrides live on the relationship field
+ * (`ui.itemView`, see {@link RelationshipItemViewConfig}).
+ */
+export type ItemViewUIConfig = {
+  /**
+   * The order of the Relationship-table sections, by their to-many
+   * relationship field name. Listed fields come first in this order; any
+   * to-many relationship not listed keeps its declaration order after them.
+   *
+   * @example
+   * ```typescript
+   * ui: { itemView: { order: ['orders', 'reviews'] } }
+   * ```
+   */
+  order?: string[]
 }
 
 /**

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -1,11 +1,21 @@
 import * as React from 'react'
 import Link from 'next/link.js'
 import { ItemFormClient } from './ItemFormClient.js'
+import { RelationshipTable } from './RelationshipTable.js'
 import { formatListName } from '../lib/utils.js'
 import { PageHeader } from './PageHeader.js'
+import { Card } from '../primitives/card.js'
 import type { ServerActionInput } from '../server/types.js'
-import { type AccessContext, getDbKey, getUrlKey, OpenSaasConfig } from '@opensaas/stack-core'
+import {
+  type AccessContext,
+  type FieldConfig,
+  type ListConfig,
+  getDbKey,
+  getUrlKey,
+  OpenSaasConfig,
+} from '@opensaas/stack-core'
 import { buildRelationshipInclude, prepareItemForm } from '../lib/prepareItemForm.js'
+import { deriveItemViewLayout, type ItemViewLayout } from '../lib/deriveItemView.js'
 
 export interface ItemFormProps {
   context: AccessContext<unknown>
@@ -16,6 +26,192 @@ export interface ItemFormProps {
   basePath?: string
   // Server action can return any shape depending on the list item type
   serverAction: (input: ServerActionInput) => Promise<unknown>
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
+type AnyListConfig = ListConfig<any>
+
+/**
+ * Build the `include` object for an item-view fetch that derives Relationship
+ * tables. To-one / details relationships are included one level deep; each
+ * to-many Relationship table is included with a nested include of its own
+ * relationship columns, so their Cells can resolve labels — all through the
+ * secured context, so only access-visible rows and fields come back.
+ */
+function buildItemViewInclude(
+  listConfig: AnyListConfig,
+  config: OpenSaasConfig,
+  layout: ItemViewLayout,
+): Record<string, boolean | { include: Record<string, boolean> }> {
+  const include: Record<string, boolean | { include: Record<string, boolean> }> = {}
+
+  for (const fieldName of layout.detailsFields) {
+    if (listConfig.fields[fieldName]?.type === 'relationship') {
+      include[fieldName] = true
+    }
+  }
+
+  for (const section of layout.sections) {
+    const relatedListConfig = config.lists[section.relatedListKey]
+    const relationshipColumns = section.columns.filter(
+      (column) => relatedListConfig?.fields[column]?.type === 'relationship',
+    )
+    include[section.fieldName] =
+      relationshipColumns.length > 0
+        ? { include: Object.fromEntries(relationshipColumns.map((column) => [column, true])) }
+        : true
+  }
+
+  return include
+}
+
+/** The related rows for a section, or `[]` when absent/denied. */
+function sectionRows(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? (value as Array<Record<string, unknown>>) : []
+}
+
+/**
+ * Edit-mode item view whose layout is DERIVED from the list shape (issue #734):
+ * scalar/to-one fields (and picker-demoted relationships) in a details card
+ * with the existing whole-form Save/Cancel, and each to-many relationship as a
+ * read-only Relationship table. The arrangement follows from the number of
+ * tables — one → two-column split, several → stacked.
+ */
+async function ItemViewLayoutView({
+  context,
+  config,
+  listConfig,
+  listKey,
+  itemId,
+  basePath,
+  serverAction,
+  layout,
+}: {
+  context: AccessContext<unknown>
+  config: OpenSaasConfig
+  listConfig: AnyListConfig
+  listKey: string
+  itemId: string
+  basePath: string
+  serverAction: (input: ServerActionInput) => Promise<unknown>
+  layout: ItemViewLayout
+}) {
+  const urlKey = getUrlKey(listKey)
+
+  // One secured read: details relationships one level deep, each Relationship
+  // table nested-included so its cells resolve. Access control on the include
+  // means only access-visible rows/fields are returned.
+  const include = buildItemViewInclude(listConfig, config, layout)
+  let itemData: Record<string, unknown> | null = null
+  try {
+    const delegate = context.db[getDbKey(listKey)]
+    if (delegate?.findUnique) {
+      itemData = await delegate.findUnique({ where: { id: itemId }, include })
+    }
+  } catch (error) {
+    console.error(`Failed to fetch item ${itemId}:`, error)
+  }
+
+  if (!itemData) {
+    return (
+      <div className="p-8">
+        <div className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-6">
+          <h2 className="text-lg font-semibold mb-2">Item not found</h2>
+          <p>
+            The item you&apos;re trying to edit doesn&apos;t exist or you don&apos;t have access to
+            it.
+          </p>
+          <Link
+            href={`${basePath}/${urlKey}`}
+            className="inline-block mt-4 text-primary hover:underline"
+          >
+            ← Back to {formatListName(listKey)}
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  // The details card owns only the scalar/to-one/picker fields. Restricting the
+  // form's fields (and data) to that subset keeps the whole-form Save/Cancel
+  // behaviour identical to the pre-#734 edit page: one update, one hook pass —
+  // the read-only Relationship tables are never part of the form payload.
+  const detailsFieldEntries = layout.detailsFields
+    .map((fieldName): [string, FieldConfig] | null => {
+      const field = listConfig.fields[fieldName]
+      return field ? [fieldName, field] : null
+    })
+    .filter((entry): entry is [string, FieldConfig] => entry !== null)
+  const detailsListConfig: AnyListConfig = {
+    ...listConfig,
+    fields: Object.fromEntries(detailsFieldEntries),
+  }
+  const detailsItemData: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(itemData)) {
+    if (!layout.sections.some((section) => section.fieldName === key)) {
+      detailsItemData[key] = value
+    }
+  }
+
+  const { serializableFields, initialData, relationshipData } = await prepareItemForm(
+    context,
+    config,
+    detailsListConfig,
+    detailsItemData,
+  )
+
+  const detailsCard = (
+    <Card data-slot="item-view-details" className="p-6">
+      <ItemFormClient
+        listKey={listKey}
+        urlKey={urlKey}
+        mode="edit"
+        fields={serializableFields}
+        initialData={initialData}
+        itemId={itemId}
+        basePath={basePath}
+        serverAction={serverAction}
+        relationshipData={relationshipData}
+      />
+    </Card>
+  )
+
+  const tables = layout.sections.map((section) => (
+    <RelationshipTable
+      key={section.fieldName}
+      config={config}
+      section={section}
+      rows={sectionRows(itemData?.[section.fieldName])}
+      basePath={basePath}
+    />
+  ))
+
+  return (
+    <div className="p-8">
+      <PageHeader
+        backHref={`${basePath}/${urlKey}`}
+        backLabel={`Back to ${formatListName(listKey)}`}
+        title={`Edit ${formatListName(listKey)}`}
+      />
+
+      {layout.arrangement === 'split' ? (
+        // One Relationship table → two-column split (details card beside it).
+        <div
+          data-slot="item-view-layout"
+          className="grid grid-cols-1 items-start gap-6 lg:grid-cols-2"
+        >
+          {detailsCard}
+          {tables}
+        </div>
+      ) : (
+        // Several Relationship tables → details card on top, tables stacked.
+        <div data-slot="item-view-layout" className="space-y-6">
+          {detailsCard}
+          {tables}
+        </div>
+      )}
+    </div>
+  )
 }
 
 /**
@@ -43,6 +239,28 @@ export async function ItemForm({
         </div>
       </div>
     )
+  }
+
+  // Edit mode: derive the item-view layout from the list shape. When the list
+  // has one or more to-many relationships rendered as Relationship tables, use
+  // the derived layout; otherwise (no tables, or create) fall through to the
+  // single details-card path below — byte-identical to the pre-#734 form.
+  if (mode === 'edit' && itemId) {
+    const layout = deriveItemViewLayout(config, listKey)
+    if (layout.sections.length > 0) {
+      return (
+        <ItemViewLayoutView
+          context={context}
+          config={config}
+          listConfig={listConfig}
+          listKey={listKey}
+          itemId={itemId}
+          basePath={basePath}
+          serverAction={serverAction}
+          layout={layout}
+        />
+      )
+    }
   }
 
   // Fetch item data if in edit mode

--- a/packages/ui/src/components/RelationshipTable.tsx
+++ b/packages/ui/src/components/RelationshipTable.tsx
@@ -1,0 +1,145 @@
+import {
+  getItemLabel,
+  getUrlKey,
+  type OpenSaasConfig,
+  type FieldConfig,
+  type ListConfig,
+} from '@opensaas/stack-core'
+import { formatFieldName } from '../lib/utils.js'
+import { serializeFieldConfig, type SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
+import type { RelationshipTableSection } from '../lib/deriveItemView.js'
+import { RelationshipTableClient } from './RelationshipTableClient.js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
+type AnyListConfig = ListConfig<any>
+
+export interface RelationshipTableProps {
+  config: OpenSaasConfig
+  /** The derived section describing this to-many relationship. */
+  section: RelationshipTableSection
+  /**
+   * The parent record's related rows for this relationship, already fetched and
+   * access-filtered through the secured context (`context.db` include). Only
+   * access-visible rows/fields are present here.
+   */
+  rows: Array<Record<string, unknown>>
+  basePath: string
+}
+
+/**
+ * Resolve a fetched relationship column value (a related record, or an array of
+ * them, or `null`) into the `{ id, label }` shape the cell registry's
+ * relationship Cell renders — using the shared label seam so it never drifts
+ * from the list page's relationship cells.
+ */
+function toRelationshipCellValue(
+  value: unknown,
+  relatedListConfig: AnyListConfig | undefined,
+): unknown {
+  if (!relatedListConfig || value == null) return value
+  const resolveOne = (entry: unknown): unknown => {
+    if (!entry || typeof entry !== 'object' || !('id' in entry)) return entry
+    const row = entry as Record<string, unknown>
+    return { id: String(row.id), label: getItemLabel(relatedListConfig, row) }
+  }
+  return Array.isArray(value) ? value.map(resolveOne) : resolveOne(value)
+}
+
+/**
+ * Serialised config for a Relationship-table column. Columns are usually
+ * declared fields on the related list; a column that isn't (e.g. an explicit
+ * `id`/`createdAt` override) falls back to a minimal text/timestamp config so
+ * the cell registry can still resolve a Cell.
+ */
+function columnFieldConfig(
+  column: string,
+  relatedListConfig: AnyListConfig | undefined,
+): SerializableFieldConfig {
+  const field = relatedListConfig?.fields[column] as FieldConfig | undefined
+  if (field) return serializeFieldConfig(field)
+  if (column === 'createdAt' || column === 'updatedAt') return { type: 'timestamp' }
+  return { type: 'text' }
+}
+
+/** Coerce a cell value to a number for footer summing, or `null` if not numeric. */
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+/**
+ * Read-only Relationship table (issue #734) — a section of the item view
+ * showing a to-many relationship's related rows. Server Component: it resolves
+ * columns, cells (via the shared serialise path), and the totals footer sums
+ * from rows already fetched through the secured context, then hands minimal,
+ * serialisable props to {@link RelationshipTableClient}.
+ *
+ * Read-only in this ticket: rows navigate to the related record on click.
+ * Inline cell edit (#737), the pre-linked create drawer (#738), and row removal
+ * (#739) extend the named Slots left in the client component — no edit/add/
+ * remove affordances are rendered here.
+ */
+export function RelationshipTable({ config, section, rows, basePath }: RelationshipTableProps) {
+  const relatedListConfig = config.lists[section.relatedListKey]
+  const relatedUrlKey = getUrlKey(section.relatedListKey)
+
+  // The related list config for each relationship column, keyed by column, so
+  // its values can be label-resolved via that column's OWN target list (a
+  // `Post.author` column resolves against User, not Post).
+  const columnRelatedList = new Map<string, AnyListConfig | undefined>()
+  for (const column of section.columns) {
+    const columnField = relatedListConfig?.fields[column]
+    if (columnField?.type === 'relationship' && 'ref' in columnField) {
+      const targetKey =
+        typeof columnField.ref === 'string' ? columnField.ref.split('.')[0] : undefined
+      columnRelatedList.set(column, targetKey ? config.lists[targetKey] : undefined)
+    }
+  }
+
+  // Resolve relationship-column values to { id, label } and drop everything
+  // outside the shown columns (keeping `id` for the row link).
+  const preparedRows = rows.map((row) => {
+    const prepared: Record<string, unknown> = { id: row.id }
+    for (const column of section.columns) {
+      prepared[column] = columnRelatedList.has(column)
+        ? toRelationshipCellValue(row[column], columnRelatedList.get(column))
+        : row[column]
+    }
+    return prepared
+  })
+
+  // Sum only explicitly-configured numeric columns, over access-visible values.
+  const sums: Record<string, number> = {}
+  for (const column of section.sumColumns) {
+    sums[column] = rows.reduce((total, row) => {
+      const numeric = toNumber(row[column])
+      return numeric === null ? total : total + numeric
+    }, 0)
+  }
+
+  const fields: Record<string, SerializableFieldConfig> = {}
+  for (const column of section.columns) {
+    fields[column] = columnFieldConfig(column, relatedListConfig)
+  }
+
+  // JSON round-trip so only serialisable data crosses to the client component.
+  const serializedRows = JSON.parse(JSON.stringify(preparedRows)) as Array<Record<string, unknown>>
+
+  return (
+    <RelationshipTableClient
+      title={formatFieldName(section.fieldName)}
+      relatedUrlKey={relatedUrlKey}
+      basePath={basePath}
+      columns={section.columns}
+      fields={fields}
+      rows={serializedRows}
+      count={rows.length}
+      sumColumns={section.sumColumns}
+      sums={sums}
+    />
+  )
+}

--- a/packages/ui/src/components/RelationshipTableClient.tsx
+++ b/packages/ui/src/components/RelationshipTableClient.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import * as React from 'react'
+import { useRouter } from 'next/navigation.js'
+import { cn, formatFieldName, isNumericField } from '../lib/utils.js'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../primitives/table.js'
+import { Card } from '../primitives/card.js'
+import { CellRenderer } from './cells/CellRenderer.js'
+import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
+
+export interface RelationshipTableClientProps {
+  /** Section heading (the relationship field name, title-cased). */
+  title: string
+  /** URL key of the related list, for row-click navigation. */
+  relatedUrlKey: string
+  /** Admin base path (e.g. `/admin`). */
+  basePath: string
+  /** Column field names, in order. */
+  columns: string[]
+  /** Serialised field config per column, driving Cell resolution. */
+  fields: Record<string, SerializableFieldConfig>
+  /** Serialised, access-filtered related rows (relationship values pre-resolved). */
+  rows: Array<Record<string, unknown>>
+  /** Total access-visible row count, always shown in the footer. */
+  count: number
+  /** Columns summed in the footer (explicit opt-in only). */
+  sumColumns: string[]
+  /** Per-column footer sum, rendered through that column's Cell. */
+  sums: Record<string, number>
+}
+
+/**
+ * Read-only Relationship table (issue #734), client half. Renders related rows
+ * as a table whose cells come from the cell registry (`CellRenderer`), so
+ * badges/formatting match the related list's own page. Rows navigate to the
+ * related record on click; the table renders no edit/add/remove affordances.
+ *
+ * Named Slots (the reviewed extension seams for the follow-up tickets):
+ * - `relationship-table` — the section container.
+ * - `relationship-table-toolbar` — header actions region; the pre-linked create
+ *   drawer's "+ Add" (#738) mounts here.
+ * - `relationship-table-row` — a related row; row removal (#739) adds its
+ *   trailing affordance here.
+ * - `relationship-table-cell` — a rendered cell; inline cell edit (#737) wraps
+ *   the Cell here.
+ * - `relationship-table-footer` — the totals footer (count + configured sums).
+ */
+export function RelationshipTableClient({
+  title,
+  relatedUrlKey,
+  basePath,
+  columns,
+  fields,
+  rows,
+  count,
+  sumColumns,
+  sums,
+}: RelationshipTableClientProps) {
+  const router = useRouter()
+  const sumColumnSet = React.useMemo(() => new Set(sumColumns), [sumColumns])
+
+  const columnFieldType = (column: string): string | undefined => fields[column]?.type
+
+  return (
+    <Card data-slot="relationship-table" className="overflow-hidden">
+      <div className="flex items-center justify-between gap-2 border-b border-border p-4">
+        <h2 className="font-heading text-lg font-semibold">{title}</h2>
+        {/* Seam: the pre-linked create drawer's "+ Add" control (#738) mounts here. */}
+        <div data-slot="relationship-table-toolbar" className="flex items-center gap-2" />
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => {
+              const numeric = isNumericField(columnFieldType(column))
+              return (
+                <TableHead key={column} className={cn(numeric && 'text-right')}>
+                  {formatFieldName(column)}
+                </TableHead>
+              )
+            })}
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell
+                data-slot="relationship-table-empty"
+                colSpan={Math.max(columns.length, 1)}
+                className="py-8 text-center text-sm text-muted-foreground"
+              >
+                No related {title.toLowerCase()} yet.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((row) => (
+              <TableRow
+                key={String(row.id)}
+                data-slot="relationship-table-row"
+                className="cursor-pointer"
+                onClick={() => router.push(`${basePath}/${relatedUrlKey}/${row.id}`)}
+              >
+                {columns.map((column) => (
+                  <TableCell
+                    key={column}
+                    data-slot="relationship-table-cell"
+                    className={cn(isNumericField(columnFieldType(column)) && 'text-right')}
+                  >
+                    {/* Read-only Cell; inline cell edit (#737) wraps this. */}
+                    <CellRenderer
+                      value={row[column]}
+                      field={fields[column] ?? { type: 'text' }}
+                      fieldName={column}
+                      basePath={basePath}
+                    />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+
+        <TableFooter>
+          <TableRow data-slot="relationship-table-footer">
+            {columns.map((column, index) => {
+              const numeric = isNumericField(columnFieldType(column))
+              const isSummed = sumColumnSet.has(column)
+              return (
+                <TableCell key={column} className={cn(numeric && 'text-right')}>
+                  {index === 0 && (
+                    <span className="text-sm text-muted-foreground">
+                      {count} {count === 1 ? 'row' : 'rows'}
+                    </span>
+                  )}
+                  {isSummed && (
+                    <span className={cn('font-medium', index === 0 && 'ml-2')}>
+                      <CellRenderer
+                        value={sums[column]}
+                        field={fields[column] ?? { type: 'text' }}
+                        fieldName={column}
+                        basePath={basePath}
+                      />
+                    </span>
+                  )}
+                </TableCell>
+              )
+            })}
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/RelationshipTableClient.tsx
+++ b/packages/ui/src/components/RelationshipTableClient.tsx
@@ -132,29 +132,37 @@ export function RelationshipTableClient({
 
         <TableFooter>
           <TableRow data-slot="relationship-table-footer">
-            {columns.map((column, index) => {
-              const numeric = isNumericField(columnFieldType(column))
-              const isSummed = sumColumnSet.has(column)
-              return (
-                <TableCell key={column} className={cn(numeric && 'text-right')}>
-                  {index === 0 && (
-                    <span className="text-sm text-muted-foreground">
-                      {count} {count === 1 ? 'row' : 'rows'}
-                    </span>
-                  )}
-                  {isSummed && (
-                    <span className={cn('font-medium', index === 0 && 'ml-2')}>
-                      <CellRenderer
-                        value={sums[column]}
-                        field={fields[column] ?? { type: 'text' }}
-                        fieldName={column}
-                        basePath={basePath}
-                      />
-                    </span>
-                  )}
-                </TableCell>
-              )
-            })}
+            {columns.length === 0 ? (
+              // No columns (related list curates to nothing but the back-reference):
+              // still always show the row count, mirroring the empty-body colSpan.
+              <TableCell colSpan={1} className="text-sm text-muted-foreground">
+                {count} {count === 1 ? 'row' : 'rows'}
+              </TableCell>
+            ) : (
+              columns.map((column, index) => {
+                const numeric = isNumericField(columnFieldType(column))
+                const isSummed = sumColumnSet.has(column)
+                return (
+                  <TableCell key={column} className={cn(numeric && 'text-right')}>
+                    {index === 0 && (
+                      <span className="text-sm text-muted-foreground">
+                        {count} {count === 1 ? 'row' : 'rows'}
+                      </span>
+                    )}
+                    {isSummed && (
+                      <span className={cn('font-medium', index === 0 && 'ml-2')}>
+                        <CellRenderer
+                          value={sums[column]}
+                          field={fields[column] ?? { type: 'text' }}
+                          fieldName={column}
+                          basePath={basePath}
+                        />
+                      </span>
+                    )}
+                  </TableCell>
+                )
+              })
+            )}
           </TableRow>
         </TableFooter>
       </Table>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,8 @@ export { ListViewClient } from './components/ListViewClient.js'
 export { RowSelectionBar } from './components/RowSelectionBar.js'
 export { ItemForm } from './components/ItemForm.js'
 export { ItemFormClient } from './components/ItemFormClient.js'
+export { RelationshipTable } from './components/RelationshipTable.js'
+export { RelationshipTableClient } from './components/RelationshipTableClient.js'
 export { SingletonView } from './components/SingletonView.js'
 export { ConfirmDialog } from './components/ConfirmDialog.js'
 export { LoadingSpinner } from './components/LoadingSpinner.js'
@@ -79,6 +81,16 @@ export type {
 } from './components/RowSelectionBar.js'
 export type { ItemFormProps } from './components/ItemForm.js'
 export type { ItemFormClientProps } from './components/ItemFormClient.js'
+export type { RelationshipTableProps } from './components/RelationshipTable.js'
+export type { RelationshipTableClientProps } from './components/RelationshipTableClient.js'
+
+// Item-view layout derivation (shape → details card + Relationship tables)
+export { deriveItemViewLayout } from './lib/deriveItemView.js'
+export type {
+  ItemViewLayout,
+  ItemViewArrangement,
+  RelationshipTableSection,
+} from './lib/deriveItemView.js'
 export type { SingletonViewProps } from './components/SingletonView.js'
 export type { ConfirmDialogProps } from './components/ConfirmDialog.js'
 export type { LoadingSpinnerProps } from './components/LoadingSpinner.js'

--- a/packages/ui/src/lib/deriveItemView.ts
+++ b/packages/ui/src/lib/deriveItemView.ts
@@ -1,0 +1,178 @@
+import type { FieldConfig, ListConfig, OpenSaasConfig } from '@opensaas/stack-core'
+
+/**
+ * The container arrangement of an item view, DERIVED from the number of
+ * to-many relationships rendered as Relationship tables (issue #734):
+ * - `single`: no Relationship tables → a single, centered details card.
+ * - `split`: exactly one Relationship table → a two-column split (details card
+ *   beside the table).
+ * - `stacked`: several Relationship tables → details card on top, tables
+ *   stacked beneath it.
+ */
+export type ItemViewArrangement = 'single' | 'split' | 'stacked'
+
+/**
+ * One derived Relationship-table section — a to-many relationship on the record
+ * being edited, rendered read-only as a table of related rows.
+ */
+export interface RelationshipTableSection {
+  /** The to-many relationship field name on the parent list. */
+  fieldName: string
+  /** The relationship `ref` (`'List.field'` or `'List'`). */
+  ref: string
+  /** The related list this table shows rows of. */
+  relatedListKey: string
+  /**
+   * The related list's field that points back at the parent record, derived
+   * from the `ref` (`'Post.author'` → `author`). Stripped from the default
+   * columns and used nowhere else. `undefined` for list-only refs.
+   */
+  backReferenceField?: string
+  /** The related-list columns to show, in order (curation minus back-reference). */
+  columns: string[]
+  /** Numeric columns to sum in the totals footer (explicit opt-in only). */
+  sumColumns: string[]
+}
+
+/**
+ * The complete derived item-view layout: which fields belong in the details
+ * card, which to-many relationships become Relationship tables, and the
+ * arrangement that follows from their count.
+ */
+export interface ItemViewLayout {
+  /** Field names for the details card (scalars, to-one, demoted to-many pickers). */
+  detailsFields: string[]
+  /** Relationship-table sections, in placement order. */
+  sections: RelationshipTableSection[]
+  /** Container arrangement derived from `sections.length`. */
+  arrangement: ItemViewArrangement
+}
+
+/**
+ * Related-list columns that are never shown by default, mirroring the list
+ * view's own default curation (`ListViewClient`): system timestamp columns and
+ * password fields.
+ */
+const DEFAULT_EXCLUDED_COLUMNS = new Set(['password', 'createdAt', 'updatedAt'])
+
+/** Read an array of strings from an unknown config value, else `undefined`. */
+function readStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+    ? (value as string[])
+    : undefined
+}
+
+/**
+ * Read a to-many relationship's item-view overrides off its serialisable `ui`
+ * config without casting: `ui.itemView` is `unknown` (index-signature) so each
+ * property is narrowed at runtime.
+ */
+function readRelationshipItemView(field: FieldConfig): {
+  displayMode: 'table' | 'picker'
+  columns?: string[]
+  sum?: string[]
+} {
+  const raw: unknown = field.ui ? field.ui.itemView : undefined
+  if (typeof raw !== 'object' || raw === null) {
+    return { displayMode: 'table' }
+  }
+  const displayMode = 'displayMode' in raw && raw.displayMode === 'picker' ? 'picker' : 'table'
+  const columns = 'columns' in raw ? readStringArray(raw.columns) : undefined
+  const sum = 'sum' in raw ? readStringArray(raw.sum) : undefined
+  return { displayMode, columns, sum }
+}
+
+/** Whether a field config is a to-many relationship. */
+function isToManyRelationship(field: FieldConfig): boolean {
+  return field.type === 'relationship' && 'many' in field && field.many === true
+}
+
+/**
+ * The default columns for a related list's Relationship table: the list's own
+ * column curation (`ui.listView.initialColumns`, else all non-system fields),
+ * with the back-reference to the parent removed.
+ */
+function defaultColumnsFor(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
+  relatedListConfig: ListConfig<any> | undefined,
+  backReferenceField: string | undefined,
+): string[] {
+  if (!relatedListConfig) return []
+  const curated =
+    relatedListConfig.ui?.listView?.initialColumns ??
+    Object.keys(relatedListConfig.fields).filter((key) => !DEFAULT_EXCLUDED_COLUMNS.has(key))
+  return curated.filter((column) => column !== backReferenceField)
+}
+
+/**
+ * Reorder sections by the list's `ui.itemView.order` (by relationship field
+ * name). Listed fields come first in that order; unlisted sections keep their
+ * relative (declaration) order after them.
+ */
+function applyOrder(
+  sections: RelationshipTableSection[],
+  order: string[] | undefined,
+): RelationshipTableSection[] {
+  if (!order || order.length === 0) return sections
+  const rank = new Map(order.map((name, index) => [name, index]))
+  return sections
+    .map((section, index) => ({ section, index }))
+    .sort((a, b) => {
+      const ra = rank.get(a.section.fieldName)
+      const rb = rank.get(b.section.fieldName)
+      if (ra !== undefined && rb !== undefined) return ra - rb
+      if (ra !== undefined) return -1
+      if (rb !== undefined) return 1
+      return a.index - b.index // stable: preserve declaration order
+    })
+    .map((entry) => entry.section)
+}
+
+/**
+ * Derive the item-view layout from a list's shape (issue #734).
+ *
+ * Pure and config-only (no I/O), so the zero / one / several arrangements are
+ * unit-testable: every to-many relationship not demoted to the picker becomes a
+ * Relationship-table section, everything else is a details-card field, and the
+ * arrangement follows from the section count. Item-view config (`ui.itemView`
+ * on the list for ordering; `ui.itemView` on the relationship for
+ * columns/sum/picker) refines this without changing the derivation rule.
+ */
+export function deriveItemViewLayout(config: OpenSaasConfig, listKey: string): ItemViewLayout {
+  const listConfig = config.lists[listKey]
+  const detailsFields: string[] = []
+  let sections: RelationshipTableSection[] = []
+
+  if (!listConfig) {
+    return { detailsFields, sections, arrangement: 'single' }
+  }
+
+  for (const [fieldName, field] of Object.entries(listConfig.fields)) {
+    const overrides = isToManyRelationship(field) ? readRelationshipItemView(field) : undefined
+
+    // A to-many relationship becomes a Relationship table unless demoted to the
+    // compact picker, which keeps it in the details card (pre-#734 behaviour).
+    if (overrides && overrides.displayMode === 'table' && 'ref' in field) {
+      const ref = typeof field.ref === 'string' ? field.ref : ''
+      const [relatedListKey, backReferenceField] = ref.split('.')
+      const relatedListConfig = config.lists[relatedListKey]
+      sections.push({
+        fieldName,
+        ref,
+        relatedListKey,
+        backReferenceField,
+        columns: overrides.columns ?? defaultColumnsFor(relatedListConfig, backReferenceField),
+        sumColumns: overrides.sum ?? [],
+      })
+    } else {
+      detailsFields.push(fieldName)
+    }
+  }
+
+  sections = applyOrder(sections, listConfig.ui?.itemView?.order)
+
+  const arrangement: ItemViewArrangement =
+    sections.length === 0 ? 'single' : sections.length === 1 ? 'split' : 'stacked'
+
+  return { detailsFields, sections, arrangement }
+}

--- a/packages/ui/tests/components/RelationshipTableClient.test.tsx
+++ b/packages/ui/tests/components/RelationshipTableClient.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RelationshipTableClient } from '../../src/components/RelationshipTableClient.js'
+import type { RelationshipTableClientProps } from '../../src/components/RelationshipTableClient.js'
+
+// Mock Next.js navigation (client component uses useRouter for row navigation).
+const mockPush = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+function baseProps(): RelationshipTableClientProps {
+  return {
+    title: 'Posts',
+    relatedUrlKey: 'post',
+    basePath: '/admin',
+    columns: ['title', 'viewCount'],
+    fields: { title: { type: 'text' }, viewCount: { type: 'integer' } },
+    rows: [
+      { id: 'p1', title: 'First', viewCount: 5 },
+      { id: 'p2', title: 'Second', viewCount: 10 },
+    ],
+    count: 2,
+    sumColumns: ['viewCount'],
+    sums: { viewCount: 15 },
+  }
+}
+
+describe('RelationshipTableClient', () => {
+  beforeEach(() => {
+    mockPush.mockClear()
+  })
+
+  it('renders the section heading, columns, and rows', () => {
+    render(<RelationshipTableClient {...baseProps()} />)
+
+    expect(screen.getByRole('heading', { name: 'Posts' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Title' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'View Count' })).toBeInTheDocument()
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('always shows the row count and sums configured numeric columns via the Cell', () => {
+    render(<RelationshipTableClient {...baseProps()} />)
+
+    const footer = document.querySelector('[data-slot="relationship-table-footer"]')
+    expect(footer).not.toBeNull()
+    // Count always shown; summed column rendered through its Cell (5 + 10 = 15).
+    expect(footer).toHaveTextContent('2 rows')
+    expect(footer).toHaveTextContent('15')
+  })
+
+  it('navigates to the related record when a row is clicked', async () => {
+    render(<RelationshipTableClient {...baseProps()} />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByText('First'))
+    expect(mockPush).toHaveBeenCalledWith('/admin/post/p1')
+  })
+
+  it('renders an empty state and a zero-count footer with no rows', () => {
+    render(<RelationshipTableClient {...baseProps()} rows={[]} count={0} />)
+
+    expect(screen.getByText(/no related posts/i)).toBeInTheDocument()
+    const footer = document.querySelector('[data-slot="relationship-table-footer"]')
+    expect(footer).toHaveTextContent('0 rows')
+  })
+
+  it('still shows the row count when there are zero columns (only the back-reference curated away)', () => {
+    render(
+      <RelationshipTableClient
+        {...baseProps()}
+        columns={[]}
+        fields={{}}
+        sumColumns={[]}
+        sums={{}}
+        count={3}
+      />,
+    )
+
+    const footer = document.querySelector('[data-slot="relationship-table-footer"]')
+    expect(footer).not.toBeNull()
+    // The always-shown count must survive the zero-column footer.
+    expect(within(footer as HTMLElement).getByText('3 rows')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/tests/lib/deriveItemView.test.ts
+++ b/packages/ui/tests/lib/deriveItemView.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { deriveItemViewLayout } from '../../src/lib/deriveItemView.js'
+import type { OpenSaasConfig } from '@opensaas/stack-core'
+
+/**
+ * Build a minimal config whose lists/fields carry just enough shape for the
+ * pure item-view derivation (types, `many`, `ref`, `ui`). The derivation is
+ * config-only, so no field-builder methods are needed.
+ */
+function makeConfig(lists: OpenSaasConfig['lists']): OpenSaasConfig {
+  return { db: { provider: 'sqlite', url: 'file:./test.db' }, lists }
+}
+
+describe('deriveItemViewLayout', () => {
+  it('derives a single centered card when there are no to-many relationships', () => {
+    const config = makeConfig({
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          author: { type: 'relationship', ref: 'User.posts' }, // to-one → details
+        },
+      },
+    })
+
+    const layout = deriveItemViewLayout(config, 'Post')
+
+    expect(layout.arrangement).toBe('single')
+    expect(layout.sections).toHaveLength(0)
+    expect(layout.detailsFields).toEqual(['title', 'author'])
+  })
+
+  it('derives a two-column split for exactly one to-many relationship', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          name: { type: 'text' },
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+        },
+      },
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          status: { type: 'select', options: [] },
+          author: { type: 'relationship', ref: 'User.posts' },
+        },
+      },
+    })
+
+    const layout = deriveItemViewLayout(config, 'User')
+
+    expect(layout.arrangement).toBe('split')
+    expect(layout.detailsFields).toEqual(['name'])
+    expect(layout.sections).toHaveLength(1)
+    const [section] = layout.sections
+    expect(section.fieldName).toBe('posts')
+    expect(section.relatedListKey).toBe('Post')
+    expect(section.backReferenceField).toBe('author')
+    // Columns = related list curation minus the back-reference (`author`).
+    expect(section.columns).toEqual(['title', 'status'])
+    expect(section.sumColumns).toEqual([])
+  })
+
+  it('stacks several to-many relationships', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          name: { type: 'text' },
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+          comments: { type: 'relationship', ref: 'Comment.author', many: true },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+      Comment: {
+        fields: { body: { type: 'text' }, author: { type: 'relationship', ref: 'User.comments' } },
+      },
+    })
+
+    const layout = deriveItemViewLayout(config, 'User')
+
+    expect(layout.arrangement).toBe('stacked')
+    expect(layout.sections.map((s) => s.fieldName)).toEqual(['posts', 'comments'])
+  })
+
+  it('honours a per-relationship column override', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: {
+            type: 'relationship',
+            ref: 'Post.author',
+            many: true,
+            ui: { itemView: { columns: ['title'] } },
+          },
+        },
+      },
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          status: { type: 'select', options: [] },
+          author: { type: 'relationship', ref: 'User.posts' },
+        },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.columns).toEqual(['title'])
+  })
+
+  it('reads summed columns from config (footer opt-in)', () => {
+    const config = makeConfig({
+      Order: {
+        fields: {
+          lineItems: {
+            type: 'relationship',
+            ref: 'LineItem.order',
+            many: true,
+            ui: { itemView: { sum: ['amount'] } },
+          },
+        },
+      },
+      LineItem: {
+        fields: {
+          amount: { type: 'integer' },
+          order: { type: 'relationship', ref: 'Order.lineItems' },
+        },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'Order').sections
+    expect(section.sumColumns).toEqual(['amount'])
+    // Default columns still exclude the back-reference.
+    expect(section.columns).toEqual(['amount'])
+  })
+
+  it('demotes a relationship to the picker (details card) when configured', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          name: { type: 'text' },
+          posts: {
+            type: 'relationship',
+            ref: 'Post.author',
+            many: true,
+            ui: { itemView: { displayMode: 'picker' } },
+          },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+
+    const layout = deriveItemViewLayout(config, 'User')
+    expect(layout.arrangement).toBe('single')
+    expect(layout.sections).toHaveLength(0)
+    // The demoted relationship stays a details-card field.
+    expect(layout.detailsFields).toEqual(['name', 'posts'])
+  })
+
+  it('reorders sections by list-level ui.itemView.order', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+          comments: { type: 'relationship', ref: 'Comment.author', many: true },
+        },
+        ui: { itemView: { order: ['comments', 'posts'] } },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+      Comment: {
+        fields: { body: { type: 'text' }, author: { type: 'relationship', ref: 'User.comments' } },
+      },
+    })
+
+    const layout = deriveItemViewLayout(config, 'User')
+    expect(layout.sections.map((s) => s.fieldName)).toEqual(['comments', 'posts'])
+  })
+
+  it('falls back to id when a related list has no curated columns', () => {
+    const config = makeConfig({
+      Team: {
+        fields: { members: { type: 'relationship', ref: 'Member', many: true } },
+      },
+      // List-only ref: no back-reference field, columns come from the list itself.
+      Member: { fields: { name: { type: 'text' } } },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'Team').sections
+    expect(section.backReferenceField).toBeUndefined()
+    expect(section.columns).toEqual(['name'])
+  })
+})


### PR DESCRIPTION
Implements #734. Part of #728.

## What this does

The record edit page now **derives its layout from the list's shape**:

- Scalar and to-one fields (plus any relationship demoted to the picker) stay in a **details card** — whole-form Save/Cancel with one update / one validation+hook pass, unchanged from before.
- Each to-many relationship renders as a read-only **Relationship table** section. The arrangement follows purely from the count:
  - **0** to-many relationships → single centered details card
  - **1** → two-column split (details card beside the table)
  - **several** → details card on top, tables stacked
- Relationship-table **columns** default to the related list's own column curation (`ui.listView.initialColumns`, else all non-system fields) **minus the back-reference** to the parent, overridable per relationship.
- **Cells come from the cell registry** (`CellRenderer`, #729) — badges/formatting match the related list's own page. No new renderer.
- A **totals footer** always shows the row count and additionally sums only explicitly-configured numeric columns, each rendered through that column's Cell.
- Rows and counts are fetched through the **secured context** (`context.db` include), so only access-visible data shows. A row click navigates to the related record.

## How the layout is derived

`deriveItemViewLayout(config, listKey)` (pure, in `packages/ui/src/lib/deriveItemView.ts`, unit-tested for zero/one/several + overrides/demote/order) walks the list's fields: every to-many relationship not demoted to the picker becomes a `RelationshipTableSection`, everything else is a details-card field, and `arrangement` is `single | split | stacked` from `sections.length`. `ItemForm` (edit mode) uses it to do **one** secured `findUnique` — details relationships one level deep, each Relationship table nested-included so its cells resolve — then splits the field set so the details card's whole-form save is byte-identical to the pre-#734 form. Create mode and zero-table edit fall through to the existing single-card path unchanged.

## Config (additive, `@opensaas/stack-core` minor)

```typescript
posts: relationship({
  ref: 'Post.author',
  many: true,
  ui: {
    itemView: {
      columns: ['title', 'status', 'viewCount'], // override columns
      sum: ['viewCount'],                          // sum in the footer
      // displayMode: 'picker',                    // demote to the details-card picker
    },
  },
})
// list level: ui: { itemView: { order: ['posts'] } }  // reorder sections
```

## Cells reuse & Slots for follow-ups

Relationship-table cells go through the existing **cell registry** (`CellRenderer`) — per-field override → custom-type → field-type → text fallback. The client component ships named Slots as the reviewed extension seams, no edit/add/remove affordances rendered:

- `relationship-table` — section container
- `relationship-table-toolbar` — where the pre-linked create drawer's "+ Add" (**#738**) mounts
- `relationship-table-row` — where row removal (**#739**) adds its affordance
- `relationship-table-cell` — where inline cell edit (**#737**) wraps the Cell
- `relationship-table-footer` — totals footer

## Tests

- **Unit** (`packages/ui`): `deriveItemViewLayout` — zero/one/several arrangements, columns-minus-back-reference, per-relationship column override, summed columns, demote-to-picker, list-level reorder, list-only ref.
- **E2E** (`e2e/starter-auth/05-item-view.spec.ts`): the User edit page renders the `posts` Relationship table with curated columns and a footer (`2 rows`, summed `viewCount` = 15); closed `Session` list renders an empty table (access-visible only); row click navigates to the post; a Post (no to-many) renders a single details card.

Ran green: core vitest (774), ui vitest (395 + 8 new), the new item-view e2e (3), and the existing admin-ui e2e (15, no regression). `pnpm lint` clean, `pnpm manypkg fix`, `pnpm format`. Changeset included (`@opensaas/stack-ui` + `@opensaas/stack-core` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_