### PR TITLE
Filter builder input UI for the admin list view (#731)

### DIFF
--- a/.changeset/filter-builder-input-ui.md
+++ b/.changeset/filter-builder-input-ui.md
@@ -1,0 +1,41 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add the Filter builder input UI for the admin list view (#731)
+
+The admin list view now ships a `FilterBuilder` that constructs the `?search=`
+filter query the filter engine already consumes (ADR-0017) — a free-text search
+box plus structured field / operator / value rows. Available fields, operators,
+and value suggestions are derived entirely from each field's self-contained
+`getFilterSpec` (via the serializable `collectFilterSuggestions` metadata), so
+there is no field-type `switch` and no functions cross the server/client
+boundary. Applied filters flow through the same secured `context.db`, so
+filtering can only ever narrow what a session may see.
+
+`@opensaas/stack-core` gains `serializeFilterQuery(tokens)` — the exact inverse
+of `parseFilterQuery` — so the builder produces the grammar the engine parses
+with the quoting and operator-prefix rules kept next to the parser.
+
+The `FilterBuilder` is composable (exported from `@opensaas/stack-ui` and
+`@opensaas/stack-ui/standalone`) with theme-token styling and `data-slot` parts
+for extension:
+
+```tsx
+import { FilterBuilder } from '@opensaas/stack-ui/standalone'
+import { collectFilterSuggestions } from '@opensaas/stack-core'
+
+// Server component: collect serializable suggestion metadata for the list.
+const suggestions = collectFilterSuggestions(listConfig, 'Post', config)
+
+// Client: build and apply a `?search=` query.
+<FilterBuilder
+  suggestions={suggestions}
+  defaultValue={search}
+  onApply={(query) => router.push(`/admin/post?search=${encodeURIComponent(query)}`)}
+/>
+```
+
+The list view wires this in automatically; existing `?search=` URLs keep
+working unchanged.

--- a/e2e/starter-auth/06-filter-builder.spec.ts
+++ b/e2e/starter-auth/06-filter-builder.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * Filter builder input UI (issue #731, part of #728; layered on the #730 filter
+ * engine / ADR-0017).
+ *
+ * These specs drive the REAL builder in the admin list view — the free-text box
+ * and the structured field/operator/value rows — and assert it writes the
+ * `?search=` filter query the secured server-side engine consumes, narrowing the
+ * table to the matching, access-scoped rows. (05-filter.spec.ts types the query
+ * straight into the URL; this exercises the UI that produces it.)
+ */
+test.describe('Filter builder input UI', () => {
+  let testUser: ReturnType<typeof generateTestUser>
+
+  test.beforeEach(async ({ page }) => {
+    testUser = generateTestUser()
+    await signUp(page, testUser)
+  })
+
+  async function createPost(
+    page: Page,
+    { title, slug, status }: { title: string; slug: string; status: 'draft' | 'published' },
+  ) {
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    await page.click('text=/create|new/i')
+    await page.waitForLoadState('networkidle')
+    await page.fill('input[name="title"]', title)
+    await page.fill('input[name="slug"]', slug)
+    await page.fill('textarea[name="content"]', 'Body content for the post.')
+    if (status === 'published') {
+      await page.getByLabel('Status').click()
+      await page.getByRole('option', { name: 'published' }).click()
+    }
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/admin\/post/, { timeout: 10000 })
+  }
+
+  /** A table cell whose exact text is the given title (the title column). */
+  function titleCell(page: Page, title: string) {
+    return page.getByRole('cell', { name: title, exact: true })
+  }
+
+  test('free-text box narrows the table and writes ?search=', async ({ page }) => {
+    await createPost(page, { title: 'Apples are red', slug: 'apples', status: 'published' })
+    await createPost(page, { title: 'Bananas are yellow', slug: 'bananas', status: 'published' })
+
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+
+    // Type into the builder's free-text search box and apply.
+    await page.getByLabel('Search').fill('Apples')
+    await page.getByRole('button', { name: 'Apply' }).click()
+
+    await page.waitForURL(/search=Apples/, { timeout: 10000 })
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Apples are red')).toBeVisible()
+    await expect(titleCell(page, 'Bananas are yellow')).toHaveCount(0)
+  })
+
+  test('a structured status filter produces a field:value query', async ({ page }) => {
+    await createPost(page, { title: 'Draft One', slug: 'draft-one', status: 'draft' })
+    await createPost(page, { title: 'Published One', slug: 'published-one', status: 'published' })
+
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+
+    // Add a structured condition, target the `status` field, pick "Published".
+    await page.getByRole('button', { name: /add filter/i }).click()
+    await page.getByLabel('Filter field').selectOption('status')
+    await page.getByLabel('Filter value').selectOption('published')
+    await page.getByRole('button', { name: 'Apply' }).click()
+
+    // The applied query is the engine's grammar (`status:published`), URL-encoded.
+    await page.waitForURL(/search=status(%3A|:)published/, { timeout: 10000 })
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Published One')).toBeVisible()
+    await expect(titleCell(page, 'Draft One')).toHaveCount(0)
+  })
+
+  test('Clear removes the filter and restores every row', async ({ page }) => {
+    await createPost(page, { title: 'Keep Me', slug: 'keep-me', status: 'published' })
+    await createPost(page, { title: 'Also Me', slug: 'also-me', status: 'published' })
+
+    // Land on an already-filtered view (the builder hydrates from the URL).
+    await page.goto('/admin/post?search=Keep')
+    await page.waitForLoadState('networkidle')
+    await expect(titleCell(page, 'Keep Me')).toBeVisible()
+    await expect(titleCell(page, 'Also Me')).toHaveCount(0)
+
+    // Clearing drops the `?search=` filter and both rows return. `exact` avoids
+    // matching the inline "Clear filter text" affordance.
+    await page.getByRole('button', { name: 'Clear', exact: true }).click()
+    await page.waitForLoadState('networkidle')
+
+    await expect(titleCell(page, 'Keep Me')).toBeVisible()
+    await expect(titleCell(page, 'Also Me')).toBeVisible()
+  })
+})

--- a/packages/core/src/filter/index.ts
+++ b/packages/core/src/filter/index.ts
@@ -10,6 +10,7 @@
 // ───────────────────────────────────────────────────────────────
 
 export { parseFilterQuery } from './parse.js'
+export { serializeFilterQuery } from './serialize.js'
 export { buildFilterWhere } from './map.js'
 export { collectFilterSpecs, buildListFilterWhere, collectFilterSuggestions } from './collect.js'
 export type {

--- a/packages/core/src/filter/serialize.test.ts
+++ b/packages/core/src/filter/serialize.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { parseFilterQuery } from './parse.js'
+import { serializeFilterQuery } from './serialize.js'
+import type { FilterToken } from './types.js'
+
+// ─────────────────────────────────────────────────────────────
+// serializeFilterQuery — the pure tokens → query-string boundary
+// (ADR-0017). The exact inverse of parseFilterQuery; this is the
+// grammar the Filter builder UI produces into the `?search=` param.
+// ─────────────────────────────────────────────────────────────
+
+const token = (partial: Partial<FilterToken>): FilterToken => ({
+  field: null,
+  operator: 'eq',
+  value: '',
+  raw: '',
+  ...partial,
+})
+
+describe('serializeFilterQuery', () => {
+  it('serialises a bare free-text word', () => {
+    expect(serializeFilterQuery([token({ field: null, value: 'beta' })])).toBe('beta')
+  })
+
+  it('serialises a field:value token with the default eq operator', () => {
+    expect(serializeFilterQuery([token({ field: 'role', value: 'Editor' })])).toBe('role:Editor')
+  })
+
+  it('serialises each comparison operator as its prefix', () => {
+    expect(serializeFilterQuery([token({ field: 'orders', operator: 'gt', value: '5' })])).toBe(
+      'orders:>5',
+    )
+    expect(serializeFilterQuery([token({ field: 'orders', operator: 'gte', value: '5' })])).toBe(
+      'orders:>=5',
+    )
+    expect(serializeFilterQuery([token({ field: 'orders', operator: 'lt', value: '5' })])).toBe(
+      'orders:<5',
+    )
+    expect(serializeFilterQuery([token({ field: 'orders', operator: 'lte', value: '5' })])).toBe(
+      'orders:<=5',
+    )
+  })
+
+  it('quotes a field value containing whitespace', () => {
+    expect(serializeFilterQuery([token({ field: 'name', value: 'Ada Lovelace' })])).toBe(
+      'name:"Ada Lovelace"',
+    )
+  })
+
+  it('quotes a bare word containing whitespace', () => {
+    expect(serializeFilterQuery([token({ field: null, value: 'multi word' })])).toBe('"multi word"')
+  })
+
+  it('quotes an eq value that would otherwise read as a comparison operator', () => {
+    // Without the guard, `field:>5` would re-parse as gt, not eq of ">5".
+    expect(serializeFilterQuery([token({ field: 'note', operator: 'eq', value: '>5' })])).toBe(
+      'note:">5"',
+    )
+  })
+
+  it('does NOT quote a leading > on a bare word (parser keeps it literal)', () => {
+    expect(serializeFilterQuery([token({ field: null, value: '>5' })])).toBe('>5')
+  })
+
+  it('joins tokens with the grammar implicit AND (a single space)', () => {
+    expect(
+      serializeFilterQuery([
+        token({ field: 'role', value: 'Editor' }),
+        token({ field: 'orders', operator: 'gt', value: '5' }),
+        token({ field: null, value: 'beta' }),
+      ]),
+    ).toBe('role:Editor orders:>5 beta')
+  })
+
+  it('omits tokens with an empty value (no dangling field: or stray quotes)', () => {
+    expect(
+      serializeFilterQuery([
+        token({ field: 'role', value: '' }),
+        token({ field: null, value: '' }),
+        token({ field: 'name', value: 'Ada' }),
+      ]),
+    ).toBe('name:Ada')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────
+// Round-trip: parse ∘ serialize is stable, and serialize ∘ parse
+// reproduces the meaning the engine assigns.
+// ─────────────────────────────────────────────────────────────
+
+describe('parse/serialize round-trip', () => {
+  const queries = [
+    'beta',
+    'role:Editor',
+    'orders:>5',
+    'orders:>=5',
+    'orders:<10',
+    'name:"Ada Lovelace"',
+    'role:Editor orders:>5 name:"Ada Lovelace" beta',
+    '"multi word" gamma',
+  ]
+
+  it.each(queries)('serialize(parse(%s)) reproduces the query', (query) => {
+    expect(serializeFilterQuery(parseFilterQuery(query))).toBe(query)
+  })
+
+  it.each(queries)('parse is idempotent through a serialize round-trip: %s', (query) => {
+    const once = parseFilterQuery(query)
+    const twice = parseFilterQuery(serializeFilterQuery(once))
+    // Compare on the semantic fields (raw differs after re-serialisation).
+    const strip = (tokens: FilterToken[]) =>
+      tokens.map(({ field, operator, value }) => ({ field, operator, value }))
+    expect(strip(twice)).toEqual(strip(once))
+  })
+})

--- a/packages/core/src/filter/serialize.ts
+++ b/packages/core/src/filter/serialize.ts
@@ -1,0 +1,75 @@
+import type { FilterOperator, FilterToken } from './types.js'
+
+/**
+ * The comparison-operator prefix each {@link FilterOperator} serialises to. The
+ * exact inverse of the prefixes {@link parseFilterQuery} recognises (`eq` has no
+ * prefix — a plain `field:value`).
+ */
+const OPERATOR_PREFIX: Record<FilterOperator, string> = {
+  eq: '',
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+}
+
+/**
+ * Whether a value must be wrapped in double quotes to survive re-parsing.
+ *
+ * A value is quoted when it contains whitespace (so `parseFilterQuery` keeps it
+ * as one token) or an embedded quote. When `guardOperatorChars` is set (an `eq`
+ * field token, where a leading `>`/`<` would otherwise be read as a comparison
+ * operator), a value starting with `<`/`>` is also quoted so it round-trips as a
+ * literal value rather than an operator.
+ */
+function quoteIfNeeded(value: string, guardOperatorChars: boolean): string {
+  const needsQuote =
+    /\s/.test(value) ||
+    value.includes('"') ||
+    (guardOperatorChars && (value.startsWith('>') || value.startsWith('<')))
+  return needsQuote ? `"${value}"` : value
+}
+
+/**
+ * Serialise {@link FilterToken}s back into a filter query string — the exact
+ * inverse of {@link parseFilterQuery} (ADR-0017). This is the grammar-producing
+ * half the Filter builder UI relies on: the builder turns UI state into tokens
+ * and serialises them into the `?search=` URL param the engine already consumes,
+ * so the same quoting and operator-prefix rules live next to the parser and can
+ * never drift.
+ *
+ * Pure and field-agnostic (no DB/Prisma imports). Tokens are joined with the
+ * grammar's implicit AND (a single space). A token with an empty value carries
+ * no filter and is omitted, so `serializeFilterQuery` never emits a dangling
+ * `field:` or a stray quote pair.
+ *
+ * @example
+ * serializeFilterQuery([
+ *   { field: 'role',   operator: 'eq', value: 'Editor',       raw: '' },
+ *   { field: 'orders', operator: 'gt', value: '5',            raw: '' },
+ *   { field: 'name',   operator: 'eq', value: 'Ada Lovelace', raw: '' },
+ *   { field: null,     operator: 'eq', value: 'beta',         raw: '' },
+ * ])
+ * // 'role:Editor orders:>5 name:"Ada Lovelace" beta'
+ */
+export function serializeFilterQuery(tokens: FilterToken[]): string {
+  const parts: string[] = []
+
+  for (const token of tokens) {
+    // An empty value is not a filter — skip it rather than emit `field:` / `""`.
+    if (token.value === '') continue
+
+    if (token.field === null) {
+      // Bare free-text word. A leading `>`/`<` stays literal for bare words
+      // (the parser only treats them as operators after a `field:`), so no
+      // operator guard is needed here.
+      parts.push(quoteIfNeeded(token.value, false))
+      continue
+    }
+
+    const prefix = OPERATOR_PREFIX[token.operator]
+    parts.push(`${token.field}:${prefix}${quoteIfNeeded(token.value, prefix === '')}`)
+  }
+
+  return parts.join(' ')
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export type { RelationshipOption, RelationshipOptionsArgs } from './query/relati
 // context, so the filter can only ever narrow visibility.
 export {
   parseFilterQuery,
+  serializeFilterQuery,
   buildFilterWhere,
   collectFilterSpecs,
   buildListFilterWhere,

--- a/packages/ui/src/components/FilterBuilder.tsx
+++ b/packages/ui/src/components/FilterBuilder.tsx
@@ -1,0 +1,356 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter } from 'next/navigation.js'
+import { Plus, X } from 'lucide-react'
+import type { FilterFieldSuggestion, FilterOperator, FilterValueSource } from '@opensaas/stack-core'
+import { Card } from '../primitives/card.js'
+import { Input } from '../primitives/input.js'
+import { Button } from '../primitives/button.js'
+import { cn, formatFieldName } from '../lib/utils.js'
+import { type FilterRow, queryToState, stateToQuery } from '../lib/filterBuilderState.js'
+
+/**
+ * Human-readable labels for the grammar's operators. `eq` reads as "is" because
+ * every field's `eq` mapping is an equality/contains match; the comparisons only
+ * ever appear on numeric/date fields.
+ */
+const OPERATOR_LABELS: Record<FilterOperator, string> = {
+  eq: 'is',
+  gt: 'greater than',
+  gte: 'greater or equal',
+  lt: 'less than',
+  lte: 'less or equal',
+}
+
+/**
+ * Native `<select>`/`<option>` controls (rather than a Radix popover) keep the
+ * builder's field/operator/value pickers robust across jsdom unit tests and real
+ * browsers, and serialisation-free. Styled to match the `Input` primitive using
+ * theme tokens only.
+ */
+const NATIVE_CONTROL_CLASS =
+  'h-10 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+
+/**
+ * Per-part `classNames` slots for {@link FilterBuilder}. Each merges onto its
+ * `data-slot` part via `cn`, consistent with the other admin components' Slot
+ * extension seam (#709/#729/#733).
+ */
+export interface FilterBuilderClassNames {
+  /** Card wrapper (`data-slot="filter-builder"`). */
+  root?: string
+  /** Wrapper around the structured condition rows. */
+  conditions?: string
+  /** A single condition row (`data-slot="filter-builder-condition"`). */
+  condition?: string
+  /** The field `<select>` in a row (`data-slot="filter-builder-field"`). */
+  field?: string
+  /** The operator `<select>` in a row (`data-slot="filter-builder-operator"`). */
+  operator?: string
+  /** The value input/select in a row (`data-slot="filter-builder-value"`). */
+  value?: string
+  /** The per-row remove button (`data-slot="filter-builder-remove"`). */
+  remove?: string
+  /** The free-text form row (`data-slot="filter-builder-form"`). */
+  form?: string
+  /** The free-text search input (`data-slot="filter-builder-search"`). */
+  search?: string
+  /** The "Add filter" button (`data-slot="filter-builder-add"`). */
+  add?: string
+  /** The Apply button (`data-slot="filter-builder-apply"`). */
+  apply?: string
+  /** The Clear button (`data-slot="filter-builder-clear"`). */
+  clear?: string
+}
+
+export interface FilterBuilderProps {
+  /**
+   * Serializable per-field filter metadata (field name, supported operators,
+   * free-text flag, value source). Produced server-side by the core engine's
+   * `collectFilterSuggestions` — it carries no functions, so it crosses the
+   * server/client boundary. When empty, only the free-text box is shown.
+   */
+  suggestions: FilterFieldSuggestion[]
+  /** The current `?search=` query, used to hydrate the builder on mount. */
+  defaultValue?: string
+  /**
+   * Called with the serialised `?search=` query when the user applies filters.
+   * When omitted, the builder navigates to `?search=<query>` on the current
+   * pathname itself (standalone use).
+   */
+  onApply?: (query: string) => void
+  /** Placeholder for the free-text search box. */
+  placeholder?: string
+  className?: string
+  /** Structured per-part class overrides; each merges onto its `data-slot` part. */
+  classNames?: FilterBuilderClassNames
+}
+
+/**
+ * The default value a fresh row gets for a given value source: enums start
+ * unset (the user picks from the dropdown), everything else starts empty.
+ */
+function initialValueForSource(_source: FilterValueSource): string {
+  return ''
+}
+
+/**
+ * Filter builder input UI (issue #731, part of #728; layered on the #730 filter
+ * engine / ADR-0017).
+ *
+ * Constructs the admin list's `?search=` filter query from a friendly UI —
+ * structured field/operator/value rows plus a free-text box — and produces the
+ * exact grammar the engine already consumes (`serializeFilterQuery`). It never
+ * invents a parallel filter path: the applied query flows through the same URL
+ * param the secured `context.db` reads server-side, so filtering can only ever
+ * narrow, never widen, what a session may see.
+ *
+ * Available fields, operators and value suggestions are derived entirely from
+ * the serializable {@link FilterFieldSuggestion}s (each field's self-contained
+ * `getFilterSpec`) — there is no `switch` on field type here, mirroring the
+ * cell/field-component registry pattern.
+ */
+export function FilterBuilder({
+  suggestions,
+  defaultValue = '',
+  onApply,
+  placeholder = 'Search…',
+  className,
+  classNames,
+}: FilterBuilderProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  // Hydrate once from the incoming query. The parent remounts this component
+  // (via a `key` on the applied query) when the URL changes, so the builder
+  // always reflects the active filter without an effect-driven prop copy.
+  const [state, setState] = React.useState(() => queryToState(defaultValue, suggestions))
+
+  const suggestionByField = React.useMemo(
+    () => new Map(suggestions.map((s) => [s.field, s])),
+    [suggestions],
+  )
+
+  const applyQuery = (query: string) => {
+    if (onApply) {
+      onApply(query)
+      return
+    }
+    router.push(query ? `${pathname}?search=${encodeURIComponent(query)}` : pathname)
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    applyQuery(stateToQuery(state))
+  }
+
+  const handleClear = () => {
+    setState({ rows: [], freeText: '' })
+    applyQuery('')
+  }
+
+  const addRow = () => {
+    const first = suggestions[0]
+    if (!first) return
+    const newRow: FilterRow = {
+      id: `row-${Date.now()}-${state.rows.length}`,
+      field: first.field,
+      operator: first.operators[0] ?? 'eq',
+      value: initialValueForSource(first.valueSource),
+    }
+    setState((prev) => ({ ...prev, rows: [...prev.rows, newRow] }))
+  }
+
+  const removeRow = (id: string) => {
+    setState((prev) => ({ ...prev, rows: prev.rows.filter((row) => row.id !== id) }))
+  }
+
+  const updateRow = (id: string, patch: Partial<Omit<FilterRow, 'id'>>) => {
+    setState((prev) => ({
+      ...prev,
+      rows: prev.rows.map((row) => {
+        if (row.id !== id) return row
+        // Changing the field resets the operator to one the new field supports
+        // and clears the value (its meaning/source differs per field).
+        if (patch.field !== undefined && patch.field !== row.field) {
+          const suggestion = suggestionByField.get(patch.field)
+          return {
+            ...row,
+            field: patch.field,
+            operator: suggestion?.operators[0] ?? 'eq',
+            value: suggestion ? initialValueForSource(suggestion.valueSource) : '',
+          }
+        }
+        return { ...row, ...patch }
+      }),
+    }))
+  }
+
+  const renderValueControl = (row: FilterRow) => {
+    const suggestion = suggestionByField.get(row.field)
+    const source = suggestion?.valueSource ?? { kind: 'none' as const }
+    const valueClass = cn(NATIVE_CONTROL_CLASS, 'min-w-[10rem]', classNames?.value)
+
+    if (source.kind === 'enum') {
+      return (
+        <select
+          data-slot="filter-builder-value"
+          aria-label="Filter value"
+          className={valueClass}
+          value={row.value}
+          onChange={(e) => updateRow(row.id, { value: e.target.value })}
+        >
+          <option value="">Select…</option>
+          {source.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )
+    }
+
+    const relationshipPlaceholder =
+      source.kind === 'relationship' ? `Search ${formatFieldName(source.listKey)}…` : 'Value'
+
+    return (
+      <Input
+        data-slot="filter-builder-value"
+        aria-label="Filter value"
+        className={cn('h-10 min-w-[10rem] flex-1', classNames?.value)}
+        value={row.value}
+        placeholder={relationshipPlaceholder}
+        onChange={(e) => updateRow(row.id, { value: e.target.value })}
+      />
+    )
+  }
+
+  return (
+    <Card data-slot="filter-builder" className={cn('space-y-3 p-4', className, classNames?.root)}>
+      {state.rows.length > 0 && (
+        <div
+          data-slot="filter-builder-conditions"
+          className={cn('space-y-2', classNames?.conditions)}
+        >
+          {state.rows.map((row) => {
+            const suggestion = suggestionByField.get(row.field)
+            const operators = suggestion?.operators ?? ['eq']
+            return (
+              <div
+                key={row.id}
+                data-slot="filter-builder-condition"
+                className={cn('flex flex-wrap items-center gap-2', classNames?.condition)}
+              >
+                <select
+                  data-slot="filter-builder-field"
+                  aria-label="Filter field"
+                  className={cn(NATIVE_CONTROL_CLASS, classNames?.field)}
+                  value={row.field}
+                  onChange={(e) => updateRow(row.id, { field: e.target.value })}
+                >
+                  {suggestions.map((s) => (
+                    <option key={s.field} value={s.field}>
+                      {formatFieldName(s.field)}
+                    </option>
+                  ))}
+                </select>
+
+                {operators.length > 1 && (
+                  <select
+                    data-slot="filter-builder-operator"
+                    aria-label="Filter operator"
+                    className={cn(NATIVE_CONTROL_CLASS, classNames?.operator)}
+                    value={row.operator}
+                    onChange={(e) =>
+                      updateRow(row.id, { operator: e.target.value as FilterOperator })
+                    }
+                  >
+                    {operators.map((op) => (
+                      <option key={op} value={op}>
+                        {OPERATOR_LABELS[op]}
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {renderValueControl(row)}
+
+                <button
+                  type="button"
+                  data-slot="filter-builder-remove"
+                  aria-label="Remove filter"
+                  onClick={() => removeRow(row.id)}
+                  className={cn(
+                    'inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground',
+                    classNames?.remove,
+                  )}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <form
+        data-slot="filter-builder-form"
+        onSubmit={handleSubmit}
+        className={cn('flex flex-wrap items-center gap-2', classNames?.form)}
+      >
+        <div className="relative min-w-[12rem] flex-1">
+          <Input
+            data-slot="filter-builder-search"
+            aria-label="Search"
+            type="text"
+            value={state.freeText}
+            placeholder={placeholder}
+            className={cn('pr-10', classNames?.search)}
+            onChange={(e) => setState((prev) => ({ ...prev, freeText: e.target.value }))}
+          />
+          {state.freeText && (
+            <button
+              type="button"
+              data-slot="filter-builder-search-clear"
+              aria-label="Clear filter text"
+              onClick={() => setState((prev) => ({ ...prev, freeText: '' }))}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        {suggestions.length > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            data-slot="filter-builder-add"
+            onClick={addRow}
+            className={classNames?.add}
+          >
+            <Plus aria-hidden="true" />
+            Add filter
+          </Button>
+        )}
+
+        <Button type="submit" data-slot="filter-builder-apply" className={classNames?.apply}>
+          Apply
+        </Button>
+
+        {(state.rows.length > 0 || state.freeText) && (
+          <Button
+            type="button"
+            variant="ghost"
+            data-slot="filter-builder-clear"
+            onClick={handleClear}
+            className={classNames?.clear}
+          >
+            Clear
+          </Button>
+        )}
+      </form>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -10,6 +10,7 @@ import {
   type AccessContext,
   type AccessControl,
   buildListFilterWhere,
+  collectFilterSuggestions,
   getDbKey,
   getItemLabel,
   getUrlKey,
@@ -201,6 +202,14 @@ export async function ListView({
   // Serialize items for client component (convert Dates, etc to JSON-safe format)
   const serializedItems = JSON.parse(JSON.stringify(itemsWithResolvedLabels))
 
+  // Collect each filterable field's serializable Filter spec metadata (fields,
+  // operators, enumerated values / relationship label search) to drive the
+  // Filter builder's pickers. This carries no functions, so it crosses the
+  // server/client boundary; it mirrors the same specs the server-side
+  // `buildListFilterWhere` above uses, so the builder can only produce queries
+  // the engine understands.
+  const filterSuggestions = collectFilterSuggestions(listConfig, listKey, config)
+
   return (
     <div className="p-8">
       <PageHeader
@@ -236,6 +245,7 @@ export async function ListView({
         pageSize={pageSize}
         total={total || 0}
         search={search}
+        filterSuggestions={filterSuggestions}
         serverAction={serverAction}
         canDelete={canDeleteList(listConfig.access?.operation?.delete)}
       />

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -13,17 +13,17 @@ import {
   TableHeader,
   TableRow,
 } from '../primitives/table.js'
-import { Input } from '../primitives/input.js'
 import { Button } from '../primitives/button.js'
-import { Card } from '../primitives/card.js'
 import { Checkbox } from '../primitives/checkbox.js'
 import { EmptyState } from './EmptyState.js'
 import { CellRenderer } from './cells/CellRenderer.js'
+import { FilterBuilder } from './FilterBuilder.js'
 import { RowSelectionBar } from './RowSelectionBar.js'
 import { useRowSelection, getPageCheckboxState } from '../lib/useRowSelection.js'
 import { useBulkStatus } from '../lib/useBulkStatus.js'
 import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
 import type { ServerActionInput } from '../server/types.js'
+import type { FilterFieldSuggestion } from '@opensaas/stack-core'
 
 /**
  * Read the `{ deleted, total }` count a bulk-delete server action returns. The
@@ -68,6 +68,13 @@ export interface ListViewClientProps {
   total: number
   search?: string
   /**
+   * Serializable per-field filter metadata (from the core engine's
+   * `collectFilterSuggestions`) that drives the Filter builder's field /
+   * operator / value pickers. Carries no functions, so it is safe to pass to
+   * this client component. When empty, the builder shows only free-text search.
+   */
+  filterSuggestions?: FilterFieldSuggestion[]
+  /**
    * The generic server action (rebuilds the session context server-side). Used
    * by the built-in Bulk action Delete to remove each selected row through the
    * secured context. When omitted, no bulk delete is offered.
@@ -101,13 +108,13 @@ export function ListViewClient({
   pageSize,
   total,
   search: initialSearch,
+  filterSuggestions = [],
   serverAction,
   canDelete = false,
 }: ListViewClientProps) {
   const router = useRouter()
   const sortBy = initialSort?.field ?? null
   const sortOrder = initialSort?.direction ?? 'asc'
-  const [searchInput, setSearchInput] = React.useState(initialSearch || '')
 
   // Row selection (issue #733). The selection is keyed on the ACTIVE FILTER
   // STATE: the `search` param is the filter engine's URL filter query (#730 —
@@ -172,25 +179,19 @@ export function ListViewClient({
     router.push(`${basePath}/${urlKey}?${withPageSize(params).toString()}`)
   }
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault()
+  // Apply a Filter builder query: write it into the `?search=` URL param the
+  // filter engine consumes, preserving the active sort/pageSize and resetting to
+  // page 1. An empty query drops the param entirely (clears the filter).
+  const applyQuery = (query: string) => {
     const params = new URLSearchParams()
-    if (searchInput.trim()) {
-      params.set('search', searchInput.trim())
+    const trimmed = query.trim()
+    if (trimmed) {
+      params.set('search', trimmed)
     }
     if (sortBy) {
       params.set('sort', `${sortBy}:${sortOrder}`)
     }
-    params.set('page', '1') // Reset to page 1 on new search
-    router.push(`${basePath}/${urlKey}?${withPageSize(params).toString()}`)
-  }
-
-  const handleClearSearch = () => {
-    setSearchInput('')
-    const params = new URLSearchParams()
-    if (sortBy) {
-      params.set('sort', `${sortBy}:${sortOrder}`)
-    }
+    params.set('page', '1') // Reset to page 1 on a new filter.
     const qs = withPageSize(params).toString()
     router.push(`${basePath}/${urlKey}${qs ? `?${qs}` : ''}`)
   }
@@ -249,30 +250,15 @@ export function ListViewClient({
 
   return (
     <div className="space-y-4">
-      {/* Search Bar */}
-      <Card className="p-4">
-        <form onSubmit={handleSearch} className="flex gap-2">
-          <div className="flex-1 relative">
-            <Input
-              type="text"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="Search..."
-              className="pr-10"
-            />
-            {searchInput && (
-              <button
-                type="button"
-                onClick={handleClearSearch}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              >
-                ✕
-              </button>
-            )}
-          </div>
-          <Button type="submit">Search</Button>
-        </form>
-      </Card>
+      {/* Filter builder (issue #731) — constructs the `?search=` filter query the
+          engine consumes. Keyed on the active query so it remounts (and re-reads
+          the URL) whenever the applied filter changes. */}
+      <FilterBuilder
+        key={initialSearch ?? ''}
+        suggestions={filterSuggestions}
+        defaultValue={initialSearch ?? ''}
+        onApply={applyQuery}
+      />
 
       {/* Bulk-action result ("N of M deleted"). Lives here (always mounted) so
           it survives the selection clearing after a delete. */}
@@ -351,7 +337,7 @@ export function ListViewClient({
                       title="No matches found"
                       description={`Nothing matched “${initialSearch}”. Try a different search term.`}
                       actions={
-                        <Button variant="outline" size="sm" onClick={handleClearSearch}>
+                        <Button variant="outline" size="sm" onClick={() => applyQuery('')}>
                           Clear search
                         </Button>
                       }

--- a/packages/ui/src/components/standalone/index.ts
+++ b/packages/ui/src/components/standalone/index.ts
@@ -3,6 +3,7 @@ export { ItemCreateForm } from './ItemCreateForm.js'
 export { ItemEditForm } from './ItemEditForm.js'
 export { ListTable } from './ListTable.js'
 export { SearchBar } from './SearchBar.js'
+export { FilterBuilder } from '../FilterBuilder.js'
 export { DeleteButton } from './DeleteButton.js'
 
 // Types
@@ -10,6 +11,7 @@ export type { ItemCreateFormProps } from './ItemCreateForm.js'
 export type { ItemEditFormProps } from './ItemEditForm.js'
 export type { ListTableProps, ListTableClassNames } from './ListTable.js'
 export type { SearchBarProps, SearchBarClassNames } from './SearchBar.js'
+export type { FilterBuilderProps, FilterBuilderClassNames } from '../FilterBuilder.js'
 export type { DeleteButtonProps, DeleteButtonClassNames } from './DeleteButton.js'
 
 // Shared per-part classNames slot shape for the create / edit forms

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export { ThemeToggle } from './components/ThemeToggle.js'
 export { ThemeScript } from './components/ThemeScript.js'
 export { ListView } from './components/ListView.js'
 export { ListViewClient } from './components/ListViewClient.js'
+export { FilterBuilder } from './components/FilterBuilder.js'
 export { RowSelectionBar } from './components/RowSelectionBar.js'
 export { ItemForm } from './components/ItemForm.js'
 export { ItemFormClient } from './components/ItemFormClient.js'
@@ -73,6 +74,7 @@ export type { UserMenuProps } from './components/UserMenu.js'
 export type { ThemeToggleProps } from './components/ThemeToggle.js'
 export type { ListViewProps } from './components/ListView.js'
 export type { ListViewClientProps } from './components/ListViewClient.js'
+export type { FilterBuilderProps, FilterBuilderClassNames } from './components/FilterBuilder.js'
 export type {
   RowSelectionBarProps,
   RowSelectionBarClassNames,
@@ -140,6 +142,10 @@ export {
   getPageCheckboxState,
 } from './lib/useRowSelection.js'
 export type { RowSelection } from './lib/useRowSelection.js'
+
+// Filter builder state helpers (UI state <-> `?search=` query round-trip)
+export { queryToState, stateToQuery } from './lib/filterBuilderState.js'
+export type { FilterRow, FilterBuilderState } from './lib/filterBuilderState.js'
 
 // Theme utilities
 export { compileTheme, presetThemes } from './lib/theme.js'

--- a/packages/ui/src/lib/filterBuilderState.ts
+++ b/packages/ui/src/lib/filterBuilderState.ts
@@ -1,0 +1,91 @@
+import {
+  parseFilterQuery,
+  serializeFilterQuery,
+  type FilterFieldSuggestion,
+  type FilterOperator,
+  type FilterToken,
+} from '@opensaas/stack-core'
+
+/**
+ * One structured condition row in the Filter builder: a field, an operator the
+ * field's spec supports, and the raw value the user typed or picked. `id` is a
+ * stable React key, never serialised into the query.
+ */
+export interface FilterRow {
+  id: string
+  field: string
+  operator: FilterOperator
+  value: string
+}
+
+/**
+ * The Filter builder's editable state: structured field-scoped rows plus a
+ * single free-text box for bare-word search. Together they serialise to the one
+ * `?search=` query the filter engine consumes.
+ */
+export interface FilterBuilderState {
+  rows: FilterRow[]
+  freeText: string
+}
+
+/**
+ * Hydrate the builder from an existing `?search=` query, using the list's
+ * serializable {@link FilterFieldSuggestion}s to decide which tokens can be
+ * shown as structured rows.
+ *
+ * A token becomes a row only when its field has a suggestion, the suggestion
+ * lists the token's operator, and the value is non-empty — mirroring exactly the
+ * conditions under which the engine's `buildFilterWhere` produces a condition
+ * rather than degrading to free text. Everything else (bare words, unknown
+ * fields, unsupported operators) is re-serialised back into the free-text box so
+ * the builder can round-trip any query the engine accepts without losing tokens.
+ */
+export function queryToState(
+  query: string,
+  suggestions: FilterFieldSuggestion[],
+): FilterBuilderState {
+  const suggestionByField = new Map(suggestions.map((s) => [s.field, s]))
+  const tokens = parseFilterQuery(query)
+
+  const rows: FilterRow[] = []
+  const freeTokens: FilterToken[] = []
+  let counter = 0
+
+  for (const token of tokens) {
+    if (token.field !== null) {
+      const suggestion = suggestionByField.get(token.field)
+      if (suggestion && suggestion.operators.includes(token.operator) && token.value !== '') {
+        rows.push({
+          id: `row-${counter++}`,
+          field: token.field,
+          operator: token.operator,
+          value: token.value,
+        })
+        continue
+      }
+    }
+    // Bare word, unknown field, unsupported operator, or empty value: keep it as
+    // free text so it survives the round-trip (the engine would treat it as free
+    // text anyway).
+    freeTokens.push(token)
+  }
+
+  return { rows, freeText: serializeFilterQuery(freeTokens) }
+}
+
+/**
+ * Serialise the builder's state back into a single `?search=` query string.
+ * Empty rows (no field or no value) are dropped; the free-text box is re-parsed
+ * so a user who types `status:draft` into it is normalised the same way a
+ * structured row would be. The result is the exact grammar
+ * {@link parseFilterQuery} consumes.
+ */
+export function stateToQuery(state: FilterBuilderState): string {
+  const rowTokens: FilterToken[] = state.rows
+    .filter((row) => row.field !== '' && row.value !== '')
+    .map((row) => ({ field: row.field, operator: row.operator, value: row.value, raw: '' }))
+
+  const freeTokens = parseFilterQuery(state.freeText)
+
+  return serializeFilterQuery([...rowTokens, ...freeTokens])
+}

--- a/packages/ui/tests/components/AdminUISingleton.test.tsx
+++ b/packages/ui/tests/components/AdminUISingleton.test.tsx
@@ -13,6 +13,7 @@ const mockPush = vi.fn()
 const mockRefresh = vi.fn()
 vi.mock('next/navigation.js', () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  usePathname: () => '/admin/post',
 }))
 
 // next/link renders an anchor; happy-dom can render it directly.

--- a/packages/ui/tests/components/FilterBuilder.test.tsx
+++ b/packages/ui/tests/components/FilterBuilder.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { FilterFieldSuggestion } from '@opensaas/stack-core'
+import { FilterBuilder } from '../../src/components/FilterBuilder.js'
+
+// FilterBuilder calls useRouter()/usePathname() at render even when `onApply`
+// is supplied (the standalone navigation fallback path).
+const push = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => '/admin/post',
+}))
+
+const suggestions: FilterFieldSuggestion[] = [
+  {
+    field: 'status',
+    operators: ['eq'],
+    freeText: false,
+    valueSource: {
+      kind: 'enum',
+      options: [
+        { value: 'draft', label: 'Draft' },
+        { value: 'published', label: 'Published' },
+      ],
+    },
+  },
+  {
+    field: 'views',
+    operators: ['eq', 'gt', 'gte', 'lt', 'lte'],
+    freeText: false,
+    valueSource: { kind: 'none' },
+  },
+  { field: 'title', operators: ['eq'], freeText: true, valueSource: { kind: 'none' } },
+]
+
+describe('FilterBuilder', () => {
+  it('renders a free-text search box and no condition rows by default', () => {
+    render(<FilterBuilder suggestions={suggestions} onApply={vi.fn()} />)
+    expect(screen.getByLabelText('Search')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Filter field')).not.toBeInTheDocument()
+  })
+
+  it('applies a free-text query', async () => {
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} onApply={onApply} />)
+
+    await user.type(screen.getByLabelText('Search'), 'hello world')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    // Two bare words are separate free-text tokens (implicit AND), matching the
+    // engine's grammar — not one quoted phrase.
+    expect(onApply).toHaveBeenCalledWith('hello world')
+  })
+
+  it('adds a condition row whose field picker lists every filterable field', async () => {
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} onApply={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /add filter/i }))
+
+    const fieldSelect = screen.getByLabelText('Filter field')
+    const optionLabels = within(fieldSelect)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    // Field names are humanised via formatFieldName.
+    expect(optionLabels).toEqual(['Status', 'Views', 'Title'])
+  })
+
+  it('offers enum options as a dropdown and produces a field:value token', async () => {
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} onApply={onApply} />)
+
+    await user.click(screen.getByRole('button', { name: /add filter/i }))
+    // First suggestion is `status` (enum) — no operator picker (eq-only).
+    expect(screen.queryByLabelText('Filter operator')).not.toBeInTheDocument()
+
+    const valueSelect = screen.getByLabelText('Filter value')
+    expect(within(valueSelect).getByRole('option', { name: 'Published' })).toBeInTheDocument()
+
+    await user.selectOptions(valueSelect, 'published')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(onApply).toHaveBeenCalledWith('status:published')
+  })
+
+  it('shows an operator picker for a comparison field and serialises the prefix', async () => {
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} onApply={onApply} />)
+
+    await user.click(screen.getByRole('button', { name: /add filter/i }))
+    // Switch the row to the numeric `views` field.
+    await user.selectOptions(screen.getByLabelText('Filter field'), 'views')
+
+    const operatorSelect = screen.getByLabelText('Filter operator')
+    await user.selectOptions(operatorSelect, 'gt')
+
+    await user.type(screen.getByLabelText('Filter value'), '5')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(onApply).toHaveBeenCalledWith('views:>5')
+  })
+
+  it('combines a structured row with free text on apply', async () => {
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} onApply={onApply} />)
+
+    await user.type(screen.getByLabelText('Search'), 'beta')
+    await user.click(screen.getByRole('button', { name: /add filter/i }))
+    await user.selectOptions(screen.getByLabelText('Filter value'), 'draft')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(onApply).toHaveBeenCalledWith('status:draft beta')
+  })
+
+  it('hydrates structured rows and free text from an existing query', () => {
+    render(
+      <FilterBuilder
+        suggestions={suggestions}
+        defaultValue="status:published gamma"
+        onApply={vi.fn()}
+      />,
+    )
+    const valueSelect = screen.getByLabelText('Filter value') as HTMLSelectElement
+    expect(valueSelect.value).toBe('published')
+    expect((screen.getByLabelText('Search') as HTMLInputElement).value).toBe('gamma')
+  })
+
+  it('removes a condition row', async () => {
+    const user = userEvent.setup()
+    render(
+      <FilterBuilder suggestions={suggestions} defaultValue="status:published" onApply={vi.fn()} />,
+    )
+
+    expect(screen.getByLabelText('Filter field')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Remove filter' }))
+    expect(screen.queryByLabelText('Filter field')).not.toBeInTheDocument()
+  })
+
+  it('clears all filters and applies an empty query', async () => {
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FilterBuilder suggestions={suggestions} defaultValue="status:draft" onApply={onApply} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(onApply).toHaveBeenCalledWith('')
+  })
+
+  it('shows only free-text search when no fields are filterable', () => {
+    render(<FilterBuilder suggestions={[]} onApply={vi.fn()} />)
+    expect(screen.getByLabelText('Search')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add filter/i })).not.toBeInTheDocument()
+  })
+
+  it('depends only on serializable suggestion data (no functions crossing the boundary)', async () => {
+    // Round-tripping the props through JSON strips any accidental function; if
+    // the component needed one it would break. Proves the server/client seam.
+    const serializable = JSON.parse(JSON.stringify(suggestions)) as FilterFieldSuggestion[]
+    const onApply = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={serializable} onApply={onApply} />)
+
+    await user.click(screen.getByRole('button', { name: /add filter/i }))
+    await user.selectOptions(screen.getByLabelText('Filter value'), 'published')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(onApply).toHaveBeenCalledWith('status:published')
+  })
+
+  it('navigates to ?search= itself when no onApply is provided', async () => {
+    const user = userEvent.setup()
+    render(<FilterBuilder suggestions={suggestions} />)
+
+    await user.type(screen.getByLabelText('Search'), 'hello')
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(push).toHaveBeenCalledWith('/admin/post?search=hello')
+  })
+})

--- a/packages/ui/tests/components/ListViewClient.test.tsx
+++ b/packages/ui/tests/components/ListViewClient.test.tsx
@@ -9,6 +9,7 @@ vi.mock('next/navigation.js', () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  usePathname: () => '/admin/post',
 }))
 
 describe('ListViewClient', () => {
@@ -208,57 +209,52 @@ describe('ListViewClient', () => {
     })
   })
 
-  describe('search', () => {
+  // The search UI is now the Filter builder (#731): a free-text box plus an
+  // Apply/Clear affordance that writes the `?search=` filter query. These tests
+  // pass no `filterSuggestions`, so only the free-text box is shown.
+  describe('search (Filter builder free-text)', () => {
     it('should render search input', () => {
       render(<ListViewClient {...defaultProps} />)
 
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument()
+      expect(screen.getByLabelText('Search')).toBeInTheDocument()
     })
 
     it('should update search input value', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
+      const searchInput = screen.getByLabelText('Search')
       await user.type(searchInput, 'test')
 
       expect(searchInput).toHaveValue('test')
     })
 
-    it('should navigate with search query when search submitted', async () => {
+    it('should navigate with search query when Apply clicked', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
-      await user.type(searchInput, 'test')
-
-      const searchButton = screen.getByRole('button', { name: /search/i })
-      await user.click(searchButton)
+      await user.type(screen.getByLabelText('Search'), 'test')
+      await user.click(screen.getByRole('button', { name: 'Apply' }))
 
       expect(mockPush).toHaveBeenCalledWith('/admin/post?search=test&page=1')
     })
 
-    it('should show clear button when search has value', async () => {
+    it('should show a Clear button when search has value', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
-      await user.type(searchInput, 'test')
+      await user.type(screen.getByLabelText('Search'), 'test')
 
-      expect(screen.getByText('✕')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument()
     })
 
-    it('should clear search when clear button clicked', async () => {
+    it('should clear search when Clear clicked (resets to page 1)', async () => {
       const user = userEvent.setup()
-      render(<ListViewClient {...defaultProps} />)
+      render(<ListViewClient {...defaultProps} search="existing" />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
-      await user.type(searchInput, 'test')
+      await user.click(screen.getByRole('button', { name: 'Clear' }))
 
-      const clearButton = screen.getByText('✕')
-      await user.click(clearButton)
-
-      expect(mockPush).toHaveBeenCalledWith('/admin/post')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?page=1')
     })
 
     it('should preserve active sort when search is cleared', async () => {
@@ -271,21 +267,17 @@ describe('ListViewClient', () => {
         />,
       )
 
-      const clearButton = screen.getByText('✕')
-      await user.click(clearButton)
+      await user.click(screen.getByRole('button', { name: 'Clear' }))
 
-      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc')
+      expect(mockPush).toHaveBeenCalledWith('/admin/post?sort=title%3Adesc&page=1')
     })
 
     it('should reset to page 1 when new search submitted', async () => {
       const user = userEvent.setup()
       render(<ListViewClient {...defaultProps} page={3} />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
-      await user.type(searchInput, 'test')
-
-      const searchButton = screen.getByRole('button', { name: /search/i })
-      await user.click(searchButton)
+      await user.type(screen.getByLabelText('Search'), 'test')
+      await user.click(screen.getByRole('button', { name: 'Apply' }))
 
       expect(mockPush).toHaveBeenCalledWith('/admin/post?search=test&page=1')
     })
@@ -293,8 +285,7 @@ describe('ListViewClient', () => {
     it('should preserve initial search value', () => {
       render(<ListViewClient {...defaultProps} search="existing" />)
 
-      const searchInput = screen.getByPlaceholderText('Search...')
-      expect(searchInput).toHaveValue('existing')
+      expect(screen.getByLabelText('Search')).toHaveValue('existing')
     })
   })
 

--- a/packages/ui/tests/components/RowSelection.test.tsx
+++ b/packages/ui/tests/components/RowSelection.test.tsx
@@ -10,6 +10,7 @@ const mockPush = vi.fn()
 const mockRefresh = vi.fn()
 vi.mock('next/navigation.js', () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  usePathname: () => '/admin/post',
 }))
 
 const page1 = [

--- a/packages/ui/tests/lib/filterBuilderState.test.ts
+++ b/packages/ui/tests/lib/filterBuilderState.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import type { FilterFieldSuggestion } from '@opensaas/stack-core'
+import { parseFilterQuery, buildFilterWhere, type FilterSpec } from '@opensaas/stack-core'
+import { queryToState, stateToQuery } from '../../src/lib/filterBuilderState.js'
+
+// A representative list's suggestion metadata: a free-text `title`, an enum
+// `status`, and a numeric `views` (the shapes `collectFilterSuggestions`
+// emits). These carry no functions — the whole point of the serializable seam.
+const suggestions: FilterFieldSuggestion[] = [
+  { field: 'title', operators: ['eq'], freeText: true, valueSource: { kind: 'none' } },
+  {
+    field: 'status',
+    operators: ['eq'],
+    freeText: false,
+    valueSource: {
+      kind: 'enum',
+      options: [
+        { value: 'draft', label: 'Draft' },
+        { value: 'published', label: 'Published' },
+      ],
+    },
+  },
+  {
+    field: 'views',
+    operators: ['eq', 'gt', 'gte', 'lt', 'lte'],
+    freeText: false,
+    valueSource: { kind: 'none' },
+  },
+]
+
+// The matching Filter specs, so a builder-produced query can be run through the
+// real engine (parse → buildFilterWhere) and asserted on the resulting `where`.
+const specs: Record<string, FilterSpec> = {
+  title: {
+    operators: ['eq'],
+    freeText: true,
+    toCondition: (op, value) => (op === 'eq' ? { title: { contains: value } } : null),
+    suggestions: { valueSource: { kind: 'none' } },
+  },
+  status: {
+    operators: ['eq'],
+    toCondition: (op, value) => (op === 'eq' ? { status: { equals: value } } : null),
+    suggestions: { valueSource: { kind: 'enum', options: [] } },
+  },
+  views: {
+    operators: ['eq', 'gt', 'gte', 'lt', 'lte'],
+    toCondition: (op, value) => {
+      const n = Number(value)
+      if (Number.isNaN(n)) return null
+      const key = { eq: 'equals', gt: 'gt', gte: 'gte', lt: 'lt', lte: 'lte' }[op]
+      return { views: { [key]: n } }
+    },
+    suggestions: { valueSource: { kind: 'none' } },
+  },
+}
+
+describe('queryToState', () => {
+  it('splits a field-scoped token into a structured row', () => {
+    const { rows, freeText } = queryToState('status:published', suggestions)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ field: 'status', operator: 'eq', value: 'published' })
+    expect(freeText).toBe('')
+  })
+
+  it('keeps bare words as free text', () => {
+    const { rows, freeText } = queryToState('hello world', suggestions)
+    expect(rows).toHaveLength(0)
+    expect(freeText).toBe('hello world')
+  })
+
+  it('demotes an unknown field to free text (no matching suggestion)', () => {
+    const { rows, freeText } = queryToState('nosuch:value', suggestions)
+    expect(rows).toHaveLength(0)
+    // Re-serialised so it survives round-trips; the engine would treat it as
+    // free text anyway.
+    expect(freeText).toBe('nosuch:value')
+  })
+
+  it('demotes a token using an operator the field does not support', () => {
+    // `status` only supports eq; a `>` token degrades to free text.
+    const { rows, freeText } = queryToState('status:>2', suggestions)
+    expect(rows).toHaveLength(0)
+    expect(freeText).toContain('status')
+  })
+
+  it('keeps a supported comparison operator as a structured row', () => {
+    const { rows } = queryToState('views:>=10', suggestions)
+    expect(rows[0]).toMatchObject({ field: 'views', operator: 'gte', value: '10' })
+  })
+
+  it('separates structured rows from trailing free text', () => {
+    const { rows, freeText } = queryToState('status:draft beta', suggestions)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ field: 'status', value: 'draft' })
+    expect(freeText).toBe('beta')
+  })
+})
+
+describe('stateToQuery', () => {
+  it('serialises a structured row into the grammar', () => {
+    const query = stateToQuery({
+      rows: [{ id: 'a', field: 'status', operator: 'eq', value: 'published' }],
+      freeText: '',
+    })
+    expect(query).toBe('status:published')
+  })
+
+  it('quotes a value containing whitespace', () => {
+    const query = stateToQuery({
+      rows: [{ id: 'a', field: 'title', operator: 'eq', value: 'hello world' }],
+      freeText: '',
+    })
+    expect(query).toBe('title:"hello world"')
+  })
+
+  it('drops rows with an empty field or value', () => {
+    const query = stateToQuery({
+      rows: [
+        { id: 'a', field: 'status', operator: 'eq', value: '' },
+        { id: 'b', field: '', operator: 'eq', value: 'x' },
+        { id: 'c', field: 'status', operator: 'eq', value: 'draft' },
+      ],
+      freeText: '',
+    })
+    expect(query).toBe('status:draft')
+  })
+
+  it('combines structured rows with free text', () => {
+    const query = stateToQuery({
+      rows: [{ id: 'a', field: 'views', operator: 'gt', value: '5' }],
+      freeText: 'beta',
+    })
+    expect(query).toBe('views:>5 beta')
+  })
+})
+
+describe('round-trip through the real filter engine', () => {
+  it('builds the expected Prisma where from a builder-produced query', () => {
+    const query = stateToQuery({
+      rows: [
+        { id: 'a', field: 'status', operator: 'eq', value: 'published' },
+        { id: 'b', field: 'views', operator: 'gte', value: '10' },
+      ],
+      freeText: 'hello',
+    })
+
+    const where = buildFilterWhere(parseFilterQuery(query), specs)
+
+    expect(where).toEqual({
+      AND: [
+        { status: { equals: 'published' } },
+        { views: { gte: 10 } },
+        // free-text `hello` OR-matched across free-text fields (just `title`).
+        { title: { contains: 'hello' } },
+      ],
+    })
+  })
+
+  it('is stable: state -> query -> state -> query', () => {
+    const state = {
+      rows: [
+        { id: 'a', field: 'status', operator: 'eq' as const, value: 'draft' },
+        { id: 'b', field: 'title', operator: 'eq' as const, value: 'Ada Lovelace' },
+      ],
+      freeText: 'beta gamma',
+    }
+    const query1 = stateToQuery(state)
+    const rebuilt = queryToState(query1, suggestions)
+    const query2 = stateToQuery(rebuilt)
+    expect(query2).toBe(query1)
+  })
+})


### PR DESCRIPTION
Implements #731. Part of #728.

## What

Adds the user-facing **Filter builder** input UI to the admin list view, layered on the already-merged filter engine (#730 / ADR-0017). The builder constructs the same `?search=` query grammar the engine already consumes — it does not invent a parallel filter path.

The builder offers:
- a **free-text search box** (bare-word search), and
- **structured condition rows** — a field picker, an operator picker (only for fields that support comparisons), and a value control that adapts per field (enum dropdown for select/checkbox, text input for text/number/date/relationship).

Applied filters are written into the `?search=` URL param and flow through the secured `context.db`, so filtering can only ever narrow what a session may see.

## How

- **`@opensaas/stack-core`** gains `serializeFilterQuery(tokens)` — the exact inverse of `parseFilterQuery`, co-located with the parser so the quoting/operator-prefix rules can never drift. Exported from the root and `./filter`.
- **`@opensaas/stack-ui`**:
  - `FilterBuilder` (`src/components/FilterBuilder.tsx`) — a `'use client'` component. Available fields/operators/value suggestions are derived entirely from each field's self-contained `getFilterSpec` via the serializable `collectFilterSuggestions` metadata — **no `switch` on field type**, and **no functions cross the server/client boundary**. Theme-token styling only; ships `data-slot` parts (`filter-builder`, `filter-builder-condition`, `filter-builder-field/operator/value`, `filter-builder-add/apply/clear`, …) and per-part `classNames` slots, consistent with #709/#729/#733.
  - Pure state helpers (`src/lib/filterBuilderState.ts`): `queryToState` / `stateToQuery` round-trip UI state ↔ query through the engine's `parseFilterQuery` + `serializeFilterQuery`.
  - `ListView` collects suggestions server-side and passes them to `ListViewClient`, which renders `FilterBuilder` in place of the old bespoke search box (keyed on the active query so it re-hydrates from the URL after each apply).
  - Exported from the root and `./standalone` subpaths.

## Tests

- **core** (`packages/core`): `serialize.test.ts` — operator prefixes, quoting rules, empty-value omission, and `parse`/`serialize` round-trip + idempotence.
- **ui** (`packages/ui`): `filterBuilderState.test.ts` (state↔query round-trips, verified against the real `buildFilterWhere`) and `FilterBuilder.test.tsx` (field/operator/value pickers per spec, enum dropdown, hydration, clear/remove, the serializable-props boundary, and the standalone navigation fallback). Existing `ListViewClient`/`RowSelection`/`AdminUISingleton` tests updated for the new search UI.
- **e2e** (`e2e/starter-auth/06-filter-builder.spec.ts`): drives the real builder — free-text search, a structured status filter, and Clear — asserting the `?search=` query and the access-scoped table.

Local results: core `832 passed`; ui `424 passed`; e2e `22 passed` (03-admin-ui, 05-bulk-delete, 05-filter, 06-filter-builder — no regressions); `pnpm lint` 0 errors; `tsc` clean.

## Changeset

`minor` for `@opensaas/stack-core` and `@opensaas/stack-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_