### PR TITLE
feat(core,ui): relationship-table row removal — disconnect by default, delete opt-in (#739)

### DIFF
--- a/.changeset/relationship-row-removal.md
+++ b/.changeset/relationship-row-removal.md
@@ -1,0 +1,38 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Add relationship-table row removal to the admin item view (ADR-0018)
+
+Each read-only Relationship table row now has a ✕ removal control. By default it
+**disconnects** the related row from the current record (non-destructive — the
+row survives and still appears on its own list), gated on the related list's
+update access. A per-relationship opt-in truly deletes the related row (behind a
+confirmation, gated on the related list's delete access), or hides the control
+entirely. Where the schema makes disconnect impossible (a required foreign key on
+the related side) the control is hidden unless delete is opted in. Removals run
+through the secured context, so an access-denied removal is a Silent failure: the
+row stays with a visible reason.
+
+Configure per relationship via `ui.itemView.removeAction`:
+
+```typescript
+User: list({
+  fields: {
+    // Default: ✕ disconnects the post (it still exists).
+    posts: relationship({ ref: 'Post.author', many: true }),
+    // Opt in to destructive delete (confirmed).
+    notes: relationship({
+      ref: 'Note.owner',
+      many: true,
+      ui: { itemView: { removeAction: 'delete' } }, // 'disconnect' (default) | 'delete' | 'none'
+    }),
+  },
+})
+```
+
+`@opensaas/stack-core` adds a `removeRelated` server action (distinct
+`{ removed }` result shape, like `bulkDelete`, so a redirect-on-success wrapper
+never hijacks an in-place removal) and the `RelationshipItemViewConfig.removeAction`
+option.

--- a/e2e/starter-auth/07-relationship-row-removal.spec.ts
+++ b/e2e/starter-auth/07-relationship-row-removal.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * Relationship-table row removal (issue #739, ADR-0018).
+ *
+ * The User item view renders two to-many Relationship tables with different
+ * removal semantics:
+ * - `posts` (default `disconnect`): the ✕ unlinks the post from the user. The
+ *   post itself survives and still appears on the Post list.
+ * - `notes` (opt-in `delete`): the ✕ confirms, then truly deletes the note.
+ *
+ * Both removals run through the secured context, so they respect the related
+ * list's own access control.
+ */
+
+async function createPost(page: Page, { title, slug }: { title: string; slug: string }) {
+  await page.goto('/admin/post')
+  await page.waitForLoadState('networkidle')
+  await page.click('text=/create|new/i')
+  await page.waitForLoadState('networkidle')
+  await page.fill('input[name="title"]', title)
+  await page.fill('input[name="slug"]', slug)
+  await page.fill('textarea[name="content"]', `${title} content`)
+  await page.click('button[type="submit"]')
+  await page.waitForURL(/admin\/post$/, { timeout: 10000 })
+}
+
+async function createNote(page: Page, body: string) {
+  await page.goto('/admin/note')
+  await page.waitForLoadState('networkidle')
+  await page.click('text=/create|new/i')
+  await page.waitForLoadState('networkidle')
+  await page.fill('textarea[name="body"]', body)
+  await page.click('button[type="submit"]')
+  await page.waitForURL(/admin\/note$/, { timeout: 10000 })
+}
+
+async function openCurrentUserEditPage(page: Page, email: string) {
+  await page.goto('/admin/user')
+  await page.waitForLoadState('networkidle')
+  await page.locator('tr', { hasText: email }).locator('a:has-text("Edit")').click()
+  await page.waitForURL(/\/admin\/user\/[^/]+$/, { timeout: 10000 })
+}
+
+function tableByHeading(page: Page, name: string) {
+  return page.locator('[data-slot="relationship-table"]', {
+    has: page.getByRole('heading', { name, exact: true }),
+  })
+}
+
+test.describe('Relationship-table row removal', () => {
+  test('default ✕ disconnects a post (the post still exists)', async ({ page }) => {
+    const user = generateTestUser()
+    await signUp(page, user)
+
+    const stamp = `${Date.now()}`
+    await createPost(page, { title: `Keep ${stamp}`, slug: `keep-${stamp}` })
+    await createPost(page, { title: `Drop ${stamp}`, slug: `drop-${stamp}` })
+
+    await openCurrentUserEditPage(page, user.email)
+
+    const posts = tableByHeading(page, 'Posts')
+    await expect(posts).toBeVisible()
+    const dropRow = posts.locator('[data-slot="relationship-table-row"]', {
+      hasText: `Drop ${stamp}`,
+    })
+    await expect(dropRow).toBeVisible()
+
+    // Disconnect: no confirmation, non-destructive.
+    await dropRow.locator('[data-slot="relationship-table-remove"]').click()
+
+    // The row leaves the user's Posts table after the refresh…
+    await expect(
+      posts.locator('[data-slot="relationship-table-row"]', { hasText: `Drop ${stamp}` }),
+    ).toHaveCount(0, { timeout: 10000 })
+    // …but the other post is untouched.
+    await expect(
+      posts.locator('[data-slot="relationship-table-row"]', { hasText: `Keep ${stamp}` }),
+    ).toBeVisible()
+
+    // The disconnected post still EXISTS — it appears on the Post list page.
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    // Its unique slug identifies exactly one row (title/content both contain the
+    // stamp, so match the slug cell to avoid an ambiguous text match).
+    await expect(page.getByText(`drop-${stamp}`, { exact: true })).toBeVisible()
+  })
+
+  test('delete opt-in ✕ confirms, then deletes the note', async ({ page }) => {
+    const user = generateTestUser()
+    await signUp(page, user)
+
+    const stamp = `${Date.now()}`
+    const noteBody = `Note ${stamp}`
+    await createNote(page, noteBody)
+
+    await openCurrentUserEditPage(page, user.email)
+
+    const notes = tableByHeading(page, 'Notes')
+    await expect(notes).toBeVisible()
+    const noteRow = notes.locator('[data-slot="relationship-table-row"]', { hasText: noteBody })
+    await expect(noteRow).toBeVisible()
+
+    // Delete opt-in: a confirmation is required.
+    await noteRow.locator('[data-slot="relationship-table-remove"]').click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Delete' }).click()
+
+    // The note leaves the table after the refresh…
+    await expect(
+      notes.locator('[data-slot="relationship-table-row"]', { hasText: noteBody }),
+    ).toHaveCount(0, { timeout: 10000 })
+
+    // …and is truly gone from the Note list page.
+    await page.goto('/admin/note')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(noteBody)).toHaveCount(0)
+  })
+})

--- a/examples/starter-auth/opensaas.config.ts
+++ b/examples/starter-auth/opensaas.config.ts
@@ -22,6 +22,14 @@ const isAuthor: AccessControl = ({ session }) => {
   }
 }
 
+// Check if the user owns a note (scopes rows to the signed-in owner)
+const isOwner: AccessControl = ({ session }) => {
+  if (!session) return false
+  return {
+    ownerId: { equals: session.userId },
+  }
+}
+
 /**
  * OpenSaas Configuration with Better-Auth
  */
@@ -72,6 +80,23 @@ export default config({
               itemView: {
                 columns: ['title', 'status', 'viewCount'],
                 sum: ['viewCount'],
+                // Default (non-destructive) row removal: the ✕ disconnects a
+                // post from this user (ADR-0018). The post itself survives and
+                // still appears on the Post list.
+                removeAction: 'disconnect',
+              },
+            },
+          }),
+          // A second to-many relationship that opts into destructive removal:
+          // notes are owned children, so the ✕ deletes the note (confirmed,
+          // gated on Note's delete access) rather than disconnecting it.
+          notes: relationship({
+            ref: 'Note.owner',
+            many: true,
+            ui: {
+              itemView: {
+                columns: ['body'],
+                removeAction: 'delete',
               },
             },
           }),
@@ -203,6 +228,35 @@ export default config({
           ) {
             addValidationError('Title cannot contain the word "spam"')
           }
+        },
+      },
+    }),
+
+    // A simple owned-child list used to demonstrate destructive row removal on
+    // the User item view's `notes` Relationship table (ADR-0018): removing a
+    // note there deletes it, because a note only belongs to its owner.
+    Note: list<Lists.Note.TypeInfo>({
+      fields: {
+        body: text({ validation: { isRequired: true }, ui: { displayMode: 'textarea' } }),
+        owner: relationship({ ref: 'User.notes' }),
+      },
+      access: {
+        operation: {
+          query: isOwner,
+          create: isSignedIn,
+          update: isOwner,
+          delete: isOwner,
+        },
+      },
+      hooks: {
+        // Auto-assign the note's owner to the signed-in user on create, so the
+        // admin create form only needs the note body.
+        resolveInput: async ({ operation, resolvedData, context }) => {
+          const data = { ...resolvedData }
+          if (operation === 'create' && !data.owner && context.session?.userId) {
+            data.owner = { connect: { id: context.session.userId } }
+          }
+          return data
         },
       },
     }),

--- a/examples/starter-auth/prisma/schema.prisma
+++ b/examples/starter-auth/prisma/schema.prisma
@@ -24,6 +24,15 @@ model Post {
   @@index([authorId])
 }
 
+model Note {
+  id      String  @id @default(cuid())
+  body    String
+  ownerId String? @map("owner")
+  owner   User?   @relation(fields: [ownerId], references: [id])
+
+  @@index([ownerId])
+}
+
 model User {
   id            String    @id @default(cuid())
   name          String
@@ -33,6 +42,7 @@ model User {
   sessions      Session[]
   accounts      Account[]
   posts         Post[]
+  notes         Note[]
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @default(now()) @updatedAt
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -978,6 +978,21 @@ export type RelationshipItemViewConfig = {
    * ```
    */
   sum?: string[]
+  /**
+   * How a row's ✕ control removes a related row from this table (ADR-0018).
+   *
+   * - `'disconnect'` (default): non-destructively unlinks the related row from
+   *   this record — the row itself is untouched and still appears on its own
+   *   list. Gated on the related list's update access. Hidden statically when
+   *   the schema makes disconnect impossible (a required foreign key on the
+   *   related side, i.e. the back-reference declares `db.isNullable: false`).
+   * - `'delete'`: opts into truly deleting the related row, behind a
+   *   confirmation, gated on the related list's delete access.
+   * - `'none'`: hides the removal control entirely.
+   *
+   * @default 'disconnect'
+   */
+  removeAction?: 'disconnect' | 'delete' | 'none'
 }
 
 export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -25,6 +25,23 @@ export type ServerActionProps =
   | { listKey: string; action: 'update'; id: string; data: Record<string, unknown> }
   | { listKey: string; action: 'delete'; id: string }
   | { listKey: string; action: 'bulkDelete'; ids: string[] }
+  // Relationship-table row removal (ADR-0018, #739). `listKey`/`id` target the
+  // RELATED row, so the related list's own access control + hooks apply (never
+  // the parent's). `mode: 'disconnect'` unlinks the row non-destructively by
+  // disconnecting its back-reference (`field`; `parentId` is the record being
+  // edited, needed only when that back-reference is to-many, e.g. a
+  // many-to-many join); `mode: 'delete'` truly deletes the row. Like
+  // `bulkDelete`, it returns a distinct `{ removed }` shape (never a
+  // single-op `success`) so a UI wrapper that redirects on `success` — the
+  // item-form pattern — does not hijack an in-place row removal.
+  | {
+      listKey: string
+      action: 'removeRelated'
+      mode: 'disconnect' | 'delete'
+      id: string
+      field?: string
+      parentId?: string
+    }
   | {
       listKey: string
       action: 'relationshipOptions'
@@ -418,6 +435,10 @@ export function getContext<
     // single-item `success` (the item-form pattern) does not hijack a
     // list-level bulk operation.
     | { deleted: number; total: number }
+    // Relationship-table row removal reports `removed` (with an optional reason)
+    // rather than `success` — same distinct-shape rationale as `bulkDelete`, so
+    // an in-place removal never triggers a redirect-on-success wrapper.
+    | { removed: boolean; error?: string }
   > {
     const dbKey = getDbKey(props.listKey)
     const listConfig = config.lists[props.listKey]
@@ -451,6 +472,48 @@ export function getContext<
         }
       }
       return { deleted, total: props.ids.length }
+    }
+
+    // Relationship-table row removal (ADR-0018, #739). Runs on the RELATED row
+    // through the secured context, so the related list's access + hooks apply.
+    // Honours Silent failure: an access-denied operation returns `null`, which
+    // becomes `{ removed: false }` with a generic reason — never leaking whether
+    // the row was denied or absent.
+    if (props.action === 'removeRelated') {
+      try {
+        let result: unknown = null
+        if (props.mode === 'delete') {
+          result = await model.delete({ where: { id: props.id } })
+        } else {
+          // Disconnect: an UPDATE on the related list nulling its back-reference,
+          // never a delete — the row itself survives. A to-one back-reference
+          // disconnects with `true`; a to-many back-reference (many-to-many)
+          // disconnects the specific parent by id.
+          if (!props.field) {
+            return { removed: false, error: 'Missing back-reference field for disconnect' }
+          }
+          const backRefField = listConfig.fields[props.field]
+          const backRefIsMany =
+            !!backRefField && 'many' in backRefField && backRefField.many === true
+          const disconnectValue = backRefIsMany
+            ? { disconnect: { id: props.parentId } }
+            : { disconnect: true }
+          result = await model.update({
+            where: { id: props.id },
+            data: { [props.field]: disconnectValue },
+          })
+        }
+        if (result === null || result === undefined) {
+          return { removed: false, error: 'Access denied or operation failed' }
+        }
+        return { removed: true }
+      } catch (error) {
+        if (error instanceof ValidationError || error instanceof DatabaseError) {
+          return { removed: false, error: error.message }
+        }
+        const dbError = parsePrismaError(error, listConfig)
+        return { removed: false, error: dbError.message }
+      }
     }
 
     try {

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -202,6 +202,142 @@ describe('getContext', () => {
       })
     })
 
+    describe('removeRelated (relationship-table row removal)', () => {
+      it('unlinks a to-one back-reference via an update on the related list', async () => {
+        const existing = { id: 'p1', title: 'T', content: 'c', authorId: 'u1' }
+        mockPrisma.post.findUnique.mockResolvedValue(existing)
+        mockPrisma.post.update.mockResolvedValue({ id: 'p1', title: 'T', authorId: null })
+
+        const context = await getContext(config, mockPrisma, { userId: 'u1' })
+        const result = await context.serverAction({
+          listKey: 'Post',
+          action: 'removeRelated',
+          mode: 'disconnect',
+          id: 'p1',
+          field: 'author',
+          parentId: 'u1',
+        })
+
+        // Disconnect is an UPDATE on the related list nulling the back-reference
+        // (a to-one back-ref disconnects with `true`), never a delete. The
+        // distinct `{ removed }` shape avoids a redirect-on-success wrapper.
+        expect(mockPrisma.post.update).toHaveBeenCalled()
+        const updateArg = mockPrisma.post.update.mock.calls[0][0]
+        expect(updateArg.where).toEqual({ id: 'p1' })
+        expect(updateArg.data.author).toEqual({ disconnect: true })
+        expect(mockPrisma.post.delete).not.toHaveBeenCalled()
+        expect(result).toEqual({ removed: true })
+      })
+
+      it('deletes the related row when mode is delete', async () => {
+        mockPrisma.post.findUnique.mockResolvedValue({ id: 'p1', title: 'T', authorId: 'u1' })
+        mockPrisma.post.delete.mockResolvedValue({ id: 'p1', title: 'T' })
+
+        const context = await getContext(config, mockPrisma, { userId: 'u1' })
+        const result = await context.serverAction({
+          listKey: 'Post',
+          action: 'removeRelated',
+          mode: 'delete',
+          id: 'p1',
+        })
+
+        expect(mockPrisma.post.delete).toHaveBeenCalled()
+        expect(mockPrisma.post.update).not.toHaveBeenCalled()
+        expect(result).toEqual({ removed: true })
+      })
+
+      it('disconnects a to-many back-reference by parent id (many-to-many)', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const m2mPrisma: any = {
+          lesson: {
+            findUnique: vi.fn().mockResolvedValue({ id: 'l1', title: 'L' }),
+            update: vi.fn().mockResolvedValue({ id: 'l1', title: 'L' }),
+            delete: vi.fn(),
+          },
+        }
+        const m2mConfig: OpenSaasConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            Lesson: {
+              fields: {
+                title: { type: 'text' },
+                teachers: { type: 'relationship', ref: 'Teacher.lessons', many: true },
+              },
+              access: {
+                operation: {
+                  query: () => true,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+            Teacher: {
+              fields: {
+                name: { type: 'text' },
+                lessons: { type: 'relationship', ref: 'Lesson.teachers', many: true },
+              },
+              access: {
+                operation: {
+                  query: () => true,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+          },
+        }
+
+        const context = await getContext(m2mConfig, m2mPrisma, { userId: 'u1' })
+        await context.serverAction({
+          listKey: 'Lesson',
+          action: 'removeRelated',
+          mode: 'disconnect',
+          id: 'l1',
+          field: 'teachers',
+          parentId: 't1',
+        })
+
+        const updateArg = m2mPrisma.lesson.update.mock.calls[0][0]
+        // A to-many back-reference disconnects the specific parent by id.
+        expect(updateArg.data.teachers).toEqual({ disconnect: { id: 't1' } })
+      })
+
+      it('returns a generic error (Silent failure) when the update is access-denied', async () => {
+        const deniedConfig: OpenSaasConfig = {
+          ...config,
+          lists: {
+            ...config.lists,
+            Post: {
+              ...config.lists.Post,
+              access: {
+                operation: {
+                  query: () => true,
+                  create: () => true,
+                  update: () => false, // no update access → disconnect denied
+                  delete: () => true,
+                },
+              },
+            },
+          },
+        }
+
+        const context = await getContext(deniedConfig, mockPrisma, { userId: 'u1' })
+        const result = await context.serverAction({
+          listKey: 'Post',
+          action: 'removeRelated',
+          mode: 'disconnect',
+          id: 'p1',
+          field: 'author',
+          parentId: 'u1',
+        })
+
+        // Denied: reported as not removed with a generic reason (no leak).
+        expect(result).toEqual({ removed: false, error: 'Access denied or operation failed' })
+      })
+    })
+
     describe('relationshipOptions', () => {
       it('returns { id, label }[] for the related list, unfiltered/unincluded', async () => {
         mockPrisma.user.findMany.mockResolvedValue([

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -183,6 +183,10 @@ async function ItemViewLayoutView({
       section={section}
       rows={sectionRows(itemData?.[section.fieldName])}
       basePath={basePath}
+      context={context}
+      parentListKey={listKey}
+      parentId={itemId}
+      serverAction={serverAction}
     />
   ))
 

--- a/packages/ui/src/components/RelationshipTable.tsx
+++ b/packages/ui/src/components/RelationshipTable.tsx
@@ -1,14 +1,17 @@
 import {
   getItemLabel,
   getUrlKey,
+  type AccessContext,
   type OpenSaasConfig,
   type FieldConfig,
   type ListConfig,
 } from '@opensaas/stack-core'
 import { formatFieldName } from '../lib/utils.js'
 import { serializeFieldConfig, type SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
+import { isOperationPotentiallyAllowed } from '../lib/operationAccess.js'
 import type { RelationshipTableSection } from '../lib/deriveItemView.js'
-import { RelationshipTableClient } from './RelationshipTableClient.js'
+import type { ServerActionInput } from '../server/types.js'
+import { RelationshipTableClient, type RemoveMode } from './RelationshipTableClient.js'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
 type AnyListConfig = ListConfig<any>
@@ -24,6 +27,46 @@ export interface RelationshipTableProps {
    */
   rows: Array<Record<string, unknown>>
   basePath: string
+  /**
+   * The access-scoped context, used to evaluate the related list's operation
+   * access so a removal control is only offered when the session may perform it.
+   */
+  context: AccessContext<unknown>
+  /** The list being edited (the parent record's list). */
+  parentListKey: string
+  /** The parent record's id — the disconnect target for many-to-many rows. */
+  parentId: string
+  /** Server action that runs removals through the secured context. */
+  serverAction: (input: ServerActionInput) => Promise<unknown>
+}
+
+/**
+ * Decide which removal control (if any) a row should show (ADR-0018, #739).
+ *
+ * The configured `removeAction` is the ceiling; operation-level access on the
+ * RELATED list is the gate. A hard deny (no update/delete access at all) hides
+ * the control — no affordance for what will always fail. A filter result is
+ * treated as "potentially allowed", so the control shows and a row-level denial
+ * surfaces at commit time as a Silent failure (row stays, reason shown).
+ */
+async function resolveRemoveMode(
+  section: RelationshipTableSection,
+  relatedListConfig: AnyListConfig | undefined,
+  context: AccessContext<unknown>,
+): Promise<RemoveMode> {
+  if (section.removeAction === 'none' || !relatedListConfig) return null
+
+  const access = relatedListConfig.access?.operation
+  const args = { session: context.session, context }
+
+  if (section.removeAction === 'delete') {
+    return (await isOperationPotentiallyAllowed(access, 'delete', args)) ? 'delete' : null
+  }
+
+  // Default: disconnect — only where the schema allows it (nullable back-ref FK)
+  // and the related list's update access is not hard-denied.
+  if (!section.disconnectable) return null
+  return (await isOperationPotentiallyAllowed(access, 'update', args)) ? 'disconnect' : null
 }
 
 /**
@@ -83,9 +126,22 @@ function toNumber(value: unknown): number | null {
  * (#739) extend the named Slots left in the client component — no edit/add/
  * remove affordances are rendered here.
  */
-export function RelationshipTable({ config, section, rows, basePath }: RelationshipTableProps) {
+export async function RelationshipTable({
+  config,
+  section,
+  rows,
+  basePath,
+  context,
+  parentListKey,
+  parentId,
+  serverAction,
+}: RelationshipTableProps) {
   const relatedListConfig = config.lists[section.relatedListKey]
   const relatedUrlKey = getUrlKey(section.relatedListKey)
+
+  // Which removal control (if any) this table's rows may show, gated on the
+  // related list's own operation access (never the parent's).
+  const removeMode = await resolveRemoveMode(section, relatedListConfig, context)
 
   // The related list config for each relationship column, keyed by column, so
   // its values can be label-resolved via that column's OWN target list (a
@@ -140,6 +196,12 @@ export function RelationshipTable({ config, section, rows, basePath }: Relations
       count={rows.length}
       sumColumns={section.sumColumns}
       sums={sums}
+      removeMode={removeMode}
+      relatedListKey={section.relatedListKey}
+      backReferenceField={section.backReferenceField}
+      parentId={parentId}
+      parentListKey={parentListKey}
+      serverAction={serverAction}
     />
   )
 }

--- a/packages/ui/src/components/RelationshipTableClient.tsx
+++ b/packages/ui/src/components/RelationshipTableClient.tsx
@@ -13,8 +13,20 @@ import {
   TableRow,
 } from '../primitives/table.js'
 import { Card } from '../primitives/card.js'
+import { Button } from '../primitives/button.js'
+import { ConfirmDialog } from './ConfirmDialog.js'
 import { CellRenderer } from './cells/CellRenderer.js'
 import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
+import type { ServerActionInput } from '../server/types.js'
+
+/**
+ * Which removal control a Relationship-table row shows (ADR-0018, issue #739):
+ * - `'disconnect'` — a ✕ that unlinks the related row (non-destructive).
+ * - `'delete'` — a ✕ that deletes the related row after a confirmation.
+ * - `null` — no control (removeAction `'none'`, a required-FK relationship, or
+ *   the session lacks the related list's update/delete access).
+ */
+export type RemoveMode = 'disconnect' | 'delete' | null
 
 export interface RelationshipTableClientProps {
   /** Section heading (the relationship field name, title-cased). */
@@ -35,20 +47,52 @@ export interface RelationshipTableClientProps {
   sumColumns: string[]
   /** Per-column footer sum, rendered through that column's Cell. */
   sums: Record<string, number>
+  /** The removal control to render per row (issue #739); `null` renders none. */
+  removeMode: RemoveMode
+  /** The related list key — the target of the disconnect/delete server action. */
+  relatedListKey: string
+  /** The back-reference field on the related list (present when disconnectable). */
+  backReferenceField?: string
+  /** The parent record id — the disconnect target for many-to-many rows. */
+  parentId: string
+  /** The list being edited (used for accessible labelling). */
+  parentListKey: string
+  /** Server action that runs removals through the secured context. */
+  serverAction: (input: ServerActionInput) => Promise<unknown>
+}
+
+/** Read the `{ removed, error? }` outcome a row-removal server action returns. */
+function readRemoveOutcome(result: unknown): { ok: boolean; error?: string } {
+  if (typeof result === 'object' && result !== null && 'removed' in result) {
+    const record = result as { removed?: unknown; error?: unknown }
+    return {
+      ok: record.removed === true,
+      error: typeof record.error === 'string' ? record.error : undefined,
+    }
+  }
+  // An unrecognised shape is treated as a failure so the row is never silently lost.
+  return { ok: false }
 }
 
 /**
- * Read-only Relationship table (issue #734), client half. Renders related rows
- * as a table whose cells come from the cell registry (`CellRenderer`), so
- * badges/formatting match the related list's own page. Rows navigate to the
- * related record on click; the table renders no edit/add/remove affordances.
+ * Read-only Relationship table (issue #734) plus row removal (issue #739),
+ * client half. Renders related rows as a table whose cells come from the cell
+ * registry (`CellRenderer`), so badges/formatting match the related list's own
+ * page. Rows navigate to the related record on click.
+ *
+ * Row removal (ADR-0018): when `removeMode` is set, each row gains a trailing ✕.
+ * `'disconnect'` unlinks the row (an update on the related list, nulling the
+ * back-reference); `'delete'` confirms then deletes it. Both run through the
+ * secured context, so a denial is a Silent failure — the row stays with a
+ * visible reason. A success refreshes the table (`router.refresh`).
  *
  * Named Slots (the reviewed extension seams for the follow-up tickets):
  * - `relationship-table` — the section container.
  * - `relationship-table-toolbar` — header actions region; the pre-linked create
  *   drawer's "+ Add" (#738) mounts here.
- * - `relationship-table-row` — a related row; row removal (#739) adds its
- *   trailing affordance here.
+ * - `relationship-table-row` — a related row; the removal ✕ (#739) is its
+ *   trailing affordance.
+ * - `relationship-table-remove` — the row-removal control (#739).
  * - `relationship-table-cell` — a rendered cell; inline cell edit (#737) wraps
  *   the Cell here.
  * - `relationship-table-footer` — the totals footer (count + configured sums).
@@ -63,11 +107,84 @@ export function RelationshipTableClient({
   count,
   sumColumns,
   sums,
+  removeMode,
+  relatedListKey,
+  backReferenceField,
+  parentId,
+  serverAction,
 }: RelationshipTableClientProps) {
   const router = useRouter()
   const sumColumnSet = React.useMemo(() => new Set(sumColumns), [sumColumns])
 
+  // Rows optimistically hidden after a successful removal (until the refresh
+  // re-fetch settles), per-row failure reasons, the in-flight row, and the row
+  // awaiting a delete confirmation.
+  const [removedIds, setRemovedIds] = React.useState<Set<string>>(() => new Set())
+  const [errors, setErrors] = React.useState<Record<string, string>>({})
+  const [pendingId, setPendingId] = React.useState<string | null>(null)
+  const [confirmId, setConfirmId] = React.useState<string | null>(null)
+
   const columnFieldType = (column: string): string | undefined => fields[column]?.type
+  const showRemove = removeMode !== null
+  const removeVerb = removeMode === 'delete' ? 'Delete' : 'Disconnect'
+  const totalColumns = columns.length + (showRemove ? 1 : 0)
+
+  const performRemove = async (rowId: string) => {
+    setPendingId(rowId)
+    setErrors((prev) => {
+      const next = { ...prev }
+      delete next[rowId]
+      return next
+    })
+
+    try {
+      let input: ServerActionInput
+      if (removeMode === 'delete') {
+        input = { listKey: relatedListKey, action: 'removeRelated', mode: 'delete', id: rowId }
+      } else if (removeMode === 'disconnect' && backReferenceField) {
+        input = {
+          listKey: relatedListKey,
+          action: 'removeRelated',
+          mode: 'disconnect',
+          id: rowId,
+          field: backReferenceField,
+          parentId,
+        }
+      } else {
+        return
+      }
+
+      const outcome = readRemoveOutcome(await serverAction(input))
+      if (outcome.ok) {
+        // Optimistically hide, then refresh so the re-fetched table no longer
+        // includes the row (or, on a race, restores it as the source of truth).
+        setRemovedIds((prev) => new Set(prev).add(rowId))
+        router.refresh()
+      } else {
+        // Silent failure: leave the row and show why (never leak "denied vs
+        // does not exist" — the reason is the generic access message).
+        setErrors((prev) => ({
+          ...prev,
+          [rowId]: outcome.error ?? 'Access denied or removal failed',
+        }))
+      }
+    } catch {
+      setErrors((prev) => ({ ...prev, [rowId]: 'Removal failed' }))
+    } finally {
+      setPendingId(null)
+      setConfirmId(null)
+    }
+  }
+
+  const onRemoveClick = (rowId: string) => {
+    if (removeMode === 'delete') {
+      setConfirmId(rowId)
+    } else {
+      void performRemove(rowId)
+    }
+  }
+
+  const visibleRows = rows.filter((row) => !removedIds.has(String(row.id)))
 
   return (
     <Card data-slot="relationship-table" className="overflow-hidden">
@@ -88,45 +205,82 @@ export function RelationshipTableClient({
                 </TableHead>
               )
             })}
+            {showRemove && (
+              <TableHead className="w-0 text-right">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            )}
           </TableRow>
         </TableHeader>
 
         <TableBody>
-          {rows.length === 0 ? (
+          {visibleRows.length === 0 ? (
             <TableRow>
               <TableCell
                 data-slot="relationship-table-empty"
-                colSpan={Math.max(columns.length, 1)}
+                colSpan={Math.max(totalColumns, 1)}
                 className="py-8 text-center text-sm text-muted-foreground"
               >
                 No related {title.toLowerCase()} yet.
               </TableCell>
             </TableRow>
           ) : (
-            rows.map((row) => (
-              <TableRow
-                key={String(row.id)}
-                data-slot="relationship-table-row"
-                className="cursor-pointer"
-                onClick={() => router.push(`${basePath}/${relatedUrlKey}/${row.id}`)}
-              >
-                {columns.map((column) => (
-                  <TableCell
-                    key={column}
-                    data-slot="relationship-table-cell"
-                    className={cn(isNumericField(columnFieldType(column)) && 'text-right')}
-                  >
-                    {/* Read-only Cell; inline cell edit (#737) wraps this. */}
-                    <CellRenderer
-                      value={row[column]}
-                      field={fields[column] ?? { type: 'text' }}
-                      fieldName={column}
-                      basePath={basePath}
-                    />
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))
+            visibleRows.map((row) => {
+              const rowId = String(row.id)
+              const error = errors[rowId]
+              return (
+                <TableRow
+                  key={rowId}
+                  data-slot="relationship-table-row"
+                  className="cursor-pointer"
+                  onClick={() => router.push(`${basePath}/${relatedUrlKey}/${rowId}`)}
+                >
+                  {columns.map((column) => (
+                    <TableCell
+                      key={column}
+                      data-slot="relationship-table-cell"
+                      className={cn(isNumericField(columnFieldType(column)) && 'text-right')}
+                    >
+                      {/* Read-only Cell; inline cell edit (#737) wraps this. */}
+                      <CellRenderer
+                        value={row[column]}
+                        field={fields[column] ?? { type: 'text' }}
+                        fieldName={column}
+                        basePath={basePath}
+                      />
+                    </TableCell>
+                  ))}
+                  {showRemove && (
+                    <TableCell className="text-right align-top">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        data-slot="relationship-table-remove"
+                        aria-label={`${removeVerb} ${title} row`}
+                        disabled={pendingId === rowId}
+                        onClick={(event) => {
+                          // Don't let the removal click also navigate the row.
+                          event.stopPropagation()
+                          onRemoveClick(rowId)
+                        }}
+                      >
+                        <span aria-hidden="true">✕</span>
+                      </Button>
+                      {error && (
+                        <p
+                          role="alert"
+                          data-slot="relationship-table-remove-error"
+                          className="mt-1 text-xs text-destructive"
+                        >
+                          {error}
+                        </p>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+              )
+            })
           )}
         </TableBody>
 
@@ -135,37 +289,56 @@ export function RelationshipTableClient({
             {columns.length === 0 ? (
               // No columns (related list curates to nothing but the back-reference):
               // still always show the row count, mirroring the empty-body colSpan.
-              <TableCell colSpan={1} className="text-sm text-muted-foreground">
+              <TableCell
+                colSpan={Math.max(totalColumns, 1)}
+                className="text-sm text-muted-foreground"
+              >
                 {count} {count === 1 ? 'row' : 'rows'}
               </TableCell>
             ) : (
-              columns.map((column, index) => {
-                const numeric = isNumericField(columnFieldType(column))
-                const isSummed = sumColumnSet.has(column)
-                return (
-                  <TableCell key={column} className={cn(numeric && 'text-right')}>
-                    {index === 0 && (
-                      <span className="text-sm text-muted-foreground">
-                        {count} {count === 1 ? 'row' : 'rows'}
-                      </span>
-                    )}
-                    {isSummed && (
-                      <span className={cn('font-medium', index === 0 && 'ml-2')}>
-                        <CellRenderer
-                          value={sums[column]}
-                          field={fields[column] ?? { type: 'text' }}
-                          fieldName={column}
-                          basePath={basePath}
-                        />
-                      </span>
-                    )}
-                  </TableCell>
-                )
-              })
+              <>
+                {columns.map((column, index) => {
+                  const numeric = isNumericField(columnFieldType(column))
+                  const isSummed = sumColumnSet.has(column)
+                  return (
+                    <TableCell key={column} className={cn(numeric && 'text-right')}>
+                      {index === 0 && (
+                        <span className="text-sm text-muted-foreground">
+                          {count} {count === 1 ? 'row' : 'rows'}
+                        </span>
+                      )}
+                      {isSummed && (
+                        <span className={cn('font-medium', index === 0 && 'ml-2')}>
+                          <CellRenderer
+                            value={sums[column]}
+                            field={fields[column] ?? { type: 'text' }}
+                            fieldName={column}
+                            basePath={basePath}
+                          />
+                        </span>
+                      )}
+                    </TableCell>
+                  )
+                })}
+                {showRemove && <TableCell className="w-0" />}
+              </>
             )}
           </TableRow>
         </TableFooter>
       </Table>
+
+      {/* Delete opt-in requires a confirmation before the destructive action. */}
+      <ConfirmDialog
+        isOpen={confirmId !== null}
+        title={`Delete ${title} row`}
+        message={`This permanently deletes the related ${title.toLowerCase()} record. This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (confirmId) void performRemove(confirmId)
+        }}
+        onCancel={() => setConfirmId(null)}
+      />
     </Card>
   )
 }

--- a/packages/ui/src/lib/deriveItemView.ts
+++ b/packages/ui/src/lib/deriveItemView.ts
@@ -32,6 +32,19 @@ export interface RelationshipTableSection {
   columns: string[]
   /** Numeric columns to sum in the totals footer (explicit opt-in only). */
   sumColumns: string[]
+  /**
+   * The configured row-removal semantics (ADR-0018, issue #739), defaulting to
+   * the non-destructive `'disconnect'`. `'delete'` truly deletes the related
+   * row (confirmed); `'none'` hides the control.
+   */
+  removeAction: 'disconnect' | 'delete' | 'none'
+  /**
+   * Whether disconnect is statically possible for this relationship: there is a
+   * back-reference field on the related list AND it is not a required foreign
+   * key (`db.isNullable: false`). When `false`, a `'disconnect'` removeAction
+   * has no control (a required FK cannot be nulled); `'delete'` is unaffected.
+   */
+  disconnectable: boolean
 }
 
 /**
@@ -71,15 +84,39 @@ function readRelationshipItemView(field: FieldConfig): {
   displayMode: 'table' | 'picker'
   columns?: string[]
   sum?: string[]
+  removeAction: 'disconnect' | 'delete' | 'none'
 } {
   const raw: unknown = field.ui ? field.ui.itemView : undefined
   if (typeof raw !== 'object' || raw === null) {
-    return { displayMode: 'table' }
+    return { displayMode: 'table', removeAction: 'disconnect' }
   }
   const displayMode = 'displayMode' in raw && raw.displayMode === 'picker' ? 'picker' : 'table'
   const columns = 'columns' in raw ? readStringArray(raw.columns) : undefined
   const sum = 'sum' in raw ? readStringArray(raw.sum) : undefined
-  return { displayMode, columns, sum }
+  const removeAction =
+    'removeAction' in raw && (raw.removeAction === 'delete' || raw.removeAction === 'none')
+      ? raw.removeAction
+      : 'disconnect'
+  return { displayMode, columns, sum, removeAction }
+}
+
+/**
+ * Whether a to-many relationship's rows can be disconnected (ADR-0018): the
+ * related list must expose a back-reference field to unlink through, and that
+ * field must not be a required foreign key (`db.isNullable: false`), which the
+ * schema would make impossible to null. List-only refs (no back-reference)
+ * cannot be disconnected via the related list and are treated as not
+ * disconnectable.
+ */
+function isDisconnectable(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
+  relatedListConfig: ListConfig<any> | undefined,
+  backReferenceField: string | undefined,
+): boolean {
+  if (!relatedListConfig || !backReferenceField) return false
+  const backRefField = relatedListConfig.fields[backReferenceField]
+  if (!backRefField) return false
+  return backRefField.db?.isNullable !== false
 }
 
 /** Whether a field config is a to-many relationship. */
@@ -163,6 +200,8 @@ export function deriveItemViewLayout(config: OpenSaasConfig, listKey: string): I
         backReferenceField,
         columns: overrides.columns ?? defaultColumnsFor(relatedListConfig, backReferenceField),
         sumColumns: overrides.sum ?? [],
+        removeAction: overrides.removeAction,
+        disconnectable: isDisconnectable(relatedListConfig, backReferenceField),
       })
     } else {
       detailsFields.push(fieldName)

--- a/packages/ui/tests/components/RelationshipTableClient.test.tsx
+++ b/packages/ui/tests/components/RelationshipTableClient.test.tsx
@@ -4,11 +4,15 @@ import userEvent from '@testing-library/user-event'
 import { RelationshipTableClient } from '../../src/components/RelationshipTableClient.js'
 import type { RelationshipTableClientProps } from '../../src/components/RelationshipTableClient.js'
 
-// Mock Next.js navigation (client component uses useRouter for row navigation).
+// Mock Next.js navigation (client component uses useRouter for row navigation
+// and refresh after a removal).
 const mockPush = vi.fn()
+const mockRefresh = vi.fn()
 vi.mock('next/navigation.js', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }))
+
+const noopAction = vi.fn(async () => ({ removed: true }))
 
 function baseProps(): RelationshipTableClientProps {
   return {
@@ -24,12 +28,20 @@ function baseProps(): RelationshipTableClientProps {
     count: 2,
     sumColumns: ['viewCount'],
     sums: { viewCount: 15 },
+    removeMode: null,
+    relatedListKey: 'Post',
+    backReferenceField: 'author',
+    parentId: 'u1',
+    parentListKey: 'User',
+    serverAction: noopAction,
   }
 }
 
 describe('RelationshipTableClient', () => {
   beforeEach(() => {
     mockPush.mockClear()
+    mockRefresh.mockClear()
+    noopAction.mockClear()
   })
 
   it('renders the section heading, columns, and rows', () => {
@@ -84,5 +96,89 @@ describe('RelationshipTableClient', () => {
     expect(footer).not.toBeNull()
     // The always-shown count must survive the zero-column footer.
     expect(within(footer as HTMLElement).getByText('3 rows')).toBeInTheDocument()
+  })
+
+  // ---- Row removal (issue #739) ----
+
+  it('renders no removal control when removeMode is null', () => {
+    render(<RelationshipTableClient {...baseProps()} removeMode={null} />)
+    expect(document.querySelector('[data-slot="relationship-table-remove"]')).toBeNull()
+  })
+
+  it('disconnects a row through the secured context and refreshes on success', async () => {
+    const serverAction = vi.fn(async () => ({ removed: true }))
+    render(
+      <RelationshipTableClient
+        {...baseProps()}
+        removeMode="disconnect"
+        serverAction={serverAction}
+      />,
+    )
+    const user = userEvent.setup()
+
+    const removeButtons = screen.getAllByRole('button', { name: /disconnect posts row/i })
+    await user.click(removeButtons[0])
+
+    // Disconnect is an UPDATE on the RELATED list, nulling the back-reference —
+    // never a delete, and never the parent's list.
+    expect(serverAction).toHaveBeenCalledWith({
+      listKey: 'Post',
+      action: 'removeRelated',
+      mode: 'disconnect',
+      id: 'p1',
+      field: 'author',
+      parentId: 'u1',
+    })
+    // Optimistically hidden, then the table refreshes so the re-fetch is source of truth.
+    expect(screen.queryByText('First')).not.toBeInTheDocument()
+    expect(mockRefresh).toHaveBeenCalled()
+    // The removal click must not also navigate the row.
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('leaves the row in place with a visible reason on a Silent failure', async () => {
+    const serverAction = vi.fn(async () => ({
+      removed: false,
+      error: 'Access denied or operation failed',
+    }))
+    render(
+      <RelationshipTableClient
+        {...baseProps()}
+        removeMode="disconnect"
+        serverAction={serverAction}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getAllByRole('button', { name: /disconnect posts row/i })[0])
+
+    // Denied: the row stays and the reason is shown (no leak of denied-vs-missing).
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(/access denied/i)
+    expect(mockRefresh).not.toHaveBeenCalled()
+  })
+
+  it('confirms before deleting when removeAction is delete', async () => {
+    const serverAction = vi.fn(async () => ({ removed: true }))
+    render(
+      <RelationshipTableClient {...baseProps()} removeMode="delete" serverAction={serverAction} />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getAllByRole('button', { name: /delete posts row/i })[0])
+
+    // A confirmation dialog appears; no action runs until confirmed.
+    expect(serverAction).not.toHaveBeenCalled()
+    const dialog = screen.getByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    // Confirmed → a delete on the related list (the secured context path).
+    expect(serverAction).toHaveBeenCalledWith({
+      listKey: 'Post',
+      action: 'removeRelated',
+      mode: 'delete',
+      id: 'p1',
+    })
+    expect(mockRefresh).toHaveBeenCalled()
   })
 })

--- a/packages/ui/tests/lib/deriveItemView.test.ts
+++ b/packages/ui/tests/lib/deriveItemView.test.ts
@@ -180,6 +180,105 @@ describe('deriveItemViewLayout', () => {
     expect(layout.sections.map((s) => s.fieldName)).toEqual(['comments', 'posts'])
   })
 
+  it('defaults row removal to disconnect and marks a nullable back-reference disconnectable', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+        },
+      },
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          author: { type: 'relationship', ref: 'User.posts' }, // nullable FK
+        },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.removeAction).toBe('disconnect')
+    expect(section.disconnectable).toBe(true)
+  })
+
+  it('reads a delete removeAction opt-in', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          notes: {
+            type: 'relationship',
+            ref: 'Note.owner',
+            many: true,
+            ui: { itemView: { removeAction: 'delete' } },
+          },
+        },
+      },
+      Note: {
+        fields: {
+          body: { type: 'text' },
+          owner: { type: 'relationship', ref: 'User.notes' },
+        },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.removeAction).toBe('delete')
+  })
+
+  it('reads a none removeAction (hides the control)', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: {
+            type: 'relationship',
+            ref: 'Post.author',
+            many: true,
+            ui: { itemView: { removeAction: 'none' } },
+          },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.removeAction).toBe('none')
+  })
+
+  it('marks a required-FK back-reference (db.isNullable:false) as not disconnectable', () => {
+    const config = makeConfig({
+      Order: {
+        fields: {
+          lineItems: { type: 'relationship', ref: 'LineItem.order', many: true },
+        },
+      },
+      LineItem: {
+        fields: {
+          amount: { type: 'integer' },
+          // A required foreign key on the related side — disconnect is
+          // statically impossible, so the default disconnect control is hidden.
+          order: { type: 'relationship', ref: 'Order.lineItems', db: { isNullable: false } },
+        },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'Order').sections
+    expect(section.removeAction).toBe('disconnect')
+    expect(section.disconnectable).toBe(false)
+  })
+
+  it('marks a list-only ref (no back-reference) as not disconnectable', () => {
+    const config = makeConfig({
+      Team: {
+        fields: { members: { type: 'relationship', ref: 'Member', many: true } },
+      },
+      Member: { fields: { name: { type: 'text' } } },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'Team').sections
+    expect(section.disconnectable).toBe(false)
+  })
+
   it('falls back to id when a related list has no curated columns', () => {
     const config = makeConfig({
       Team: {


### PR DESCRIPTION
Implements #739. Part of #728.

## What

Adds a `✕` row-removal control to the read-only Relationship tables delivered by #734 on the admin item view, per **ADR-0018**. It mounts on the `relationship-table-row` seam #734 left for exactly this ticket.

Removal semantics (config-driven via `ui.itemView.removeAction`):

- **`'disconnect'` (default)** — non-destructively unlinks the related row from the current record. The related row still exists and appears on its own list page. Gated on the **related list's update access**.
- **`'delete'` (opt-in)** — truly deletes the related row, behind a `ConfirmDialog`, gated on the **related list's delete access**.
- **`'none'`** — hides the control.
- Where the schema makes disconnect statically impossible (a required FK on the related side — the back-reference declares `db.isNullable: false`), the control is hidden unless `delete` is opted in. No runtime error path.

## How

- **`@opensaas/stack-core`**
  - New `removeRelated` server action (`mode: 'disconnect' | 'delete'`). It operates on the **related row** through the secured context, so the related list's own operation/field access and hooks apply — never the parent's. Disconnect is an `update` nulling the back-reference (`{ disconnect: true }` for a to-one back-ref; `{ disconnect: { id: parentId } }` for a to-many/M2M back-ref); delete is a secured `delete`.
  - It returns a **distinct `{ removed }` shape** (mirroring `bulkDelete`'s `{ deleted, total }`), so a `serverAction` wrapper that `redirect()`s on `{ success: true }` — the item-form pattern used in the example — does **not** hijack an in-place removal. This was the concrete bug caught in testing: without it, removing a row redirected to the related list.
  - New `RelationshipItemViewConfig.removeAction` config option.
- **`@opensaas/stack-ui`**
  - `deriveItemViewLayout` now resolves `removeAction` and a static `disconnectable` flag per section.
  - `RelationshipTable` (server) evaluates the related list's operation access via the existing `isOperationPotentiallyAllowed` helper and passes a resolved `removeMode` (hard-deny hides the control; a filter result shows it and surfaces row-level denials at commit time).
  - `RelationshipTableClient` renders the accessible `✕` (aria-label, keyboard, `data-slot="relationship-table-remove"`), confirms before delete, optimistically hides + `router.refresh()` on success, and reverts with a visible `role="alert"` reason on a Silent failure.
  - Read-only behaviour for everything else is unchanged — no inline cell edit (#737) or create drawer (#738).
- **`examples/starter-auth`** — adds a `Note` owned-child list; the User item view now shows `posts` (disconnect default) and `notes` (delete opt-in) as two distinct relationship tables.

## Removal semantics rationale

Per ADR-0018 and `CONTEXT.md` ("every edit in a Relationship table is an operation on the related list — subject to that list's access control, never the parent's"), both disconnect and delete are operations on the **related** list, gated on the **FK-owning (related) side**. Disconnect is the default because a generic admin UI can't know whether a related row is an owned child (delete is right) or a shared reference like a tag (delete would destroy data other records use).

## Tests (all green locally)

- **core** (`context.test.ts`): `removeRelated` disconnect (to-one), delete, to-many/M2M disconnect payload, and access-denied Silent failure. 836 core tests pass.
- **ui unit**: `deriveItemView` (default/delete/none removeAction, required-FK + list-only ⇒ not disconnectable) and `RelationshipTableClient` (disconnect happy path + refresh, delete confirm, denied revert-with-reason, no control when `removeMode` null). 446 unit + 69 browser tests pass.
- **e2e** (`07-relationship-row-removal.spec.ts`): disconnect default (post disconnected, still on its list) and delete opt-in (note confirmed + deleted, gone from its list). Existing `05-item-view` / `03-admin-ui` specs re-run green against the modified example.
- `pnpm lint` (0 errors), `pnpm manypkg check`, `prettier --check`, and `tsc` (via package builds + `next build`) all clean.

## Changeset

`minor` for `@opensaas/stack-core` (new `removeRelated` action + `removeAction` config — additive) and `@opensaas/stack-ui` (removal affordance).

## Reviewer focus

- **Access-control path**: disconnect/delete are scoped through the related list's access; a hard deny hides the affordance, a filter-scoped denial surfaces as commit-and-revert with a generic reason (no leak of denied-vs-absent).
- The `{ removed }` distinct-shape decision (vs. reusing `delete`/`success`) — it's what keeps redirect-on-success wrappers from hijacking the removal.
- `disconnectable` derivation uses `db.isNullable === false` as the required-FK signal (relationship FKs are generated nullable by default, so this reflects declared intent); list-only refs are treated as not disconnectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_