### PR TITLE
feat(core,ui): to-many relationship count columns — count cells, count sort, count filter (#732)

### DIFF
--- a/.changeset/tall-otters-count.md
+++ b/.changeset/tall-otters-count.md
@@ -1,0 +1,25 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Admin list view: to-many relationship columns render an access-visible count, sort by relation count, and filter by numeric count comparisons (issue #732). Virtual fields render via their Cell but are excluded from sorting and filtering.
+
+A to-many relationship used as a list column now shows the count of the related rows the session may see — fetched in the SAME query via a filtered Prisma `_count`, with the related list's `query` access folded into the count's `where`, so it never counts rows the session cannot read and issues no per-row query. Clicking the column header sorts by relation `_count`, and its Filter spec offers numeric comparisons on the count (`posts:>5`) in the filter builder and in shared URLs.
+
+Because Prisma cannot compare a relation count in a `where`, a to-many relationship's Filter spec emits a structured count marker that is resolved to an access-scoped `{ id: { in } }` before the query runs, through the secured context.
+
+New `@opensaas/stack-core` exports: `buildRelationshipCountSelect`, `resolveRelationshipCountFilters`, `isToManyRelationshipField`, and `RELATIONSHIP_COUNT_FILTER_KEY` (with the `RelationshipCountFilterMarker` type).
+
+```ts
+// A to-many relationship column now shows an access-scoped count and is
+// sortable / filterable by that count — zero config:
+User: list({
+  fields: {
+    name: text(),
+    posts: relationship({ ref: 'Post.author', many: true }),
+  },
+})
+// List view: the `posts` column renders the count; its header sorts by count;
+// `posts:>5` filters by count in the builder and in a shared URL.
+```

--- a/e2e/starter-auth/09-relationship-count-columns.spec.ts
+++ b/e2e/starter-auth/09-relationship-count-columns.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page } from '@playwright/test'
+import { signUp, generateTestUser } from '../utils/auth.js'
+
+/**
+ * To-many relationship COUNT columns in the admin list view (issue #732, part of
+ * #728; builds on the #729 cell registry and the #730/#731 filter engine +
+ * builder).
+ *
+ * The User list's `posts` relationship (to-many, `User.posts` ↔ `Post.author`)
+ * renders as an access-visible COUNT column. These specs drive the real admin UI
+ * to prove:
+ *  • the count cell shows the number of related rows the session may see,
+ *  • the column header sorts by relation count,
+ *  • a count comparison (`posts:>N`) filters via the builder and a shared URL.
+ *
+ * Posts are auto-authored to the signed-in user (the Post `resolveInput` hook),
+ * so a fresh user's `posts` count equals the number of posts it creates.
+ */
+test.describe('To-many relationship count columns', () => {
+  let user: ReturnType<typeof generateTestUser>
+
+  test.beforeEach(async ({ page }) => {
+    user = generateTestUser()
+    await signUp(page, user)
+  })
+
+  async function createPost(page: Page, { title, slug }: { title: string; slug: string }) {
+    await page.goto('/admin/post')
+    await page.waitForLoadState('networkidle')
+    await page.click('text=/create|new/i')
+    await page.waitForLoadState('networkidle')
+    await page.fill('input[name="title"]', title)
+    await page.fill('input[name="slug"]', slug)
+    await page.fill('textarea[name="content"]', 'Body content for the post.')
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/admin\/post/, { timeout: 10000 })
+  }
+
+  async function createPosts(page: Page, count: number, prefix: string) {
+    for (let i = 0; i < count; i++) {
+      await createPost(page, { title: `${prefix} ${i}`, slug: `${prefix}-${i}` })
+    }
+  }
+
+  /** The 0-based index of the table column whose header reads exactly `name`. */
+  async function columnIndex(page: Page, name: string): Promise<number> {
+    const headers = page.locator('table thead th')
+    const total = await headers.count()
+    for (let i = 0; i < total; i++) {
+      const text = (await headers.nth(i).innerText()).trim()
+      if (text === name) return i
+    }
+    throw new Error(`Column "${name}" not found in the table header`)
+  }
+
+  test('shows the access-visible related count in the Posts column', async ({ page }) => {
+    await createPosts(page, 3, 'count-display')
+
+    // Isolate this user's row via the unique email (free-text filter), so the
+    // assertion is robust to other users in the shared database.
+    await page.goto(`/admin/user?search=${encodeURIComponent(user.email)}`)
+    await page.waitForLoadState('networkidle')
+
+    const postsIdx = await columnIndex(page, 'Posts')
+    const row = page.locator('tbody tr', { hasText: user.email })
+    await expect(row).toHaveCount(1)
+
+    // The Posts cell renders the count via the dedicated count-cell slot.
+    const postsCell = row.locator('td').nth(postsIdx)
+    await expect(postsCell.locator('[data-slot="cell-relationship-count"]')).toHaveText('3')
+  })
+
+  test('sorts the list by relation count when the Posts header is clicked', async ({ page }) => {
+    // Give this user a distinctive number of posts so the ordering is observable.
+    await createPosts(page, 4, 'count-sort')
+
+    await page.goto('/admin/user')
+    await page.waitForLoadState('networkidle')
+
+    const postsIdx = await columnIndex(page, 'Posts')
+    // Not `exact`: after a sort the header's accessible name gains the sort-arrow
+    // indicator ("Posts ↑"/"Posts ↓"), so match by substring.
+    const header = page.getByRole('columnheader', { name: 'Posts' })
+    const postsColumn = () => page.locator('tbody tr').locator(`td:nth-child(${postsIdx + 1})`)
+
+    const columnCounts = async (): Promise<number[]> => {
+      const texts = await postsColumn().allInnerTexts()
+      return texts.map((t) => Number(t.trim())).filter((n) => Number.isFinite(n))
+    }
+
+    // First click → ascending count sort: the column is non-decreasing.
+    await header.click()
+    await page.waitForURL(/sort=posts(%3A|:)asc/, { timeout: 10000 })
+    await page.waitForLoadState('networkidle')
+    const asc = await columnCounts()
+    for (let i = 1; i < asc.length; i++) {
+      expect(asc[i]).toBeGreaterThanOrEqual(asc[i - 1])
+    }
+
+    // Second click → descending count sort: the column is non-increasing, and
+    // the top row has the highest count on the page (at least this user's 4).
+    await header.click()
+    await page.waitForURL(/sort=posts(%3A|:)desc/, { timeout: 10000 })
+    await page.waitForLoadState('networkidle')
+    const desc = await columnCounts()
+    for (let i = 1; i < desc.length; i++) {
+      expect(desc[i]).toBeLessThanOrEqual(desc[i - 1])
+    }
+    expect(desc[0]).toBeGreaterThanOrEqual(4)
+  })
+
+  test('filters by a count comparison via a shared URL (posts:>N)', async ({ page }) => {
+    await createPosts(page, 4, 'count-url')
+
+    // `posts:>3` keeps this user (4 > 3)…
+    await page.goto('/admin/user?search=posts:%3E3')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('tbody tr', { hasText: user.email })).toHaveCount(1)
+
+    // …and `posts:>4` excludes it (4 is not > 4). This is self-contained: it
+    // asserts only about this user's own row, independent of other users.
+    await page.goto('/admin/user?search=posts:%3E4')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('tbody tr', { hasText: user.email })).toHaveCount(0)
+  })
+
+  test('filters by a count comparison built in the Filter builder', async ({ page }) => {
+    await createPosts(page, 4, 'count-builder')
+
+    await page.goto('/admin/user')
+    await page.waitForLoadState('networkidle')
+
+    // Build `posts > 3` with the structured row: field Posts, operator greater
+    // than, value 3.
+    await page.getByRole('button', { name: /add filter/i }).click()
+    await page.getByLabel('Filter field').selectOption('posts')
+    await page.getByLabel('Filter operator').selectOption('gt')
+    await page.getByLabel('Filter value').fill('3')
+    await page.getByRole('button', { name: 'Apply' }).click()
+
+    // The builder writes the engine's grammar (`posts:>3`) into ?search=.
+    await page.waitForURL(/search=posts(%3A|:)(%3E|>)3/, { timeout: 10000 })
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('tbody tr', { hasText: user.email })).toHaveCount(1)
+  })
+})

--- a/packages/core/src/access/relationship-count.test.ts
+++ b/packages/core/src/access/relationship-count.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest'
+import { list } from '../config/index.js'
+import { text, relationship, integer } from '../fields/index.js'
+import type { OpenSaasConfig } from '../config/types.js'
+import type { AccessContext } from './types.js'
+import {
+  buildRelationshipCountSelect,
+  resolveRelationshipCountFilters,
+  isToManyRelationshipField,
+} from './relationship-count.js'
+import { RELATIONSHIP_COUNT_FILTER_KEY } from '../filter/types.js'
+
+/**
+ * Access-scoped to-many relationship counts (issue #732). Verifies:
+ *  • the filtered `_count` select folds in the related list's query access,
+ *  • a denied related list is omitted (its count renders as 0, never a leak),
+ *  • count-filter markers resolve to access-scoped `{ id: { in } }` via a single
+ *    secured read (never a per-row query), including the fully-denied case.
+ */
+
+// User (published-only for anon via a filter), plus a Widget list that is fully
+// closed by default (no query access) to prove the denied path.
+function makeConfig(): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+    lists: {
+      User: list({
+        fields: {
+          name: text(),
+          posts: relationship({ ref: 'Post.author', many: true }),
+          widgets: relationship({ ref: 'Widget', many: true }),
+          manager: relationship({ ref: 'User' }), // to-one — never counted
+        },
+        access: { operation: { query: () => true } },
+      }),
+      Post: list({
+        fields: { title: text(), views: integer(), author: relationship({ ref: 'User.posts' }) },
+        // Only published posts are visible → the count must be access-scoped.
+        access: { operation: { query: () => ({ status: { equals: 'published' } }) } },
+      }),
+      // Widget ships closed (no access block) → query denied by default.
+      Widget: list({ fields: { name: text() } }),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+  } as any
+}
+
+function makeContext(
+  findMany?: (args: unknown) => Promise<Array<Record<string, unknown>>>,
+): AccessContext {
+  return {
+    session: null,
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+    db: findMany ? { user: { findMany } } : {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
+  } as any
+}
+
+describe('isToManyRelationshipField', () => {
+  const config = makeConfig()
+  const userFields = config.lists.User.fields
+  it('is true only for a to-many relationship', () => {
+    expect(isToManyRelationshipField(userFields.posts)).toBe(true)
+    expect(isToManyRelationshipField(userFields.widgets)).toBe(true)
+    expect(isToManyRelationshipField(userFields.manager)).toBe(false)
+    expect(isToManyRelationshipField(userFields.name)).toBe(false)
+  })
+})
+
+describe('buildRelationshipCountSelect', () => {
+  it("folds the related list's query filter into each to-many count and omits denied/to-one", async () => {
+    const config = makeConfig()
+    const select = await buildRelationshipCountSelect(
+      config.lists.User,
+      { session: null, context: makeContext() },
+      config,
+    )
+    // `posts` → access-scoped where; `widgets` → denied (omitted); `manager` →
+    // to-one (never counted).
+    expect(select).toEqual({ posts: { where: { status: { equals: 'published' } } } })
+  })
+
+  it('uses a bare `true` when the related list is fully readable', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        Tag: list({ fields: { name: text() }, access: { operation: { query: () => true } } }),
+        Post: list({ fields: { title: text(), tags: relationship({ ref: 'Tag', many: true }) } }),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any
+    const select = await buildRelationshipCountSelect(
+      config.lists.Post,
+      { session: null, context: makeContext() },
+      config,
+    )
+    expect(select).toEqual({ tags: true })
+  })
+
+  it('returns undefined when there are no countable to-many relationships', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: { Post: list({ fields: { title: text() } }) },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any
+    const select = await buildRelationshipCountSelect(
+      config.lists.Post,
+      { session: null, context: makeContext() },
+      config,
+    )
+    expect(select).toBeUndefined()
+  })
+})
+
+describe('resolveRelationshipCountFilters', () => {
+  const marker = (operator: string, value: number) => ({
+    posts: { [RELATIONSHIP_COUNT_FILTER_KEY]: { operator, value } },
+  })
+
+  it('returns the where unchanged when there are no count markers', async () => {
+    const config = makeConfig()
+    const where = { name: { contains: 'ada' } }
+    const resolved = await resolveRelationshipCountFilters(
+      where,
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext() },
+      config,
+    )
+    expect(resolved).toBe(where)
+  })
+
+  it('resolves a count marker to an access-scoped { id: { in } } via a single secured read', async () => {
+    const config = makeConfig()
+    // Two users; the secured read returns each with its access-scoped `_count`.
+    const findMany = vi.fn(async () => [
+      { id: 'u1', _count: { posts: 3 } },
+      { id: 'u2', _count: { posts: 7 } },
+    ])
+    const resolved = await resolveRelationshipCountFilters(
+      marker('gt', 5),
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    // Only u2 (7 > 5) matches; the read was access-scoped (published-only count).
+    expect(resolved).toEqual({ id: { in: ['u2'] } })
+    expect(findMany).toHaveBeenCalledTimes(1)
+    expect(findMany).toHaveBeenCalledWith({
+      include: { _count: { select: { posts: { where: { status: { equals: 'published' } } } } } },
+    })
+  })
+
+  it('includes zero-count rows for comparisons that admit zero (no complement bug)', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn(async () => [
+      { id: 'u1', _count: { posts: 0 } },
+      { id: 'u2', _count: { posts: 4 } },
+    ])
+    const resolved = await resolveRelationshipCountFilters(
+      marker('lt', 1), // count < 1 → only the zero-count user
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    expect(resolved).toEqual({ id: { in: ['u1'] } })
+  })
+
+  it('resolves a denied related list without any query: count is always 0', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn(async () => [])
+    // `widgets`' related list (Widget) is fully denied → every count is 0.
+    const where = { widgets: { [RELATIONSHIP_COUNT_FILTER_KEY]: { operator: 'gt', value: 5 } } }
+    const resolved = await resolveRelationshipCountFilters(
+      where,
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    // 0 is not > 5 → nothing matches, and no read was issued.
+    expect(resolved).toEqual({ id: { in: [] } })
+    expect(findMany).not.toHaveBeenCalled()
+  })
+
+  it('preserves sibling conditions, ANDing the resolved id constraint', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn(async () => [{ id: 'u2', _count: { posts: 7 } }])
+    const where = { AND: [{ name: { contains: 'ada' } }, marker('gte', 1)] }
+    const resolved = await resolveRelationshipCountFilters(
+      where,
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    expect(resolved).toEqual({ AND: [{ name: { contains: 'ada' } }, { id: { in: ['u2'] } }] })
+  })
+})

--- a/packages/core/src/access/relationship-count.ts
+++ b/packages/core/src/access/relationship-count.ts
@@ -1,0 +1,266 @@
+import type { Session, AccessContext, PrismaFilter } from './types.js'
+import type { OpenSaasConfig, ListConfig, FieldConfig } from '../config/types.js'
+import type { FilterOperator, RelationshipCountFilterMarker } from '../filter/types.js'
+import { RELATIONSHIP_COUNT_FILTER_KEY } from '../filter/types.js'
+import { checkAccess, getRelatedListConfig } from './engine.js'
+import { getDbKey } from '../lib/case-utils.js'
+
+/**
+ * Access-scoped to-many relationship counts for the admin list view (issue
+ * #732).
+ *
+ * A to-many relationship column shows the count of the related rows the session
+ * may see — fetched in the SAME query as the row via Prisma's filtered
+ * `_count` (`_count: { select: { orders: { where: <access filter> } } }`), so no
+ * per-row query is issued and the count can never include rows the session
+ * cannot read. This module is the single place the related list's
+ * operation-level `query` access is folded into that `_count`, mirroring how
+ * `buildIncludeWithAccessControl` folds it into relation includes.
+ *
+ * It also resolves the count Filter spec's markers: Prisma cannot compare a
+ * relation count in a `where`, so a to-many relationship's Filter spec emits a
+ * {@link RELATIONSHIP_COUNT_FILTER_KEY} marker that
+ * {@link resolveRelationshipCountFilters} turns into an access-scoped
+ * `{ id: { in } }` before the query runs — never leaking counts of related rows
+ * the session cannot see.
+ */
+
+type CountArgs = {
+  session: Session | null
+  context: AccessContext
+}
+
+/**
+ * Whether a field is a to-many relationship — the only field kind that carries a
+ * relationship count (a to-one relationship has at most one related row).
+ */
+export function isToManyRelationshipField(field: FieldConfig | undefined): boolean {
+  return (
+    field?.type === 'relationship' &&
+    'many' in field &&
+    field.many === true &&
+    'ref' in field &&
+    typeof field.ref === 'string' &&
+    field.ref.length > 0
+  )
+}
+
+/** The per-relation entry the count `_count.select` uses for one relationship. */
+type CountAccessEntry =
+  | { kind: 'all' } // related list fully readable → count every related row
+  | { kind: 'scoped'; where: PrismaFilter } // count only rows matching the access filter
+  | { kind: 'denied' } // related list not readable at all → count is always 0
+
+/**
+ * Resolve the related list's operation-level `query` access for one to-many
+ * relationship into the entry its `_count` select needs. Returns `null` when the
+ * field is not a resolvable to-many relationship.
+ */
+async function relationshipCountAccessEntry(
+  field: FieldConfig | undefined,
+  args: CountArgs,
+  config: OpenSaasConfig,
+): Promise<CountAccessEntry | null> {
+  if (!field || !isToManyRelationshipField(field) || !('ref' in field)) {
+    return null
+  }
+  const ref = field.ref
+  if (typeof ref !== 'string') return null
+  const related = getRelatedListConfig(ref, config)
+  if (!related) return null
+
+  const queryAccess = related.listConfig.access?.operation?.query
+  const result = await checkAccess(queryAccess, { session: args.session, context: args.context })
+
+  if (result === false) return { kind: 'denied' }
+  if (typeof result === 'object') return { kind: 'scoped', where: result }
+  return { kind: 'all' }
+}
+
+/**
+ * Build the object to place at `include._count.select` for a list's to-many
+ * relationships, with each related list's `query` access folded into the
+ * per-relation `where` so the returned counts are access-scoped. A relationship
+ * whose related list is fully denied is omitted (its count renders as 0). Returns
+ * `undefined` when the list has no countable to-many relationships.
+ */
+export async function buildRelationshipCountSelect(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  args: CountArgs,
+  config: OpenSaasConfig,
+): Promise<Record<string, unknown> | undefined> {
+  const select: Record<string, unknown> = {}
+  for (const [fieldName, field] of Object.entries(listConfig.fields)) {
+    const entry = await relationshipCountAccessEntry(field, args, config)
+    if (entry === null || entry.kind === 'denied') continue
+    select[fieldName] = entry.kind === 'scoped' ? { where: entry.where } : true
+  }
+  return Object.keys(select).length > 0 ? select : undefined
+}
+
+/** Read a to-many relationship's count off a fetched row's `_count` payload. */
+function readRelationshipCount(row: Record<string, unknown>, fieldName: string): number {
+  const counts = row._count
+  if (counts && typeof counts === 'object') {
+    const value = (counts as Record<string, unknown>)[fieldName]
+    if (typeof value === 'number') return value
+  }
+  return 0
+}
+
+/** Whether a count satisfies a Filter operator/value comparison. */
+function matchesCount(count: number, operator: FilterOperator, value: number): boolean {
+  switch (operator) {
+    case 'eq':
+      return count === value
+    case 'gt':
+      return count > value
+    case 'gte':
+      return count >= value
+    case 'lt':
+      return count < value
+    case 'lte':
+      return count <= value
+  }
+}
+
+/** Minimal shape the resolver needs off the secured `context.db` delegate. */
+interface CountFindManyDelegate {
+  findMany: (args: { include: { _count: { select: Record<string, unknown> } } }) => Promise<unknown>
+}
+
+function asCountDelegate(value: unknown): CountFindManyDelegate | null {
+  if (value && typeof value === 'object' && 'findMany' in value) {
+    const candidate = value as { findMany?: unknown }
+    if (typeof candidate.findMany === 'function') {
+      return value as CountFindManyDelegate
+    }
+  }
+  return null
+}
+
+/** Extract the `RelationshipCountFilterMarker` from a condition value, if present. */
+function readCountMarker(value: unknown): RelationshipCountFilterMarker | null {
+  if (!value || typeof value !== 'object') return null
+  const marker = (value as Record<string, unknown>)[RELATIONSHIP_COUNT_FILTER_KEY]
+  if (!marker || typeof marker !== 'object') return null
+  const { operator, value: n } = marker as { operator?: unknown; value?: unknown }
+  if (
+    (operator === 'eq' ||
+      operator === 'gt' ||
+      operator === 'gte' ||
+      operator === 'lt' ||
+      operator === 'lte') &&
+    typeof n === 'number'
+  ) {
+    return { operator, value: n }
+  }
+  return null
+}
+
+/**
+ * Resolve one to-many relationship count-filter marker into a Prisma `where`
+ * fragment constraining the parent by id. Runs a single access-scoped read
+ * through the SECURED context — never a raw/unscoped query and never a per-row
+ * query — computing the access-visible count per parent and keeping the ids
+ * whose count satisfies the comparison. A fully-denied related list makes every
+ * count 0, resolved without any query.
+ */
+async function resolveOneCountFilter(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listKey: string,
+  fieldName: string,
+  marker: RelationshipCountFilterMarker,
+  args: CountArgs,
+  config: OpenSaasConfig,
+): Promise<PrismaFilter> {
+  const field = listConfig.fields[fieldName]
+  const entry = await relationshipCountAccessEntry(field, args, config)
+
+  // Not resolvable (shouldn't happen for a marker the spec emitted) → no-op.
+  if (entry === null) return {}
+
+  // Related list fully denied → every parent's access-visible count is 0.
+  if (entry.kind === 'denied') {
+    return matchesCount(0, marker.operator, marker.value) ? {} : { id: { in: [] } }
+  }
+
+  const delegate = asCountDelegate(args.context.db[getDbKey(listKey)])
+  if (!delegate) return {}
+
+  const countSelect = entry.kind === 'scoped' ? { where: entry.where } : true
+  const rows = await delegate.findMany({
+    include: { _count: { select: { [fieldName]: countSelect } } },
+  })
+
+  const matchingIds: string[] = []
+  if (Array.isArray(rows)) {
+    for (const row of rows) {
+      if (!row || typeof row !== 'object') continue
+      const record = row as Record<string, unknown>
+      if (matchesCount(readRelationshipCount(record, fieldName), marker.operator, marker.value)) {
+        matchingIds.push(String(record.id))
+      }
+    }
+  }
+  return { id: { in: matchingIds } }
+}
+
+/**
+ * Replace any to-many relationship count-filter markers in a filter `where` with
+ * access-scoped `{ id: { in } }` fragments. Markers only ever appear as
+ * top-level AND members (the pure filter engine pushes each field condition into
+ * the top-level AND, and never nests a marker inside the free-text OR), so this
+ * walks only the top level. Returns the `where` unchanged when it contains no
+ * markers, so lists without count filters pay nothing.
+ */
+export async function resolveRelationshipCountFilters(
+  where: Record<string, unknown> | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listKey: string,
+  args: CountArgs,
+  config: OpenSaasConfig,
+): Promise<Record<string, unknown> | undefined> {
+  if (!where) return where
+
+  const andValue = where.AND
+  const members: Array<Record<string, unknown>> = Array.isArray(andValue)
+    ? (andValue as Array<Record<string, unknown>>)
+    : [where]
+
+  const findMarker = (
+    member: Record<string, unknown>,
+  ): { field: string; marker: RelationshipCountFilterMarker } | null => {
+    for (const key of Object.keys(member)) {
+      if (!isToManyRelationshipField(listConfig.fields[key])) continue
+      const marker = readCountMarker(member[key])
+      if (marker) return { field: key, marker }
+    }
+    return null
+  }
+
+  if (!members.some((member) => findMarker(member) !== null)) {
+    return where
+  }
+
+  const resolvedMembers: Array<Record<string, unknown>> = []
+  for (const member of members) {
+    const found = findMarker(member)
+    if (!found) {
+      resolvedMembers.push(member)
+      continue
+    }
+    resolvedMembers.push(
+      await resolveOneCountFilter(listConfig, listKey, found.field, found.marker, args, config),
+    )
+  }
+
+  // Drop no-op members (a fully-denied related list where 0 satisfies the
+  // comparison resolves to `{}` — matches everything, so it need not be ANDed).
+  const effective = resolvedMembers.filter((member) => Object.keys(member).length > 0)
+  if (effective.length === 0) return undefined
+  return effective.length === 1 ? effective[0] : { AND: effective }
+}

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -19,6 +19,7 @@ import { hashPassword, isHashedPassword, HashedPassword } from '../utils/passwor
 import { formatPrismaDefault } from './format-prisma-default.js'
 import { getLabelFieldName } from '../config/label.js'
 import type { FilterOperator, FilterSpec } from '../filter/types.js'
+import { RELATIONSHIP_COUNT_FILTER_KEY } from '../filter/types.js'
 
 /**
  * Operators shared by numeric/date fields: plain equality plus the four
@@ -1459,11 +1460,17 @@ export function relationship<
     config: OpenSaasConfig,
   ) => getPrismaRelation(field as RelationshipField, fieldName, listKey, config)
 
-  // Relationships filter by the related Item's label — `author:"Ada Lovelace"`
-  // becomes a nested `contains` on the target list's Label field (`is` for a
-  // to-one, `some` for a to-many). The mapper stays pure: it emits a Prisma
-  // nested filter, no DB lookup. Suggestions point the client at the target
-  // list so it can use the existing access-controlled label lookup.
+  // Relationships filter differently by cardinality (issue #732):
+  //  • to-one filters by the related Item's label — `author:"Ada Lovelace"`
+  //    becomes a nested `is` `contains` on the target list's Label field.
+  //  • to-many filters by the access-visible related COUNT with numeric
+  //    comparisons — `orders:>5`. Prisma cannot compare a relation count in a
+  //    `where`, so the mapper emits a structured count marker
+  //    (RELATIONSHIP_COUNT_FILTER_KEY) that `resolveRelationshipCountFilters`
+  //    later turns into an access-scoped `{ id: { in } }`.
+  // The mapper stays pure in both cases (no DB lookup). Suggestions point a
+  // to-one at the target list's label lookup; a to-many exposes no value source
+  // (a numeric compare, like an integer field).
   field.getFilterSpec = (
     _fieldName: string,
     _listKey: string,
@@ -1473,21 +1480,35 @@ export function relationship<
     const relatedListConfig = config.lists[targetList]
     if (!relatedListConfig) return undefined
 
+    if (field.many === true) {
+      return {
+        operators: COMPARISON_OPERATORS,
+        toCondition: (operator, value) => {
+          const trimmed = value.trim()
+          // A non-integer count comparison can't be interpreted → degrade to
+          // free text (matching the integer field's behaviour).
+          if (!/^-?\d+$/.test(trimmed)) return null
+          return {
+            [_fieldName]: { [RELATIONSHIP_COUNT_FILTER_KEY]: { operator, value: Number(trimmed) } },
+          }
+        },
+        suggestions: { valueSource: { kind: 'none' } },
+      }
+    }
+
     const labelField = getLabelFieldName(relatedListConfig)
     const labelFieldConfig = relatedListConfig.fields[labelField]
     // A virtual label field has no queryable column, so `contains` can't run
     // against it — the relationship is then not filterable.
     if (labelFieldConfig?.virtual === true) return undefined
 
-    const many = field.many === true
     return {
       operators: ['eq'],
       toCondition: (operator, value) => {
         if (operator !== 'eq') return null
-        const inner = { [labelField]: { contains: value } }
-        return many ? { [_fieldName]: { some: inner } } : { [_fieldName]: { is: inner } }
+        return { [_fieldName]: { is: { [labelField]: { contains: value } } } }
       },
-      suggestions: { valueSource: { kind: 'relationship', listKey: targetList, many } },
+      suggestions: { valueSource: { kind: 'relationship', listKey: targetList, many: false } },
     }
   }
 

--- a/packages/core/src/filter/filter.test.ts
+++ b/packages/core/src/filter/filter.test.ts
@@ -344,6 +344,48 @@ describe('buildListFilterWhere (end-to-end over a real list config)', () => {
   })
 })
 
+describe('to-many relationship Filter spec (count comparisons — issue #732)', () => {
+  function countConfig(): OpenSaasConfig {
+    return {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        User: list({
+          fields: {
+            name: text(),
+            posts: relationship({ ref: 'Post.author', many: true }),
+          },
+        }),
+        Post: list({
+          fields: { title: text(), author: relationship({ ref: 'User.posts' }) },
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+      } as any,
+    } as OpenSaasConfig
+  }
+
+  it('supports numeric comparisons and emits a count marker (not a label filter)', () => {
+    const config = countConfig()
+    const spec = config.lists.User.fields.posts.getFilterSpec!('posts', 'User', config)!
+    expect(spec.operators).toEqual(['eq', 'gt', 'gte', 'lt', 'lte'])
+    expect(spec.toCondition('gt', '5')).toEqual({
+      posts: { _countFilter: { operator: 'gt', value: 5 } },
+    })
+    expect(spec.toCondition('eq', '0')).toEqual({
+      posts: { _countFilter: { operator: 'eq', value: 0 } },
+    })
+    // A non-integer count degrades to free text (like an integer field).
+    expect(spec.toCondition('gt', 'lots')).toBeNull()
+    // No enumerated value source — a count is a plain numeric compare.
+    expect(spec.suggestions.valueSource).toEqual({ kind: 'none' })
+  })
+
+  it('end-to-end: buildListFilterWhere carries a count marker for `posts:>5`', () => {
+    const config = countConfig()
+    const where = buildListFilterWhere('posts:>5', config.lists.User, 'User', config)
+    expect(where).toEqual({ posts: { _countFilter: { operator: 'gt', value: 5 } } })
+  })
+})
+
 describe('collectFilterSuggestions', () => {
   it('returns serializable, function-free suggestion metadata', () => {
     const config = makeConfig()

--- a/packages/core/src/filter/index.ts
+++ b/packages/core/src/filter/index.ts
@@ -13,6 +13,7 @@ export { parseFilterQuery } from './parse.js'
 export { serializeFilterQuery } from './serialize.js'
 export { buildFilterWhere } from './map.js'
 export { collectFilterSpecs, buildListFilterWhere, collectFilterSuggestions } from './collect.js'
+export { RELATIONSHIP_COUNT_FILTER_KEY } from './types.js'
 export type {
   FilterOperator,
   FilterToken,
@@ -20,4 +21,5 @@ export type {
   FilterSpec,
   FilterValueSource,
   FilterFieldSuggestion,
+  RelationshipCountFilterMarker,
 } from './types.js'

--- a/packages/core/src/filter/types.ts
+++ b/packages/core/src/filter/types.ts
@@ -59,6 +59,26 @@ export type FilterValueSource =
   | { kind: 'relationship'; listKey: string; many: boolean }
 
 /**
+ * Marker key a to-many relationship's Filter spec emits for a count comparison
+ * (`orders:>5`). Prisma cannot express a relation-count comparison in a `where`
+ * (there is no `{ orders: { _count: { gt: 5 } } }`), so the pure spec can only
+ * emit a structured marker; `resolveRelationshipCountFilters` later turns each
+ * marker into an access-scoped `{ id: { in | notIn } }` before the query runs.
+ * Kept here (the pure boundary) so the field builder and the resolver agree on
+ * the shape without depending on each other.
+ */
+export const RELATIONSHIP_COUNT_FILTER_KEY = '_countFilter' as const
+
+/**
+ * The payload a {@link RELATIONSHIP_COUNT_FILTER_KEY} marker carries: the
+ * numeric comparison to apply to a to-many relationship's access-visible count.
+ */
+export interface RelationshipCountFilterMarker {
+  operator: FilterOperator
+  value: number
+}
+
+/**
  * A field's self-declared filtering capability. Returned by the optional
  * `getFilterSpec` field-builder method.
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export {
   collectFilterSpecs,
   buildListFilterWhere,
   collectFilterSuggestions,
+  RELATIONSHIP_COUNT_FILTER_KEY,
 } from './filter/index.js'
 export type {
   FilterOperator,
@@ -104,4 +105,15 @@ export type {
   FilterSpec,
   FilterValueSource,
   FilterFieldSuggestion,
+  RelationshipCountFilterMarker,
 } from './filter/index.js'
+
+// Access-scoped to-many relationship counts for the admin list view (#732):
+// build the filtered `_count` select for count cells/sort, and resolve the
+// count Filter spec's markers into `{ id: { in } }` — all through the secured
+// context, so counts never include related rows the session cannot read.
+export {
+  buildRelationshipCountSelect,
+  resolveRelationshipCountFilters,
+  isToManyRelationshipField,
+} from './access/relationship-count.js'

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -12,13 +12,17 @@ import {
   type AccessControl,
   type BulkAction,
   buildListFilterWhere,
+  buildRelationshipCountSelect,
   collectFilterSuggestions,
   getDbKey,
   getItemLabel,
   getLabelFieldName,
   getUrlKey,
+  isToManyRelationshipField,
   OpenSaasConfig,
+  resolveRelationshipCountFilters,
 } from '@opensaas/stack-core'
+import type { FieldConfig } from '@opensaas/stack-core'
 
 /**
  * Whether the list's delete access is NOT statically false (issue #733).
@@ -89,6 +93,29 @@ function toRelationshipLabel(
 }
 
 /**
+ * Whether a field can seed an `orderBy` for the list table (issue #732).
+ * Virtual fields have no column to order by, and a to-one relationship has no
+ * scalar to order by; a to-many relationship orders by its related `_count`, and
+ * every scalar column orders by its own value.
+ */
+function isSortableField(field: FieldConfig | undefined): boolean {
+  if (!field) return false
+  if (field.virtual === true) return false
+  if (field.type === 'relationship') return isToManyRelationshipField(field)
+  return true
+}
+
+/** Read a to-many relationship's access-scoped count off a fetched row's `_count`. */
+function readRelationshipCount(item: Record<string, unknown>, fieldName: string): number {
+  const counts = item._count
+  if (counts && typeof counts === 'object') {
+    const value = (counts as Record<string, unknown>)[fieldName]
+    if (typeof value === 'number') return value
+  }
+  return 0
+}
+
+/**
  * Default sort for the list table, mirroring Keystone's `ui.listView.initialSort`.
  * Plain serializable data so it can cross the server/client boundary.
  */
@@ -156,9 +183,11 @@ export async function ListView({
     )
   }
 
-  // URL sort takes precedence over config initialSort, but only if the field
-  // actually exists on the list — an unknown field would cause Prisma to throw.
-  const validatedSort = sort && sort.field in listConfig.fields ? sort : undefined
+  // URL sort takes precedence over config initialSort, but only if the field is
+  // actually sortable — an unknown field, a virtual field, or a to-one
+  // relationship has no orderable column and would make Prisma throw (issue
+  // #732).
+  const validatedSort = sort && isSortableField(listConfig.fields[sort.field]) ? sort : undefined
   const activeSort = validatedSort ?? initialSort
 
   // Fetch items using access-controlled context
@@ -178,21 +207,54 @@ export async function ListView({
     // hard-coded `type === 'text'` search here. The fragment is handed to the
     // secured `context.db` below, which ANDs it with the access filter, so the
     // filter can only ever narrow (never widen) what this session may see.
-    const where =
+    const parsedWhere =
       search && search.trim()
         ? buildListFilterWhere(search, listConfig, listKey, config)
         : undefined
 
-    // Build include object for relationship fields
-    const include: Record<string, boolean> = {}
+    // Resolve any to-many relationship count-filter markers (`orders:>5`) into
+    // access-scoped `{ id: { in } }` fragments. Prisma cannot compare a relation
+    // count in a `where`, so the filter engine emits a marker the secured
+    // resolver turns into an id constraint — counting only rows the session may
+    // see (issue #732).
+    const where = await resolveRelationshipCountFilters(
+      parsedWhere,
+      listConfig,
+      listKey,
+      { session: context.session, context },
+      config,
+    )
+
+    // Build the include: to-one relationships fetch the related row (for its
+    // Item label), while to-many relationships fetch only an access-scoped
+    // COUNT via a filtered `_count` — never the related rows themselves. This
+    // both powers the count cell and avoids an unbounded per-row fetch of every
+    // related row (issue #732).
+    const include: Record<string, unknown> = {}
     Object.entries(listConfig.fields).forEach(([fieldName, field]) => {
-      if ((field as { type: string }).type === 'relationship') {
+      if (field.type === 'relationship' && !isToManyRelationshipField(field)) {
         include[fieldName] = true
       }
     })
+    const countSelect = await buildRelationshipCountSelect(
+      listConfig,
+      { session: context.session, context },
+      config,
+    )
+    if (countSelect) {
+      include._count = { select: countSelect }
+    }
+
+    // A to-many relationship column sorts by its related `_count`; every other
+    // sortable column orders by its own value.
+    const orderBy = activeSort
+      ? isToManyRelationshipField(listConfig.fields[activeSort.field])
+        ? { [activeSort.field]: { _count: activeSort.direction } }
+        : { [activeSort.field]: activeSort.direction }
+      : undefined
+
     const delegate = dbContext[key]
     if (delegate?.findMany && delegate?.count) {
-      const orderBy = activeSort ? { [activeSort.field]: activeSort.direction } : undefined
       ;[items, total] = await Promise.all([
         delegate.findMany({
           where,
@@ -221,12 +283,20 @@ export async function ListView({
     }
   })
 
-  // Resolve each relationship value into { id, label } via the shared label
-  // seam before crossing the server/client boundary — ListConfig objects
-  // carry functions and can't be passed as props to the client component.
+  // Resolve each relationship value before crossing the server/client boundary
+  // (ListConfig objects carry functions and can't be passed as props):
+  //  • to-one → the related row's `{ id, label }` via the shared label seam.
+  //  • to-many → the access-visible related COUNT (a number) read off `_count`.
+  // The raw `_count` payload is dropped from the serialized item (issue #732).
   const itemsWithResolvedLabels = items.map((item) => {
     const resolved: Record<string, unknown> = { ...item }
+    delete resolved._count
     for (const [fieldName, ref] of Object.entries(relationshipRefs)) {
+      const field = listConfig.fields[fieldName]
+      if (isToManyRelationshipField(field)) {
+        resolved[fieldName] = readRelationshipCount(item, fieldName)
+        continue
+      }
       const [relatedListKey] = ref.split('.')
       const relatedListConfig = config.lists[relatedListKey]
       const rawValue = item[fieldName]

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Link from 'next/link.js'
 import { Inbox, Plus, SearchX } from 'lucide-react'
 import { useRouter } from 'next/navigation.js'
-import { cn, formatFieldName, isNumericField } from '../lib/utils.js'
+import { cn, formatFieldName, isCountAlignedColumn, isSortableColumn } from '../lib/utils.js'
 import {
   Table,
   TableBody,
@@ -399,12 +399,26 @@ export function ListViewClient({
                 </TableHead>
               )}
               {displayColumns.map((column) => {
-                const numeric = isNumericField(fieldTypes[column])
+                const field = columnField(column)
+                const numeric = isCountAlignedColumn(field)
+                // Virtual and to-one relationship columns have no orderable
+                // column, so they expose no sort affordance (issue #732).
+                const sortable = isSortableColumn(field)
                 return (
                   <TableHead
                     key={column}
-                    className="cursor-pointer transition-colors hover:bg-muted/70"
-                    onClick={() => handleSort(column)}
+                    className={cn(
+                      'transition-colors',
+                      sortable && 'cursor-pointer hover:bg-muted/70',
+                    )}
+                    onClick={sortable ? () => handleSort(column) : undefined}
+                    aria-sort={
+                      sortable && sortBy === column
+                        ? sortOrder === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : undefined
+                    }
                   >
                     <div
                       className={cn(
@@ -413,7 +427,7 @@ export function ListViewClient({
                       )}
                     >
                       <span>{formatFieldName(column)}</span>
-                      {sortBy === column && (
+                      {sortable && sortBy === column && (
                         <span className="text-primary">{sortOrder === 'asc' ? '↑' : '↓'}</span>
                       )}
                     </div>
@@ -481,7 +495,7 @@ export function ListViewClient({
                     {displayColumns.map((column) => (
                       <TableCell
                         key={column}
-                        className={cn(isNumericField(fieldTypes[column]) && 'text-right')}
+                        className={cn(isCountAlignedColumn(columnField(column)) && 'text-right')}
                       >
                         {renderCell(column, item)}
                       </TableCell>

--- a/packages/ui/src/components/cells/RelationshipCell.tsx
+++ b/packages/ui/src/components/cells/RelationshipCell.tsx
@@ -33,12 +33,29 @@ function EmptyDash() {
 }
 
 /**
- * To-one relationship Cell — renders the related row's Item label, linked to
- * its edit page when the field's `ref` (and `basePath`) resolve a URL. Arrays
- * (to-many) render as comma-separated labels, preserving the list view's
- * long-standing behaviour. Slot: `cell-relationship`.
+ * Relationship Cell (issue #732):
+ *
+ * - **To-many** (`field.many`) renders the access-visible related COUNT — a
+ *   right-aligned tabular number the list view resolves via the secured query's
+ *   filtered `_count`, so it only ever counts rows the session may see. Slot:
+ *   `cell-relationship-count`.
+ * - **To-one** renders the related row's Item label, linked to its edit page
+ *   when the field's `ref` (and `basePath`) resolve a URL. Slot:
+ *   `cell-relationship`.
+ *
+ * A to-many value is normally the resolved count (a number); an array of
+ * resolved refs is tolerated as a fallback (its length is the count).
  */
 export function RelationshipCell({ value, field, basePath = '/admin' }: CellComponentProps) {
+  if (field.many === true) {
+    const count = typeof value === 'number' ? value : Array.isArray(value) ? value.length : 0
+    return (
+      <span data-slot="cell-relationship-count" className="tabular-nums">
+        {count}
+      </span>
+    )
+  }
+
   const relatedUrlKey = field.ref ? getUrlKey(field.ref.split('.')[0] ?? '') : undefined
 
   const renderRef = (ref: RelatedRef, key: React.Key) => {

--- a/packages/ui/src/lib/serializeFieldConfig.ts
+++ b/packages/ui/src/lib/serializeFieldConfig.ts
@@ -23,6 +23,12 @@ export type SerializableFieldConfig = {
   options?: Array<SelectOption>
   many?: boolean
   ref?: string
+  /**
+   * Whether the field is a virtual (computed, non-DB) field. Serialised so the
+   * client can omit sort affordances for virtual columns (issue #732) — virtual
+   * fields have no column to order by.
+   */
+  virtual?: boolean
   ui?: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     component?: ComponentType<any>
@@ -78,6 +84,12 @@ export function serializeFieldConfig(fieldConfig: FieldConfig): SerializableFiel
   // Extract ref for relationship fields
   if ('ref' in fieldConfig && fieldConfig.ref !== undefined) {
     config.ref = fieldConfig.ref as string
+  }
+
+  // Extract the virtual flag so the client can suppress sort affordances for
+  // computed fields (issue #732).
+  if ('virtual' in fieldConfig && fieldConfig.virtual === true) {
+    config.virtual = true
   }
 
   return config

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import type { SerializableFieldConfig } from './serializeFieldConfig.js'
 
 /**
  * Merge Tailwind CSS classes with clsx
@@ -40,6 +41,38 @@ const NUMERIC_FIELD_TYPES = new Set(['integer', 'float', 'decimal', 'bigint'])
  */
 export function isNumericField(fieldType: string | undefined): boolean {
   return fieldType !== undefined && NUMERIC_FIELD_TYPES.has(fieldType)
+}
+
+/**
+ * Whether a to-many relationship column renders a count (issue #732). Such a
+ * column shows the access-visible related count as a number, so it aligns and
+ * sorts like a numeric column rather than rendering related labels.
+ */
+export function isToManyRelationshipColumn(field: SerializableFieldConfig | undefined): boolean {
+  return field?.type === 'relationship' && field.many === true
+}
+
+/**
+ * Whether a column renders numerically for table alignment — a scalar numeric
+ * field, or a to-many relationship count column (issue #732).
+ */
+export function isCountAlignedColumn(field: SerializableFieldConfig | undefined): boolean {
+  return isNumericField(field?.type) || isToManyRelationshipColumn(field)
+}
+
+/**
+ * Whether a column exposes a sort affordance (issue #732).
+ *
+ * - Virtual fields have no database column to order by → not sortable.
+ * - A to-one relationship has no scalar to order by → not sortable.
+ * - A to-many relationship sorts by its related count → sortable.
+ * - Every other (scalar) column sorts by its own value → sortable.
+ */
+export function isSortableColumn(field: SerializableFieldConfig | undefined): boolean {
+  if (!field) return true
+  if (field.virtual === true) return false
+  if (field.type === 'relationship') return field.many === true
+  return true
 }
 
 /**

--- a/packages/ui/tests/components/CellRenderer.test.tsx
+++ b/packages/ui/tests/components/CellRenderer.test.tsx
@@ -55,6 +55,26 @@ describe('CellRenderer resolution priority', () => {
     expect(badge).toHaveAttribute('data-slot', 'cell-select')
   })
 
+  it('per-field override wins for a to-many relationship count column too (issue #732)', () => {
+    const field: SerializableFieldConfig = {
+      type: 'relationship',
+      ref: 'Post.author',
+      many: true,
+      ui: { cell: OverrideCell },
+    }
+    // Without the override this would render the default count Cell; the
+    // per-field override still takes precedence.
+    render(<CellRenderer value={7} field={field} fieldName="posts" />)
+    expect(screen.getByText('override:7')).toBeInTheDocument()
+  })
+
+  it('a to-many relationship with no override renders the default count Cell', () => {
+    const field: SerializableFieldConfig = { type: 'relationship', ref: 'Post.author', many: true }
+    const { container } = render(<CellRenderer value={3} field={field} fieldName="posts" />)
+    const cell = container.querySelector('[data-slot="cell-relationship-count"]')
+    expect(cell).toHaveTextContent('3')
+  })
+
   it('4. unknown / third-party types without a registered Cell fall back to plain text', () => {
     const field: SerializableFieldConfig = { type: 'someUnregisteredThirdPartyType' }
     render(<CellRenderer value="raw value" field={field} fieldName="f" />)

--- a/packages/ui/tests/components/Cells.test.tsx
+++ b/packages/ui/tests/components/Cells.test.tsx
@@ -114,6 +114,38 @@ describe('RelationshipCell', () => {
     render(<RelationshipCell value={null} field={field} fieldName="author" />)
     expect(screen.getByText('-')).toBeInTheDocument()
   })
+
+  it('renders a to-many relationship as its access-visible count (issue #732)', () => {
+    const manyField: SerializableFieldConfig = {
+      type: 'relationship',
+      ref: 'Post.author',
+      many: true,
+    }
+    const { container, rerender } = render(
+      <RelationshipCell value={4} field={manyField} fieldName="posts" />,
+    )
+    const cell = container.querySelector('[data-slot="cell-relationship-count"]')
+    expect(cell).toHaveTextContent('4')
+    // No related-label links are rendered for a count column.
+    expect(screen.queryByRole('link')).toBeNull()
+
+    // A zero count still renders (a closed related list shows 0, not a leak).
+    rerender(<RelationshipCell value={0} field={manyField} fieldName="posts" />)
+    expect(container.querySelector('[data-slot="cell-relationship-count"]')).toHaveTextContent('0')
+
+    // Tolerates a resolved-refs array fallback by counting its length.
+    rerender(
+      <RelationshipCell
+        value={[
+          { id: 'a', label: 'A' },
+          { id: 'b', label: 'B' },
+        ]}
+        field={manyField}
+        fieldName="posts"
+      />,
+    )
+    expect(container.querySelector('[data-slot="cell-relationship-count"]')).toHaveTextContent('2')
+  })
 })
 
 describe('TextCell', () => {

--- a/packages/ui/tests/components/ListView.test.tsx
+++ b/packages/ui/tests/components/ListView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import * as React from 'react'
 import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
 import { list } from '@opensaas/stack-core'
-import { text, relationship, select } from '@opensaas/stack-core/fields'
+import { text, relationship, select, virtual } from '@opensaas/stack-core/fields'
 import { ListView } from '../../src/components/ListView.js'
 import { ListViewClient, type ListViewClientProps } from '../../src/components/ListViewClient.js'
 
@@ -117,11 +117,14 @@ describe('ListView relationship label resolution (shared label seam)', () => {
     expect(props.items[0].author).toEqual({ id: 'user-1', label: 'ada@example.com' })
   })
 
-  it('resolves a many relationship to an array of { id, label } pairs', async () => {
+  it('resolves a to-many relationship to its access-visible count (issue #732)', async () => {
     const config: OpenSaasConfig = {
       db: { provider: 'sqlite', url: 'file:./test.db' },
       lists: {
-        Tag: list({ fields: { name: text() } }),
+        Tag: list({
+          fields: { name: text() },
+          access: { operation: { query: () => true } },
+        }),
         Post: list({
           fields: {
             title: text(),
@@ -131,29 +134,24 @@ describe('ListView relationship label resolution (shared label seam)', () => {
       },
     }
 
+    // The list view fetches a to-many column as a filtered `_count`, not the
+    // related rows — the resolved column value is that count, and the raw
+    // `_count` payload is dropped before crossing to the client.
+    const findMany = vi.fn(async () => [{ id: '1', title: 'Post 1', _count: { tags: 2 } }])
     const context = makeContext({
-      post: {
-        findMany: vi.fn(async () => [
-          {
-            id: '1',
-            title: 'Post 1',
-            tags: [
-              { id: 'tag-1', name: 'JavaScript' },
-              { id: 'tag-2', name: 'TypeScript' },
-            ],
-          },
-        ]),
-        count: vi.fn(async () => 1),
-      },
+      post: { findMany, count: vi.fn(async () => 1) },
     })
 
     const tree = await ListView({ context, config, listKey: 'Post', basePath: '/admin' })
     const props = findListViewClientProps(tree)
 
-    expect(props.items[0].tags).toEqual([
-      { id: 'tag-1', label: 'JavaScript' },
-      { id: 'tag-2', label: 'TypeScript' },
-    ])
+    expect(props.items[0].tags).toBe(2)
+    expect(props.items[0]._count).toBeUndefined()
+
+    // The to-many relationship was requested as an access-scoped `_count`
+    // select, never as a row-fetching include.
+    const call = findMany.mock.calls[0]?.[0] as { include?: Record<string, unknown> }
+    expect(call.include).toEqual({ _count: { select: { tags: true } } })
   })
 
   it('falls back to id when the related row is missing the label field (e.g. stripped by access control)', async () => {
@@ -272,5 +270,99 @@ describe('ListView server-side filtering (filter engine, secured context)', () =
     await ListView({ context, config, listKey: 'Post', basePath: '/admin' })
 
     expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: undefined }))
+  })
+})
+
+describe('ListView to-many relationship count sort & filter (issue #732)', () => {
+  const config: OpenSaasConfig = {
+    db: { provider: 'sqlite', url: 'file:./test.db' },
+    lists: {
+      User: list({
+        fields: {
+          name: text(),
+          fullName: virtual({
+            type: 'string',
+            hooks: { resolveOutput: ({ item }) => String(item.name ?? '') },
+          }),
+          posts: relationship({ ref: 'Post.author', many: true }),
+        },
+        access: { operation: { query: () => true } },
+      }),
+      Post: list({
+        fields: { title: text(), author: relationship({ ref: 'User.posts' }) },
+        access: { operation: { query: () => true } },
+      }),
+    },
+  }
+
+  it('sorts a to-many column by its relation _count', async () => {
+    const findMany = vi.fn(async () => [])
+    const context = makeContext({ user: { findMany, count: vi.fn(async () => 0) } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'User',
+      basePath: '/admin',
+      sort: { field: 'posts', direction: 'desc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { posts: { _count: 'desc' } } }),
+    )
+  })
+
+  it('sorts a scalar column by its own value', async () => {
+    const findMany = vi.fn(async () => [])
+    const context = makeContext({ user: { findMany, count: vi.fn(async () => 0) } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'User',
+      basePath: '/admin',
+      sort: { field: 'name', direction: 'asc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { name: 'asc' } }))
+  })
+
+  it('ignores a sort on a virtual field (no orderBy, never reaches Prisma)', async () => {
+    const findMany = vi.fn(async () => [])
+    const context = makeContext({ user: { findMany, count: vi.fn(async () => 0) } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'User',
+      basePath: '/admin',
+      sort: { field: 'fullName', direction: 'asc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }))
+  })
+
+  it('resolves a count filter (posts:>5) to an access-scoped id constraint', async () => {
+    const rows = [
+      { id: 'u1', _count: { posts: 7 } },
+      { id: 'u2', _count: { posts: 2 } },
+    ]
+    const findMany = vi.fn(async () => rows)
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ user: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'User',
+      basePath: '/admin',
+      search: 'posts:>5',
+    })
+
+    // The main query (and its count) is narrowed to the users whose
+    // access-visible post count exceeds 5 — only u1.
+    const mainCall = findMany.mock.calls.at(-1)?.[0] as { where?: unknown }
+    expect(mainCall.where).toEqual({ id: { in: ['u1'] } })
+    expect(count).toHaveBeenCalledWith({ where: { id: { in: ['u1'] } } })
   })
 })


### PR DESCRIPTION
Implements #732. Part of #728.

## What

To-many relationship fields used as list columns are now first-class:

- **Count cells** — a to-many column renders the **access-visible related count** (e.g. a User's post count), fetched in the *same* secured query.
- **Count sort** — clicking the column header sorts rows by relation count (`orderBy: { posts: { _count } }`).
- **Count filter** — the field's Filter spec offers numeric comparisons on the count (`posts:>5`), working in the filter builder and in shared URLs.
- **Virtual fields** render via their Cell but are excluded from sorting and filtering (no sort affordance, no Filter spec) — so a `?sort=<virtual>` can no longer reach Prisma.

To-one relationship columns are unchanged (linked Item label; label search filter).

## How

- **Access-scoped counts (single query, no per-row queries):** counts come from a filtered Prisma `_count` — `include: { _count: { select: { posts: { where: <related query access> } } } }`. New core helper `buildRelationshipCountSelect` folds each related list's operation-level `query` access into the count's `where`, mirroring how `buildIncludeWithAccessControl` scopes relation includes. A fully-denied related list is omitted → the cell shows `0` (never a leak). This also **removes the previous unbounded per-row fetch** of every related row for to-many columns (aligns with the #752 bounding concern).
- **Count filter:** Prisma cannot compare a relation `_count` in a `where` (verified empirically against Prisma 7). So the to-many relationship's `getFilterSpec` emits a structured marker (`RELATIONSHIP_COUNT_FILTER_KEY`) instead of a where fragment; `resolveRelationshipCountFilters` resolves it — through the **secured context** — into an access-scoped `{ id: { in } }` before the list query runs. Zero-count parents are handled correctly (fetched with count `0` and filtered in memory), and a denied related list resolves to count `0` with no query.
- **Count sort** passes `orderBy: { <rel>: { _count: dir } }` straight through the secured context.
- New core exports: `buildRelationshipCountSelect`, `resolveRelationshipCountFilters`, `isToManyRelationshipField`, `RELATIONSHIP_COUNT_FILTER_KEY` (+ `RelationshipCountFilterMarker`). Cell/registry edits are additive; no `switch` on field type — the count Cell resolves through the existing registry (`ui.cell` override still wins).

## Access-scoping

Every count (cell, sort input, and filter) flows through the secured context. The count's `where` is the related list's own `query` access, so a session only ever counts rows it may read; a closed related list yields `0`, not a leak. Count **sort** orders by the unfiltered relation `_count` (Prisma cannot filter an `orderBy` count) — a documented limitation that affects only row ordering, never displayed values.

## Bounding

Count cells and count sort issue **no** extra queries (the `_count`/`orderBy` ride the row query). A count **filter** issues exactly one extra aggregate read per count token (not per row) to resolve matching ids; that read fetches parent ids + counts under parent access. This is the deliberate trade for an access-correct count filter given Prisma's lack of relation-count `where` support.

## Tests

- **Core** (`relationship-count.test.ts`, `filter.test.ts`): filtered `_count` select folds in related access; denied list omitted; markers resolve to access-scoped `{ id: { in } }` incl. zero-count and denied cases; to-many Filter spec emits count comparisons (to-one still label search).
- **UI** (`ListView.test.tsx`, `Cells.test.tsx`, `CellRenderer.test.tsx`): to-many column resolves to a count via `_count` (never a row include); count sort builds nested `orderBy`; virtual sort ignored; count Cell renders count/zero; per-field `ui.cell` override still wins.
- **e2e** (`09-relationship-count-columns.spec.ts`): count display, count sort (asc/desc), count filter via shared URL and via the filter builder, on the User list's `posts` column.

Local: `pnpm lint` clean, `tsc`/`pnpm build` clean, core 865 + ui 496 unit tests pass, full e2e suite 66/66 pass (4 new + no regressions).

Changeset: `minor` for `@opensaas/stack-core` and `@opensaas/stack-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_