### PR TITLE
fix(core): harden relationship count-filter over-fetch + marker-member replace

### DIFF
--- a/.changeset/quiet-otters-hum.md
+++ b/.changeset/quiet-otters-hum.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Harden relationship count-filter resolution: preserve any sibling conditions co-present in a `_countFilter` marker's AND-member instead of replacing it wholesale, and document why the secured count read intentionally keeps its full projection (`context.db` does not honour `select`).

--- a/packages/core/src/access/relationship-count.test.ts
+++ b/packages/core/src/access/relationship-count.test.ts
@@ -199,4 +199,71 @@ describe('resolveRelationshipCountFilters', () => {
     )
     expect(resolved).toEqual({ AND: [{ name: { contains: 'ada' } }, { id: { in: ['u2'] } }] })
   })
+
+  it('reads with only the filtered `_count` include — no over-fetching `select` projection', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn((_args: unknown) =>
+      Promise.resolve([{ id: 'u2', _count: { posts: 7 } }]),
+    )
+    await resolveRelationshipCountFilters(
+      marker('gt', 5),
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    // The secured read is issued with the access-scoped `_count` include and NO
+    // `select` — the secured findMany does not honour `select`, so forcing one
+    // would be an ignored no-op. Access-scoping lives entirely in `_count.where`.
+    expect(findMany).toHaveBeenCalledTimes(1)
+    const callArg = findMany.mock.calls[0][0]
+    expect(callArg).not.toHaveProperty('select')
+    expect(callArg).toEqual({
+      include: { _count: { select: { posts: { where: { status: { equals: 'published' } } } } } },
+    })
+  })
+
+  it('preserves a sibling condition co-present in the same member as the marker', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn(async () => [{ id: 'u2', _count: { posts: 7 } }])
+    // A single AND-member carrying BOTH a scalar condition and the count marker.
+    // The marker resolution must keep the co-present sibling, not replace the
+    // member wholesale (guards against a future filter-engine change that merges
+    // conditions into one member).
+    const where = {
+      AND: [
+        {
+          name: { contains: 'ada' },
+          posts: { [RELATIONSHIP_COUNT_FILTER_KEY]: { operator: 'gt', value: 5 } },
+        },
+      ],
+    }
+    const resolved = await resolveRelationshipCountFilters(
+      where,
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    expect(resolved).toEqual({ name: { contains: 'ada' }, id: { in: ['u2'] } })
+  })
+
+  it('ANDs the resolved id constraint with a co-present sibling id condition (no silent drop)', async () => {
+    const config = makeConfig()
+    const findMany = vi.fn(async () => [{ id: 'u2', _count: { posts: 7 } }])
+    // Contrived: a member carrying its own `id` condition alongside the marker.
+    // Spreading would let one `id` overwrite the other; instead both are ANDed.
+    const where = {
+      id: { in: ['u1', 'u2'] },
+      posts: { [RELATIONSHIP_COUNT_FILTER_KEY]: { operator: 'gt', value: 5 } },
+    }
+    const resolved = await resolveRelationshipCountFilters(
+      where,
+      config.lists.User,
+      'User',
+      { session: null, context: makeContext(findMany) },
+      config,
+    )
+    expect(resolved).toEqual({ AND: [{ id: { in: ['u1', 'u2'] } }, { id: { in: ['u2'] } }] })
+  })
 })

--- a/packages/core/src/access/relationship-count.ts
+++ b/packages/core/src/access/relationship-count.ts
@@ -191,6 +191,17 @@ async function resolveOneCountFilter(
   if (!delegate) return {}
 
   const countSelect = entry.kind === 'scoped' ? { where: entry.where } : true
+  // This over-fetches the parent's scalar columns — it reads only `id` + `_count`
+  // per row yet materialises every scalar. It is left un-narrowed on purpose: the
+  // secured `context.db` `findMany` does NOT honour Prisma `select` (it
+  // warns-and-ignores it and returns the full access-filtered record — see
+  // `warnIfSelectIgnored` in context/index.ts and the "Narrowing Reads" note in
+  // packages/core/CLAUDE.md). The only supported narrowing is `include`/fragment
+  // `query`, neither of which can drop scalar columns. So adding
+  // `select: { id: true, _count: {...} }` here would be a silent no-op that also
+  // trips the ignore-warning, not a real projection. The count stays access-scoped
+  // via the filtered `_count` include below regardless; trimming the projection
+  // would first require the read pipeline to honour `select`.
   const rows = await delegate.findMany({
     include: { _count: { select: { [fieldName]: countSelect } } },
   })
@@ -206,6 +217,22 @@ async function resolveOneCountFilter(
     }
   }
   return { id: { in: matchingIds } }
+}
+
+/**
+ * Merge a marker member's non-marker sibling conditions with the resolved
+ * `{ id: { in } }` fragment. With no siblings (the guaranteed case today) this is
+ * just the resolved fragment. When a sibling shares the resolved `id` key — a
+ * contrived case that cannot arise under the current one-condition-per-member
+ * invariant — both are ANDed so neither condition is silently lost.
+ */
+function mergeResolvedMember(
+  siblings: Record<string, unknown>,
+  resolved: Record<string, unknown>,
+): Record<string, unknown> {
+  if (Object.keys(siblings).length === 0) return resolved
+  const collides = Object.keys(resolved).some((key) => key in siblings)
+  return collides ? { AND: [siblings, resolved] } : { ...siblings, ...resolved }
 }
 
 /**
@@ -253,9 +280,24 @@ export async function resolveRelationshipCountFilters(
       resolvedMembers.push(member)
       continue
     }
-    resolvedMembers.push(
-      await resolveOneCountFilter(listConfig, listKey, found.field, found.marker, args, config),
+    const resolved = await resolveOneCountFilter(
+      listConfig,
+      listKey,
+      found.field,
+      found.marker,
+      args,
+      config,
     )
+    // Preserve any sibling conditions co-present on this member rather than
+    // replacing it wholesale with the resolved `{ id: { in } }`. The filter engine
+    // currently guarantees each AND-member (and the no-AND single object) carries
+    // exactly one field condition, so `siblings` is empty today and this equals the
+    // previous wholesale replacement — but if a future engine change ever merged
+    // multiple conditions into one member, spreading keeps the marker's siblings
+    // from being silently dropped.
+    const siblings: Record<string, unknown> = { ...member }
+    delete siblings[found.field]
+    resolvedMembers.push(mergeResolvedMember(siblings, resolved))
   }
 
   // Drop no-op members (a fully-denied related list where 0 satisfies the


### PR DESCRIPTION
Implements #765. Part of #728.

Two non-blocking hardening items from the #732 review, both in `packages/core/src/access/relationship-count.ts`.

## 1. Count-filter over-fetch (efficiency)

The issue asked to add `select: { id: true, _count: { select: { <rel>: { where: <access> } } } }` to `resolveRelationshipCountFilters`' secured per-token `findMany`, *first verifying the secured `context.db` `findMany` honours `select`*.

**It does not.** The secured `findMany` accepts `select` only to make its no-op visible — it `warns-and-ignores` it (`warnIfSelectIgnored` in `context/index.ts`, and the "Narrowing Reads" note in `packages/core/CLAUDE.md`) and never forwards it to the underlying Prisma call; only `include`/fragment `query` reach Prisma, and neither can drop scalar columns. Forcing a `select` here would therefore be a silent no-op that also trips the ignore-warning, not a real projection.

Per the issue's instruction, the projection is **left as-is** and the reasoning is documented in a code comment (and here). Access-scoping is unchanged — it lives entirely in the filtered `_count.where` include. A real fix would require the read pipeline to honour `select` first, which is out of scope.

## 2. Marker-member replace robustness

When resolving a `_countFilter` marker, the matched AND-member was replaced **wholesale** by the resolved `{ id: { in } }`. This is safe only under the filter engine's current one-condition-per-member invariant. Hardened by spreading the member's non-marker sibling keys into the result via a small `mergeResolvedMember` helper, so a future engine change that merges multiple conditions into one member can't silently drop siblings. Behaviour is byte-identical for the current single-condition case (siblings empty → returns the resolved fragment). On the contrived chance a sibling shares the resolved `id` key, both are ANDed rather than one overwriting the other.

## Tests

Extended `relationship-count.test.ts`:
- the secured read is issued with only the filtered `_count` include and **no** `select` projection (access-scoped counts preserved — existing denied→0 and zero-count tests still pass);
- a sibling condition co-present in the same member as the marker is preserved (not dropped);
- a co-present sibling `id` condition is ANDed with the resolved id constraint.

## Verification
- `pnpm build` (tsc) — clean
- core vitest — 871 passed (42 files), incl. 12 in `relationship-count.test.ts`
- `pnpm lint` — 0 errors (3 pre-existing warnings, unrelated)
- `pnpm manypkg fix` + `pnpm format` — clean
- Changeset: `@opensaas/stack-core` **patch** (bug-fix/hardening)

No security impact — counts/reads stay access-scoped through the secured `context.db`; no raw Prisma introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_