### PR TITLE
test(core): lock the createRelated back-reference overwrite (#758)

### DIFF
--- a/.changeset/quick-owls-guard.md
+++ b/.changeset/quick-owls-guard.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Harden `createRelated` server action: reject malformed calls that supply only one of `field`/`parentId`, and validate that the back-reference names a relationship field before injecting the parent connect.

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -620,11 +620,35 @@ export function getContext<
     // as `{ created: false }` with a generic reason (no denied-vs-absent leak).
     if (props.action === 'createRelated') {
       try {
+        // Defensive guard (hardening; unreachable from the drawer, which always
+        // mounts on a valid back-reference and sends BOTH field and parentId).
+        // A lone field/parentId is a malformed direct call — reject it rather
+        // than silently skip back-reference injection and let a client-supplied
+        // data[field] slip through unguarded to the create.
+        if (!!props.field !== !!props.parentId) {
+          return {
+            created: false,
+            error: 'createRelated requires both field and parentId, or neither',
+          }
+        }
         const data: Record<string, unknown> = { ...props.data }
         if (props.field && props.parentId) {
           const backRefField = listConfig.fields[props.field]
-          const backRefIsMany =
-            !!backRefField && 'many' in backRefField && backRefField.many === true
+          // The back-reference must name a relationship field on this list; a
+          // non-relationship field would otherwise receive a nonsensical
+          // { connect } value. Also hardening — the drawer only ever passes a
+          // real relationship back-reference here.
+          if (!backRefField || backRefField.type !== 'relationship') {
+            return {
+              created: false,
+              error: `Field "${props.field}" on list "${props.listKey}" is not a relationship field`,
+            }
+          }
+          const backRefIsMany = 'many' in backRefField && backRefField.many === true
+          // The back-reference is set on the SERVER from the trusted parentId,
+          // OVERWRITING any client-supplied data[field] spread in above, so a
+          // hostile client can never re-target the link (a to-many back-ref
+          // connects the parent by id).
           data[props.field] = backRefIsMany
             ? { connect: [{ id: props.parentId }] }
             : { connect: { id: props.parentId } }

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -671,6 +671,137 @@ describe('getContext', () => {
         expect(createArg.data.teachers).toEqual({ connect: [{ id: 't1' }] })
       })
 
+      // Security-critical invariant (#758): the server sets the back-reference by
+      // spreading client `data` and THEN overwriting `data[field]` from the
+      // trusted `parentId`, so a HOSTILE client-supplied `data[field]` can never
+      // re-target the link to a different parent. These lock that overwrite for
+      // both the to-one and the to-many back-reference shapes.
+      it('overwrites a hostile client-supplied to-one back-reference with the trusted parentId', async () => {
+        const created = { id: 'p1', title: 'New', authorId: 'u1' }
+        mockPrisma.post.create.mockResolvedValue(created)
+        // The connect target must be reachable (the related list's read access).
+        mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+        const context = await getContext(config, mockPrisma, { userId: 'u1' })
+        await context.serverAction({
+          listKey: 'Post',
+          action: 'createRelated',
+          // Hostile: the client tries to re-target the link to a different parent
+          // by supplying the back-reference field itself.
+          data: { title: 'New', author: 'evil-id' },
+          field: 'author',
+          parentId: 'u1',
+        })
+
+        // The server OVERWRITES the spread-in hostile value with a connect to the
+        // trusted parentId — the evil id never reaches the secured create.
+        const createArg = mockPrisma.post.create.mock.calls[0][0]
+        expect(createArg.data.author).toEqual({ connect: { id: 'u1' } })
+        expect(createArg.data.author).not.toBe('evil-id')
+      })
+
+      it('overwrites a hostile client-supplied to-many back-reference with the trusted parentId', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const m2mPrisma: any = {
+          lesson: {
+            findUnique: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+            create: vi.fn().mockResolvedValue({ id: 'l1', title: 'L' }),
+          },
+          teacher: {
+            findUnique: vi.fn().mockResolvedValue({ id: 't1' }),
+            update: vi.fn(),
+            delete: vi.fn(),
+            create: vi.fn(),
+          },
+        }
+        const m2mConfig: OpenSaasConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            Lesson: {
+              fields: {
+                title: { type: 'text' },
+                teachers: { type: 'relationship', ref: 'Teacher.lessons', many: true },
+              },
+              access: {
+                operation: {
+                  query: () => true,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+            Teacher: {
+              fields: {
+                name: { type: 'text' },
+                lessons: { type: 'relationship', ref: 'Lesson.teachers', many: true },
+              },
+              access: {
+                operation: {
+                  query: () => true,
+                  create: () => true,
+                  update: () => true,
+                  delete: () => true,
+                },
+              },
+            },
+          },
+        }
+
+        const context = await getContext(m2mConfig, m2mPrisma, { userId: 'u1' })
+        await context.serverAction({
+          listKey: 'Lesson',
+          action: 'createRelated',
+          // Hostile: the client tries to connect a different teacher.
+          data: { title: 'L', teachers: { connect: [{ id: 'evil-id' }] } },
+          field: 'teachers',
+          parentId: 't1',
+        })
+
+        // The to-many back-reference is overwritten to connect exactly the trusted
+        // parent by id — the hostile connect is discarded.
+        const createArg = m2mPrisma.lesson.create.mock.calls[0][0]
+        expect(createArg.data.teachers).toEqual({ connect: [{ id: 't1' }] })
+      })
+
+      // Defensive guard (#758): malformed direct calls (unreachable from the
+      // drawer, which always sends a valid relationship back-reference plus both
+      // field and parentId) are rejected rather than degrading to an unguarded
+      // create.
+      it('rejects a malformed call supplying only one of field/parentId (defensive guard)', async () => {
+        const context = await getContext(config, mockPrisma, { userId: 'u1' })
+        const result = await context.serverAction({
+          listKey: 'Post',
+          action: 'createRelated',
+          data: { title: 'New', author: 'evil-id' },
+          field: 'author',
+          // parentId omitted — a lone back-reference field is malformed.
+        })
+
+        expect(result).toEqual({
+          created: false,
+          error: 'createRelated requires both field and parentId, or neither',
+        })
+        // The unguarded create is never attempted.
+        expect(mockPrisma.post.create).not.toHaveBeenCalled()
+      })
+
+      it('rejects a back-reference that does not name a relationship field (defensive guard)', async () => {
+        const context = await getContext(config, mockPrisma, { userId: 'u1' })
+        const result = await context.serverAction({
+          listKey: 'Post',
+          action: 'createRelated',
+          data: { title: 'New' },
+          field: 'title', // a scalar field, not a relationship
+          parentId: 'u1',
+        })
+
+        expect(result).toMatchObject({ created: false })
+        expect(mockPrisma.post.create).not.toHaveBeenCalled()
+      })
+
       it('returns a generic error (Silent failure) when the create is access-denied', async () => {
         const deniedConfig: OpenSaasConfig = {
           ...config,


### PR DESCRIPTION
Implements #758. Part of #728.

## Summary

`createRelated` (`packages/core/src/context/index.ts`) sets the parent back-reference on the **server** by spreading the client `data` and **then** overwriting `data[field] = { connect: { id: parentId } }`, so a hostile client-supplied `data[field]` can never re-target the link. This invariant was only implicitly guaranteed by code — this PR locks it with tests and adds a small defensive guard.

### Primary — tests (the load-bearing deliverable)

Added to `packages/core/tests/context.test.ts`:

- **To-one back-ref:** calls `createRelated` with hostile `data: { title, author: 'evil-id' }` and asserts the secured `create` receives `author: { connect: { id: 'u1' } }` (the trusted `parentId`), not `'evil-id'`.
- **To-many / M2M back-ref:** calls `createRelated` with hostile `data: { title, teachers: { connect: [{ id: 'evil-id' }] } }` and asserts the secured `create` receives `teachers: { connect: [{ id: 't1' }] }` (trusted parent by id).

Both run through the **secured** delegate (`db[dbKey]`), never raw prisma.

### Secondary — defensive guard (hardening, not a fix)

Minimal guard in `createRelated`, unreachable from the drawer (which always sends both `field` and `parentId` with a valid relationship back-reference), so happy-path behaviour is unchanged:

- Reject a malformed direct call that supplies only one of `field`/`parentId` (rather than silently skipping injection and letting `data[field]` slip through).
- Validate that `field` names a relationship field before injecting the connect.

Each guarded case has a test. `backRefField.type` is a plain `string` on `BaseFieldConfig`, so no casts were needed.

### Deferred

The perf note (`resolveCreateForm` eager `prepareItemForm`) is explicitly deferred per the issue — not touched here.

## Verification

- `packages/core` vitest: **875 passed (42 files)**, including the 4 new tests.
- `pnpm lint`: 0 errors (only pre-existing warnings).
- Core `tsc` build: clean.
- `pnpm manypkg fix` + `pnpm format`: clean.
- Changeset: `patch` for `@opensaas/stack-core` (shipped guard code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_