### PR TITLE
feat(ui): bound item-view relationship tables with take + "showing N of M" footer

### DIFF
--- a/.changeset/spicy-rivers-bound.md
+++ b/.changeset/spicy-rivers-bound.md
@@ -1,0 +1,34 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Bound the admin item-view Relationship tables with a `take` and a "showing N of M" footer
+
+The read-only Relationship tables on a record's edit page (issue #734) previously
+fetched every related row unbounded. They now fetch a bounded page of related rows
+and surface the full access-scoped total in the footer.
+
+- **Bounded fetch:** each to-many Relationship table fetches at most a default cap
+  of related rows (`DEFAULT_ITEM_VIEW_TAKE`, 10), overridable per relationship via
+  `ui.itemView.take`. Rows are still fetched through the secured context, so only
+  access-visible rows come back.
+- **"Showing N of M" footer:** the totals footer now reads `Showing N of M rows`,
+  where N is the rendered (bounded) count and M is the full access-scoped total,
+  fetched via a filtered `_count` that folds the related list's own `query` access
+  in (mirroring the list view's count columns). A fully-denied related list reads
+  `Showing 0 of 0` and never leaks a true total. The row count is always shown,
+  including the zero-column footer path.
+
+```typescript
+sessions: relationship({
+  ref: 'Session.user',
+  many: true,
+  // Cap this table at 5 rows; the footer still shows the full access-scoped total.
+  ui: { itemView: { take: 5 } },
+})
+```
+
+Core: `mergeIncludeWithAccessControl` now preserves a caller-supplied `take` on a
+to-many relation include (it only narrows the fetch, never widening past the access
+`where`), so the secured `findUnique`/`findMany` include can bound related-row reads.

--- a/e2e/starter-auth/05-item-view.spec.ts
+++ b/e2e/starter-auth/05-item-view.spec.ts
@@ -72,9 +72,11 @@ test.describe('Item view layout', () => {
     await expect(table.getByText('View Post A')).toBeVisible()
     await expect(table.getByText('View Post B')).toBeVisible()
 
-    // Footer: row count always, plus the summed numeric column (5 + 10 = 15).
+    // Footer: "showing N of M" (issue #752) with M the access-scoped total —
+    // here the fetch is under the default cap, so N === M === 2 — plus the
+    // summed numeric column (5 + 10 = 15).
     const footer = table.locator('[data-slot="relationship-table-footer"]')
-    await expect(footer).toContainText('2 rows')
+    await expect(footer).toContainText('Showing 2 of 2 rows')
     await expect(footer).toContainText('15')
 
     // Rows show only access-visible data: the closed Session list (ADR-0013,
@@ -83,6 +85,24 @@ test.describe('Item view layout', () => {
       has: page.getByRole('heading', { name: 'Sessions', exact: true }),
     })
     await expect(sessions.locator('[data-slot="relationship-table-empty"]')).toBeVisible()
+    // Access-scoped M (issue #752): the denied Session list's total is 0, never
+    // a leaked true count of the user's sessions.
+    await expect(sessions.locator('[data-slot="relationship-table-footer"]')).toContainText(
+      'Showing 0 of 0 rows',
+    )
+
+    // Secondary note (issue #752): the example curates the auth Account/Session
+    // Relationship tables so credential/token columns are NOT surfaced by
+    // default. The Account table shows non-sensitive columns only.
+    const accounts = page.locator('[data-slot="relationship-table"]', {
+      has: page.getByRole('heading', { name: 'Accounts', exact: true }),
+    })
+    await expect(accounts.getByRole('columnheader', { name: 'Access Token' })).toHaveCount(0)
+    await expect(accounts.getByRole('columnheader', { name: 'Refresh Token' })).toHaveCount(0)
+    await expect(accounts.getByRole('columnheader', { name: 'Id Token' })).toHaveCount(0)
+    await expect(accounts.getByRole('columnheader', { name: 'Provider Id' })).toBeVisible()
+    // The Session table likewise omits its `token` column.
+    await expect(sessions.getByRole('columnheader', { name: 'Token', exact: true })).toHaveCount(0)
   })
 
   test('clicking an editable relationship-table cell edits in place instead of navigating', async ({

--- a/examples/starter-auth/opensaas.config.ts
+++ b/examples/starter-auth/opensaas.config.ts
@@ -69,6 +69,36 @@ export default config({
       // Extend User list with custom fields
       extendUserList: {
         fields: {
+          // Curate the auth-derived `accounts`/`sessions` Relationship tables on
+          // the User item view (issue #752). Their default columns come from the
+          // Account/Session lists' own curation, which surfaces credential
+          // columns (Account's `accessToken`/`refreshToken`/`idToken`, Session's
+          // `token`) as table headers by default. Field-level access still
+          // governs the VALUES, but the example should not model surfacing token
+          // columns at all — so we override the columns to non-sensitive fields
+          // and disable ad-hoc row removal (these are better-auth-managed). This
+          // re-declares the derived relationship with the same `ref`/`many`, so
+          // the generated schema is unchanged; only the item-view UI differs.
+          accounts: relationship({
+            ref: 'Account.user',
+            many: true,
+            ui: {
+              itemView: {
+                columns: ['providerId', 'accountId'],
+                removeAction: 'none',
+              },
+            },
+          }),
+          sessions: relationship({
+            ref: 'Session.user',
+            many: true,
+            ui: {
+              itemView: {
+                columns: ['ipAddress', 'userAgent', 'expiresAt'],
+                removeAction: 'none',
+              },
+            },
+          }),
           // Add a posts relationship. On the User item view this renders as a
           // read-only Relationship table (issue #734): its columns default to
           // Post's curation minus the `author` back-reference, and the totals

--- a/packages/core/src/access/access-filter.test.ts
+++ b/packages/core/src/access/access-filter.test.ts
@@ -147,3 +147,82 @@ describe('mergeIncludeWithAccessControl — bare-true leaf on a cyclic graph', (
     expect(includeDepth(merged)).toBeLessThanOrEqual(3)
   })
 })
+
+/**
+ * A caller-supplied `take` on a to-many relation include must survive the
+ * access-controlled merge (issue #752). It only narrows the fetched rows and can
+ * never widen past the access `where`, so the merge re-attaches it on top of the
+ * per-relation access filter — powering the item view's bounded relationship
+ * tables without dropping row-level access.
+ */
+describe('mergeIncludeWithAccessControl — caller take on a to-many relation (issue #752)', () => {
+  // A one-list config whose `posts` to-many is query-scoped by an access filter.
+  function scopedConfig(): OpenSaasConfig {
+    return {
+      db: { provider: 'sqlite', url: 'file:./dev.db' },
+      lists: {
+        User: {
+          fields: { name: { type: 'text' } as FieldConfig, posts: rel('Post.author', true) },
+          access: { operation: { query: () => true } },
+        },
+        Post: {
+          fields: { title: { type: 'text' } as FieldConfig, author: rel('User.posts') },
+          // Scoped read access → the merge must fold this into the relation include.
+          access: { operation: { query: () => ({ published: { equals: true } }) } },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any
+  }
+
+  it('preserves the take and AND-combines it with the access where', async () => {
+    const config = scopedConfig()
+    const accessControlledInclude = await buildIncludeWithAccessControl(
+      config.lists.User.fields,
+      { session: null, context: makeContext() },
+      config,
+      0,
+      ['User'],
+    )
+
+    const merged = mergeIncludeWithAccessControl(
+      { posts: { take: 10 } },
+      accessControlledInclude,
+      config.lists.User.fields,
+      config,
+    )
+
+    // The bound rides on top of the access filter — neither is dropped. The
+    // access-controlled include also auto-nests Post's `author` back-relation.
+    expect(merged).toEqual({
+      posts: {
+        where: { published: { equals: true } },
+        include: { author: true },
+        take: 10,
+      },
+    })
+  })
+
+  it('drops a take for a relation whose query access is denied', async () => {
+    const config = scopedConfig()
+    // Deny Post reads entirely.
+    config.lists.Post.access = { operation: { query: () => false } }
+    const accessControlledInclude = await buildIncludeWithAccessControl(
+      config.lists.User.fields,
+      { session: null, context: makeContext() },
+      config,
+      0,
+      ['User'],
+    )
+
+    const merged = mergeIncludeWithAccessControl(
+      { posts: { take: 10 } },
+      accessControlledInclude,
+      config.lists.User.fields,
+      config,
+    )
+
+    // A denied relation is dropped wholesale — the take cannot resurrect it.
+    expect(merged).toEqual({})
+  })
+})

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -120,25 +120,33 @@ export async function buildIncludeWithAccessControl(
  * (fetch with no extra constraints) or an object that scopes the fetch with a
  * `where` filter and/or a nested `include`.
  */
-type IncludeEntry = boolean | { where?: PrismaFilter; include?: IncludeObject }
+type IncludeEntry = boolean | { where?: PrismaFilter; include?: IncludeObject; take?: number }
 type IncludeObject = Record<string, IncludeEntry>
 
 /** The structured (object) form of a relation include entry. */
-type IncludeEntryObject = { where?: PrismaFilter; include?: IncludeObject }
+type IncludeEntryObject = { where?: PrismaFilter; include?: IncludeObject; take?: number }
 
 /**
  * Narrow an unknown include value to the structured object form (vs bare `true`
  * or any other primitive). Caller-supplied includes arrive untyped at the
  * runtime boundary, so we validate the shape here rather than casting.
+ *
+ * A numeric `take` on a to-many relation include (a caller-supplied row bound,
+ * issue #752) is carried through: it only ever NARROWS the fetched rows and can
+ * never widen past the access `where`, so preserving it is access-neutral. The
+ * access-controlled include never sets `take` itself — it originates solely
+ * from the caller — so `mergeIncludeWithAccessControl` re-attaches it below.
  */
 function asEntryObject(value: unknown): IncludeEntryObject | null {
   if (value && typeof value === 'object') {
     const obj = value as Record<string, unknown>
     const where = obj.where
     const include = obj.include
+    const take = obj.take
     const entry: IncludeEntryObject = {}
     if (where && typeof where === 'object') entry.where = where as PrismaFilter
     if (include && typeof include === 'object') entry.include = include as IncludeObject
+    if (typeof take === 'number') entry.take = take
     return entry
   }
   return null
@@ -260,11 +268,14 @@ export function mergeIncludeWithAccessControl(
       mergedNested = accessEntry.include
     }
 
-    const entry: { where?: PrismaFilter; include?: Record<string, unknown> } = {}
+    const entry: { where?: PrismaFilter; include?: Record<string, unknown>; take?: number } = {}
     if (mergedWhere) entry.where = mergedWhere
     if (mergedNested && Object.keys(mergedNested).length > 0) entry.include = mergedNested
+    // Preserve a caller-supplied row bound on the relation (issue #752). It only
+    // narrows, never widens, so it rides on top of the access `where`/include.
+    if (callerEntry?.take !== undefined) entry.take = callerEntry.take
 
-    // A bare-`true` relation with no access filter and no nested include stays `true`.
+    // A bare-`true` relation with no access filter, nested include, or row bound stays `true`.
     merged[relationName] = Object.keys(entry).length > 0 ? entry : true
   }
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -964,6 +964,27 @@ export type RelationshipItemViewConfig = {
    */
   columns?: string[]
   /**
+   * The maximum number of related rows to fetch and render in this
+   * Relationship table (issue #752). The item view fetches related rows
+   * through the secured context bounded by this `take`, so a record with many
+   * related rows never loads/renders every one on edit-page open. The totals
+   * footer still shows the full access-scoped total ("showing N of M").
+   *
+   * When omitted, a sensible default cap applies (the UI's
+   * `DEFAULT_ITEM_VIEW_TAKE`). Must be a positive integer; non-positive or
+   * non-integer values fall back to the default.
+   *
+   * @example
+   * ```typescript
+   * sessions: relationship({
+   *   ref: 'Session.user',
+   *   many: true,
+   *   ui: { itemView: { take: 5 } },
+   * })
+   * ```
+   */
+  take?: number
+  /**
    * The numeric columns whose values are summed in the Relationship table's
    * totals footer. The row count is always shown; sums appear only for the
    * columns listed here, each formatted by that column's Cell.

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -10,6 +10,7 @@ import {
   type AccessContext,
   type FieldConfig,
   type ListConfig,
+  buildRelationshipCountSelect,
   getDbKey,
   getUrlKey,
   OpenSaasConfig,
@@ -31,19 +32,26 @@ export interface ItemFormProps {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
 type AnyListConfig = ListConfig<any>
 
+/** A single relation entry in the item-view include (bounded to-many, or bare). */
+type ItemViewIncludeEntry = boolean | { take?: number; include?: Record<string, boolean> }
+
 /**
  * Build the `include` object for an item-view fetch that derives Relationship
  * tables. To-one / details relationships are included one level deep; each
  * to-many Relationship table is included with a nested include of its own
- * relationship columns, so their Cells can resolve labels — all through the
- * secured context, so only access-visible rows and fields come back.
+ * relationship columns (so their Cells can resolve labels) AND a `take` that
+ * BOUNDS the related-row fetch (issue #752) to the section's cap — all through
+ * the secured context, so only access-visible rows and fields come back. The
+ * bound is per-relationship (`ui.itemView.take`, default `DEFAULT_ITEM_VIEW_TAKE`);
+ * the full access-scoped total for the footer is fetched separately via `_count`
+ * (see {@link ItemViewLayoutView}), never by fetching every row.
  */
-function buildItemViewInclude(
+export function buildItemViewInclude(
   listConfig: AnyListConfig,
   config: OpenSaasConfig,
   layout: ItemViewLayout,
-): Record<string, boolean | { include: Record<string, boolean> }> {
-  const include: Record<string, boolean | { include: Record<string, boolean> }> = {}
+): Record<string, ItemViewIncludeEntry> {
+  const include: Record<string, ItemViewIncludeEntry> = {}
 
   for (const fieldName of layout.detailsFields) {
     if (listConfig.fields[fieldName]?.type === 'relationship') {
@@ -56,10 +64,13 @@ function buildItemViewInclude(
     const relationshipColumns = section.columns.filter(
       (column) => relatedListConfig?.fields[column]?.type === 'relationship',
     )
-    include[section.fieldName] =
-      relationshipColumns.length > 0
-        ? { include: Object.fromEntries(relationshipColumns.map((column) => [column, true])) }
-        : true
+    // Always carry the row bound; add a nested include only when the table has
+    // relationship columns whose Cells need the related record to label.
+    const entry: { take: number; include?: Record<string, boolean> } = { take: section.take }
+    if (relationshipColumns.length > 0) {
+      entry.include = Object.fromEntries(relationshipColumns.map((column) => [column, true]))
+    }
+    include[section.fieldName] = entry
   }
 
   return include
@@ -68,6 +79,28 @@ function buildItemViewInclude(
 /** The related rows for a section, or `[]` when absent/denied. */
 function sectionRows(value: unknown): Array<Record<string, unknown>> {
   return Array.isArray(value) ? (value as Array<Record<string, unknown>>) : []
+}
+
+/**
+ * Read the access-scoped total (M) for a Relationship-table section off the
+ * parent record's filtered `_count` payload (issue #752). The `_count` is built
+ * by {@link buildRelationshipCountSelect}, which folds each related list's own
+ * `query` access into the count's `where` and OMITS a fully-denied related list
+ * entirely — so a denied list has no key here and reads as `fallback` (the
+ * bounded rows length, which is itself 0 for a denied list), never leaking a
+ * true total. When the value is present it is the authoritative access-scoped
+ * total (always ≥ the bounded row count).
+ */
+export function readAccessScopedTotal(
+  countPayload: unknown,
+  fieldName: string,
+  fallback: number,
+): number {
+  if (countPayload && typeof countPayload === 'object') {
+    const value = (countPayload as Record<string, unknown>)[fieldName]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return fallback
 }
 
 /**
@@ -99,9 +132,21 @@ async function ItemViewLayoutView({
   const urlKey = getUrlKey(listKey)
 
   // One secured read: details relationships one level deep, each Relationship
-  // table nested-included so its cells resolve. Access control on the include
-  // means only access-visible rows/fields are returned.
-  const include = buildItemViewInclude(listConfig, config, layout)
+  // table nested-included (bounded by `take`, issue #752) so its cells resolve.
+  // Access control on the include means only access-visible rows/fields are
+  // returned. The full access-scoped total for each table's "showing N of M"
+  // footer comes from a filtered `_count` in the SAME read — folding each
+  // related list's own `query` access into the count so a denied related list
+  // never leaks a true total (mirrors the list view's #732 count columns).
+  const include: Record<string, unknown> = { ...buildItemViewInclude(listConfig, config, layout) }
+  const countSelect = await buildRelationshipCountSelect(
+    listConfig,
+    { session: context.session, context },
+    config,
+  )
+  if (countSelect) {
+    include._count = { select: countSelect }
+  }
   let itemData: Record<string, unknown> | null = null
   try {
     const delegate = context.db[getDbKey(listKey)]
@@ -176,19 +221,27 @@ async function ItemViewLayoutView({
     </Card>
   )
 
-  const tables = layout.sections.map((section) => (
-    <RelationshipTable
-      key={section.fieldName}
-      config={config}
-      section={section}
-      rows={sectionRows(itemData?.[section.fieldName])}
-      basePath={basePath}
-      context={context}
-      parentListKey={listKey}
-      parentId={itemId}
-      serverAction={serverAction}
-    />
-  ))
+  const countPayload = itemData?._count
+  const tables = layout.sections.map((section) => {
+    const rows = sectionRows(itemData?.[section.fieldName])
+    return (
+      <RelationshipTable
+        key={section.fieldName}
+        config={config}
+        section={section}
+        rows={rows}
+        // M for "showing N of M": the access-scoped total from `_count`, falling
+        // back to the bounded row count when the related list is denied (0) or
+        // uncounted — never a leak of a denied list's true total.
+        total={readAccessScopedTotal(countPayload, section.fieldName, rows.length)}
+        basePath={basePath}
+        context={context}
+        parentListKey={listKey}
+        parentId={itemId}
+        serverAction={serverAction}
+      />
+    )
+  })
 
   return (
     <div className="p-8">

--- a/packages/ui/src/components/RelationshipTable.tsx
+++ b/packages/ui/src/components/RelationshipTable.tsx
@@ -26,10 +26,18 @@ export interface RelationshipTableProps {
   section: RelationshipTableSection
   /**
    * The parent record's related rows for this relationship, already fetched and
-   * access-filtered through the secured context (`context.db` include). Only
-   * access-visible rows/fields are present here.
+   * access-filtered through the secured context (`context.db` include) and
+   * BOUNDED by the section's `take` (issue #752). Only access-visible rows/fields
+   * are present here, and at most `section.take` of them.
    */
   rows: Array<Record<string, unknown>>
+  /**
+   * The full access-scoped total of related rows (M in "showing N of M", issue
+   * #752): the count the secured context reports through a filtered `_count`,
+   * folding the related list's own `query` access in — always ≥ `rows.length`,
+   * and 0 (never a leaked true total) for a denied related list.
+   */
+  total: number
   basePath: string
   /**
    * The access-scoped context, used to evaluate the related list's operation
@@ -240,6 +248,7 @@ export async function RelationshipTable({
   config,
   section,
   rows,
+  total,
   basePath,
   context,
   parentListKey,
@@ -312,6 +321,7 @@ export async function RelationshipTable({
       fields={fields}
       rows={serializedRows}
       count={rows.length}
+      total={total}
       sumColumns={section.sumColumns}
       sums={sums}
       removeMode={removeMode}

--- a/packages/ui/src/components/RelationshipTableClient.tsx
+++ b/packages/ui/src/components/RelationshipTableClient.tsx
@@ -41,10 +41,22 @@ export interface RelationshipTableClientProps {
   columns: string[]
   /** Serialised field config per column, driving Cell resolution. */
   fields: Record<string, SerializableFieldConfig>
-  /** Serialised, access-filtered related rows (relationship values pre-resolved). */
+  /**
+   * Serialised, access-filtered related rows (relationship values pre-resolved),
+   * BOUNDED by the section's `take` (issue #752) — at most `take` rows.
+   */
   rows: Array<Record<string, unknown>>
-  /** Total access-visible row count, always shown in the footer. */
+  /**
+   * The number of rows rendered (N in "showing N of M") — the bounded row count,
+   * always shown in the footer.
+   */
   count: number
+  /**
+   * The full access-scoped total of related rows (M in "showing N of M", issue
+   * #752). Defaults to `count` when absent, so the footer still shows the row
+   * count. Always ≥ `count`; 0 for a denied related list (never a leaked total).
+   */
+  total?: number
   /** Columns summed in the footer (explicit opt-in only). */
   sumColumns: string[]
   /** Per-column footer sum, rendered through that column's Cell. */
@@ -87,6 +99,17 @@ export interface RelationshipTableClientProps {
    * (fully read-only), preserving the #734 behaviour.
    */
   editableColumns?: string[]
+}
+
+/**
+ * The footer's "showing N of M" label (issue #752): N is the rendered
+ * (bounded) row count, M the full access-scoped total. When no total is
+ * supplied M falls back to N, so the row count is ALWAYS shown — a bounded
+ * table reads "Showing 10 of 42 rows", an unbounded one "Showing 3 of 3 rows".
+ */
+export function formatCountLabel(count: number, total: number | undefined): string {
+  const m = total ?? count
+  return `Showing ${count} of ${m} ${m === 1 ? 'row' : 'rows'}`
 }
 
 /** Read the `{ removed, error? }` outcome a row-removal server action returns. */
@@ -140,6 +163,7 @@ export function RelationshipTableClient({
   fields,
   rows,
   count,
+  total,
   sumColumns,
   sums,
   removeMode,
@@ -166,6 +190,7 @@ export function RelationshipTableClient({
   const [confirmId, setConfirmId] = React.useState<string | null>(null)
 
   const columnFieldType = (column: string): string | undefined => fields[column]?.type
+  const countLabel = formatCountLabel(count, total)
   const showRemove = removeMode !== null
   const removeVerb = removeMode === 'delete' ? 'Delete' : 'Disconnect'
   const totalColumns = columns.length + (showRemove ? 1 : 0)
@@ -357,7 +382,7 @@ export function RelationshipTableClient({
                 colSpan={Math.max(totalColumns, 1)}
                 className="text-sm text-muted-foreground"
               >
-                {count} {count === 1 ? 'row' : 'rows'}
+                {countLabel}
               </TableCell>
             ) : (
               <>
@@ -367,9 +392,7 @@ export function RelationshipTableClient({
                   return (
                     <TableCell key={column} className={cn(numeric && 'text-right')}>
                       {index === 0 && (
-                        <span className="text-sm text-muted-foreground">
-                          {count} {count === 1 ? 'row' : 'rows'}
-                        </span>
+                        <span className="text-sm text-muted-foreground">{countLabel}</span>
                       )}
                       {isSummed && (
                         <span className={cn('font-medium', index === 0 && 'ml-2')}>

--- a/packages/ui/src/lib/deriveItemView.ts
+++ b/packages/ui/src/lib/deriveItemView.ts
@@ -12,6 +12,17 @@ import type { FieldConfig, ListConfig, OpenSaasConfig } from '@opensaas/stack-co
 export type ItemViewArrangement = 'single' | 'split' | 'stacked'
 
 /**
+ * The default maximum number of related rows a Relationship table fetches and
+ * renders (issue #752). The item view is a bounded preview — a record with many
+ * related rows must not load/render every one on edit-page open — so each
+ * to-many relationship is fetched with a `take` capped here unless the field's
+ * `ui.itemView.take` overrides it. The totals footer still reports the full
+ * access-scoped total ("showing N of M"), and the related list's own (paginated)
+ * page remains the way to browse past the cap.
+ */
+export const DEFAULT_ITEM_VIEW_TAKE = 10
+
+/**
  * One derived Relationship-table section — a to-many relationship on the record
  * being edited, rendered read-only as a table of related rows.
  */
@@ -30,6 +41,13 @@ export interface RelationshipTableSection {
   backReferenceField?: string
   /** The related-list columns to show, in order (curation minus back-reference). */
   columns: string[]
+  /**
+   * The maximum number of related rows to fetch and render for this table
+   * (issue #752): the field's `ui.itemView.take` when it is a positive integer,
+   * else {@link DEFAULT_ITEM_VIEW_TAKE}. The totals footer still shows the full
+   * access-scoped total.
+   */
+  take: number
   /** Numeric columns to sum in the totals footer (explicit opt-in only). */
   sumColumns: string[]
   /**
@@ -76,6 +94,18 @@ function readStringArray(value: unknown): string[] | undefined {
 }
 
 /**
+ * Read a positive-integer row bound (`ui.itemView.take`) from an unknown config
+ * value, falling back to {@link DEFAULT_ITEM_VIEW_TAKE} for anything that is not
+ * a positive integer (missing, zero, negative, fractional, or non-numeric) so a
+ * malformed override can never disable the bound.
+ */
+function readPositiveInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : DEFAULT_ITEM_VIEW_TAKE
+}
+
+/**
  * Read a to-many relationship's item-view overrides off its serialisable `ui`
  * config without casting: `ui.itemView` is `unknown` (index-signature) so each
  * property is narrowed at runtime.
@@ -84,20 +114,22 @@ function readRelationshipItemView(field: FieldConfig): {
   displayMode: 'table' | 'picker'
   columns?: string[]
   sum?: string[]
+  take: number
   removeAction: 'disconnect' | 'delete' | 'none'
 } {
   const raw: unknown = field.ui ? field.ui.itemView : undefined
   if (typeof raw !== 'object' || raw === null) {
-    return { displayMode: 'table', removeAction: 'disconnect' }
+    return { displayMode: 'table', take: DEFAULT_ITEM_VIEW_TAKE, removeAction: 'disconnect' }
   }
   const displayMode = 'displayMode' in raw && raw.displayMode === 'picker' ? 'picker' : 'table'
   const columns = 'columns' in raw ? readStringArray(raw.columns) : undefined
   const sum = 'sum' in raw ? readStringArray(raw.sum) : undefined
+  const take = 'take' in raw ? readPositiveInteger(raw.take) : DEFAULT_ITEM_VIEW_TAKE
   const removeAction =
     'removeAction' in raw && (raw.removeAction === 'delete' || raw.removeAction === 'none')
       ? raw.removeAction
       : 'disconnect'
-  return { displayMode, columns, sum, removeAction }
+  return { displayMode, columns, sum, take, removeAction }
 }
 
 /**
@@ -199,6 +231,7 @@ export function deriveItemViewLayout(config: OpenSaasConfig, listKey: string): I
         relatedListKey,
         backReferenceField,
         columns: overrides.columns ?? defaultColumnsFor(relatedListConfig, backReferenceField),
+        take: overrides.take,
         sumColumns: overrides.sum ?? [],
         removeAction: overrides.removeAction,
         disconnectable: isDisconnectable(relatedListConfig, backReferenceField),

--- a/packages/ui/tests/components/ItemViewInclude.test.ts
+++ b/packages/ui/tests/components/ItemViewInclude.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { buildItemViewInclude, readAccessScopedTotal } from '../../src/components/ItemForm.js'
+import { deriveItemViewLayout, DEFAULT_ITEM_VIEW_TAKE } from '../../src/lib/deriveItemView.js'
+import type { OpenSaasConfig } from '@opensaas/stack-core'
+
+/**
+ * Unit coverage for the item-view bounded fetch + access-scoped total (issue
+ * #752): the include applies a per-relationship `take`, and the footer's M is
+ * read from the parent's filtered `_count` — denied/absent → no leaked total.
+ */
+
+function makeConfig(lists: OpenSaasConfig['lists']): OpenSaasConfig {
+  return { db: { provider: 'sqlite', url: 'file:./test.db' }, lists }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- read a nested include entry in tests
+function entryOf(include: Record<string, unknown>, field: string): any {
+  return include[field]
+}
+
+describe('buildItemViewInclude (issue #752 bounded fetch)', () => {
+  it('applies the default take to a to-many relationship include', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          name: { type: 'text' },
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+    const layout = deriveItemViewLayout(config, 'User')
+    const include = buildItemViewInclude(config.lists.User, config, layout)
+
+    expect(entryOf(include, 'posts').take).toBe(DEFAULT_ITEM_VIEW_TAKE)
+  })
+
+  it('applies a per-relationship take override', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: {
+            type: 'relationship',
+            ref: 'Post.author',
+            many: true,
+            ui: { itemView: { take: 3 } },
+          },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+    const layout = deriveItemViewLayout(config, 'User')
+    const include = buildItemViewInclude(config.lists.User, config, layout)
+
+    expect(entryOf(include, 'posts').take).toBe(3)
+  })
+
+  it('nests relationship-column includes alongside the take', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+        },
+      },
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          author: { type: 'relationship', ref: 'User.posts' },
+          // A relationship column on the related list → nested include so its
+          // Cell can resolve a label, carried WITH the row bound.
+          category: { type: 'relationship', ref: 'Category' },
+        },
+      },
+      Category: { fields: { name: { type: 'text' } } },
+    })
+    const layout = deriveItemViewLayout(config, 'User')
+    const include = buildItemViewInclude(config.lists.User, config, layout)
+
+    const entry = entryOf(include, 'posts')
+    expect(entry.take).toBe(DEFAULT_ITEM_VIEW_TAKE)
+    expect(entry.include).toEqual({ category: true })
+  })
+})
+
+describe('readAccessScopedTotal (issue #752 "showing N of M")', () => {
+  it('reads the access-scoped total from the _count payload when present', () => {
+    expect(readAccessScopedTotal({ posts: 42 }, 'posts', 2)).toBe(42)
+  })
+
+  it('reads a zero total from the _count payload', () => {
+    expect(readAccessScopedTotal({ posts: 0 }, 'posts', 0)).toBe(0)
+  })
+
+  it('falls back (no leaked total) when the related list is denied — absent from _count', () => {
+    // A fully-denied related list is OMITTED from the filtered _count select, so
+    // its key is absent here; M falls back to the bounded row count (0), never a
+    // leaked true total.
+    expect(readAccessScopedTotal({ posts: 5 }, 'sessions', 0)).toBe(0)
+  })
+
+  it('falls back when there is no _count payload at all', () => {
+    expect(readAccessScopedTotal(undefined, 'posts', 7)).toBe(7)
+    expect(readAccessScopedTotal(null, 'posts', 7)).toBe(7)
+  })
+
+  it('ignores a non-numeric count value and falls back', () => {
+    expect(readAccessScopedTotal({ posts: 'nope' }, 'posts', 4)).toBe(4)
+  })
+})

--- a/packages/ui/tests/components/RelationshipTableClient.test.tsx
+++ b/packages/ui/tests/components/RelationshipTableClient.test.tsx
@@ -59,9 +59,26 @@ describe('RelationshipTableClient', () => {
 
     const footer = document.querySelector('[data-slot="relationship-table-footer"]')
     expect(footer).not.toBeNull()
-    // Count always shown; summed column rendered through its Cell (5 + 10 = 15).
-    expect(footer).toHaveTextContent('2 rows')
+    // Count always shown (N of M, unbounded here → 2 of 2); summed column
+    // rendered through its Cell (5 + 10 = 15).
+    expect(footer).toHaveTextContent('Showing 2 of 2 rows')
     expect(footer).toHaveTextContent('15')
+  })
+
+  it('shows "showing N of M" when the fetch is bounded below the access-scoped total', () => {
+    // Bounded fetch (issue #752): 2 rows rendered, 42 total access-scoped rows.
+    render(<RelationshipTableClient {...baseProps()} total={42} />)
+
+    const footer = document.querySelector('[data-slot="relationship-table-footer"]')
+    // N is the rendered count (always shown), M the full access-scoped total.
+    expect(footer).toHaveTextContent('Showing 2 of 42 rows')
+  })
+
+  it('falls back to the row count for M when no total is provided (row count always shown)', () => {
+    render(<RelationshipTableClient {...baseProps()} total={undefined} />)
+
+    const footer = document.querySelector('[data-slot="relationship-table-footer"]')
+    expect(footer).toHaveTextContent('Showing 2 of 2 rows')
   })
 
   it('navigates to the related record when a row is clicked', async () => {
@@ -77,7 +94,7 @@ describe('RelationshipTableClient', () => {
 
     expect(screen.getByText(/no related posts/i)).toBeInTheDocument()
     const footer = document.querySelector('[data-slot="relationship-table-footer"]')
-    expect(footer).toHaveTextContent('0 rows')
+    expect(footer).toHaveTextContent('Showing 0 of 0 rows')
   })
 
   it('still shows the row count when there are zero columns (only the back-reference curated away)', () => {
@@ -89,13 +106,14 @@ describe('RelationshipTableClient', () => {
         sumColumns={[]}
         sums={{}}
         count={3}
+        total={12}
       />,
     )
 
     const footer = document.querySelector('[data-slot="relationship-table-footer"]')
     expect(footer).not.toBeNull()
-    // The always-shown count must survive the zero-column footer.
-    expect(within(footer as HTMLElement).getByText('3 rows')).toBeInTheDocument()
+    // The always-shown N-of-M count must survive the zero-column footer path.
+    expect(within(footer as HTMLElement).getByText('Showing 3 of 12 rows')).toBeInTheDocument()
   })
 
   // ---- Row removal (issue #739) ----

--- a/packages/ui/tests/lib/deriveItemView.test.ts
+++ b/packages/ui/tests/lib/deriveItemView.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveItemViewLayout } from '../../src/lib/deriveItemView.js'
+import { deriveItemViewLayout, DEFAULT_ITEM_VIEW_TAKE } from '../../src/lib/deriveItemView.js'
 import type { OpenSaasConfig } from '@opensaas/stack-core'
 
 /**
@@ -106,6 +106,69 @@ describe('deriveItemViewLayout', () => {
 
     const [section] = deriveItemViewLayout(config, 'User').sections
     expect(section.columns).toEqual(['title'])
+  })
+
+  it('bounds the row fetch by the default take when none is configured (issue #752)', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: { type: 'relationship', ref: 'Post.author', many: true },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.take).toBe(DEFAULT_ITEM_VIEW_TAKE)
+  })
+
+  it('honours a per-relationship take override', () => {
+    const config = makeConfig({
+      User: {
+        fields: {
+          posts: {
+            type: 'relationship',
+            ref: 'Post.author',
+            many: true,
+            ui: { itemView: { take: 5 } },
+          },
+        },
+      },
+      Post: {
+        fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+      },
+    })
+
+    const [section] = deriveItemViewLayout(config, 'User').sections
+    expect(section.take).toBe(5)
+  })
+
+  it('falls back to the default take for a non-positive or non-integer override', () => {
+    const makeUser = (take: number): OpenSaasConfig =>
+      makeConfig({
+        User: {
+          fields: {
+            posts: {
+              type: 'relationship',
+              ref: 'Post.author',
+              many: true,
+              // A malformed take (zero, negative, fractional, NaN) must never
+              // disable the bound — it falls back to the default.
+              ui: { itemView: { take } },
+            },
+          },
+        },
+        Post: {
+          fields: { title: { type: 'text' }, author: { type: 'relationship', ref: 'User.posts' } },
+        },
+      })
+
+    for (const bad of [0, -3, 2.5, Number.NaN]) {
+      const [section] = deriveItemViewLayout(makeUser(bad), 'User').sections
+      expect(section.take).toBe(DEFAULT_ITEM_VIEW_TAKE)
+    }
   })
 
   it('reads summed columns from config (footer opt-in)', () => {


### PR DESCRIPTION
## Summary

Implements #752. Part of #728.

The read-only item-view Relationship tables (#734) previously fetched every related row with **no `take`/limit** — a record with many related rows loaded and rendered every one on each edit-page open. This bounds the fetch and surfaces the full access-scoped total in the footer.

### What changed

- **Bounded fetch:** each to-many Relationship table is now fetched with a `take` — default `DEFAULT_ITEM_VIEW_TAKE` (10), overridable per relationship via `ui.itemView.take`. Rows remain access-scoped through the secured context (`context.db` include), never raw prisma.
- **"Showing N of M" footer:** the totals footer now reads `Showing N of M rows`, where **N** is the rendered (bounded) count and **M** is the full **access-scoped** total. M comes from a filtered `_count` fetched in the *same* secured `findUnique`, folding each related list's own `query` access into the count (reusing #732's `buildRelationshipCountSelect`). A fully-denied related list is omitted from the count → reads `Showing 0 of 0` and **never leaks a true total**. The row count is always shown, including the zero-column footer path (#734's guarantee kept).
- **Core:** `mergeIncludeWithAccessControl` now preserves a caller-supplied `take` on a to-many relation include. It only ever *narrows* the fetched rows and can never widen past the access `where`, so it rides on top of the per-relation access filter — this is what lets the secured `findUnique` bound related-row reads without dropping row-level access.
- **Example (secondary note):** curated starter-auth's auth-derived `Account`/`Session` Relationship-table columns (`ui.itemView.columns`) so credential/token columns (`accessToken`/`refreshToken`/`idToken`, and Session's `token`) are **not** surfaced by default on the User edit page. Field-level access already governs the values; this keeps the example from *modelling* token-column exposure.

### Access-scoping of M (reviewer note)

M is fetched only through the secured context via `buildRelationshipCountSelect`, which folds the related list's `query` access into the `_count` `where` and omits fully-denied lists. `readAccessScopedTotal` falls back to the bounded row count (0 for a denied list) when a field is absent from `_count`, so a denied related list can never expose a real total. `checkAccess(undefined)` denies by default (ADR-0013), so closed auth lists (Account/Session in the example) correctly report `0`.

### Scope

Item-view relationship-table bounding + N-of-M footer + example column curation only. No list-view or edit/create/remove-affordance changes beyond adding the footer/take.

## Tests

- **Unit (core):** `mergeIncludeWithAccessControl` preserves a caller `take` and AND-combines it with the access `where`; drops it for a denied relation. Full core suite: **877 passed**.
- **Unit (ui):** `deriveItemView` take default + override + malformed-fallback; `buildItemViewInclude` applies take (default + override) alongside nested includes; `readAccessScopedTotal` (present / zero / denied→fallback / no-leak); footer "Showing N of M" incl. bounded, fallback, zero-count, and zero-column paths. Full ui suite: **520 passed**.
- **e2e (`e2e/starter-auth`):** full suite **68 passed** — the User edit page shows `Showing 2 of 2 rows` (access-scoped), the denied Session table shows `Showing 0 of 0 rows`, and the Account/Session tables no longer surface token columns.
- `pnpm lint` (0 errors), `pnpm format` (clean), `pnpm build` (all packages typecheck) — clean.

## Changeset

`minor` for `@opensaas/stack-core` and `@opensaas/stack-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_