### PR TITLE
fix(core,ui): harden relationship-table inline-edit and custom bulk actions (#761)

### DIFF
--- a/.changeset/quiet-foxes-run.md
+++ b/.changeset/quiet-foxes-run.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Return a generic "Action failed" message (and log the real error server-side) when a custom bulk-action handler throws an unexpected non-Prisma error, instead of surfacing its internal message to the client

--- a/.changeset/tidy-owls-hide.md
+++ b/.changeset/tidy-owls-hide.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Exclude json columns from relationship-table inline editing so an unchanged json cell no longer wastes a secured update round-trip

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -564,7 +564,15 @@ export function getContext<
           return { bulkAction: false, error: error.message }
         }
         const dbError = parsePrismaError(error, listConfig)
-        return { bulkAction: false, error: dbError.message }
+        // A recognised Prisma error carries a user-safe, translated message.
+        if (dbError instanceof DatabaseError) {
+          return { bulkAction: false, error: dbError.message }
+        }
+        // Anything else is an unexpected handler bug whose raw `.message` could
+        // leak internal detail to the client — log it server-side and return a
+        // generic client-facing message instead.
+        console.error(`Bulk action "${props.key}" on list "${props.listKey}" failed:`, error)
+        return { bulkAction: false, error: 'Action failed' }
       }
     }
 

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -469,6 +469,41 @@ describe('getContext', () => {
         // The handler never ran.
         expect(mockPrisma.post.update).not.toHaveBeenCalled()
       })
+
+      it('returns a generic message (not the internal text) and logs when the handler throws a plain Error', async () => {
+        // An unexpected, non-Prisma, non-known-error bug inside the handler must
+        // not surface its internal message to the client (#761).
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+          const context = await getContext(
+            configWithPublishAction({
+              handler: async () => {
+                throw new Error('secret internal detail: connection string leaked')
+              },
+            }),
+            mockPrisma,
+            { userId: 'u1' },
+          )
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'bulkAction',
+            key: 'publish',
+            ids: ['p1', 'p2'],
+          })
+
+          // Client sees the generic fallback — never the internal message.
+          expect(result).toEqual({ bulkAction: false, error: 'Action failed' })
+          if ('error' in result) {
+            expect(result.error).not.toContain('secret internal detail')
+          }
+          // The real error is logged server-side for the operator.
+          expect(consoleError).toHaveBeenCalled()
+          const loggedArgs = consoleError.mock.calls[0]
+          expect(loggedArgs.some((arg) => arg instanceof Error)).toBe(true)
+        } finally {
+          consoleError.mockRestore()
+        }
+      })
     })
 
     describe('updateRelated (relationship-table inline cell edit)', () => {

--- a/packages/ui/src/components/RelationshipTable.tsx
+++ b/packages/ui/src/components/RelationshipTable.tsx
@@ -94,6 +94,9 @@ const NON_EDITABLE_COLUMNS = new Set(['id', 'createdAt', 'updatedAt'])
  * - relationship columns (relationship editing is out of scope here — they render
  *   as `{ id, label }` and stay read-only),
  * - virtual/computed fields (not stored; nothing to write),
+ * - json columns (their draft is a fresh object reference, so the no-op
+ *   `draft === displayValue` guard never holds and an unchanged cell would waste
+ *   a round-trip; they also need a proper structured editor — out of scope here),
  * - password fields and system columns (`id`/`createdAt`/`updatedAt`),
  * - any field whose UPDATE field-access is statically denied.
  *
@@ -102,7 +105,7 @@ const NON_EDITABLE_COLUMNS = new Set(['id', 'createdAt', 'updatedAt'])
  * commit as a revert (never a denied-vs-absent leak). All evaluation is on the
  * related list's own access — never the parent's.
  */
-async function resolveEditableColumns(
+export async function resolveEditableColumns(
   section: RelationshipTableSection,
   relatedListConfig: AnyListConfig | undefined,
   context: AccessContext<unknown>,
@@ -123,6 +126,7 @@ async function resolveEditableColumns(
     if (!field) continue
     if (field.type === 'relationship') continue
     if (field.type === 'password') continue
+    if (field.type === 'json') continue
     if ('virtual' in field && field.virtual) continue
     if (await isFieldPotentiallyWritable(field.access, { session: context.session, context })) {
       editable.push(column)

--- a/packages/ui/tests/components/RelationshipTableEditableColumns.test.ts
+++ b/packages/ui/tests/components/RelationshipTableEditableColumns.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import type { AccessContext } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text, json, integer, password, virtual } from '@opensaas/stack-core/fields'
+import { resolveEditableColumns } from '../../src/components/RelationshipTable.js'
+import type { RelationshipTableSection } from '../../src/lib/deriveItemView.js'
+
+// A minimal access-scoped context: resolveEditableColumns only forwards it to
+// the related list's own access functions (which ignore it here).
+function makeContext(): AccessContext<unknown> {
+  const context = {
+    db: {},
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  return context as unknown as AccessContext<unknown>
+}
+
+function section(columns: string[]): RelationshipTableSection {
+  return {
+    fieldName: 'items',
+    ref: 'Item.parent',
+    relatedListKey: 'Item',
+    backReferenceField: 'parent',
+    columns,
+    take: 10,
+    sumColumns: [],
+    removeAction: 'disconnect',
+    disconnectable: true,
+  }
+}
+
+describe('resolveEditableColumns — json exclusion (#761)', () => {
+  it('excludes json columns from inline-editable columns', async () => {
+    // The related list allows update at the operation level, and every field's
+    // update field-access is allow-by-default — so only the field TYPE gates it.
+    const relatedListConfig = list({
+      access: { operation: { update: () => true } },
+      fields: {
+        title: text(),
+        metadata: json(),
+      },
+    })
+
+    const editable = await resolveEditableColumns(
+      section(['title', 'metadata']),
+      relatedListConfig,
+      makeContext(),
+    )
+
+    // The scalar text column is editable; the json column is not (it needs a
+    // proper structured editor, and its fresh-reference draft would otherwise
+    // waste a round-trip on the reference-equality no-op guard).
+    expect(editable).toEqual(['title'])
+    expect(editable).not.toContain('metadata')
+  })
+
+  it('keeps the existing scalar / relationship / virtual / password / system exclusions intact', async () => {
+    const relatedListConfig = list({
+      access: { operation: { update: () => true } },
+      fields: {
+        title: text(),
+        count: integer(),
+        secret: password(),
+        computed: virtual({ type: 'string', hooks: { resolveOutput: () => 'x' } }),
+        payload: json(),
+      },
+    })
+
+    const editable = await resolveEditableColumns(
+      section(['id', 'title', 'count', 'secret', 'computed', 'payload', 'createdAt']),
+      relatedListConfig,
+      makeContext(),
+    )
+
+    // Only the writable scalars remain; json joins password/virtual/system in
+    // the excluded set.
+    expect(editable).toEqual(['title', 'count'])
+  })
+})


### PR DESCRIPTION
Implements #761. Part of #728.

Two small, independent hardening items surfaced during review of #737 and #736. Both are additive and low-risk.

## Item 1 — inline-edit json no-op round-trip (`@opensaas/stack-ui`)

`RelationshipTableCell.commit()` skips the server round-trip only when `draft === displayValue` (reference equality). That is correct for scalar fields, but `json` columns were **not** excluded from `editableColumns`, and a json draft is always a fresh object reference — so an unchanged json cell always round-tripped to the secured `updateRelated` on Enter/blur (harmless, but a wasted request).

**Chosen approach (the issue's preferred option): exclude `json` from inline-editable columns.** In `resolveEditableColumns` (`packages/ui/src/components/RelationshipTable.tsx`), `json` now joins the existing excluded types (relationship / virtual / password / system columns). This is cleaner than a normalised value-equality compare, matches the reference-equality assumption the cell's no-op guard already relies on, and json fields need a proper structured editor anyway (out of scope here). No change to `RelationshipTableCell` itself.

- Test: `packages/ui/tests/components/RelationshipTableEditableColumns.test.ts` — a json column is not editable; existing scalar/relationship/virtual/password/system exclusions stay intact.

## Item 2 — custom-bulk-action error fallback (`@opensaas/stack-core`)

In the `bulkAction` branch of `packages/core/src/context/index.ts`, an unexpected error thrown inside a custom handler (not a `ValidationError`/`DatabaseError`) was passed to `parsePrismaError`, whose `.message` was returned to the client — potentially surfacing an internal message.

Now: recognised Prisma errors (a `DatabaseError` from `parsePrismaError`) keep their user-safe, translated message; anything else is logged server-side via `console.error` and the client receives a generic `"Action failed"`. `ValidationError`/`DatabaseError` behaviour is unchanged. The handler still runs through the **secured** context — no change to access-scoping or silent-failure semantics.

- Test: `packages/core/tests/context.test.ts` — a handler throwing a plain `Error` returns `"Action failed"` (never the internal text) and logs the real error server-side.

## Verification (local)

- Unit: `@opensaas/stack-core` 878 passed; `@opensaas/stack-ui` 522 passed.
- e2e (throwaway config, non-default port 3123, local Chromium; not committed): `05-item-view`, `08-relationship-inline-edit`, `08-custom-bulk-actions` — 6/6 passed. No regression to inline-edit or custom bulk actions.
- `pnpm build` (typecheck) clean for both packages; `pnpm lint` (no new warnings/errors), `pnpm manypkg fix`, `pnpm format` clean.

## Changesets

- `@opensaas/stack-ui`: patch (json inline-edit exclusion)
- `@opensaas/stack-core`: patch (bulk-action generic error fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN

---
_Generated by [Claude Code](https://claude.ai/code/session_019ioUYPsYU34CkmxPEKhBNN)_