### PR TITLE
fix(storage,storage-vercel): make delete() idempotent, fix Vercel Blob v2 not-found semantics

### DIFF
--- a/.changeset/spicy-otters-kneel.md
+++ b/.changeset/spicy-otters-kneel.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage': patch
+---
+
+`StorageProvider.delete()` is now documented as idempotent; the local provider swallows `ENOENT` on delete instead of throwing.

--- a/.changeset/tame-goats-whistle.md
+++ b/.changeset/tame-goats-whistle.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage-vercel': patch
+---
+
+Fix `delete()`/`download()` for `@vercel/blob` v2, which rejects `head()` with `BlobNotFoundError` for missing blobs instead of resolving `null`. `delete()` of a missing blob is now a no-op and no longer round-trips through `head()`.

--- a/docs/content/reference/storage.md
+++ b/docs/content/reference/storage.md
@@ -457,7 +457,7 @@ export class CustomStorageProvider implements StorageProvider {
   }
 
   async delete(filename: string): Promise<void> {
-    // Your delete logic
+    // Your delete logic — must be idempotent (see below)
   }
 
   getUrl(filename: string): string {
@@ -469,6 +469,22 @@ export class CustomStorageProvider implements StorageProvider {
   }
 }
 ```
+
+### `delete()` is idempotent
+
+`StorageProvider.delete()` must resolve without error when the given filename
+doesn't exist in the backing store — treat a missing file as an already-deleted
+file, not a failure. Only propagate errors that aren't about existence
+(permissions, network failures, etc.). This lets callers (e.g.
+`cleanupOnDelete`/`cleanupOnReplace` field hooks) delete unconditionally
+without first checking whether the file is still there.
+
+The built-in providers follow this contract:
+
+- **Local**: `delete()` swallows `ENOENT` (file already gone); other
+  filesystem errors still propagate.
+- **Vercel Blob**: `delete()` swallows `BlobNotFoundError`; other SDK errors
+  still propagate.
 
 ## Common Patterns
 

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -1,4 +1,4 @@
-import { put, del, head, PutCommandOptions } from '@vercel/blob'
+import { put, del, head, BlobNotFoundError, PutCommandOptions } from '@vercel/blob'
 import { randomBytes } from 'node:crypto'
 import type { StorageProvider, UploadOptions, UploadResult } from '@opensaas/stack-storage'
 
@@ -107,12 +107,16 @@ export class VercelBlobStorageProvider implements StorageProvider {
     const pathname = this.getFullPath(filename)
 
     // Get blob metadata to retrieve URL
-    const metadata = await head(pathname, {
-      token: this.config.token,
-    })
-
-    if (!metadata) {
-      throw new Error(`File not found: ${filename}`)
+    let metadata
+    try {
+      metadata = await head(pathname, {
+        token: this.config.token,
+      })
+    } catch (error) {
+      if (error instanceof BlobNotFoundError) {
+        throw new Error(`File not found: ${filename}`)
+      }
+      throw error
     }
 
     // Fetch the file content
@@ -129,15 +133,14 @@ export class VercelBlobStorageProvider implements StorageProvider {
   async delete(filename: string): Promise<void> {
     const pathname = this.getFullPath(filename)
 
-    // Get the URL first
-    const metadata = await head(pathname, {
-      token: this.config.token,
-    })
-
-    if (metadata) {
-      await del(metadata.url, {
+    try {
+      await del(pathname, {
         token: this.config.token,
       })
+    } catch (error) {
+      if (!(error instanceof BlobNotFoundError)) {
+        throw error
+      }
     }
   }
 

--- a/packages/storage-vercel/tests/vercel-blob-provider.test.ts
+++ b/packages/storage-vercel/tests/vercel-blob-provider.test.ts
@@ -2,11 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { VercelBlobStorageProvider, vercelBlobStorage } from '../src/index.js'
 import type { VercelBlobStorageConfig } from '../src/index.js'
 
+// Mirrors @vercel/blob's real BlobNotFoundError shape (extends BlobError)
+const { BlobNotFoundError } = vi.hoisted(() => {
+  class BlobNotFoundError extends Error {
+    constructor() {
+      super('The requested blob does not exist')
+      this.name = 'BlobNotFoundError'
+    }
+  }
+  return { BlobNotFoundError }
+})
+
 // Mock Vercel Blob SDK
 vi.mock('@vercel/blob', () => ({
   put: vi.fn(),
   del: vi.fn(),
   head: vi.fn(),
+  BlobNotFoundError,
 }))
 
 // Mock crypto for deterministic filename testing
@@ -360,17 +372,29 @@ describe('VercelBlobStorageProvider', () => {
       expect(head).toHaveBeenCalledWith('documents/report.pdf', { token: 'test-token' })
     })
 
-    it('should throw error when file not found (head returns null)', async () => {
+    it('should throw a descriptive error when file not found (head rejects with BlobNotFoundError)', async () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
         token: 'test-token',
       }
       const provider = new VercelBlobStorageProvider(config)
-      head.mockResolvedValueOnce(null)
+      head.mockRejectedValueOnce(new BlobNotFoundError())
 
       await expect(provider.download('nonexistent.txt')).rejects.toThrow(
         'File not found: nonexistent.txt',
       )
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+    it('should propagate non-not-found errors from head', async () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: 'test-token',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+      head.mockRejectedValueOnce(new Error('Network error'))
+
+      await expect(provider.download('test.txt')).rejects.toThrow('Network error')
       expect(fetch).not.toHaveBeenCalled()
     })
 
@@ -410,24 +434,17 @@ describe('VercelBlobStorageProvider', () => {
   })
 
   describe('delete', () => {
-    it('should delete file successfully', async () => {
+    it('should delete file successfully by pathname, without a head() round-trip', async () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
         token: 'test-token',
       }
       const provider = new VercelBlobStorageProvider(config)
 
-      head.mockResolvedValueOnce({
-        url: 'https://blob.vercel-storage.com/test.txt',
-        pathname: 'test.txt',
-        size: 100,
-        uploadedAt: new Date(),
-      })
-
       await provider.delete('test.txt')
 
-      expect(head).toHaveBeenCalledWith('test.txt', { token: 'test-token' })
-      expect(del).toHaveBeenCalledWith('https://blob.vercel-storage.com/test.txt', {
+      expect(head).not.toHaveBeenCalled()
+      expect(del).toHaveBeenCalledWith('test.txt', {
         token: 'test-token',
       })
     })
@@ -440,46 +457,28 @@ describe('VercelBlobStorageProvider', () => {
       }
       const provider = new VercelBlobStorageProvider(config)
 
-      head.mockResolvedValueOnce({
-        url: 'https://blob.vercel-storage.com/temp/old-file.txt',
-        pathname: 'temp/old-file.txt',
-        size: 100,
-        uploadedAt: new Date(),
-      })
-
       await provider.delete('old-file.txt')
 
-      expect(head).toHaveBeenCalledWith('temp/old-file.txt', { token: 'test-token' })
+      expect(del).toHaveBeenCalledWith('temp/old-file.txt', { token: 'test-token' })
     })
 
-    it('should handle file not found gracefully', async () => {
+    it('should resolve without error when deleting a nonexistent pathname (idempotent)', async () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
         token: 'test-token',
       }
       const provider = new VercelBlobStorageProvider(config)
-      head.mockResolvedValueOnce(null)
+      del.mockRejectedValueOnce(new BlobNotFoundError())
 
-      // Should not throw error
-      await provider.delete('nonexistent.txt')
-
-      expect(head).toHaveBeenCalledWith('nonexistent.txt', { token: 'test-token' })
-      expect(del).not.toHaveBeenCalled()
+      await expect(provider.delete('nonexistent.txt')).resolves.toBeUndefined()
     })
 
-    it('should handle deletion errors', async () => {
+    it('should propagate non-not-found deletion errors', async () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
         token: 'test-token',
       }
       const provider = new VercelBlobStorageProvider(config)
-
-      head.mockResolvedValueOnce({
-        url: 'https://blob.vercel-storage.com/test.txt',
-        pathname: 'test.txt',
-        size: 100,
-        uploadedAt: new Date(),
-      })
 
       del.mockRejectedValueOnce(new Error('Deletion failed'))
 

--- a/packages/storage/src/config/types.ts
+++ b/packages/storage/src/config/types.ts
@@ -24,7 +24,11 @@ export interface StorageProvider {
   download(filename: string): Promise<Buffer>
 
   /**
-   * Deletes a file from the storage provider
+   * Deletes a file from the storage provider.
+   *
+   * Idempotent: deleting a filename that doesn't exist in the backing store
+   * resolves without error. Only non-not-found errors (permissions, network,
+   * etc.) should reject.
    * @param filename - Filename to delete
    */
   delete(filename: string): Promise<void>

--- a/packages/storage/src/providers/local.ts
+++ b/packages/storage/src/providers/local.ts
@@ -76,7 +76,13 @@ export class LocalStorageProvider implements StorageProvider {
 
   async delete(filename: string): Promise<void> {
     const filePath = path.join(this.config.uploadDir, filename)
-    await fs.unlink(filePath)
+    try {
+      await fs.unlink(filePath)
+    } catch (error) {
+      if ((error as { code?: string }).code !== 'ENOENT') {
+        throw error
+      }
+    }
   }
 
   getUrl(filename: string): string {

--- a/packages/storage/tests/local-provider.test.ts
+++ b/packages/storage/tests/local-provider.test.ts
@@ -304,6 +304,21 @@ describe('LocalStorageProvider', () => {
 
       await expect(provider.delete('protected.txt')).rejects.toThrow('Permission denied')
     })
+
+    it('should resolve without error when deleting a nonexistent file (idempotent)', async () => {
+      const config: LocalStorageConfig = {
+        type: 'local',
+        uploadDir: './uploads',
+        serveUrl: '/uploads',
+      }
+      const provider = new LocalStorageProvider(config)
+      const enoent = Object.assign(new Error('ENOENT: no such file or directory'), {
+        code: 'ENOENT',
+      })
+      fs.unlink.mockRejectedValueOnce(enoent)
+
+      await expect(provider.delete('nonexistent.txt')).resolves.toBeUndefined()
+    })
   })
 
   describe('getUrl', () => {


### PR DESCRIPTION
## Summary

- Document `StorageProvider.delete()` as **idempotent**: deleting a file that no longer exists resolves without error, per the interface JSDoc and `docs/content/reference/storage.md`.
- `LocalStorageProvider.delete()` now swallows `ENOENT` (file already gone) and still propagates other filesystem errors.
- `VercelBlobStorageProvider`:
  - `delete()` no longer round-trips through `head()` — it calls `del(pathname, ...)` directly (v2's `del()` accepts pathnames), and swallows `BlobNotFoundError` so deleting a missing blob is a no-op. Other SDK errors still propagate.
  - `download()` now catches `BlobNotFoundError` from `head()` and rejects with a descriptive "File not found" error; other errors propagate.
- Re-modeled the Vercel provider's test doubles on the real `@vercel/blob` v2 contract — `head()` rejects with `BlobNotFoundError` for missing blobs (never resolves `null`), matching what the SDK actually does.
- Added coverage for no-op delete and not-found download on both providers.
- Added patch changesets for `@opensaas/stack-storage` and `@opensaas/stack-storage-vercel`.

## Why

In `@vercel/blob` v2, `head()` throws `BlobNotFoundError` for a missing blob instead of resolving `null`. The provider's old not-found handling in `download()` was unreachable dead code, and `delete()` of a missing blob threw instead of gracefully skipping. The local provider already threw `ENOENT` on missing-file deletes, so there was no consistent `delete()` contract across providers. The old Vercel provider tests mocked `head → null`, encoding the wrong SDK contract, which is why the dead paths stayed green.

## Test plan

- [x] `pnpm --filter @opensaas/stack-storage test` — 148 passed
- [x] `pnpm --filter @opensaas/stack-storage-vercel test` — 31 passed
- [x] `pnpm build` (full monorepo, including docs link-check)
- [x] `pnpm lint` — no new errors/warnings
- [x] `pnpm format` — no changes needed

Closes #766

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKJ3z9hSUpihmQof8USuuJ)_