### PR TITLE
fix(storage-vercel): getUrl() now returns a resolvable Vercel Blob URL

### DIFF
--- a/.changeset/fix-vercel-blob-get-url.md
+++ b/.changeset/fix-vercel-blob-get-url.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage-vercel': patch
+---
+
+Fix `getUrl()` returning a fabricated host that never resolves. It now derives the store ID from the configured token/store ID (the same way the SDK does internally) and embeds it along with the access mode, matching the real URL the SDK returns at upload time. A token that doesn't yield a store ID now throws a descriptive error instead of producing a silently wrong URL.

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -4,6 +4,24 @@ import { randomBytes } from 'node:crypto'
 import type { StorageProvider, UploadOptions, UploadResult } from '@opensaas/stack-storage'
 
 /**
+ * Derives the store ID embedded in a Vercel Blob read-write token
+ * (`vercel_blob_rw_<storeId>_<secret>`), the same way `@vercel/blob` derives
+ * it internally to build blob URLs. This format is undocumented and not a
+ * stable public API — it's parity with the SDK's internal parsing, not a
+ * contract Vercel guarantees. Returns `''` if the token doesn't match the
+ * expected shape.
+ */
+function parseStoreIdFromToken(token: string): string {
+  const segments = token.split('_')
+  return segments.length >= 4 ? segments[3] : ''
+}
+
+/** Strips the `store_` prefix some store ID values are given with. */
+function normalizeStoreId(storeId: string): string {
+  return storeId.startsWith('store_') ? storeId.slice('store_'.length) : storeId
+}
+
+/**
  * Configuration for Vercel Blob storage
  */
 export interface VercelBlobStorageConfig {
@@ -96,6 +114,48 @@ export class VercelBlobStorageProvider implements StorageProvider {
     return this.config.public !== false ? 'public' : 'private'
   }
 
+  /**
+   * Resolves the Vercel Blob store ID used to construct blob URLs, mirroring
+   * the SDK's own credential precedence: an explicit read-write token wins
+   * (its embedded store ID is authoritative), otherwise an explicit/env store
+   * ID is used, otherwise the store ID is parsed from the env read-write
+   * token.
+   */
+  private resolveStoreId(): string {
+    const token = this.config.token ?? process.env.BLOB_READ_WRITE_TOKEN?.trim()
+    if (this.config.token) {
+      const storeId = parseStoreIdFromToken(this.config.token)
+      if (!storeId) {
+        throw new Error(
+          'Cannot determine the Vercel Blob store ID: the configured `token` does not match the ' +
+            'expected "vercel_blob_rw_<storeId>_<secret>" format. Pass `storeId` explicitly to construct blob URLs.',
+        )
+      }
+      return storeId
+    }
+
+    const storeId = this.config.storeId ?? process.env.BLOB_STORE_ID?.trim()
+    if (storeId) {
+      return normalizeStoreId(storeId)
+    }
+
+    if (token) {
+      const parsedStoreId = parseStoreIdFromToken(token)
+      if (!parsedStoreId) {
+        throw new Error(
+          'Cannot determine the Vercel Blob store ID: BLOB_READ_WRITE_TOKEN does not match the ' +
+            'expected "vercel_blob_rw_<storeId>_<secret>" format. Pass `storeId` explicitly to construct blob URLs.',
+        )
+      }
+      return parsedStoreId
+    }
+
+    throw new Error(
+      'Cannot determine the Vercel Blob store ID: configure `token`, `storeId`, BLOB_STORE_ID, or ' +
+        'BLOB_READ_WRITE_TOKEN to construct blob URLs.',
+    )
+  }
+
   async upload(
     file: Buffer | Uint8Array,
     filename: string,
@@ -166,10 +226,9 @@ export class VercelBlobStorageProvider implements StorageProvider {
   }
 
   getUrl(filename: string): string {
-    // For Vercel Blob, we need to have uploaded the file first to get the URL
-    // This method is less useful for Vercel Blob, but we provide a pathname
     const pathname = this.getFullPath(filename)
-    return `https://blob.vercel-storage.com/${pathname}`
+    const storeId = this.resolveStoreId()
+    return `https://${storeId}.${this.getAccess()}.blob.vercel-storage.com/${pathname}`
   }
 
   async getSignedUrl(filename: string, expiresIn: number = 3600): Promise<string> {

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -134,7 +134,7 @@ export class VercelBlobStorageProvider implements StorageProvider {
       return storeId
     }
 
-    const storeId = this.config.storeId ?? process.env.BLOB_STORE_ID?.trim()
+    const storeId = this.config.storeId?.trim() || process.env.BLOB_STORE_ID?.trim()
     if (storeId) {
       return normalizeStoreId(storeId)
     }

--- a/packages/storage-vercel/tests/vercel-blob-provider.test.ts
+++ b/packages/storage-vercel/tests/vercel-blob-provider.test.ts
@@ -580,41 +580,145 @@ describe('VercelBlobStorageProvider', () => {
   })
 
   describe('getUrl', () => {
-    it('should return correct URL format', () => {
+    const VALID_TOKEN = 'vercel_blob_rw_STORE123_supersecretvalue'
+
+    it('should return the public-host URL derived from the token store ID', () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
-        token: 'test-token',
+        token: VALID_TOKEN,
       }
       const provider = new VercelBlobStorageProvider(config)
 
       const url = provider.getUrl('photo.jpg')
 
-      expect(url).toBe('https://blob.vercel-storage.com/photo.jpg')
+      expect(url).toBe('https://STORE123.public.blob.vercel-storage.com/photo.jpg')
+    })
+
+    it('should return the private-host URL when public is false', () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: VALID_TOKEN,
+        public: false,
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const url = provider.getUrl('secret.pdf')
+
+      expect(url).toBe('https://STORE123.private.blob.vercel-storage.com/secret.pdf')
     })
 
     it('should apply pathPrefix to URL', () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
-        token: 'test-token',
+        token: VALID_TOKEN,
         pathPrefix: 'images',
       }
       const provider = new VercelBlobStorageProvider(config)
 
       const url = provider.getUrl('photo.jpg')
 
-      expect(url).toBe('https://blob.vercel-storage.com/images/photo.jpg')
+      expect(url).toBe('https://STORE123.public.blob.vercel-storage.com/images/photo.jpg')
     })
 
     it('should handle filenames with special characters', () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
-        token: 'test-token',
+        token: VALID_TOKEN,
       }
       const provider = new VercelBlobStorageProvider(config)
 
       const url = provider.getUrl('my file (1).txt')
 
-      expect(url).toBe('https://blob.vercel-storage.com/my file (1).txt')
+      expect(url).toBe('https://STORE123.public.blob.vercel-storage.com/my file (1).txt')
+    })
+
+    it('should derive the store ID from an explicit storeId when using OIDC auth', () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        storeId: 'store_abc123',
+        oidcToken: 'oidc-token-789',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const url = provider.getUrl('photo.jpg')
+
+      expect(url).toBe('https://abc123.public.blob.vercel-storage.com/photo.jpg')
+    })
+
+    it('should derive the store ID from BLOB_STORE_ID env var', () => {
+      process.env.BLOB_STORE_ID = 'store_envstore'
+
+      const config: VercelBlobStorageConfig = { type: 'vercel-blob' }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const url = provider.getUrl('photo.jpg')
+
+      expect(url).toBe('https://envstore.public.blob.vercel-storage.com/photo.jpg')
+
+      delete process.env.BLOB_STORE_ID
+    })
+
+    it('should derive the store ID from BLOB_READ_WRITE_TOKEN env var', () => {
+      process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_ENVSTORE_secret'
+
+      const config: VercelBlobStorageConfig = { type: 'vercel-blob' }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const url = provider.getUrl('photo.jpg')
+
+      expect(url).toBe('https://ENVSTORE.public.blob.vercel-storage.com/photo.jpg')
+
+      delete process.env.BLOB_READ_WRITE_TOKEN
+    })
+
+    it('should prefer the explicit token over storeId when both are set', () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: VALID_TOKEN,
+        storeId: 'store_other',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const url = provider.getUrl('photo.jpg')
+
+      expect(url).toBe('https://STORE123.public.blob.vercel-storage.com/photo.jpg')
+    })
+
+    it('should throw a descriptive error when the token does not yield a store ID', () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: 'not-a-real-token',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      expect(() => provider.getUrl('photo.jpg')).toThrow(
+        /Cannot determine the Vercel Blob store ID/,
+      )
+    })
+
+    it('should throw a descriptive error when BLOB_READ_WRITE_TOKEN does not yield a store ID', () => {
+      process.env.BLOB_READ_WRITE_TOKEN = 'not-a-real-token'
+
+      const config: VercelBlobStorageConfig = { type: 'vercel-blob' }
+      const provider = new VercelBlobStorageProvider(config)
+
+      expect(() => provider.getUrl('photo.jpg')).toThrow(
+        /Cannot determine the Vercel Blob store ID/,
+      )
+
+      delete process.env.BLOB_READ_WRITE_TOKEN
+    })
+
+    it('should throw a descriptive error when no credentials are configured at all', () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN
+      delete process.env.BLOB_STORE_ID
+
+      const config: VercelBlobStorageConfig = { type: 'vercel-blob' }
+      const provider = new VercelBlobStorageProvider(config)
+
+      expect(() => provider.getUrl('photo.jpg')).toThrow(
+        /Cannot determine the Vercel Blob store ID/,
+      )
     })
   })
 


### PR DESCRIPTION
## Summary
- `getUrl()` on the Vercel Blob provider fabricated a host without the store subdomain (`https://blob.vercel-storage.com/...`), which always 404'd.
- It now derives the store ID from the configured `token`/`storeId` (or the `BLOB_READ_WRITE_TOKEN`/`BLOB_STORE_ID` env vars), mirroring the same precedence and parsing `@vercel/blob` uses internally, and constructs `https://<storeId>.<access>.blob.vercel-storage.com/<pathname>` — matching the URL the SDK returns at upload time.
- Private-mode stores (`public: false`) now produce the private-host form, servable via the signed/authorized paths added in #767.
- A token that doesn't yield a store ID throws a descriptive error instead of producing a silently wrong URL, since the token format is undocumented (parity-with-SDK, not a stable API).

## Test plan
- [x] Added tests covering: public URL derived from token, private-host URL, `pathPrefix`, special characters in filename, store ID from explicit `storeId` (OIDC), from `BLOB_STORE_ID` env, from `BLOB_READ_WRITE_TOKEN` env, token-over-storeId precedence, and descriptive errors for malformed token / no credentials
- [x] `pnpm test` in `packages/storage-vercel` — 48/48 passing
- [x] `pnpm build` (via turbo, including `@opensaas/stack-core` and `@opensaas/stack-storage` deps) — passes
- [x] `pnpm lint` (eslint on changed files) — no errors
- [x] `pnpm manypkg fix` / `prettier --check` — no changes needed
- [x] Changeset added (`patch` for `@opensaas/stack-storage-vercel`)

Closes #768

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnqgPzigsjAVNEwzhazSxh)_