### PR TITLE
fix(storage-vercel): add allowOverwrite so stable-filename uploads can replace existing blobs

### DIFF
--- a/.changeset/tame-otters-overwrite.md
+++ b/.changeset/tame-otters-overwrite.md
@@ -1,0 +1,13 @@
+---
+'@opensaas/stack-storage-vercel': minor
+---
+
+Add `allowOverwrite` config option to `vercelBlobStorage`. The Vercel Blob API rejects uploads to an existing pathname unless this is sent, which made stable-filename replace workflows (`generateUniqueFilenames: false`, e.g. a field with `cleanupOnReplace`) throw "blob already exists". `allowOverwrite` now defaults to `true` when `generateUniqueFilenames` is `false`, and `false` otherwise; an explicit setting always wins.
+
+```typescript
+vercelBlobStorage({
+  token: process.env.BLOB_READ_WRITE_TOKEN,
+  generateUniqueFilenames: false,
+  allowOverwrite: false, // opt back into reject-on-overwrite with stable names
+})
+```

--- a/docs/content/reference/storage.md
+++ b/docs/content/reference/storage.md
@@ -264,6 +264,24 @@ storage: {
 }
 ```
 
+The Blob API rejects uploads to an existing pathname unless `allowOverwrite` is
+sent. With `generateUniqueFilenames: false` (stable filenames), `allowOverwrite`
+defaults to `true` since re-uploading to the same pathname is the expected
+replace workflow (e.g. a field configured with `cleanupOnReplace`). With
+generated filenames, collisions aren't expected, so it's left at the API's
+default of rejecting overwrites. Set `allowOverwrite` explicitly to override
+either default:
+
+```typescript
+storage: {
+  avatars: vercelBlobStorage({
+    token: process.env.BLOB_READ_WRITE_TOKEN,
+    generateUniqueFilenames: false,
+    allowOverwrite: false, // restore reject-on-overwrite even with stable names
+  }),
+}
+```
+
 ## Image Transformations
 
 Automatically generate multiple image variants with different sizes and formats:

--- a/packages/storage-vercel/README.md
+++ b/packages/storage-vercel/README.md
@@ -45,10 +45,22 @@ vercelBlobStorage({
   // Optional - Storage options
   pathPrefix?: string               // Prefix for all files (e.g., 'avatars/')
   generateUniqueFilenames?: boolean // Generate unique filenames (default: true)
+  allowOverwrite?: boolean          // Allow overwriting an existing blob at the same pathname
+                                    // (default: true when generateUniqueFilenames is false, false otherwise)
   public?: boolean                  // Make files publicly accessible (default: true)
   cacheControl?: string             // Cache control header (default: 'public, max-age=31536000, immutable')
 })
 ```
+
+### Overwriting existing files
+
+The Vercel Blob API rejects uploads to an existing pathname unless `allowOverwrite`
+is sent. With `generateUniqueFilenames: false` (stable filenames), the provider
+defaults `allowOverwrite` to `true` since re-uploading to the same pathname is
+the expected replace workflow (e.g. a field configured with `cleanupOnReplace`).
+With generated filenames, collisions aren't expected, so it's left at the API's
+default of rejecting overwrites. Set `allowOverwrite` explicitly to override
+either default.
 
 ## Authentication
 

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -44,6 +44,13 @@ export interface VercelBlobStorageConfig {
   oidcToken?: string
   /** Whether to generate unique filenames (default: true) */
   generateUniqueFilenames?: boolean
+  /**
+   * Whether to allow overwriting an existing blob at the same pathname.
+   * The Blob API rejects overwrites unless this is sent. Defaults to `true`
+   * when `generateUniqueFilenames` is `false` (stable filenames imply replace
+   * semantics), and `false` otherwise. An explicit setting always wins.
+   */
+  allowOverwrite?: boolean
   /** Path prefix for all uploaded files */
   pathPrefix?: string
   /** Whether files should be publicly accessible (default: true) */
@@ -103,6 +110,21 @@ export class VercelBlobStorageProvider implements StorageProvider {
       return `${this.config.pathPrefix}/${filename}`
     }
     return filename
+  }
+
+  /**
+   * Resolves whether uploads may overwrite an existing blob at the same
+   * pathname. An explicit `allowOverwrite` always wins; otherwise stable
+   * filenames (`generateUniqueFilenames: false`) imply replace semantics and
+   * default to `true`. With generated filenames collisions aren't expected,
+   * so the key is left unset and the Blob API's own reject-by-default
+   * behavior applies.
+   */
+  private resolveAllowOverwrite(): boolean | undefined {
+    if (this.config.allowOverwrite !== undefined) {
+      return this.config.allowOverwrite
+    }
+    return this.config.generateUniqueFilenames === false ? true : undefined
   }
 
   /**
@@ -176,6 +198,11 @@ export class VercelBlobStorageProvider implements StorageProvider {
 
     if (this.config.cacheControlMaxAge) {
       uploadOptions.cacheControlMaxAge = this.config.cacheControlMaxAge
+    }
+
+    const allowOverwrite = this.resolveAllowOverwrite()
+    if (allowOverwrite !== undefined) {
+      uploadOptions.allowOverwrite = allowOverwrite
     }
 
     const blob = await put(pathname, buffer, uploadOptions)

--- a/packages/storage-vercel/tests/vercel-blob-provider.test.ts
+++ b/packages/storage-vercel/tests/vercel-blob-provider.test.ts
@@ -411,6 +411,86 @@ describe('VercelBlobStorageProvider', () => {
         'Upload failed',
       )
     })
+
+    describe('allowOverwrite', () => {
+      it('should not send allowOverwrite by default with unique filenames (real API defaults to reject)', async () => {
+        const config: VercelBlobStorageConfig = {
+          type: 'vercel-blob',
+          token: 'test-token',
+        }
+        const provider = new VercelBlobStorageProvider(config)
+
+        await provider.upload(Buffer.from('test'), 'test.txt')
+
+        const putOptions = put.mock.calls[0][2] as Record<string, unknown>
+        expect('allowOverwrite' in putOptions).toBe(false)
+      })
+
+      it('should default allowOverwrite to true when generateUniqueFilenames is false', async () => {
+        const config: VercelBlobStorageConfig = {
+          type: 'vercel-blob',
+          token: 'test-token',
+          generateUniqueFilenames: false,
+        }
+        const provider = new VercelBlobStorageProvider(config)
+
+        await provider.upload(Buffer.from('test'), 'stable-name.txt')
+
+        expect(put).toHaveBeenCalledWith(
+          'stable-name.txt',
+          expect.any(Buffer),
+          expect.objectContaining({ allowOverwrite: true }),
+        )
+      })
+
+      it('should let an explicit allowOverwrite: false win even with stable filenames', async () => {
+        const config: VercelBlobStorageConfig = {
+          type: 'vercel-blob',
+          token: 'test-token',
+          generateUniqueFilenames: false,
+          allowOverwrite: false,
+        }
+        const provider = new VercelBlobStorageProvider(config)
+
+        await provider.upload(Buffer.from('test'), 'stable-name.txt')
+
+        expect(put).toHaveBeenCalledWith(
+          'stable-name.txt',
+          expect.any(Buffer),
+          expect.objectContaining({ allowOverwrite: false }),
+        )
+      })
+
+      it('should let an explicit allowOverwrite: true win with generated filenames', async () => {
+        const config: VercelBlobStorageConfig = {
+          type: 'vercel-blob',
+          token: 'test-token',
+          allowOverwrite: true,
+        }
+        const provider = new VercelBlobStorageProvider(config)
+
+        await provider.upload(Buffer.from('test'), 'test.txt')
+
+        expect(put).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Buffer),
+          expect.objectContaining({ allowOverwrite: true }),
+        )
+      })
+
+      it('should reject an upload to an existing pathname when allowOverwrite resolves to false (real API behavior)', async () => {
+        const config: VercelBlobStorageConfig = {
+          type: 'vercel-blob',
+          token: 'test-token',
+        }
+        const provider = new VercelBlobStorageProvider(config)
+        put.mockRejectedValueOnce(new Error('This blob already exists, use `allowOverwrite`'))
+
+        await expect(provider.upload(Buffer.from('test'), 'test.txt')).rejects.toThrow(
+          /already exists/,
+        )
+      })
+    })
   })
 
   describe('download', () => {


### PR DESCRIPTION
## Summary
- The Vercel Blob API rejects uploads to an existing pathname unless `allowOverwrite` is sent, but the provider never sent it — so with `generateUniqueFilenames: false`, re-uploading to the same pathname (e.g. a field configured with `cleanupOnReplace`) always threw "blob already exists".
- Added `allowOverwrite?: boolean` to `VercelBlobStorageConfig`. When unset, it defaults to `true` iff `generateUniqueFilenames === false` (stable names imply replace semantics); an explicit setting always wins in either direction.
- Updated the package README and `docs/content/reference/storage.md` to describe the option and its default.
- Added a minor changeset for `@opensaas/stack-storage-vercel`.

## Test plan
- [x] New tests cover the default matrix (unique filenames → no `allowOverwrite` sent, matching the real API's reject-by-default behavior; stable filenames → defaults to `true`) and explicit overrides in both directions
- [x] `pnpm vitest run` in `packages/storage-vercel` (53 tests passing)
- [x] `pnpm lint` passes
- [x] `pnpm turbo build` for `@opensaas/stack-core`, `@opensaas/stack-storage`, `@opensaas/stack-storage-vercel` passes

Closes #769


---
_Generated by [Claude Code](https://claude.ai/code/session_017TS31DXc6CAK1U5SfwL8vv)_