### PR TITLE
Admin UI: route standalone ListTable through the cell registry

### DIFF
--- a/.changeset/tame-crabs-jump.md
+++ b/.changeset/tame-crabs-jump.md
@@ -1,0 +1,23 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Standalone `ListTable` now routes every cell through the shared cell registry (`CellRenderer`), matching `ListView`. The bespoke relationship renderer and `fieldTypes[column] === 'relationship'` branch are gone in favour of `RelationshipCell`, which already handles link navigation and `stopPropagation`.
+
+A new optional `fieldOptions` prop lets `select` columns resolve label mapping and `ui.variant` badge colour, exactly like `ListView`:
+
+```tsx
+<ListTable
+  items={posts}
+  fieldTypes={{ title: 'text', status: 'select' }}
+  fieldOptions={{
+    status: [
+      { label: 'Published', value: 'published', ui: { variant: 'success' } },
+      { label: 'Draft', value: 'draft' },
+    ],
+  }}
+  columns={['title', 'status']}
+/>
+```
+
+Existing `ListTable` call sites keep working unchanged.

--- a/packages/ui/src/components/standalone/ListTable.tsx
+++ b/packages/ui/src/components/standalone/ListTable.tsx
@@ -1,10 +1,9 @@
 'use client'
 import * as React from 'react'
 import { useState } from 'react'
-import Link from 'next/link.js'
 import { Inbox } from 'lucide-react'
 import { cn, formatFieldName, isNumericField } from '../../lib/utils.js'
-import { getUrlKey } from '@opensaas/stack-core'
+import type { SelectOption } from '@opensaas/stack-core/fields'
 import {
   Table,
   TableBody,
@@ -15,6 +14,7 @@ import {
 } from '../../primitives/table.js'
 import { EmptyState } from '../EmptyState.js'
 import { CellRenderer } from '../cells/CellRenderer.js'
+import type { SerializableFieldConfig } from '../../lib/serializeFieldConfig.js'
 
 /**
  * Per-part `classNames` slots for `ListTable` (issue #709). Each slot is merged
@@ -48,41 +48,17 @@ export interface ListTableClassNames {
   empty?: string
 }
 
-/**
- * `ListTable` is a standalone component embedded by consumers with raw
- * Prisma-shaped items and no list config, so it can't resolve labels via the
- * shared label seam (`getItemLabel`) the way `ListView`/`ListViewClient` do.
- * This local fallback (name → title → label → id) is intentionally private
- * to this component so it can't drift against another copy elsewhere.
- */
-function getRelationshipDisplayValue(value: unknown): string {
-  if (!value || typeof value !== 'object') {
-    return '-'
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) return '-'
-    return value.map((item) => getRelationshipDisplayValue(item)).join(', ')
-  }
-
-  let displayValue: unknown
-  if ('name' in value) {
-    displayValue = value.name
-  } else if ('title' in value) {
-    displayValue = value.title
-  } else if ('label' in value) {
-    displayValue = value.label
-  } else if ('id' in value) {
-    displayValue = value.id
-  }
-
-  return displayValue ? String(displayValue) : '-'
-}
-
 export interface ListTableProps {
   items: Array<Record<string, unknown>>
   fieldTypes: Record<string, string>
   relationshipRefs?: Record<string, string>
+  /**
+   * Select options per column (issue #748) — lets a standalone `select` column
+   * resolve label mapping and `ui.variant` badge colour via `SelectCell`,
+   * matching `ListView`. Columns without an entry render the raw value in the
+   * neutral badge, same as before this option existed.
+   */
+  fieldOptions?: Record<string, Array<SelectOption>>
   basePath?: string
   columns?: string[]
   onRowClick?: (item: Record<string, unknown>) => void
@@ -116,6 +92,7 @@ export function ListTable({
   items,
   fieldTypes,
   relationshipRefs,
+  fieldOptions,
   basePath = '/admin',
   columns,
   onRowClick,
@@ -129,66 +106,19 @@ export function ListTable({
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
 
   /**
-   * Render a relationship field as a clickable link or links
+   * Build the serialised field config for one column so its value can be
+   * routed through the shared cell registry (`CellRenderer`), exactly the path
+   * `ListView` uses (issue #748). `many` is deliberately omitted: unlike
+   * `ListView`'s pre-resolved access-scoped `_count`, this standalone table
+   * only ever receives the raw relationship value, so `RelationshipCell`'s
+   * array-vs-single branching (not its `many`-driven count branch) is what
+   * renders the linked value(s).
    */
-  const renderRelationshipCell = (value: unknown, fieldName: string) => {
-    if (!relationshipRefs) {
-      return getRelationshipDisplayValue(value)
-    }
-
-    const ref = relationshipRefs[fieldName]
-    if (!ref) {
-      return getRelationshipDisplayValue(value)
-    }
-
-    // Parse ref to get related list name
-    const [relatedListKey] = ref.split('.')
-    const relatedUrlKey = getUrlKey(relatedListKey)
-
-    if (!value || typeof value !== 'object') {
-      return <span className="text-muted-foreground">-</span>
-    }
-
-    // Handle array of relationships (many: true)
-    if (Array.isArray(value)) {
-      if (value.length === 0) return <span className="text-muted-foreground">-</span>
-      return (
-        <span className="flex flex-wrap gap-1">
-          {value.map((item, idx) => {
-            if (!item || typeof item !== 'object') return null
-            const displayValue = getRelationshipDisplayValue(item)
-            const itemId = 'id' in item ? item.id : null
-            const key = itemId || idx
-            return (
-              <React.Fragment key={key}>
-                {idx > 0 && <span className="text-muted-foreground">, </span>}
-                <Link
-                  href={`${basePath}/${relatedUrlKey}/${itemId}`}
-                  className="text-primary hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {displayValue}
-                </Link>
-              </React.Fragment>
-            )
-          })}
-        </span>
-      )
-    }
-
-    // Handle single relationship
-    const itemId = 'id' in value ? value.id : null
-    const displayValue = getRelationshipDisplayValue(value)
-    return (
-      <Link
-        href={`${basePath}/${relatedUrlKey}/${itemId}`}
-        className="text-primary hover:underline"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {displayValue}
-      </Link>
-    )
-  }
+  const getFieldConfig = (fieldName: string): SerializableFieldConfig => ({
+    type: fieldTypes[fieldName],
+    ref: relationshipRefs?.[fieldName],
+    options: fieldOptions?.[fieldName],
+  })
 
   // Determine which columns to show
   const displayColumns =
@@ -285,16 +215,12 @@ export function ListTable({
                         classNames?.cell,
                       )}
                     >
-                      {fieldTypes[column] === 'relationship' ? (
-                        renderRelationshipCell(item[column], column)
-                      ) : (
-                        <CellRenderer
-                          value={item[column]}
-                          field={{ type: fieldTypes[column] }}
-                          fieldName={column}
-                          basePath={basePath}
-                        />
-                      )}
+                      <CellRenderer
+                        value={item[column]}
+                        field={getFieldConfig(column)}
+                        fieldName={column}
+                        basePath={basePath}
+                      />
                     </TableCell>
                   ))}
                   {renderActions && (

--- a/packages/ui/tests/components/ListTable.test.tsx
+++ b/packages/ui/tests/components/ListTable.test.tsx
@@ -399,6 +399,46 @@ describe('ListTable', () => {
     })
   })
 
+  describe('select fields (issue #748)', () => {
+    it('renders a select column as a coloured badge using fieldOptions, matching ListView', () => {
+      const items = [
+        { id: '1', title: 'Post 1', status: 'published' },
+        { id: '2', title: 'Post 2', status: 'archived' },
+      ]
+
+      render(
+        <ListTable
+          items={items}
+          fieldTypes={{ title: 'text', status: 'select' }}
+          fieldOptions={{
+            status: [
+              { label: 'Published', value: 'published', ui: { variant: 'success' } },
+              { label: 'Archived', value: 'archived' },
+            ],
+          }}
+          columns={['title', 'status']}
+        />,
+      )
+
+      const publishedBadge = screen.getByText('Published')
+      expect(publishedBadge).toHaveAttribute('data-slot', 'cell-select')
+      expect(publishedBadge.className).toContain('text-success')
+
+      // No `ui.variant` on this option — falls back to the neutral badge.
+      const archivedBadge = screen.getByText('Archived')
+      expect(archivedBadge.className).toContain('bg-secondary')
+      expect(archivedBadge.className).not.toContain('text-success')
+    })
+
+    it('renders the raw value in a neutral badge when fieldOptions is not provided', () => {
+      render(<ListTable {...defaultProps} columns={['title', 'status']} />)
+
+      const badges = screen.getAllByText('published')
+      expect(badges[0]).toHaveAttribute('data-slot', 'cell-select')
+      expect(badges[0].className).toContain('bg-secondary')
+    })
+  })
+
   describe('column filtering', () => {
     it('should exclude password fields by default', () => {
       const items = [{ id: '1', username: 'john', password: 'secret123' }]


### PR DESCRIPTION
## Summary

- Standalone `ListTable` now resolves every cell via `CellRenderer`/the cell registry, removing the `fieldTypes[column] === 'relationship'` branch and the duplicated relationship renderer/display-value helper — `RelationshipCell` already handles link navigation and `stopPropagation`.
- Added an optional `fieldOptions` prop so a `select` column can resolve label mapping and `ui.variant` badge colour, matching `ListView`'s cell rendering. Columns without an entry still render the raw value in the neutral badge (no regression vs. before).
- Existing `ListTable` call sites (no `fieldOptions`) keep working with zero config changes — verified via the existing relationship/select/checkbox/timestamp test suite, all passing unchanged.
- Added a changeset (`.changeset/tame-crabs-jump.md`, minor bump for `@opensaas/stack-ui`).

## Test plan

- [x] `pnpm test` in `packages/ui` — 526 tests passing, including new tests for select-column badge rendering via `fieldOptions` and the neutral-badge fallback without it
- [x] `tsc --noEmit` in `packages/ui` — clean
- [x] `pnpm exec eslint` on changed files — clean
- [x] Existing relationship tests (single/array/null/no-ref/no-propagation-on-click) still pass unchanged, confirming row-click/stopPropagation parity after removing the bespoke renderer

Closes #748


---
_Generated by [Claude Code](https://claude.ai/code/session_016fnuLyTj74c1NDByZvyTfv)_