### PR TITLE
fix(storage-vercel): extension-less filenames and cacheControlMaxAge: 0

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-storage-vercel': patch
+---
+
+Fix unique filename generation to use `path.extname` semantics (matching the local provider) so extension-less originals no longer get the whole name appended, and pass through an explicit `cacheControlMaxAge: 0` instead of dropping it.

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -1,6 +1,7 @@
 import { put, del, get, issueSignedToken, presignUrl, BlobNotFoundError } from '@vercel/blob'
 import type { PutCommandOptions } from '@vercel/blob'
 import { randomBytes } from 'node:crypto'
+import path from 'node:path'
 import type { StorageProvider, UploadOptions, UploadResult } from '@opensaas/stack-storage'
 
 /**
@@ -96,7 +97,7 @@ export class VercelBlobStorageProvider implements StorageProvider {
       return originalFilename
     }
 
-    const ext = originalFilename.substring(originalFilename.lastIndexOf('.'))
+    const ext = path.extname(originalFilename)
     const uniqueId = randomBytes(16).toString('hex')
     const timestamp = Date.now()
     return `${timestamp}-${uniqueId}${ext}`
@@ -196,7 +197,7 @@ export class VercelBlobStorageProvider implements StorageProvider {
       ...this.authOptions(),
     }
 
-    if (this.config.cacheControlMaxAge) {
+    if (this.config.cacheControlMaxAge !== undefined) {
       uploadOptions.cacheControlMaxAge = this.config.cacheControlMaxAge
     }
 

--- a/packages/storage-vercel/tests/vercel-blob-provider.test.ts
+++ b/packages/storage-vercel/tests/vercel-blob-provider.test.ts
@@ -250,6 +250,23 @@ describe('VercelBlobStorageProvider', () => {
       expect(resultNoExt.filename).not.toMatch(/\./)
     })
 
+    it('should generate a clean filename with no trailing fragment for extension-less originals', async () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: 'test-token',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      const result = await provider.upload(Buffer.from('test'), 'README')
+
+      expect(result.filename).toBe(`${MOCK_TIMESTAMP}-${'a'.repeat(32)}`)
+      expect(put).toHaveBeenCalledWith(
+        `${MOCK_TIMESTAMP}-${'a'.repeat(32)}`,
+        expect.any(Buffer),
+        expect.any(Object),
+      )
+    })
+
     it('should apply pathPrefix to uploaded files', async () => {
       const config: VercelBlobStorageConfig = {
         type: 'vercel-blob',
@@ -343,6 +360,38 @@ describe('VercelBlobStorageProvider', () => {
           cacheControlMaxAge: 3600,
         }),
       )
+    })
+
+    it('should apply an explicit cacheControlMaxAge of 0', async () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: 'test-token',
+        cacheControlMaxAge: 0,
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      await provider.upload(Buffer.from('test'), 'test.txt')
+
+      expect(put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Buffer),
+        expect.objectContaining({
+          cacheControlMaxAge: 0,
+        }),
+      )
+    })
+
+    it('should omit cacheControlMaxAge entirely when not configured', async () => {
+      const config: VercelBlobStorageConfig = {
+        type: 'vercel-blob',
+        token: 'test-token',
+      }
+      const provider = new VercelBlobStorageProvider(config)
+
+      await provider.upload(Buffer.from('test'), 'test.txt')
+
+      const putOptions = put.mock.calls[0][2] as Record<string, unknown>
+      expect('cacheControlMaxAge' in putOptions).toBe(false)
     })
 
     it('should include custom metadata in result', async () => {


### PR DESCRIPTION
## Summary
- Unique filename generation now uses `path.extname` semantics (matching the local storage provider), so an extension-less original like `README` produces a clean generated name with no trailing original-name fragment, while real extensions are still preserved.
- `cacheControlMaxAge: 0` is now passed through to the `@vercel/blob` `put()` call instead of being dropped by a truthiness check.
- Verified the SDK's put-options type (`PutCommandOptions`) is already imported type-only on `main`, so no change was needed there.

## Test plan
- [x] Added tests covering the extension-less filename case and the `cacheControlMaxAge: 0` case (both the explicit-zero and omitted-by-default paths)
- [x] `pnpm test` in `packages/storage-vercel` (56 passed)
- [x] `pnpm lint` passes
- [x] `pnpm build` for `@opensaas/stack-core`, `@opensaas/stack-storage`, `@opensaas/stack-storage-vercel`
- [x] Patch changeset added for `@opensaas/stack-storage-vercel`

Closes #770


---
_Generated by [Claude Code](https://claude.ai/code/session_012Vg1ySDW5c2NpX77ZxHQsP)_