### PR TITLE
fix(docs): replace lucide-react Github icon with vendored SVG

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -5,7 +5,6 @@ import {
   BookOpen,
   Bot,
   Braces,
-  Github,
   LayoutDashboard,
   ShieldCheck,
   Sparkles,
@@ -13,6 +12,7 @@ import {
   Wand2,
 } from 'lucide-react'
 import { CodeBlockServer } from '@/components/CodeBlockServer'
+import { GithubIcon } from '@/components/icons/GithubIcon'
 import { SessionSwitcher } from '@/components/landing/SessionSwitcher'
 
 const INSTALL_COMMAND = 'npm create opensaas-app@latest my-app'
@@ -157,7 +157,7 @@ export default function HomePage() {
               className="p-2 text-zinc-300 hover:text-zinc-50 transition-colors"
               aria-label="Stack on GitHub"
             >
-              <Github className="h-5 w-5" />
+              <GithubIcon className="h-5 w-5" />
             </a>
             <Link
               href="/docs/tutorials/quick-start"

--- a/docs/components/DocLayout.tsx
+++ b/docs/components/DocLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { Github } from 'lucide-react'
+import { GithubIcon } from './icons/GithubIcon'
 import { Sidebar } from './Sidebar'
 import { CopyMarkdownButton } from './CopyMarkdownButton'
 import { SearchModal } from './SearchModal'
@@ -45,7 +45,7 @@ export function DocLayout({ children, slug }: DocLayoutProps) {
                 rel="noopener noreferrer"
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
               >
-                <Github className="h-4 w-4" />
+                <GithubIcon className="h-4 w-4" />
                 GitHub
               </a>
             </nav>
@@ -73,7 +73,7 @@ export function DocLayout({ children, slug }: DocLayoutProps) {
                   rel="noopener noreferrer"
                   className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-2"
                 >
-                  <Github className="h-4 w-4" />
+                  <GithubIcon className="h-4 w-4" />
                   Edit this page on GitHub
                 </a>
               </div>

--- a/docs/components/MobileNav.tsx
+++ b/docs/components/MobileNav.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { Github, Menu, X } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
+import { GithubIcon } from './icons/GithubIcon'
 import { SidebarNav } from './Sidebar'
 
 /** Hamburger-triggered navigation drawer for viewports below `md`. */
@@ -52,7 +53,7 @@ export function MobileNav() {
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
-                <Github className="h-4 w-4" />
+                <GithubIcon className="h-4 w-4" />
                 GitHub
               </a>
             </div>

--- a/docs/components/icons/GithubIcon.tsx
+++ b/docs/components/icons/GithubIcon.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react'
+
+/**
+ * lucide-react removed brand/logo icons (including GitHub) in its v1 major release,
+ * so the GitHub mark is vendored locally instead of imported from the package.
+ */
+export function GithubIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.17-.02-2.12-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.75 2.69 1.25 3.34.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.18a10.9 10.9 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.59.23 2.76.11 3.05.73.8 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.68.8.56A10.52 10.52 0 0 0 23.5 12c0-6.35-5.15-11.5-11.5-11.5Z" />
+    </svg>
+  )
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "@opensaas/stack-rag": "workspace:*",
     "@vercel/analytics": "^2.0.1",
     "clipboard-copy": "^4.0.1",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.25.0",
     "next": "^16.2.10",
     "openai": "^6.32.0",
     "react": "^19.2.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,7 +82,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.25.0",
     "react-hook-form": "^7.71.2",
     "tailwind-merge": "^3.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       lucide-react:
-        specifier: ^0.562.0
-        version: 0.562.0(react@19.2.4)
+        specifier: ^1.25.0
+        version: 1.25.0(react@19.2.4)
       next:
         specifier: ^16.2.10
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1232,8 +1232,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       lucide-react:
-        specifier: ^0.562.0
-        version: 0.562.0(react@19.2.4)
+        specifier: ^1.25.0
+        version: 1.25.0(react@19.2.4)
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
@@ -6296,8 +6296,8 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
-  lucide-react@0.562.0:
-    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
+  lucide-react@1.25.0:
+    resolution: {integrity: sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -12999,7 +12999,7 @@ snapshots:
 
   lru.min@1.1.4: {}
 
-  lucide-react@0.562.0(react@19.2.4):
+  lucide-react@1.25.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 


### PR DESCRIPTION
## Summary

- Includes the `lucide-react` `0.562.0` → `1.25.0` bump from #791
- `lucide-react` 1.x removed brand/logo icons (including `Github`), which broke the docs Next.js build (`The export Github was not found in module ... lucide-react.mjs`)
- Vendors a local `GithubIcon` SVG component (`docs/components/icons/GithubIcon.tsx`) and swaps it in wherever the lucide `Github` icon was used: `docs/app/page.tsx`, `docs/components/DocLayout.tsx`, `docs/components/MobileNav.tsx`

## Test plan

- [x] `pnpm build` (full turbo build, including `opensaas-stack-docs`) succeeds
- [x] `pnpm -r --filter=./packages/* test` — all package test suites pass (2400+ tests)
- [x] `pnpm lint` — no new errors (pre-existing unrelated warnings only)
- [x] `pnpm format` / `pnpm manypkg fix` — no diff

Supersedes #791 (this branch is rebased on top of its commit).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5nC8GoWvNzELv1i7f8okA)_