### PR TITLE
fix(ui): strip synthetic _count from item-view details data

### DIFF
--- a/.changeset/thirty-cobras-shout.md
+++ b/.changeset/thirty-cobras-shout.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Fix Save failing on the edit page for any list with a `many: true` relationship table: strip the synthetic `_count` payload before it reaches the details form data, and harden `transformItemFormData` to drop any submitted key with no matching field.

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -104,13 +104,35 @@ export function readAccessScopedTotal(
 }
 
 /**
+ * Strip a fetched item-view record down to the details-card fields (issue
+ * #797): every Relationship-table section's field (rendered separately as a
+ * read-only table) AND the synthetic `_count` payload the fetch adds
+ * alongside the real fields (for {@link readAccessScopedTotal}'s "showing N of
+ * M" footer). Neither belongs in the details form's data — `_count` in
+ * particular is not a field of the list, so if it survived into the submit
+ * payload the server would reject the whole update.
+ */
+export function buildDetailsItemData(
+  itemData: Record<string, unknown>,
+  layout: ItemViewLayout,
+): Record<string, unknown> {
+  const detailsItemData: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(itemData)) {
+    if (key !== '_count' && !layout.sections.some((section) => section.fieldName === key)) {
+      detailsItemData[key] = value
+    }
+  }
+  return detailsItemData
+}
+
+/**
  * Edit-mode item view whose layout is DERIVED from the list shape (issue #734):
  * scalar/to-one fields (and picker-demoted relationships) in a details card
  * with the existing whole-form Save/Cancel, and each to-many relationship as a
  * read-only Relationship table. The arrangement follows from the number of
  * tables — one → two-column split, several → stacked.
  */
-async function ItemViewLayoutView({
+export async function ItemViewLayoutView({
   context,
   config,
   listConfig,
@@ -191,12 +213,7 @@ async function ItemViewLayoutView({
     ...listConfig,
     fields: Object.fromEntries(detailsFieldEntries),
   }
-  const detailsItemData: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(itemData)) {
-    if (!layout.sections.some((section) => section.fieldName === key)) {
-      detailsItemData[key] = value
-    }
-  }
+  const detailsItemData = buildDetailsItemData(itemData, layout)
 
   const { serializableFields, initialData, relationshipData } = await prepareItemForm(
     context,

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -132,7 +132,7 @@ export function buildDetailsItemData(
  * read-only Relationship table. The arrangement follows from the number of
  * tables — one → two-column split, several → stacked.
  */
-export async function ItemViewLayoutView({
+async function ItemViewLayoutView({
   context,
   config,
   listConfig,

--- a/packages/ui/src/lib/useItemForm.ts
+++ b/packages/ui/src/lib/useItemForm.ts
@@ -18,6 +18,8 @@ const SYSTEM_FIELDS = ['id', 'createdAt', 'updatedAt']
  * it testable without rendering a component.
  *
  * Behaviour (the superset applied by all forms):
+ * - Keys with no corresponding entry in `fields` are dropped (defense-in-depth:
+ *   guards against a non-field key like `_count` reaching the submit payload).
  * - Relationship fields are converted to Prisma `connect` shape (single or many).
  *   Empty single relationships and empty many-arrays are omitted.
  * - Password fields whose value is an `{ isSet }` sentinel (an unchanged password
@@ -33,13 +35,16 @@ export function transformItemFormData(
 
   for (const [fieldName, value] of Object.entries(formData)) {
     const fieldConfig = fields[fieldName]
+    if (!fieldConfig) {
+      continue
+    }
 
     // Skip password fields carrying an { isSet } sentinel (unchanged password).
     if (typeof value === 'object' && value !== null && 'isSet' in value) {
       continue
     }
 
-    if (fieldConfig?.type === 'relationship') {
+    if (fieldConfig.type === 'relationship') {
       if (fieldConfig.many) {
         if (Array.isArray(value) && value.length > 0) {
           transformed[fieldName] = { connect: value.map((id: string) => ({ id })) }

--- a/packages/ui/tests/components/ItemFormCountStrip.test.tsx
+++ b/packages/ui/tests/components/ItemFormCountStrip.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { buildDetailsItemData } from '../../src/components/ItemForm.js'
+import { prepareItemForm } from '../../src/lib/prepareItemForm.js'
+import { transformItemFormData } from '../../src/lib/useItemForm.js'
+import { deriveItemViewLayout } from '../../src/lib/deriveItemView.js'
+
+/**
+ * Regression coverage for issue #797: the derived item view (issue #734/#752)
+ * adds a synthetic `_count` select to the record fetch (for the Relationship
+ * table's "Showing N of M" footer) alongside the real fields. Before this fix,
+ * that `_count` key rode through `detailsItemData` -> `prepareItemForm` ->
+ * `transformItemFormData` and ended up in every update payload, which the
+ * server rejected ("it is not a field of this list") — Save silently failed
+ * on the edit page for ANY list with a `many: true` relationship rendered as
+ * a table (the default item-view display mode).
+ *
+ * This threads the real fetch -> details-data -> submit-transform pipeline
+ * `ItemViewLayoutView` runs (`buildDetailsItemData` -> `prepareItemForm` ->
+ * `transformItemFormData`), the same functions the component calls, without
+ * needing to render the async Relationship-table server components (not
+ * supported by this test environment's React DOM renderer).
+ */
+
+interface DelegateStub {
+  findMany?: (args?: unknown) => Promise<Array<Record<string, unknown>>>
+  findFirst?: (args?: unknown) => Promise<Record<string, unknown> | null>
+}
+
+function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  // Cast: this is a stub for pipeline tests, not a full Prisma-backed context.
+  return context as unknown as AccessContext<unknown>
+}
+
+/**
+ * A list with a `many: true` relationship in the default (table) item-view
+ * display mode — the shape that makes `deriveItemViewLayout` produce a
+ * Relationship-table section and routes the edit page through
+ * `ItemViewLayoutView`.
+ */
+function makeConfig(): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite', url: 'file:./test.db' },
+    lists: {
+      Post: {
+        fields: {
+          title: { type: 'text' },
+          comments: { type: 'relationship', ref: 'Comment.post', many: true },
+        },
+        access: { operation: { query: () => true, update: () => true } },
+      },
+      Comment: {
+        fields: {
+          body: { type: 'text' },
+          post: { type: 'relationship', ref: 'Post.comments' },
+        },
+        access: { operation: { query: () => true } },
+      },
+    },
+  } as unknown as OpenSaasConfig
+}
+
+describe('ItemForm derived item-view pipeline (issue #797 regression)', () => {
+  it('never lets the synthetic `_count` payload survive fetch -> details data -> submit transform', async () => {
+    const config = makeConfig()
+    const layout = deriveItemViewLayout(config, 'Post')
+    expect(layout.sections).toHaveLength(1) // sanity: the to-many relationship became a table section
+
+    const context = makeContext({})
+
+    // The record `ItemViewLayoutView` fetches: the real fields, the bounded
+    // relationship rows, AND the synthetic `_count` the fetch adds for the
+    // table footer (built by `buildRelationshipCountSelect`).
+    const itemData = {
+      id: '1',
+      title: 'Hello',
+      comments: [{ id: 'c1', body: 'Nice post' }],
+      _count: { comments: 5 },
+    }
+
+    const detailsItemData = buildDetailsItemData(itemData, layout)
+    expect(detailsItemData).not.toHaveProperty('_count')
+    expect(detailsItemData).not.toHaveProperty('comments') // section field, not a details field
+    expect(detailsItemData).toEqual({ id: '1', title: 'Hello' })
+
+    const detailsListConfig = {
+      ...config.lists.Post,
+      fields: Object.fromEntries(
+        layout.detailsFields.map((fieldName) => [fieldName, config.lists.Post.fields[fieldName]]),
+      ),
+    }
+
+    const { serializableFields, initialData } = await prepareItemForm(
+      context,
+      config,
+      detailsListConfig,
+      detailsItemData,
+    )
+
+    // Simulate an unmodified Save: the client form state starts as `initialData`.
+    const submitted = transformItemFormData(serializableFields, initialData)
+
+    expect(submitted).not.toHaveProperty('_count')
+    expect(submitted).toEqual({ title: 'Hello' })
+  })
+
+  it('drops `_count` even if it somehow survived into the form fields map (hardening)', () => {
+    // Defense-in-depth: even if a future regression let `_count` leak into
+    // `detailsItemData`, `transformItemFormData` drops any key absent from the
+    // fields map, so it still cannot reach the update payload.
+    const fields = { title: { type: 'text' } }
+    const formData = { title: 'Hello', _count: { comments: 5 } }
+    expect(transformItemFormData(fields, formData)).toEqual({ title: 'Hello' })
+  })
+})

--- a/packages/ui/tests/lib/useItemForm.test.ts
+++ b/packages/ui/tests/lib/useItemForm.test.ts
@@ -53,6 +53,13 @@ describe('transformItemFormData', () => {
     expect(transformItemFormData(fields, { password: 'secret' })).toEqual({ password: 'secret' })
   })
 
+  it('drops a key with no corresponding field config (e.g. a synthetic `_count`)', () => {
+    const fields = { title: text() }
+    expect(transformItemFormData(fields, { title: 'Hi', _count: { comments: 3 } })).toEqual({
+      title: 'Hi',
+    })
+  })
+
   it('handles a mixed payload end-to-end', () => {
     const fields = {
       title: text(),


### PR DESCRIPTION
## Summary

- The derived item view's record fetch (`ItemViewLayoutView` in `ItemForm.tsx`) adds a synthetic `_count` select alongside the real fields, for the Relationship table's "Showing N of M" footer. That key was never stripped before the record was split into "details form data," so it rode through `prepareItemForm` → `ItemFormClient` → `useItemForm`'s `transformItemFormData` and ended up as a raw key in every update payload — which the server correctly rejected (`Cannot update "_count": it is not a field of this list`), silently breaking Save on the edit page for any list with at least one non-`picker`-mode to-many relationship field.
- **Direct fix**: extracted the details-data filtering into a new exported `buildDetailsItemData(itemData, layout)` helper that excludes both the section fields and `_count`, so `_count` never reaches `detailsItemData`/`initialData`/client form state.
- **Hardening (defense-in-depth)**: `transformItemFormData` (`useItemForm.ts`) now drops any key from `formData` that has no corresponding entry in the `fields` map it's given, turning any future non-field key that reaches this boundary into a silent no-op removal instead of a full save failure.

## Test plan

- [x] Unit test: `transformItemFormData` drops a bogus non-field key (`_count`) from the submit payload.
- [x] Regression test threading the real `buildDetailsItemData` → `prepareItemForm` → `transformItemFormData` pipeline for a list with a `many: true` relationship table, asserting `_count` never survives into the final submit payload (reproduces the original failure prior to the fix).
- [x] Existing `picker`-mode item-view tests pass unchanged (no regression).
- [x] `pnpm test` (full `@opensaas/stack-ui` suite — 529 tests) passes.
- [x] `pnpm build` (typecheck) passes.
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` run clean.
- [x] Changeset added (patch — bug fix).

Closes #797


---
_Generated by [Claude Code](https://claude.ai/code/session_01V8boyfgPM1q3xt9m2VHKMx)_