### PR TITLE
feat(storage): support pathname/contentType extras in file() multi-column mode

### DIFF
--- a/.changeset/tall-otters-jump.md
+++ b/.changeset/tall-otters-jump.md
@@ -1,0 +1,24 @@
+---
+'@opensaas/stack-storage': minor
+---
+
+Add `pathname` and `contentType` as optional extra columns for `file()`'s `db.columns: 'keystone'` multi-column mode, matching the parts `image()`'s multi-column mode already supports.
+
+By default, multi-column `file()` fields still emit exactly the same three columns as before (`filename`/`filesize`/`url`) — no changes for existing configs. To opt into the extras (e.g. for a legacy Keystone `file` field that content-sniffs a MIME type or stores a storage-provider pathname), pass `parts`:
+
+```typescript
+import { file } from '@opensaas/stack-storage/fields'
+import { FILE_COLUMN_PARTS } from '@opensaas/stack-storage'
+
+resume: file({
+  storage: 'documents',
+  db: {
+    columns: {
+      mode: 'keystone',
+      parts: FILE_COLUMN_PARTS, // all five: filename, filesize, url, pathname, contentType
+    },
+  },
+})
+```
+
+The two extras round-trip through `FileMetadata.metadata.pathname` / `FileMetadata.metadata.contentType`, the same way `image()`'s `contentDisposition` round-trips through `ImageMetadata.metadata`.

--- a/packages/storage/src/fields/index.ts
+++ b/packages/storage/src/fields/index.ts
@@ -10,6 +10,7 @@ import type { FileValidationOptions } from '../utils/upload.js'
 import {
   assembleFileMetadata,
   assembleImageMetadata,
+  DEFAULT_FILE_COLUMN_PARTS,
   fileColumnDescriptors,
   fileColumnNames,
   imageColumnDescriptors,
@@ -19,6 +20,7 @@ import {
   splitFileMetadata,
   splitImageMetadata,
   type FileColumnMap,
+  type FileColumnPart,
   type ImageColumnMap,
 } from '../utils/multi-column.js'
 
@@ -61,8 +63,15 @@ export interface FileDbConfig {
    * Enable multi-column mode by setting `'keystone'`. Per-part column-name
    * overrides may be supplied; any omitted part falls back to the Keystone
    * default `<field>_<part>`.
+   *
+   * By default only `filename`/`filesize`/`url` are emitted. Pass `parts` to
+   * additionally opt into the `pathname`/`contentType` Keystone-parity
+   * extras (e.g. `parts: FILE_COLUMN_PARTS` for all five, or a custom subset)
+   * — see {@link FILE_COLUMN_PARTS} / {@link DEFAULT_FILE_COLUMN_PARTS}.
    */
-  columns?: 'keystone' | { mode: 'keystone'; map?: Partial<FileColumnMap> }
+  columns?:
+    | 'keystone'
+    | { mode: 'keystone'; map?: Partial<FileColumnMap>; parts?: readonly FileColumnPart[] }
 }
 
 /** Whether a field-level `db.columns` option requests multi-column mode. */
@@ -79,6 +88,11 @@ function imageColumnOverrides(
 
 function fileColumnOverrides(columns: FileDbConfig['columns']): Partial<FileColumnMap> | undefined {
   return typeof columns === 'object' ? columns.map : undefined
+}
+
+/** The file parts a field-level `db.columns` option opts into (defaults to the base three). */
+function fileColumnPartsFor(columns: FileDbConfig['columns']): readonly FileColumnPart[] {
+  return typeof columns === 'object' && columns.parts ? columns.parts : DEFAULT_FILE_COLUMN_PARTS
 }
 
 /**
@@ -206,6 +220,7 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
   const multiColumn = isMultiColumn(options.db?.columns)
   const columnMapFor = (fieldName: string): FileColumnMap =>
     resolveFileColumnMap(fieldName, fileColumnOverrides(options.db?.columns))
+  const fileParts: readonly FileColumnPart[] = fileColumnPartsFor(options.db?.columns)
 
   const fieldConfig: FileFieldConfig<TTypeInfo> = {
     type: 'file',
@@ -338,7 +353,7 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
   if (multiColumn) {
     fieldConfig.getPrismaColumns = (fieldName: string): MultiColumnPrismaResult[] => {
       const map = columnMapFor(fieldName)
-      return fileColumnDescriptors(map).map((col) => ({
+      return fileColumnDescriptors(map, fileParts).map((col) => ({
         name: col.name,
         type: col.type,
         modifiers: '?',
@@ -346,11 +361,11 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
       }))
     }
     fieldConfig.getColumnNames = (fieldName: string): string[] =>
-      fileColumnNames(columnMapFor(fieldName))
+      fileColumnNames(columnMapFor(fieldName), fileParts)
     fieldConfig.assembleColumns = (fieldName: string, row: Record<string, unknown>): unknown =>
-      assembleFileMetadata(row, columnMapFor(fieldName), fieldConfig.storage)
+      assembleFileMetadata(row, columnMapFor(fieldName), fieldConfig.storage, fileParts)
     fieldConfig.splitColumns = (fieldName: string, value: unknown): Record<string, unknown> =>
-      splitFileMetadata((value ?? null) as FileMetadata | null, columnMapFor(fieldName))
+      splitFileMetadata((value ?? null) as FileMetadata | null, columnMapFor(fieldName), fileParts)
   }
 
   return fieldConfig

--- a/packages/storage/src/utils/multi-column.ts
+++ b/packages/storage/src/utils/multi-column.ts
@@ -22,9 +22,14 @@ export type ImageColumnPart =
   'url' | 'width' | 'height' | 'filesize' | 'contentType' | 'contentDisposition' | 'pathname'
 
 /**
- * The logical "parts" of a Keystone file field.
+ * The logical "parts" of a Keystone file field. `pathname` and `contentType`
+ * are optional Keystone-parity extras (mirroring the equivalent `image()`
+ * parts) for projects whose legacy `file` field emits extra columns — e.g. a
+ * content-sniffed MIME type distinct from the public `url`, or a storage
+ * provider's blob pathname. They are not emitted unless explicitly opted into
+ * (see {@link DEFAULT_FILE_COLUMN_PARTS}).
  */
-export type FileColumnPart = 'filename' | 'filesize' | 'url'
+export type FileColumnPart = 'filename' | 'filesize' | 'url' | 'pathname' | 'contentType'
 
 /** Ordered list of image parts, matching Keystone's column layout. */
 export const IMAGE_COLUMN_PARTS: readonly ImageColumnPart[] = [
@@ -37,8 +42,27 @@ export const IMAGE_COLUMN_PARTS: readonly ImageColumnPart[] = [
   'pathname',
 ] as const
 
-/** Ordered list of file parts, matching Keystone's column layout. */
-export const FILE_COLUMN_PARTS: readonly FileColumnPart[] = ['filename', 'filesize', 'url'] as const
+/** Ordered list of every file part multi-column mode can emit. */
+export const FILE_COLUMN_PARTS: readonly FileColumnPart[] = [
+  'filename',
+  'filesize',
+  'url',
+  'pathname',
+  'contentType',
+] as const
+
+/**
+ * The file parts emitted by default (unchanged since multi-column mode was
+ * introduced). `pathname` and `contentType` are additive-only extras — a
+ * field must explicitly opt into them via `db.columns.parts` to emit those
+ * columns, so existing multi-column `file()` configs keep their exact
+ * three-column shape.
+ */
+export const DEFAULT_FILE_COLUMN_PARTS: readonly FileColumnPart[] = [
+  'filename',
+  'filesize',
+  'url',
+] as const
 
 /** The Prisma scalar type each image part is stored as. */
 const IMAGE_PART_PRISMA_TYPE: Record<ImageColumnPart, 'String' | 'Int'> = {
@@ -56,6 +80,8 @@ const FILE_PART_PRISMA_TYPE: Record<FileColumnPart, 'String' | 'Int'> = {
   filename: 'String',
   filesize: 'Int',
   url: 'String',
+  pathname: 'String',
+  contentType: 'String',
 }
 
 /**
@@ -107,6 +133,8 @@ export function keystoneFileColumnMap(fieldName: string): FileColumnMap {
     filename: `${fieldName}_filename`,
     filesize: `${fieldName}_filesize`,
     url: `${fieldName}_url`,
+    pathname: `${fieldName}_pathname`,
+    contentType: `${fieldName}_contentType`,
   }
 }
 
@@ -160,9 +188,15 @@ export function imageColumnDescriptors(map: ImageColumnMap): MultiColumnDescript
 
 /**
  * Describe the physical columns a file field emits in multi-column mode.
+ * `parts` defaults to {@link DEFAULT_FILE_COLUMN_PARTS} — pass
+ * {@link FILE_COLUMN_PARTS} (or a custom subset) to opt into the
+ * `pathname`/`contentType` Keystone-parity extras.
  */
-export function fileColumnDescriptors(map: FileColumnMap): MultiColumnDescriptor[] {
-  return FILE_COLUMN_PARTS.map((part) => ({
+export function fileColumnDescriptors(
+  map: FileColumnMap,
+  parts: readonly FileColumnPart[] = DEFAULT_FILE_COLUMN_PARTS,
+): MultiColumnDescriptor[] {
+  return parts.map((part) => ({
     name: filePartFieldName(map, part),
     type: FILE_PART_PRISMA_TYPE[part],
     map: map[part],
@@ -174,9 +208,16 @@ export function imageColumnNames(map: ImageColumnMap): string[] {
   return IMAGE_COLUMN_PARTS.map((part) => imagePartFieldName(map, part))
 }
 
-/** The physical column field names a file field owns (for read stripping). */
-export function fileColumnNames(map: FileColumnMap): string[] {
-  return FILE_COLUMN_PARTS.map((part) => filePartFieldName(map, part))
+/**
+ * The physical column field names a file field owns (for read stripping).
+ * `parts` defaults to {@link DEFAULT_FILE_COLUMN_PARTS}, matching
+ * {@link fileColumnDescriptors}.
+ */
+export function fileColumnNames(
+  map: FileColumnMap,
+  parts: readonly FileColumnPart[] = DEFAULT_FILE_COLUMN_PARTS,
+): string[] {
+  return parts.map((part) => filePartFieldName(map, part))
 }
 
 /** Coerce an unknown column value to a string, or `null` when absent/empty. */
@@ -289,11 +330,20 @@ export function splitImageMetadata(
 /**
  * Assemble the per-part file columns from a database row into a
  * {@link FileMetadata}. Returns `null` when no file is present.
+ *
+ * `parts` defaults to {@link DEFAULT_FILE_COLUMN_PARTS}. When the optional
+ * `pathname`/`contentType` extras are included, their column values are
+ * preserved via `metadata.metadata.pathname` / `metadata.metadata.contentType`
+ * — mirroring how {@link assembleImageMetadata} round-trips
+ * `contentDisposition` — since neither is a native top-level `FileMetadata`
+ * field (unlike `image()`, `file()`'s `mimeType` is not sourced from a
+ * multi-column part).
  */
 export function assembleFileMetadata(
   row: Record<string, unknown>,
   map: FileColumnMap,
   storageProvider: string,
+  parts: readonly FileColumnPart[] = DEFAULT_FILE_COLUMN_PARTS,
 ): FileMetadata | null {
   const url = asString(row[map.url])
   const filename = asString(row[map.filename])
@@ -305,7 +355,7 @@ export function assembleFileMetadata(
 
   const resolvedFilename = filename ?? url ?? ''
 
-  return {
+  const metadata: FileMetadata = {
     filename: resolvedFilename,
     originalFilename: resolvedFilename,
     url: url ?? '',
@@ -314,27 +364,65 @@ export function assembleFileMetadata(
     uploadedAt: '',
     storageProvider,
   }
+
+  const extra: Record<string, string> = {}
+  if (parts.includes('pathname')) {
+    const pathname = asString(row[map.pathname])
+    if (pathname !== null) extra.pathname = pathname
+  }
+  if (parts.includes('contentType')) {
+    const contentType = asString(row[map.contentType])
+    if (contentType !== null) extra.contentType = contentType
+  }
+  if (Object.keys(extra).length > 0) {
+    metadata.metadata = extra
+  }
+
+  return metadata
 }
 
 /**
  * Split a {@link FileMetadata} (or `null`) back into the per-part file columns
  * for writing. A `null`/`undefined` metadata clears every column.
+ *
+ * `parts` defaults to {@link DEFAULT_FILE_COLUMN_PARTS}. When the optional
+ * `pathname`/`contentType` extras are included, their values are read from
+ * `metadata.metadata.pathname` / `metadata.metadata.contentType` (falling
+ * back to `null`, clearing the column, when absent).
  */
 export function splitFileMetadata(
   metadata: FileMetadata | null | undefined,
   map: FileColumnMap,
+  parts: readonly FileColumnPart[] = DEFAULT_FILE_COLUMN_PARTS,
 ): Record<string, string | number | null> {
+  const columns: Record<string, string | number | null> = {
+    [map.filename]: null,
+    [map.filesize]: null,
+    [map.url]: null,
+  }
+  if (parts.includes('pathname')) columns[map.pathname] = null
+  if (parts.includes('contentType')) columns[map.contentType] = null
+
   if (metadata === null || metadata === undefined) {
-    return {
-      [map.filename]: null,
-      [map.filesize]: null,
-      [map.url]: null,
-    }
+    return columns
   }
 
-  return {
-    [map.filename]: metadata.filename ?? null,
-    [map.filesize]: metadata.size ?? null,
-    [map.url]: metadata.url ?? null,
+  columns[map.filename] = metadata.filename ?? null
+  columns[map.filesize] = metadata.size ?? null
+  columns[map.url] = metadata.url ?? null
+
+  if (parts.includes('pathname')) {
+    columns[map.pathname] =
+      metadata.metadata && typeof metadata.metadata.pathname === 'string'
+        ? metadata.metadata.pathname
+        : null
   }
+  if (parts.includes('contentType')) {
+    columns[map.contentType] =
+      metadata.metadata && typeof metadata.metadata.contentType === 'string'
+        ? metadata.metadata.contentType
+        : null
+  }
+
+  return columns
 }

--- a/packages/storage/tests/multi-column.test.ts
+++ b/packages/storage/tests/multi-column.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   IMAGE_COLUMN_PARTS,
   FILE_COLUMN_PARTS,
+  DEFAULT_FILE_COLUMN_PARTS,
   keystoneImageColumnMap,
   keystoneFileColumnMap,
   resolveImageColumnMap,
@@ -36,6 +37,8 @@ describe('multi-column mapper', () => {
         filename: 'doc_filename',
         filesize: 'doc_filesize',
         url: 'doc_url',
+        pathname: 'doc_pathname',
+        contentType: 'doc_contentType',
       })
     })
 
@@ -78,9 +81,24 @@ describe('multi-column mapper', () => {
       expect(byName.image_contentType).toBe('String')
     })
 
-    it('emits three file columns with @map names', () => {
+    it('emits three file columns by default (no regression)', () => {
       const descriptors = fileColumnDescriptors(keystoneFileColumnMap('doc'))
       expect(descriptors.map((d) => d.map)).toEqual(['doc_filename', 'doc_filesize', 'doc_url'])
+    })
+
+    it('opts into pathname/contentType extras via an explicit parts list', () => {
+      const map = keystoneFileColumnMap('doc')
+      const descriptors = fileColumnDescriptors(map, FILE_COLUMN_PARTS)
+      expect(descriptors.map((d) => d.map)).toEqual([
+        'doc_filename',
+        'doc_filesize',
+        'doc_url',
+        'doc_pathname',
+        'doc_contentType',
+      ])
+      const byName = Object.fromEntries(descriptors.map((d) => [d.map, d.type]))
+      expect(byName.doc_pathname).toBe('String')
+      expect(byName.doc_contentType).toBe('String')
     })
 
     it('lists column names for read stripping', () => {
@@ -90,8 +108,13 @@ describe('multi-column mapper', () => {
         'doc_filesize',
         'doc_url',
       ])
+      expect(fileColumnNames(keystoneFileColumnMap('doc'), ['pathname', 'contentType'])).toEqual([
+        'doc_pathname',
+        'doc_contentType',
+      ])
       expect(IMAGE_COLUMN_PARTS).toHaveLength(7)
-      expect(FILE_COLUMN_PARTS).toHaveLength(3)
+      expect(FILE_COLUMN_PARTS).toHaveLength(5)
+      expect(DEFAULT_FILE_COLUMN_PARTS).toEqual(['filename', 'filesize', 'url'])
     })
   })
 
@@ -259,6 +282,128 @@ describe('multi-column mapper', () => {
         doc_filesize: null,
         doc_url: null,
       })
+    })
+
+    it('does not read/write pathname/contentType columns when not opted in', () => {
+      const row = {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+        doc_pathname: 'blobs/report.pdf',
+        doc_contentType: 'application/pdf',
+      }
+      const meta = assembleFileMetadata(row, map, 'documents')
+      expect(meta?.metadata).toBeUndefined()
+      expect(splitFileMetadata(meta, map)).toEqual({
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+      })
+    })
+  })
+
+  describe('file pathname/contentType extras (opt-in)', () => {
+    const map = keystoneFileColumnMap('doc')
+    const parts = FILE_COLUMN_PARTS
+
+    it('assembles pathname/contentType columns into metadata.metadata', () => {
+      const row = {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+        doc_pathname: 'blobs/report.pdf',
+        doc_contentType: 'application/pdf',
+      }
+      const meta = assembleFileMetadata(row, map, 'documents', parts)
+      expect(meta).toEqual({
+        filename: 'report.pdf',
+        originalFilename: 'report.pdf',
+        url: 'https://cdn/report.pdf',
+        mimeType: 'application/octet-stream',
+        size: 4096,
+        uploadedAt: '',
+        storageProvider: 'documents',
+        metadata: { pathname: 'blobs/report.pdf', contentType: 'application/pdf' },
+      })
+    })
+
+    it('round-trips columns → metadata → columns with the extras included', () => {
+      const row = {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+        doc_pathname: 'blobs/report.pdf',
+        doc_contentType: 'application/pdf',
+      }
+      const meta = assembleFileMetadata(row, map, 'documents', parts)
+      expect(splitFileMetadata(meta, map, parts)).toEqual(row)
+    })
+
+    it('assembles with only one extra present (contentType absent from metadata)', () => {
+      const meta = assembleFileMetadata(
+        {
+          doc_filename: 'report.pdf',
+          doc_filesize: 4096,
+          doc_url: 'https://cdn/report.pdf',
+          doc_pathname: 'blobs/report.pdf',
+        },
+        map,
+        'documents',
+        parts,
+      )
+      expect(meta?.metadata).toEqual({ pathname: 'blobs/report.pdf' })
+    })
+
+    it('assembles with neither extra present — no metadata bag at all', () => {
+      const meta = assembleFileMetadata(
+        { doc_filename: 'report.pdf', doc_filesize: 4096, doc_url: 'https://cdn/report.pdf' },
+        map,
+        'documents',
+        parts,
+      )
+      expect(meta?.metadata).toBeUndefined()
+    })
+
+    it('splits a FileMetadata without the extras into null columns (clearing them)', () => {
+      const meta = assembleFileMetadata(
+        { doc_filename: 'report.pdf', doc_filesize: 4096, doc_url: 'https://cdn/report.pdf' },
+        map,
+        'documents',
+      )
+      expect(splitFileMetadata(meta, map, parts)).toEqual({
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+        doc_pathname: null,
+        doc_contentType: null,
+      })
+    })
+
+    it('splits null metadata into all-null columns including the extras', () => {
+      expect(splitFileMetadata(null, map, parts)).toEqual({
+        doc_filename: null,
+        doc_filesize: null,
+        doc_url: null,
+        doc_pathname: null,
+        doc_contentType: null,
+      })
+    })
+
+    it('honours per-part @map overrides for the extras', () => {
+      const custom = resolveFileColumnMap('doc', { pathname: 'doc_blob_path' })
+      const row = {
+        doc_filename: 'report.pdf',
+        doc_filesize: 4096,
+        doc_url: 'https://cdn/report.pdf',
+        doc_blob_path: 'blobs/report.pdf',
+        doc_contentType: 'application/pdf',
+      }
+      const meta = assembleFileMetadata(row, custom, 'documents', parts)
+      expect(meta?.metadata).toEqual({
+        pathname: 'blobs/report.pdf',
+        contentType: 'application/pdf',
+      })
+      expect(splitFileMetadata(meta, custom, parts)).toEqual(row)
     })
   })
 


### PR DESCRIPTION
## Summary
- Extends `file()`'s `db.columns: 'keystone'` multi-column mode with two new optional column parts, `pathname` and `contentType`, mirroring the parts `image()`'s multi-column mode already supports (`ImageColumnPart`'s seven-part union).
- Opt in per-field via `db.columns.parts` (e.g. `parts: FILE_COLUMN_PARTS` for all five, or a custom subset). Without it, multi-column `file()` fields keep emitting exactly the same three columns (`filename`/`filesize`/`url`) with the same default `<field>_<part>` names as before — no regression for existing configs.
- Per-part `@map` overrides continue to work for the new parts via the existing `db.columns.map` mechanism.
- `pathname`/`contentType` round-trip through `FileMetadata.metadata.pathname` / `FileMetadata.metadata.contentType`, the same way `image()`'s `contentDisposition` round-trips through `ImageMetadata.metadata` — neither is a native top-level `FileMetadata` field.
- Unexported `DEFAULT_FILE_COLUMN_PARTS` (the three-part default) and widened `FILE_COLUMN_PARTS` (all five) are exported from `@opensaas/stack-storage`/`@opensaas/stack-storage/fields` for configuring `parts`.

## Test plan
- [x] Added unit tests in `packages/storage/tests/multi-column.test.ts` covering: default (3-column, no-regression) behavior, opting into the extras via `parts`, per-part `@map` overrides for the extras, assemble/split round-trips with one/both/neither extra present, and null-clearing writes — mirroring the existing `image()` `contentDisposition` coverage.
- [x] `pnpm test` in `packages/storage` — 167 passed (8 files)
- [x] `pnpm build` in `packages/core` and `packages/storage` (typecheck)
- [x] `pnpm lint` (repo root) — clean (only pre-existing, unrelated warnings)
- [x] `pnpm format` / `pnpm manypkg fix` (repo root)
- [x] Changeset added (`@opensaas/stack-storage`: minor)

Closes #815


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyYAvWo4YpCF9EqSdFTUiC)_