### PR TITLE
docs: record admin chrome slot decision (ADR-0021)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -142,6 +142,14 @@ _Avoid_: CSS hook, part, element selector
 The persistent shell the admin UI wraps around list and item content — navigation, page headers, user menu, dashboard framing.
 _Avoid_: layout, shell, frame
 
+**Chrome slot**:
+The seam through which a host application supplies its own Admin chrome, replacing the built-in sidebar wholesale while the admin keeps ownership of routing, the page shell, and content rendering. Supplied at the mount site, never through config — host navigation is the host's routing, not shared schema, and config cannot carry React icons (ADR-0021).
+_Avoid_: custom nav, chrome override, sidebar prop
+
+**Nav item**:
+One entry in the Admin chrome's sidebar. Built-in items are derived from the config's lists and singletons; host-supplied items are contributed through the Chrome slot's children region and render with the same active state, icon slot, count badge, and Slot contract as built-in ones.
+_Avoid_: nav link (that's the component), menu entry, sidebar item
+
 **Filter builder**:
 The list view's single query input that turns a typed query into scoped, server-executed filtering. Filter state lives in the URL, so a filtered view is shareable and survives refresh; filtering always runs through the secured context so access control is never bypassed.
 _Avoid_: search bar (that's the free-text subset), query builder

--- a/docs/adr/0021-admin-chrome-is-a-replaceable-slot.md
+++ b/docs/adr/0021-admin-chrome-is-a-replaceable-slot.md
@@ -1,0 +1,19 @@
+# Admin chrome is a replaceable slot; nav entries live at the mount site
+
+`AdminUI` rendered its sidebar unconditionally, so an app mounting the admin at a sub-path beside its own bespoke admin had no way to link back out — and no way to supply chrome of its own short of reimplementing `AdminUI`'s routing (URL-segment parsing, the singleton redirect, per-route Suspense skeletons, theme compilation, nav-count resolution). We decided the Admin chrome is a **replaceable slot**: `AdminUI` accepts a `navigation` node that replaces the built-in sidebar wholesale while `AdminUI` keeps routing and the shell, `Navigation` accepts `children` in a dedicated region below its list and singleton groups, and `NavLink` becomes public so host entries carry the same active state, icon slot, count badge, and `data-slot` contract as built-in ones. A `navItems` array on `AdminUI` is sugar over that same children region for the common "add one link" case. Nav entries are supplied at the **mount site**, never through `UIConfig`.
+
+## Considered Options
+
+- **A narrow `navItems`-only extension point**: smallest surface and covers the filed request, but leaves ADR-0016's "compose your own pages" rung unreachable for chrome — the ladder's top rung assumes composition is available, and for the sidebar it wasn't.
+- **A content-only `chrome={false}` mode**: maximum freedom, but a blunt boolean that can't express "my sidebar, your layout", and it pushes the shell and scroll container onto every host.
+- **Splitting into `AdminChrome` + `AdminContent`**: architecturally cleanest, but a second public component whose props contract every future routing change must stay compatible with.
+- **A render-prop or component-type `navigation`** that receives `AdminUI`'s already-resolved `currentPath`/`navCounts`: avoids the host re-resolving them, at the cost of a function or component prop crossing a server-component boundary and a wider contract to keep stable. Rejected in favour of a plain node plus public helpers (`resolveNavCounts`, and an exported derivation of `currentPath` from route params so that rule keeps one owner).
+- **Config-level nav entries under `UIConfig`**: rejected. `UIConfig` lives in `@opensaas/stack-core`, which must not import React, so config-borne icons could only ever be name strings resolved through a second registry. Host links are also routing owned by the host application, not schema that belongs in shared config.
+
+## Consequences
+
+- This does **not** reopen ADR-0016. The line is: chrome may be replaced wholesale at the mount site; components _inside_ the built-in chrome still may not be swapped. "Can I swap the Button inside `AdminUI`?" remains no.
+- `NavLink` joins the public API, so its props and its `data-slot="nav-link"` handle become a compatibility promise. `active` and `icon` are optional (`active` defaults to `false`, correct for links leaving the mount; an icon-less entry still reserves the icon box so labels align).
+- `navigation` and `navItems` cannot merge — the slot is a prebuilt node — so the slot wins and `navItems` is ignored with a development-only warning. Both props absent reproduces today's rendering exactly.
+- Host-owned chrome resolves its own access-scoped counts; `AdminUI` skips `resolveNavCounts` when the slot is supplied, so the queries aren't paid twice.
+- The `navCount` precedent (per-list opt-in in list config) still stands for the admin's _own_ lists. That is list configuration; host links are not.


### PR DESCRIPTION
Docs-only. Records the design decision reached while triaging #823, so the implementation work has a settled contract to build against.

## What's here

- **`docs/adr/0021-admin-chrome-is-a-replaceable-slot.md`** — the Admin chrome becomes a replaceable slot on `AdminUI`, `Navigation` gains a children region, and `NavLink` joins the public API. Nav entries are supplied at the mount site rather than through `UIConfig`. Records the rejected alternatives too: a `navItems`-only extension point, a content-only `chrome={false}` mode, an `AdminChrome`/`AdminContent` split, a render-prop slot, and config-level entries.
- **`CONTEXT.md`** — glossary entries for **Chrome slot** and **Nav item** under the Admin UI section.

## Why it went wider than the issue asked

#823 requested a `navItems` prop. `Navigation`, `ListView`, `ItemForm` and friends are already exported, but `AdminUI` renders its sidebar unconditionally and nothing exposes "just the routed content" — so ADR-0016's "compose your own pages" rung was unreachable for chrome. The slot closes that gap; `navItems` still ships, as sugar over the same children region.

Config-level entries (the issue's third option) are rejected: `UIConfig` lives in `@opensaas/stack-core`, which must not import React, so config-borne icons could only ever be name strings resolved through a second registry. Host links are also the host's routing, not shared schema.

## Relationship to ADR-0016

ADR-0021 does not reopen it. The line it draws: chrome may be replaced wholesale at the mount site; components *inside* the built-in chrome still may not be swapped. "Can I swap the Button inside `AdminUI`?" remains no.

## Notes

- No changeset — nothing under `packages/*` changes.
- No implementation here. The `packages/ui` work is specified in the agent brief on #823, which is now `ready-for-agent`.

Refs #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WT2mUmH6fcoPdg6HZLZiET

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT2mUmH6fcoPdg6HZLZiET)_