### PR TITLE
fix(e2e): derive relationship-count spec slugs per-attempt

### DIFF
--- a/e2e/starter-auth/09-relationship-count-columns.spec.ts
+++ b/e2e/starter-auth/09-relationship-count-columns.spec.ts
@@ -37,8 +37,14 @@ test.describe('To-many relationship count columns', () => {
   }
 
   async function createPosts(page: Page, count: number, prefix: string) {
+    // Derive the slug from the per-attempt test user (its email is already
+    // unique per attempt, including Playwright retries — see generateTestUser),
+    // not just the fixed `prefix`. Post.slug is globally unique, so a retry
+    // that reused the first attempt's slugs would collide with rows the first
+    // attempt already wrote and end up asserting against its own empty state.
+    const uniquePrefix = `${prefix}-${user.email.split('@')[0]}`
     for (let i = 0; i < count; i++) {
-      await createPost(page, { title: `${prefix} ${i}`, slug: `${prefix}-${i}` })
+      await createPost(page, { title: `${prefix} ${i}`, slug: `${uniquePrefix}-${i}` })
     }
   }
 


### PR DESCRIPTION
## Summary
- `e2e/starter-auth/09-relationship-count-columns.spec.ts` built post slugs from a fixed prefix + index (`count-display-0…N`, etc.). `examples/starter-auth`'s `Post.slug` is globally unique, and each test attempt signs up a fresh user, so a Playwright retry hit the same slugs as the first attempt, its creates collided, and it ended up asserting against a user with zero posts — a navigation flake then presented as "the count filter returns no rows".
- `createPosts` now derives its slug prefix from the per-attempt test user's email (`generateTestUser` already makes this unique per attempt, including retries), so no two attempts or tests can ever produce colliding slugs.
- No change to `Post.slug`'s uniqueness, the count column/sort/filter behavior, retry counts, or timeouts — scope is limited to the test fixtures per the issue's "out of scope" list.

## Test plan
- [x] `pnpm lint` — clean (only 3 pre-existing, unrelated warnings)
- [x] `pnpm format` / `pnpm manypkg fix` — no changes needed
- [ ] `pnpm test:e2e` run of `09-relationship-count-columns.spec.ts` against `examples/starter-auth` (requires the dev server + browsers; not run in this environment — please confirm in CI)

Closes #825

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01D6Hey2wbdzPjRXhTGbp5Kz

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6Hey2wbdzPjRXhTGbp5Kz)_