### PR TITLE
Fix serial relationship-options fetch in admin item form

### DIFF
--- a/.changeset/tame-rivers-jump.md
+++ b/.changeset/tame-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Fix the admin item form fetching relationship options serially (N sequential round-trips before first paint). Fetches now run concurrently via `Promise.all`.

--- a/packages/ui/src/lib/prepareItemForm.ts
+++ b/packages/ui/src/lib/prepareItemForm.ts
@@ -71,29 +71,32 @@ export async function prepareItemForm(
   // fetch that always unions the item's currently-selected id(s) so their
   // label renders even outside the window.
   const relationshipData: Record<string, Array<{ id: string; label: string }>> = {}
-  for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
-    const fieldConfigAny = fieldConfig as { type: string; ref?: string; many?: boolean }
-    if (fieldConfigAny.type === 'relationship') {
-      const ref = fieldConfigAny.ref
-      if (ref) {
-        // Parse ref format: "ListName.fieldName"
-        const relatedListName = ref.split('.')[0]
+  const relationshipFields = Object.entries(listConfig.fields).filter(
+    ([, fieldConfig]) => (fieldConfig as { type: string }).type === 'relationship',
+  ) as Array<[string, { type: string; ref?: string; many?: boolean }]>
 
-        if (config.lists[relatedListName]) {
-          try {
-            relationshipData[fieldName] = await getRelationshipOptions(
-              context,
-              config,
-              relatedListName,
-              { selectedIds: extractSelectedIds(itemData[fieldName], fieldConfigAny.many) },
-            )
-          } catch (error) {
-            console.error(`Failed to fetch relationship items for ${fieldName}:`, error)
-            relationshipData[fieldName] = []
-          }
-        }
+  const relationshipResults = await Promise.all(
+    relationshipFields.map(async ([fieldName, fieldConfigAny]) => {
+      const ref = fieldConfigAny.ref
+      if (!ref) return null
+      // Parse ref format: "ListName.fieldName"
+      const relatedListName = ref.split('.')[0]
+      if (!config.lists[relatedListName]) return null
+
+      try {
+        const options = await getRelationshipOptions(context, config, relatedListName, {
+          selectedIds: extractSelectedIds(itemData[fieldName], fieldConfigAny.many),
+        })
+        return [fieldName, options] as const
+      } catch (error) {
+        console.error(`Failed to fetch relationship items for ${fieldName}:`, error)
+        return [fieldName, []] as const
       }
-    }
+    }),
+  )
+
+  for (const result of relationshipResults) {
+    if (result) relationshipData[result[0]] = [...result[1]]
   }
 
   // Serialize field configs to remove non-serializable properties

--- a/packages/ui/tests/lib/prepareItemForm.test.ts
+++ b/packages/ui/tests/lib/prepareItemForm.test.ts
@@ -125,6 +125,45 @@ describe('prepareItemForm', () => {
     expect(selectedIdCall.where).toEqual({ id: { in: ['t9'] } })
   })
 
+  it('fetches relationship options for multiple fields concurrently, not serially', async () => {
+    // Neither findMany ever resolves in this test. If the fetches are kicked
+    // off serially (an `await` inside a `for` loop), `tagFindMany` is never
+    // even invoked until `authorFindMany`'s promise resolves — which it
+    // never does here — so `tagCalled` would stay `false` forever. Fetching
+    // concurrently invokes both before either resolves.
+    let authorCalled = false
+    let tagCalled = false
+    let resolveAuthor!: (value: Array<Record<string, unknown>>) => void
+    let resolveTag!: (value: Array<Record<string, unknown>>) => void
+
+    const authorFindMany = vi.fn(() => {
+      authorCalled = true
+      return new Promise<Array<Record<string, unknown>>>((resolve) => {
+        resolveAuthor = resolve
+      })
+    })
+    const tagFindMany = vi.fn(() => {
+      tagCalled = true
+      return new Promise<Array<Record<string, unknown>>>((resolve) => {
+        resolveTag = resolve
+      })
+    })
+    const context = makeContext({
+      author: { findMany: authorFindMany, findFirst: vi.fn() },
+      tag: { findMany: tagFindMany, findFirst: vi.fn() },
+    })
+    const config = makeConfig()
+
+    const promise = prepareItemForm(context, config, config.lists.Post, {})
+
+    expect(authorCalled).toBe(true)
+    expect(tagCalled).toBe(true)
+
+    resolveAuthor([])
+    resolveTag([])
+    await promise
+  })
+
   it('passes no selectedIds when the relationship is empty (create mode)', async () => {
     const authorFindMany = vi.fn(async () => [])
     const context = makeContext({


### PR DESCRIPTION
## Summary

- `prepareItemForm` (`packages/ui/src/lib/prepareItemForm.ts`) fetched each relationship field's options with an `await` inside a `for` loop, causing up to 2N sequential DB round-trips before the item form's first paint (N = number of relationship fields on the list).
- Fetches now run concurrently via `Promise.all`, turning 2N sequential round-trips into 2 concurrent waves.
- Per-field error handling is preserved: a failed fetch still degrades that field to `[]` and logs the error, it just no longer blocks sibling fields from resolving.

## Test plan

- [x] Added a regression test (`fetches relationship options for multiple fields concurrently, not serially`) that uses two never-resolving mock `findMany` promises to assert both fetches are kicked off before either resolves — fails against the old serial `for` loop, passes against the fix.
- [x] `pnpm test` in `packages/ui` — all 530 tests pass
- [x] `pnpm build` in `packages/core` and `packages/ui`
- [x] `pnpm lint` — no new warnings/errors
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed beyond the diff
- [x] Changeset added (`@opensaas/stack-ui` patch)

Closes #822


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpqqF63AJoZPWf2kEuVD97)_