### PR TITLE
fix(ui): render virtual fields read-only in the Admin UI item view

### DIFF
--- a/.changeset/silent-otters-render.md
+++ b/.changeset/silent-otters-render.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Fix virtual fields rendering "Unsupported field type: virtual" in the Admin UI item view — they now display their resolved value read-only, and are never offered as an editable control or included in create/update payloads.

--- a/packages/ui/src/components/fields/FieldRenderer.tsx
+++ b/packages/ui/src/components/fields/FieldRenderer.tsx
@@ -166,5 +166,11 @@ export function FieldRenderer(props: FieldRendererProps) {
     )
   }
 
-  return <FieldRendererInner {...props} Component={Component} />
+  // A virtual field is computed and never writable — force read-only
+  // presentation regardless of the requested mode (issue #821). This is a
+  // display-only guard: it never skips rendering (unlike id/createdAt/
+  // updatedAt above), it just never offers an editable input.
+  const effectiveMode = fieldConfig.virtual ? 'read' : mode
+
+  return <FieldRendererInner {...props} mode={effectiveMode} Component={Component} />
 }

--- a/packages/ui/src/components/fields/VirtualField.tsx
+++ b/packages/ui/src/components/fields/VirtualField.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { FieldRoot, FieldLabel, FieldReadValue } from './field-shell.js'
+
+export interface VirtualFieldProps {
+  name: string
+  value: unknown
+  onChange: (value: unknown) => void
+  label: string
+  mode?: 'read' | 'edit'
+}
+
+/**
+ * Format a resolved virtual value for read-only display.
+ *
+ * A virtual field may declare any `outputType` (e.g. `Decimal`, a plain
+ * object) and crosses the server/client boundary through a JSON round-trip,
+ * so a non-primitive value must be stringified rather than rendered via
+ * `String()` (which would print `[object Object]`).
+ */
+function formatVirtualValue(value: unknown): string {
+  if (value === null || value === undefined) return '-'
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+/**
+ * Default read-only renderer for `virtual` fields (issue #821). Virtual
+ * fields are computed and unwritable, so this component never offers an
+ * editable control — `FieldRenderer` forces `mode: 'read'` for any field
+ * config flagged `virtual`, but the component itself renders read-only
+ * regardless of the `mode` it's given as defence-in-depth.
+ */
+export function VirtualField({ label, value }: VirtualFieldProps) {
+  return (
+    <FieldRoot mode="read">
+      <FieldLabel muted>{label}</FieldLabel>
+      <FieldReadValue>{formatVirtualValue(value)}</FieldReadValue>
+    </FieldRoot>
+  )
+}

--- a/packages/ui/src/components/fields/index.ts
+++ b/packages/ui/src/components/fields/index.ts
@@ -12,6 +12,7 @@ export { RelationshipManager } from './RelationshipManager.js'
 export { FieldRenderer } from './FieldRenderer.js'
 export { FileField } from './FileField.js'
 export { ImageField } from './ImageField.js'
+export { VirtualField } from './VirtualField.js'
 
 // Shared field shell primitives (consistent label / help / error rhythm)
 export {
@@ -44,4 +45,5 @@ export type {
 export type { FieldRendererProps } from './FieldRenderer.js'
 export type { FileFieldProps } from './FileField.js'
 export type { ImageFieldProps } from './ImageField.js'
+export type { VirtualFieldProps } from './VirtualField.js'
 export type { FieldComponent, FieldComponentProps } from './registry.js'

--- a/packages/ui/src/components/fields/registry.ts
+++ b/packages/ui/src/components/fields/registry.ts
@@ -9,6 +9,7 @@ import { RelationshipField } from './RelationshipField.js'
 import { JsonField } from './JsonField.js'
 import { FileField } from './FileField.js'
 import { ImageField } from './ImageField.js'
+import { VirtualField } from './VirtualField.js'
 
 /**
  * Base props that all field components must accept
@@ -51,6 +52,7 @@ export const fieldComponentRegistry: Record<string, ComponentType<any>> = {
   json: JsonField,
   file: FileField,
   image: ImageField,
+  virtual: VirtualField,
 }
 
 /**

--- a/packages/ui/src/lib/useItemForm.ts
+++ b/packages/ui/src/lib/useItemForm.ts
@@ -39,6 +39,15 @@ export function transformItemFormData(
       continue
     }
 
+    // Virtual fields are computed and never writable. Core already strips
+    // them before they reach Prisma, so this is defence-in-depth: a virtual
+    // field's value can reach `formData` via `initialData` (the server's
+    // resolved value for the item being edited) even though no editable
+    // control ever calls `onChange` for it.
+    if (fieldConfig.virtual) {
+      continue
+    }
+
     // Skip password fields carrying an { isSet } sentinel (unchanged password).
     if (typeof value === 'object' && value !== null && 'isSet' in value) {
       continue
@@ -86,12 +95,23 @@ export function transformInitialData<TData extends Record<string, unknown>>(
 
 /**
  * Drop system fields (id, createdAt, updatedAt) from a field-config map,
- * returning the editable entries in declaration order.
+ * returning the fields an item form should render, in declaration order.
+ *
+ * On `create` there is no item yet, so a virtual (computed) field has nothing
+ * to show — it's dropped entirely. On `update` a virtual field is kept so the
+ * form can display its resolved value read-only; `FieldRenderer` forces
+ * read-only presentation for any field config flagged `virtual`, so it never
+ * becomes an editable control (issue #821).
  */
 export function getEditableFields(
   fields: Record<string, SerializableFieldConfig>,
+  mode: ItemFormAction = 'update',
 ): Array<[string, SerializableFieldConfig]> {
-  return Object.entries(fields).filter(([key]) => !SYSTEM_FIELDS.includes(key))
+  return Object.entries(fields).filter(([key, fieldConfig]) => {
+    if (SYSTEM_FIELDS.includes(key)) return false
+    if (mode === 'create' && fieldConfig.virtual) return false
+    return true
+  })
 }
 
 /**
@@ -190,7 +210,7 @@ export function useItemForm({
     errors,
     generalError,
     isPending,
-    editableFields: getEditableFields(fields),
+    editableFields: getEditableFields(fields, mode),
     handleFieldChange,
     handleSubmit,
     setGeneralError,

--- a/packages/ui/tests/components/FieldRenderer.test.tsx
+++ b/packages/ui/tests/components/FieldRenderer.test.tsx
@@ -45,3 +45,83 @@ describe('FieldRenderer helpText wiring', () => {
     expect(findHelp(container)).toBeNull()
   })
 })
+
+/**
+ * A `virtual` field is computed and unwritable. Before issue #821 there was no
+ * registry entry for `virtual`, so `FieldRenderer` fell through to the
+ * "Unsupported field type" placeholder in both read and edit mode, and the
+ * edit form offered an (unusable) editable control for it.
+ */
+describe('FieldRenderer virtual fields', () => {
+  const fieldConfig: SerializableFieldConfig = {
+    type: 'virtual',
+    label: 'Full Name',
+    virtual: true,
+  }
+
+  it('renders the resolved value and label in read mode without the unsupported-type placeholder', () => {
+    render(
+      <FieldRenderer
+        fieldName="fullName"
+        fieldConfig={fieldConfig}
+        value="Ada Lovelace"
+        onChange={vi.fn()}
+        mode="read"
+      />,
+    )
+
+    expect(screen.getByText('Full Name')).toBeInTheDocument()
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.queryByText(/Unsupported field type/)).not.toBeInTheDocument()
+  })
+
+  it('does not warn about a missing registered component', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(
+      <FieldRenderer
+        fieldName="fullName"
+        fieldConfig={fieldConfig}
+        value="Ada Lovelace"
+        onChange={vi.fn()}
+        mode="read"
+      />,
+    )
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('renders read-only (no editable input) even when asked for edit mode', () => {
+    render(
+      <FieldRenderer
+        fieldName="fullName"
+        fieldConfig={fieldConfig}
+        value="Ada Lovelace"
+        onChange={vi.fn()}
+        mode="edit"
+      />,
+    )
+
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('lets a per-field ui.component override still take priority over the default virtual renderer', () => {
+    function CustomVirtual({ value }: { value: unknown }) {
+      return <div data-testid="custom-virtual">custom: {String(value)}</div>
+    }
+
+    render(
+      <FieldRenderer
+        fieldName="fullName"
+        fieldConfig={{ ...fieldConfig, ui: { component: CustomVirtual } }}
+        value="Ada Lovelace"
+        onChange={vi.fn()}
+        mode="read"
+      />,
+    )
+
+    expect(screen.getByTestId('custom-virtual')).toHaveTextContent('custom: Ada Lovelace')
+  })
+})

--- a/packages/ui/tests/components/VirtualField.test.tsx
+++ b/packages/ui/tests/components/VirtualField.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { VirtualField } from '../../src/components/fields/VirtualField.js'
+
+describe('VirtualField', () => {
+  it('renders the resolved value read-only with the label', () => {
+    render(
+      <VirtualField name="fullName" value="Ada Lovelace" onChange={vi.fn()} label="Full Name" />,
+    )
+
+    expect(screen.getByText('Full Name')).toBeInTheDocument()
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+  })
+
+  it('renders no editable control', () => {
+    render(
+      <VirtualField name="fullName" value="Ada Lovelace" onChange={vi.fn()} label="Full Name" />,
+    )
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('renders the empty-value affordance for null/undefined rather than the string "null"', () => {
+    const { rerender } = render(
+      <VirtualField name="fullName" value={null} onChange={vi.fn()} label="Full Name" />,
+    )
+    expect(screen.getByText('-')).toBeInTheDocument()
+    expect(screen.queryByText('null')).not.toBeInTheDocument()
+
+    rerender(
+      <VirtualField name="fullName" value={undefined} onChange={vi.fn()} label="Full Name" />,
+    )
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('renders a non-string value as readable text rather than [object Object]', () => {
+    render(
+      <VirtualField
+        name="total"
+        value={{ amount: '19.99', currency: 'USD' }}
+        onChange={vi.fn()}
+        label="Total"
+      />,
+    )
+
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+    expect(screen.getByText('{"amount":"19.99","currency":"USD"}')).toBeInTheDocument()
+  })
+
+  it('renders a numeric value as text', () => {
+    render(<VirtualField name="count" value={42} onChange={vi.fn()} label="Count" />)
+
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/tests/lib/useItemForm.test.ts
+++ b/packages/ui/tests/lib/useItemForm.test.ts
@@ -10,6 +10,7 @@ const text = (): SerializableFieldConfig => ({ type: 'text' })
 const singleRel = (): SerializableFieldConfig => ({ type: 'relationship', many: false })
 const manyRel = (): SerializableFieldConfig => ({ type: 'relationship', many: true })
 const password = (): SerializableFieldConfig => ({ type: 'password' })
+const virtual = (): SerializableFieldConfig => ({ type: 'virtual', virtual: true })
 
 describe('transformItemFormData', () => {
   it('passes scalar fields through unchanged', () => {
@@ -56,6 +57,13 @@ describe('transformItemFormData', () => {
   it('drops a key with no corresponding field config (e.g. a synthetic `_count`)', () => {
     const fields = { title: text() }
     expect(transformItemFormData(fields, { title: 'Hi', _count: { comments: 3 } })).toEqual({
+      title: 'Hi',
+    })
+  })
+
+  it('drops a virtual field key even when a value for it is present (defence-in-depth)', () => {
+    const fields = { title: text(), fullName: virtual() }
+    expect(transformItemFormData(fields, { title: 'Hi', fullName: 'Ada Lovelace' })).toEqual({
       title: 'Hi',
     })
   })
@@ -110,5 +118,20 @@ describe('getEditableFields', () => {
       updatedAt: text(),
     }
     expect(getEditableFields(fields).map(([k]) => k)).toEqual(['title', 'body'])
+  })
+
+  it('keeps virtual fields by default (update mode) so they render read-only', () => {
+    const fields = { title: text(), fullName: virtual() }
+    expect(getEditableFields(fields).map(([k]) => k)).toEqual(['title', 'fullName'])
+  })
+
+  it('keeps virtual fields for update mode explicitly', () => {
+    const fields = { title: text(), fullName: virtual() }
+    expect(getEditableFields(fields, 'update').map(([k]) => k)).toEqual(['title', 'fullName'])
+  })
+
+  it('drops virtual fields for create mode — there is no item yet to compute a value from', () => {
+    const fields = { title: text(), fullName: virtual() }
+    expect(getEditableFields(fields, 'create').map(([k]) => k)).toEqual(['title'])
   })
 })


### PR DESCRIPTION
## Summary
- Any list with a `virtual()` field rendered that field in the Admin UI item view (create, edit, singleton) as the literal placeholder text `Unsupported field type: virtual`, because the form-field component registry had no entry for `virtual` and `FieldRenderer` fell through to its unsupported-type fallback.
- Adds a default read-only `VirtualField` component, registered for the `virtual` field type, that renders the resolved value with the field's label using the shared field-shell (`FieldRoot`/`FieldLabel`/`FieldReadValue`) presentation.
- `FieldRenderer` now forces read-only presentation for any field config flagged `virtual`, regardless of the requested mode — a virtual field can never become an editable input, the same way `id`/`createdAt`/`updatedAt` are already excluded from editable forms.
- `getEditableFields` (the shared item-form field filter) now omits virtual fields entirely on **create** — there's no item yet, so there's no computed value to show — and keeps them (read-only) on **update**/singleton edit.
- `transformItemFormData` (the submit transform) drops virtual field values defensively before building the create/update payload. Core already strips virtual keys before they reach Prisma (#628), so this is defence-in-depth, not a live-break fix.
- A `null`/`undefined` virtual value renders the shared empty-value affordance (`-`); a non-string value (e.g. `Decimal`, a plain object) is JSON-stringified rather than rendering `[object Object]`.
- Per-field `ui.component` / `ui.fieldType` overrides continue to take priority over the new default, exactly as for every other field type.

Out of scope (per the issue): the Cell registry / list-table rendering of virtual columns (already correct via its plain-text fallback), and any change to core's virtual-field resolution or write-time stripping.

## Test plan
- [x] New tests: `VirtualField.test.tsx` (read-mode rendering, empty-value affordance, non-string value formatting, no editable control)
- [x] New tests: `FieldRenderer.test.tsx` (virtual field renders without the unsupported-type placeholder or `console.warn`, forces read-only even when asked for `mode="edit"`, `ui.component` override still wins)
- [x] New tests: `useItemForm.test.ts` (`getEditableFields` excludes virtual on `create`, keeps it on `update`; `transformItemFormData` drops virtual field values)
- [x] `pnpm exec vitest run` in `packages/ui` — 46 files / 542 tests passing
- [x] `pnpm lint` — no new errors (3 pre-existing unrelated warnings)
- [x] `pnpm manypkg fix` / `pnpm format`
- [x] Changeset added for `@opensaas/stack-ui` (patch)

Closes #821


---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5op6CDtUKUQF9aenGsqC)_