### PR TITLE
feat(ui): add admin chrome slot for host-supplied navigation

### DIFF
--- a/.changeset/thirty-cobras-shout.md
+++ b/.changeset/thirty-cobras-shout.md
@@ -1,0 +1,17 @@
+---
+'@opensaas/stack-ui': minor
+---
+
+Add an admin chrome slot for host-supplied navigation (ADR-0021, issue #823).
+
+`AdminUI` now accepts a `navigation` prop that replaces the built-in sidebar wholesale (skipping nav-count resolution), and a `navItems` prop that adds one or more links to the built-in sidebar's new children region:
+
+```tsx
+// Add a link to the built-in sidebar
+<AdminUI {...props} navItems={[{ label: 'Back to App', href: '/' }]} />
+
+// Or replace the sidebar entirely
+<AdminUI {...props} navigation={<MyOwnSidebar />} />
+```
+
+`NavLink` is now exported from `@opensaas/stack-ui` (with `active` and `icon` optional) so host-supplied entries render identically to built-in ones, and `deriveCurrentPath` is exported to derive the same `currentPath` `AdminUI` computes internally, for host-owned chrome that needs it.

--- a/docs/content/how-to/composability.md
+++ b/docs/content/how-to/composability.md
@@ -346,6 +346,28 @@ This provides:
 - Field-level access control
 - Relationship handling
 
+### Linking back to a host app: the chrome slot
+
+Mounting `AdminUI` at a sub-path inside a larger app (incremental adoption,
+alongside a bespoke top-level admin) needs a way for its sidebar to link back
+out. Two props cover this without reopening "swap the components inside
+AdminUI" — chrome may be replaced wholesale at the mount site, but components
+_inside_ the built-in chrome still can't be individually swapped:
+
+```tsx
+// The one-line path: add a link to the built-in sidebar
+<AdminUI {...props} navItems={[{ label: 'Back to App', href: '/' }]} />
+
+// The full-control path: supply your own sidebar entirely
+<AdminUI {...props} navigation={<MyOwnSidebar />} />
+```
+
+`navigation` replaces the sidebar wholesale (and skips the built-in nav-count
+resolution, since your own chrome resolves its own counts); `navItems` adds
+entries to the built-in one. See the [UI reference](/docs/reference/ui#admin-chrome-slot-and-navitems)
+for the full API, including the public `NavLink` component and the
+`deriveCurrentPath` helper for computing active state in your own chrome.
+
 ## Real-World Use Cases
 
 ### Use Case 1: Multi-Step Wizard

--- a/docs/content/reference/ui.md
+++ b/docs/content/reference/ui.md
@@ -141,6 +141,8 @@ export default async function AdminPage() {
 - `context` - Access-controlled context from `.opensaas/context`
 - `config` - OpenSaas configuration object
 - `serverAction` - `'use server'` wrapper around `context.serverAction` for mutations
+- `navigation?` - Replaces the built-in sidebar wholesale (see [Admin chrome slot](#admin-chrome-slot-and-navitems) below)
+- `navItems?` - Adds host-supplied links to the built-in sidebar (see below); ignored when `navigation` is also supplied
 
 **Features:**
 
@@ -150,6 +152,66 @@ export default async function AdminPage() {
 - List views with search and sorting
 - Create and edit forms
 - Delete confirmations
+
+### Admin chrome slot and `navItems`
+
+When `AdminUI` is mounted at a sub-path alongside a host application's own
+navigation, the built-in sidebar has no link back out. Two props address this
+(ADR-0021):
+
+**`navItems`** — the smallest change, for adding one or more links to the
+built-in sidebar. Each item renders as a `NavLink` after the Lists and
+Settings groups, above the footer:
+
+```tsx
+<AdminUI
+  context={context}
+  config={config}
+  serverAction={serverAction}
+  navItems={[{ label: 'Back to App', href: '/', icon: <HomeIcon className="h-4 w-4" /> }]}
+/>
+```
+
+**`navigation`** — replaces the sidebar wholesale with any React node, for
+hosts building their own chrome entirely. `AdminUI` still owns routing, the
+per-route Suspense skeletons, and theme compilation; the supplied node owns
+its own width/height like the built-in sidebar does. When `navigation` is
+supplied, `AdminUI` skips `resolveNavCounts` — host-owned chrome resolves its
+own access-scoped counts (it's already exported for this):
+
+```tsx
+import { NavLink, resolveNavCounts } from '@opensaas/stack-ui'
+import { deriveCurrentPath } from '@opensaas/stack-ui'
+
+const currentPath = deriveCurrentPath(params.admin)
+const navCounts = await resolveNavCounts(context, config)
+
+<AdminUI
+  context={context}
+  config={config}
+  serverAction={serverAction}
+  navigation={
+    <nav className="w-64 border-r p-4">
+      <NavLink href="/" icon={<HomeIcon className="h-4 w-4" />}>Back to App</NavLink>
+      <NavLink href="/admin/post" active={currentPath.startsWith('/post')} count={navCounts.Post}>
+        Posts
+      </NavLink>
+    </nav>
+  }
+/>
+```
+
+If both `navigation` and `navItems` are supplied, `navigation` wins and
+`navItems` is ignored, with a development-only console warning.
+
+`NavLink` (importable from `@opensaas/stack-ui`) is the same component the
+built-in sidebar uses, so host-supplied entries render identically — same
+active-state fill, icon box, count badge, and `data-slot="nav-link"` handle.
+Both `active` (default `false`) and `icon` are optional.
+
+`deriveCurrentPath(params)` derives the `currentPath` string `AdminUI` computes
+internally from the route params array, so host-owned chrome that needs it for
+active-state highlighting doesn't have to re-derive the rule.
 
 ### Dashboard
 

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { redirect } from 'next/navigation.js'
-import { Navigation } from './Navigation.js'
+import { Navigation, NavLink } from './Navigation.js'
 import { Dashboard } from './Dashboard.js'
 import { ListView } from './ListView.js'
 import { ItemForm } from './ItemForm.js'
@@ -15,6 +15,7 @@ import {
   resolveNavCounts,
 } from '@opensaas/stack-core'
 import { compileTheme } from '../lib/theme.js'
+import { deriveCurrentPath } from '../lib/currentPath.js'
 
 export interface AdminUIProps {
   context: AccessContext<unknown>
@@ -25,6 +26,22 @@ export interface AdminUIProps {
   // Server action can return any shape depending on the list item type
   serverAction: (input: ServerActionInput) => Promise<unknown>
   onSignOut?: () => Promise<void>
+  /**
+   * Replaces the built-in sidebar wholesale (ADR-0021, the "chrome slot").
+   * `AdminUI` keeps routing, the shell, and theme compilation; it skips
+   * `resolveNavCounts` when this is supplied, since host-owned chrome resolves
+   * its own access-scoped counts. Takes precedence over `navItems` — if both
+   * are supplied, `navigation` renders and `navItems` is ignored with a
+   * development-only warning.
+   */
+  navigation?: React.ReactNode
+  /**
+   * Sugar over the built-in `Navigation`'s children region: one host-supplied
+   * nav link per entry, rendered after the Lists and Settings groups and
+   * above the footer. Ignored (with a dev-only warning) when `navigation` is
+   * also supplied.
+   */
+  navItems?: Array<{ label: string; href: string; icon?: React.ReactNode }>
 }
 
 /**
@@ -45,7 +62,15 @@ export async function AdminUI({
   basePath = '/admin',
   serverAction,
   onSignOut,
+  navigation,
+  navItems,
 }: AdminUIProps) {
+  if (process.env.NODE_ENV !== 'production' && navigation && navItems) {
+    console.warn(
+      'AdminUI: both `navigation` and `navItems` were supplied. `navigation` takes precedence and `navItems` is ignored.',
+    )
+  }
+
   // Parse route from params
   const [urlSegment, action] = params
 
@@ -53,7 +78,7 @@ export async function AdminUI({
   const listKey = urlSegment ? getListKeyFromUrl(urlSegment) : undefined
 
   // Determine current path for navigation highlighting
-  const currentPath = params.length > 0 ? `/${params.join('/')}` : ''
+  const currentPath = deriveCurrentPath(params)
 
   // Route to appropriate component
   let content: React.ReactNode
@@ -172,21 +197,32 @@ export async function AdminUI({
   // Access-scoped nav counts for opted-in lists (issue #735). Runs zero queries
   // when no list sets `ui.navCount`, so existing apps pay nothing; each count is
   // fetched through the secured `context.db`, reflecting only what this session
-  // may see.
-  const navCounts = await resolveNavCounts(context, config)
+  // may see. Skipped entirely when the chrome slot is supplied (ADR-0021) —
+  // host-owned chrome resolves its own counts, so this avoids paying twice.
+  const navCounts = navigation ? undefined : await resolveNavCounts(context, config)
+
+  const sidebar = navigation ?? (
+    <Navigation
+      context={context}
+      config={config}
+      basePath={basePath}
+      currentPath={currentPath}
+      onSignOut={onSignOut}
+      navCounts={navCounts}
+    >
+      {navItems?.map((item) => (
+        <NavLink key={item.href} href={item.href} icon={item.icon}>
+          {item.label}
+        </NavLink>
+      ))}
+    </Navigation>
+  )
 
   return (
     <>
       {themeStyles && <style dangerouslySetInnerHTML={{ __html: themeStyles }} />}
       <div className="flex min-h-screen bg-background">
-        <Navigation
-          context={context}
-          config={config}
-          basePath={basePath}
-          currentPath={currentPath}
-          onSignOut={onSignOut}
-          navCounts={navCounts}
-        />
+        {sidebar}
         <main className="flex-1 overflow-y-auto">
           <React.Suspense fallback={fallback}>{content}</React.Suspense>
         </main>

--- a/packages/ui/src/components/Navigation.tsx
+++ b/packages/ui/src/components/Navigation.tsx
@@ -21,24 +21,28 @@ export interface NavigationProps {
    * query access is statically denied — is simply absent and renders no badge.
    */
   navCounts?: Record<string, number>
+  /**
+   * Host-supplied navigation entries (ADR-0021), rendered in a dedicated
+   * region after the Lists and Settings groups and above the footer. Absent
+   * children leaves this output unchanged — existing markup is untouched.
+   */
+  children?: React.ReactNode
 }
 
-/**
- * A single sidebar navigation link. Active links use a solid brand fill and
- * carry `aria-current="page"` (the accessible, testable active-state signal);
- * gradients are deliberately NOT used here — the spec limits them to a few
- * signature moments, so active nav is a quiet solid fill, not a glow.
- */
-function NavLink({
-  href,
-  active,
-  icon,
-  count,
-  children,
-}: {
+export interface NavLinkProps {
   href: string
-  active: boolean
-  icon: React.ReactNode
+  /**
+   * Whether this link represents the current route. Defaults to `false` —
+   * the correct default for a link leaving the mount (e.g. a host-supplied
+   * entry pointing back to the surrounding application).
+   */
+  active?: boolean
+  /**
+   * Optional icon rendered in a fixed-size box. The box is reserved even when
+   * no icon is supplied, so icon-less entries stay label-aligned with
+   * built-in entries that do have one.
+   */
+  icon?: React.ReactNode
   /**
    * Optional access-scoped record count shown as a trailing badge (issue #735).
    * `undefined` renders no badge; `0` renders a "0" badge (the list opted in and
@@ -46,7 +50,18 @@ function NavLink({
    */
   count?: number
   children: React.ReactNode
-}) {
+}
+
+/**
+ * A single sidebar navigation link. Active links use a solid brand fill and
+ * carry `aria-current="page"` (the accessible, testable active-state signal);
+ * gradients are deliberately NOT used here — the spec limits them to a few
+ * signature moments, so active nav is a quiet solid fill, not a glow.
+ *
+ * Public (ADR-0021): host-supplied nav entries import this so they render
+ * identically to built-in ones, including the `data-slot="nav-link"` handle.
+ */
+export function NavLink({ href, active = false, icon, count, children }: NavLinkProps) {
   return (
     <Link
       href={href}
@@ -94,6 +109,7 @@ export function Navigation({
   currentPath = '',
   onSignOut,
   navCounts,
+  children,
 }: NavigationProps) {
   const allLists = Object.keys(config.lists || {})
   // Split lists into standard lists (under "Lists") and singletons (under
@@ -171,6 +187,8 @@ export function Navigation({
               })}
             </>
           )}
+
+          {children}
         </div>
       </div>
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,7 @@
 // Main components
 export { AdminUI } from './components/AdminUI.js'
 export { Dashboard } from './components/Dashboard.js'
-export { Navigation } from './components/Navigation.js'
+export { Navigation, NavLink } from './components/Navigation.js'
 export { UserMenu } from './components/UserMenu.js'
 export { ThemeToggle } from './components/ThemeToggle.js'
 export { ThemeScript } from './components/ThemeScript.js'
@@ -79,7 +79,7 @@ export type { CellComponent, CellComponentProps } from './components/cells/index
 // Types
 export type { AdminUIProps } from './components/AdminUI.js'
 export type { DashboardProps } from './components/Dashboard.js'
-export type { NavigationProps } from './components/Navigation.js'
+export type { NavigationProps, NavLinkProps } from './components/Navigation.js'
 export type { UserMenuProps } from './components/UserMenu.js'
 export type { ThemeToggleProps } from './components/ThemeToggle.js'
 export type { ListViewProps } from './components/ListView.js'
@@ -95,6 +95,9 @@ export type { ItemFormClientProps } from './components/ItemFormClient.js'
 export type { RelationshipTableProps } from './components/RelationshipTable.js'
 export type { RelationshipTableClientProps } from './components/RelationshipTableClient.js'
 export type { RelationshipCreateDrawerProps } from './components/RelationshipCreateDrawer.js'
+
+// Admin `currentPath` derivation (route params → nav active-state path; ADR-0021)
+export { deriveCurrentPath } from './lib/currentPath.js'
 
 // Item-view layout derivation (shape → details card + Relationship tables)
 export { deriveItemViewLayout } from './lib/deriveItemView.js'

--- a/packages/ui/src/lib/currentPath.ts
+++ b/packages/ui/src/lib/currentPath.ts
@@ -1,0 +1,9 @@
+/**
+ * Derives the admin's `currentPath` (used for nav active-state highlighting)
+ * from the route params array `AdminUI` receives. Exported (ADR-0021) so
+ * host-owned chrome computing active state shares this one rule instead of
+ * re-deriving it.
+ */
+export function deriveCurrentPath(params: string[] = []): string {
+  return params.length > 0 ? `/${params.join('/')}` : ''
+}

--- a/packages/ui/tests/components/AdminUINavigationSlot.test.tsx
+++ b/packages/ui/tests/components/AdminUINavigationSlot.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { AdminUI } from '../../src/components/AdminUI.js'
+import { Navigation } from '../../src/components/Navigation.js'
+
+// next/link renders an anchor; happy-dom can render it directly.
+vi.mock('next/link.js', () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode
+    href: string
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+interface DelegateStub {
+  findMany?: (args: unknown) => Promise<Array<Record<string, unknown>>>
+  count?: (args: unknown) => Promise<number>
+}
+
+function makeContext(delegates: Record<string, DelegateStub> = {}): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputCounter: { depth: 0 },
+  }
+  return context as unknown as AccessContext<unknown>
+}
+
+const noopServerAction = vi.fn(async () => ({ success: true }))
+
+/**
+ * AdminUI returns <> {style?} <div><sidebar/><main>{content}</main></div> </>.
+ * Recover whatever the sidebar slot resolved to (built-in `Navigation` or the
+ * host-supplied `navigation` node). Uses raw children arrays rather than
+ * `React.Children.toArray` — the latter clones elements to assign keys, which
+ * breaks `toBe` identity checks against the original `navigation` node.
+ */
+function sidebarOf(tree: React.ReactNode): React.ReactNode {
+  const fragment = tree as React.ReactElement<{ children: React.ReactNode }>
+  const fragmentChildren = fragment.props.children
+  const topLevel = Array.isArray(fragmentChildren) ? fragmentChildren : [fragmentChildren]
+  const wrapper = topLevel.find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'div',
+  )
+  if (!wrapper) throw new Error('AdminUI layout wrapper not found')
+  const wrapperChildren = wrapper.props.children
+  const items = Array.isArray(wrapperChildren) ? wrapperChildren : [wrapperChildren]
+  const sidebar = items.find((child) => !(React.isValidElement(child) && child.type === 'main'))
+  if (!sidebar) throw new Error('AdminUI sidebar not found')
+  return sidebar
+}
+
+const baseConfig: OpenSaasConfig = {
+  db: { provider: 'sqlite', url: 'file:./test.db' },
+  lists: {
+    Post: list({ fields: { title: text() } }),
+  },
+}
+
+describe('AdminUI navigation slot (ADR-0021)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the built-in sidebar and resolves nav counts when neither prop is supplied', async () => {
+    const count = vi.fn(async () => 3)
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: { title: text() },
+          ui: { navCount: true },
+          access: { operation: { query: () => true } },
+        }),
+      },
+    }
+    const context = makeContext({ post: { count } })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    expect((sidebarOf(tree) as React.ReactElement).type).toBe(Navigation)
+    expect(count).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the supplied `navigation` node in place of the built-in sidebar', async () => {
+    const custom = <nav data-testid="host-nav">Host chrome</nav>
+
+    const tree = await AdminUI({
+      context: makeContext(),
+      config: baseConfig,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+      navigation: custom,
+    })
+
+    expect(sidebarOf(tree)).toBe(custom)
+  })
+
+  it('performs no nav-count resolution when `navigation` is supplied', async () => {
+    const count = vi.fn(async () => 3)
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: {
+        Post: list({
+          fields: { title: text() },
+          ui: { navCount: true },
+          access: { operation: { query: () => true } },
+        }),
+      },
+    }
+    const context = makeContext({ post: { count } })
+
+    await AdminUI({
+      context,
+      config,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+      navigation: <nav>Host chrome</nav>,
+    })
+
+    expect(count).not.toHaveBeenCalled()
+  })
+
+  it('renders routed content for every route when `navigation` is supplied', async () => {
+    const context = makeContext({
+      post: { findMany: vi.fn(async () => []), count: vi.fn(async () => 0) },
+    })
+
+    for (const params of [[], ['post'], ['post', 'create'], ['post', '1']]) {
+      const tree = await AdminUI({
+        context,
+        config: baseConfig,
+        params,
+        basePath: '/admin',
+        serverAction: noopServerAction,
+        navigation: <nav>Host chrome</nav>,
+      })
+      const fragment = tree as React.ReactElement<{ children: React.ReactNode }>
+      expect(fragment).toBeTruthy()
+    }
+  })
+
+  it('renders the built-in sidebar plus one entry per navItems item, after Lists/Settings and above the footer', async () => {
+    const tree = await AdminUI({
+      context: makeContext(),
+      config: baseConfig,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+      navItems: [{ label: 'Back to App', href: '/app' }],
+    })
+
+    render(sidebarOf(tree) as React.ReactElement)
+
+    const hostLink = screen.getByRole('link', { name: 'Back to App' })
+    expect(hostLink).toBeInTheDocument()
+    expect(hostLink).toHaveAttribute('href', '/app')
+
+    // Order: Dashboard, Post (Lists), then the host entry, then the footer.
+    const nav = hostLink.closest('nav')
+    if (!nav) throw new Error('nav not found')
+    const linkOrder = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent)
+    expect(linkOrder.indexOf('Back to App')).toBeGreaterThan(linkOrder.indexOf('Post'))
+  })
+
+  it('renders the `navigation` node and no navItems entries when both are supplied, with a dev-only warning', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const custom = <nav data-testid="host-nav">Host chrome</nav>
+
+    const tree = await AdminUI({
+      context: makeContext(),
+      config: baseConfig,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+      navigation: custom,
+      navItems: [{ label: 'Back to App', href: '/app' }],
+    })
+
+    expect(sidebarOf(tree)).toBe(custom)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('navigation')
+    expect(warnSpy.mock.calls[0][0]).toContain('navItems')
+  })
+
+  it('does not throw when both are supplied in production', async () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      await expect(
+        AdminUI({
+          context: makeContext(),
+          config: baseConfig,
+          params: [],
+          basePath: '/admin',
+          serverAction: noopServerAction,
+          navigation: <nav>Host chrome</nav>,
+          navItems: [{ label: 'Back to App', href: '/app' }],
+        }),
+      ).resolves.toBeTruthy()
+    } finally {
+      process.env.NODE_ENV = originalEnv
+    }
+  })
+})

--- a/packages/ui/tests/components/NavigationChildrenRegion.test.tsx
+++ b/packages/ui/tests/components/NavigationChildrenRegion.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { Navigation, NavLink } from '../../src/components/Navigation.js'
+
+vi.mock('next/link.js', () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode
+    href: string
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+const config: OpenSaasConfig = {
+  db: { provider: 'sqlite', url: 'file:./test.db' },
+  lists: {
+    Post: list({ fields: { title: text() } }),
+  },
+}
+
+const context = {
+  db: {},
+  session: null,
+  storage: {},
+  plugins: {},
+  _isSudo: false,
+  _resolveOutputCounter: { depth: 0 },
+} as unknown as AccessContext<unknown>
+
+describe('Navigation children region (ADR-0021)', () => {
+  it('with no children, produces unchanged output', () => {
+    render(<Navigation context={context} config={config} basePath="/admin" currentPath="" />)
+
+    // Only the header wordmark + built-in Dashboard/Lists links are present —
+    // no extra region rendered when children is absent.
+    expect(screen.getAllByRole('link')).toHaveLength(3)
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Post' })).toBeInTheDocument()
+  })
+
+  it('renders children after Lists/Settings and above the footer', () => {
+    render(
+      <Navigation context={context} config={config} basePath="/admin" currentPath="">
+        <NavLink href="/app">Back to App</NavLink>
+      </Navigation>,
+    )
+
+    const hostLink = screen.getByRole('link', { name: 'Back to App' })
+    expect(hostLink).toBeInTheDocument()
+
+    const nav = hostLink.closest('nav')
+    if (!nav) throw new Error('nav not found')
+    const linkTexts = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent)
+    expect(linkTexts.indexOf('Back to App')).toBeGreaterThan(linkTexts.indexOf('Post'))
+  })
+})
+
+describe('NavLink public API (ADR-0021)', () => {
+  it('renders without an `active` prop as inactive', () => {
+    render(<NavLink href="/app">Back to App</NavLink>)
+    const link = screen.getByRole('link', { name: 'Back to App' })
+    expect(link).not.toHaveAttribute('aria-current')
+    expect(link).not.toHaveAttribute('data-active')
+  })
+
+  it('renders without an `icon` prop, keeping the label aligned via the reserved icon box', () => {
+    render(<NavLink href="/app">Back to App</NavLink>)
+    const link = screen.getByRole('link', { name: 'Back to App' })
+    const iconBox = link.querySelector('span[aria-hidden="true"]')
+    expect(iconBox).toBeInTheDocument()
+  })
+
+  it('keeps the data-slot="nav-link" handle', () => {
+    render(<NavLink href="/app">Back to App</NavLink>)
+    const link = screen.getByRole('link', { name: 'Back to App' })
+    expect(link).toHaveAttribute('data-slot', 'nav-link')
+  })
+})

--- a/packages/ui/tests/lib/currentPath.test.ts
+++ b/packages/ui/tests/lib/currentPath.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { deriveCurrentPath } from '../../src/lib/currentPath.js'
+
+describe('deriveCurrentPath', () => {
+  it('returns an empty string for an empty params array', () => {
+    expect(deriveCurrentPath([])).toBe('')
+  })
+
+  it('returns an empty string when params is omitted', () => {
+    expect(deriveCurrentPath()).toBe('')
+  })
+
+  it('returns a leading-slash path for a single-segment route', () => {
+    expect(deriveCurrentPath(['post'])).toBe('/post')
+  })
+
+  it('returns a leading-slash path for a multi-segment route', () => {
+    expect(deriveCurrentPath(['post', 'create'])).toBe('/post/create')
+    expect(deriveCurrentPath(['post', 'abc123'])).toBe('/post/abc123')
+  })
+})


### PR DESCRIPTION
## Summary

- Add a `navigation` prop to `AdminUI` that replaces the built-in sidebar wholesale (the "chrome slot"). `AdminUI` keeps routing, the shell, per-route Suspense skeletons, and theme compilation; it skips `resolveNavCounts` when `navigation` is supplied, since host-owned chrome resolves its own access-scoped counts.
- Add a `navItems` prop (`{ label, href, icon? }[]`) as sugar over the built-in `Navigation`'s new children region — the one-line path for adding a link back to a host app.
- `Navigation` now accepts `children`, rendered in a dedicated region after the Lists and Settings groups and above the footer. With no children, output is unchanged.
- `NavLink` is now part of the public API (exported from `@opensaas/stack-ui`), with `active` (defaults to `false`) and `icon` optional, so host-supplied entries render identically to built-in ones (same active-state fill, icon box, count badge, and `data-slot="nav-link"` handle).
- Export a `deriveCurrentPath` helper so host-owned chrome computing active state shares one rule with `AdminUI`'s internal derivation.
- If both `navigation` and `navItems` are supplied, `navigation` wins and `navItems` is ignored, with a development-only console warning; it never throws.
- Docs: updated the composability how-to and the UI reference with the new props, `NavLink`, and `deriveCurrentPath`.
- Changeset added for `@opensaas/stack-ui` (minor).

Implements design decisions recorded in ADR-0021 ("Admin chrome is a replaceable slot; nav entries live at the mount site").

## Test plan

- [x] `pnpm test` in `packages/ui` — 559 tests pass, including new coverage for: slot replacement, the nav-count skip, `navItems` rendering/placement, the both-props precedence + dev warning (and no-throw in production), the children-region no-op when absent, and `NavLink`/`deriveCurrentPath` defaults.
- [x] `pnpm build` in `packages/core` and `packages/ui` — no type errors.
- [x] `pnpm lint` — no new warnings/errors introduced.
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed.

Closes #823


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXyABXN6Tn6uMM8Ero22N1)_