### PR TITLE
fix(core): bound the resolveOutput resolve chain with a cycle guard

### DIFF
--- a/.changeset/curly-otters-bound.md
+++ b/.changeset/curly-otters-bound.md
@@ -26,7 +26,9 @@ This also fixes a related bug where a plain top-level read running concurrently 
 
 ```ts
 // Before
-_resolveOutputCounter: { depth: 0 }
+_resolveOutputCounter: {
+  depth: 0
+}
 // After
 _resolveOutputChain: []
 ```

--- a/.changeset/curly-otters-bound.md
+++ b/.changeset/curly-otters-bound.md
@@ -1,0 +1,32 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Fix unbounded recursion when a `resolveOutput` hook issues its own read (#844): a hook's read could return rows whose own `resolveOutput` hooks issued further reads with no bound, driving the process to the V8 heap limit on a cyclic readable-relationship graph.
+
+Reads are now tracked with a resolve chain — the ordered `(list, field)` pairs a read has entered via `resolveOutput` hooks. A hook that would re-enter a pair already on its own chain throws the new `ResolveOutputCycleError` naming the full chain, instead of recursing forever:
+
+```ts
+import { ResolveOutputCycleError } from '@opensaas/stack-core'
+
+try {
+  await context.db.user.findMany({})
+} catch (err) {
+  if (err instanceof ResolveOutputCycleError) {
+    // err.chain: readonly { listKey: string; fieldKey: string }[]
+  }
+}
+```
+
+An acyclic chain that runs deeper than `RESOLVE_CHAIN_MAX_LENGTH` (a cost limit, not a correctness guard) omits the field and logs a single `console.warn` instead of throwing — a legitimately terminating hook chain (e.g. a virtual field reading another virtual field several hops deep) is never denied.
+
+This also fixes a related bug where a plain top-level read running concurrently with an unrelated in-flight `resolveOutput` hook could have its own nested auto-include silently collapsed, because the previous implementation tracked "am I inside a hook?" on one mutable counter shared by the whole request.
+
+**Breaking (internal plumbing only):** `AccessContext`'s underscore-prefixed `_resolveOutputCounter: { depth: number }` is replaced by `_resolveOutputChain: readonly { listKey: string; fieldKey: string }[]`. Application code never reads this field. Hand-built `AccessContext` mocks in tests need a one-line update:
+
+```ts
+// Before
+_resolveOutputCounter: { depth: 0 }
+// After
+_resolveOutputChain: []
+```

--- a/packages/core/src/access/access-filter.test.ts
+++ b/packages/core/src/access/access-filter.test.ts
@@ -50,10 +50,14 @@ function cyclicConfig(): OpenSaasConfig {
 }
 
 function makeContext(resolveOutputDepth = 0): AccessContext {
+  const chain = Array.from({ length: resolveOutputDepth }, (_, i) => ({
+    listKey: 'TestHook',
+    fieldKey: `hook${i}`,
+  }))
   return {
     session: null,
     _isSudo: false,
-    _resolveOutputCounter: { depth: resolveOutputDepth },
+    _resolveOutputChain: chain,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
   } as any
 }

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -117,13 +117,18 @@ export async function buildIncludeWithAccessControl(
 
   // Inside a resolveOutput/virtual-field context we still scope each immediate
   // relation (its own access `where`), but do not auto-expand INTO its nested
-  // relations — no recursive call is made, so a self-referential relation
-  // terminates after one level regardless of cycles. This prevents the
-  // infinite loops the original passthrough guarded against (hooks making DB
-  // queries that include relationships back to the same entity), while still
-  // row-scoping the relation itself rather than skipping scoping altogether
-  // (issue #830's second trigger).
-  const insideResolveOutput = args.context._resolveOutputCounter.depth > 0
+  // relations — this keeps a single hook-issued read's include from growing
+  // depth-first. Correction (ADR-0023): this does NOT by itself terminate a
+  // cycle, despite what an earlier version of this comment claimed. A
+  // self-referential relation read from inside a hook is a NEW top-level
+  // read, invisible to this function's own recursion — the loop runs through
+  // the hook↔read boundary, not through repeated calls to
+  // `buildIncludeWithAccessControl`. Loop termination is the resolve chain's
+  // job: `field-visibility.ts`'s `resolveReadableFieldValue` refuses to
+  // re-enter a `(list, field)` pair already on the chain. What this check
+  // still does correctly is row-scope the immediate relation rather than
+  // skipping scoping altogether (issue #830's second trigger).
+  const insideResolveOutput = args.context._resolveOutputChain.length > 0
 
   const include: RichIncludeObject = {}
   let hasRelationships = false

--- a/packages/core/src/access/depth-limits.ts
+++ b/packages/core/src/access/depth-limits.ts
@@ -9,3 +9,18 @@
  * than passed through unscoped — see ADR-0022 and issue #830.
  */
 export const READ_INCLUDE_MAX_DEPTH = 5
+
+/**
+ * Maximum length of the resolve chain — the ordered sequence of `resolveOutput`
+ * hooks a read has entered, each entry extended by a hook that issues its own
+ * read (see `_resolveOutputChain` on `AccessContext`).
+ *
+ * This is a COST limit, not an access-control boundary: an acyclic chain
+ * genuinely can exceed it and still be correct (e.g. a virtual `Order.total`
+ * reading a virtual `LineItem.subtotal` reading further virtuals), so
+ * exceeding it omits the field and emits a single `console.warn` rather than
+ * throwing. Termination itself is guaranteed by the separate cycle guard,
+ * which refuses to re-enter a `(list, field)` pair already on the chain
+ * regardless of this cap. See ADR-0023.
+ */
+export const RESOLVE_CHAIN_MAX_LENGTH = 5

--- a/packages/core/src/access/errors.ts
+++ b/packages/core/src/access/errors.ts
@@ -30,3 +30,33 @@ export class AccessScopeDepthExceededError extends Error {
     this.depth = depth
   }
 }
+
+/**
+ * Thrown when a `resolveOutput` hook re-enters a `(list, field)` pair already
+ * on its own resolve chain — a hook whose own read (directly or transitively)
+ * comes back around to itself. Deliberately distinct from `ValidationError`
+ * (same reasoning as `AccessScopeDepthExceededError`): this is not bad user
+ * input, it is the engine refusing to run a hook chain that cannot terminate.
+ *
+ * This is a loud failure, not a Silent one, on purpose: a repeated pair never
+ * terminated before this guard existed, so no working application can depend
+ * on the old (hanging) behaviour, and staying silent here would return
+ * `undefined` for a field with nothing in the logs to explain why. Contrast
+ * with exceeding `RESOLVE_CHAIN_MAX_LENGTH`, which can happen on a chain that
+ * would otherwise terminate correctly and therefore only warns. See ADR-0023.
+ */
+export class ResolveOutputCycleError extends Error {
+  public chain: readonly { listKey: string; fieldKey: string }[]
+
+  constructor(chain: readonly { listKey: string; fieldKey: string }[]) {
+    const path = chain.map((link) => `${link.listKey}.${link.fieldKey}`).join(' → ')
+    super(
+      `resolveOutput cycle detected: ${path}. A hook that re-enters a (list, field) pair ` +
+        `already on its own resolve chain cannot terminate, so the read is refused rather than ` +
+        `left to recurse until the process runs out of memory. Restructure the hooks so the read ` +
+        `does not loop back into itself.`,
+    )
+    this.name = 'ResolveOutputCycleError'
+    this.chain = chain
+  }
+}

--- a/packages/core/src/access/field-visibility.ts
+++ b/packages/core/src/access/field-visibility.ts
@@ -2,6 +2,15 @@ import type { Session, AccessContext } from './types.js'
 import type { OpenSaasConfig, FieldConfig } from '../config/types.js'
 import { getRelatedListConfig } from './engine.js'
 import { checkFieldAccess } from './field-access.js'
+import { RESOLVE_CHAIN_MAX_LENGTH } from './depth-limits.js'
+import { ResolveOutputCycleError } from './errors.js'
+// NOTE: `context/index.ts` imports `filterReadableFields` from this module
+// (via the `access/index.ts` barrel) — this is an intentional cyclic
+// dependency, the same shape and for the same reason as the one documented in
+// `context/write-pipeline.ts`. `buildDbDelegate` is only INVOKED when a
+// `resolveOutput` hook actually runs (never during module evaluation), so by
+// the time it runs the export is fully initialised.
+import { buildDbDelegate } from '../context/index.js'
 
 /**
  * Field Visibility — phase 2 of the two-phase read (post-query).
@@ -37,6 +46,44 @@ type FieldVisibilityArgs = {
 }
 
 /**
+ * Derive the context passed to a single `resolveOutput` hook invocation: a
+ * NEW context object whose `_resolveOutputChain` extends the caller's chain
+ * with this hook's own `(list, field)` link. The chain is never mutated in
+ * place — this is what lets concurrent hook invocations (e.g. sibling rows in
+ * a to-many relation, filtered via `Promise.all`) each see their own chain
+ * rather than racing on one shared value (ADR-0023).
+ *
+ * A plain `{ ...context, _resolveOutputChain }` spread is not enough on its
+ * own: `context.db`'s operations capture their `context` at construction
+ * (see `populateDbDelegate`), so a hook that calls `context.db.x.findMany(…)`
+ * would otherwise reach the ORIGINAL closures — bound to the ORIGINAL
+ * context — and its read would silently fall back to the un-extended chain,
+ * defeating the cycle guard entirely. Rebuilding `db` via `buildDbDelegate`
+ * against the derived context is what makes a hook-issued read's own nested
+ * hooks actually observe the extended chain.
+ *
+ * `config` is required to rebuild `db`; callers that cannot supply one (e.g. a
+ * narrow unit test exercising field access in isolation) still get a correct
+ * chain for THIS hook's own cycle/cap check, but a read that hook issues
+ * would not carry the chain any further — those callers are not exercising
+ * the read pipeline, so there is nothing for it to reach.
+ */
+function deriveResolveOutputContext(
+  context: AccessContext & { _isSudo?: boolean },
+  link: { listKey: string; fieldKey: string },
+  config: OpenSaasConfig | undefined,
+): AccessContext & { _isSudo?: boolean } {
+  const derived: AccessContext & { _isSudo?: boolean } = {
+    ...context,
+    _resolveOutputChain: [...context._resolveOutputChain, link],
+  }
+  if (config) {
+    derived.db = buildDbDelegate(config, context.prisma, derived)
+  }
+  return derived
+}
+
+/**
  * The core Field Visibility step for a single field: check read access and, if
  * granted, produce the output value by running any `resolveOutput` hook.
  *
@@ -58,8 +105,9 @@ async function resolveReadableFieldValue(params: {
   hookItem: Record<string, unknown>
   listKey: string | undefined
   args: FieldVisibilityArgs
+  config: OpenSaasConfig | undefined
 }): Promise<{ readable: false } | { readable: true; value: unknown }> {
-  const { fieldConfig, fieldName, value, accessItem, hookItem, listKey, args } = params
+  const { fieldConfig, fieldName, value, accessItem, hookItem, listKey, args, config } = params
 
   // Check field access (checkFieldAccess already handles sudo mode)
   const canRead = await checkFieldAccess(fieldConfig?.access, 'read', {
@@ -76,25 +124,44 @@ async function resolveReadableFieldValue(params: {
     // Cast to runtime type for generic execution
     // At runtime, the hook will receive the correct value type for the field
     const hook = fieldConfig.hooks.resolveOutput as unknown as ResolveOutputHookRuntime
-    // Increment depth counter to prevent infinite loops from hooks making DB queries
-    // that include relationships back to the same entity
-    args.context._resolveOutputCounter.depth++
-    try {
-      // Use Promise.resolve() to handle both sync and async hooks
-      const resolved = await Promise.resolve(
-        hook({
-          value,
-          operation: 'query',
-          fieldName,
-          listKey,
-          item: hookItem,
-          context: args.context,
-        }),
-      )
-      return { readable: true, value: resolved }
-    } finally {
-      args.context._resolveOutputCounter.depth--
+    const link = { listKey, fieldKey: fieldName }
+    const chain = args.context._resolveOutputChain
+
+    // Cycle guard: a hook that would re-enter a (list, field) pair already on
+    // its own chain cannot terminate — refuse loudly rather than recurse
+    // until the process runs out of memory (issue #844, ADR-0023).
+    const alreadyOnChain = chain.some(
+      (entry) => entry.listKey === link.listKey && entry.fieldKey === link.fieldKey,
+    )
+    if (alreadyOnChain) {
+      throw new ResolveOutputCycleError([...chain, link])
     }
+
+    // Cost cap: a chain this long is refused only as a cost limit, never a
+    // correctness one — an acyclic chain that works today can legitimately
+    // reach this. Omit the field and warn instead of throwing.
+    if (chain.length >= RESOLVE_CHAIN_MAX_LENGTH) {
+      const path = [...chain, link].map((entry) => `${entry.listKey}.${entry.fieldKey}`).join(' → ')
+      console.warn(
+        `resolveOutput: omitting "${listKey}.${fieldName}" — its resolve chain exceeded ` +
+          `RESOLVE_CHAIN_MAX_LENGTH (${RESOLVE_CHAIN_MAX_LENGTH}): ${path}. This is a cost limit, ` +
+          `not an access denial.`,
+      )
+      return { readable: false }
+    }
+
+    // Use Promise.resolve() to handle both sync and async hooks
+    const resolved = await Promise.resolve(
+      hook({
+        value,
+        operation: 'query',
+        fieldName,
+        listKey,
+        item: hookItem,
+        context: deriveResolveOutputContext(args.context, link, config),
+      }),
+    )
+    return { readable: true, value: resolved }
   }
 
   return { readable: true, value }
@@ -227,6 +294,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       hookItem: workingItem,
       listKey,
       args,
+      config,
     })
 
     if (result.readable) {
@@ -265,6 +333,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       hookItem: filtered,
       listKey,
       args,
+      config,
     })
 
     if (result.readable) {

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -33,3 +33,5 @@ export type { AccessIncludeResult } from './access-filter.js'
 export { filterReadableFields } from './field-visibility.js'
 // Thrown when a caller include reaches past the depth the Access Filter can scope.
 export { AccessScopeDepthExceededError } from './errors.js'
+// Thrown when a resolveOutput hook's own resolve chain cycles back into itself.
+export { ResolveOutputCycleError } from './errors.js'

--- a/packages/core/src/access/multi-column-read-write.test.ts
+++ b/packages/core/src/access/multi-column-read-write.test.ts
@@ -52,7 +52,7 @@ function makeContext(overrides: { isSudo?: boolean } = {}): AccessContext {
   return {
     session: null,
     _isSudo: overrides.isSudo ?? false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
   } as any
 }

--- a/packages/core/src/access/relationship-count.test.ts
+++ b/packages/core/src/access/relationship-count.test.ts
@@ -51,7 +51,7 @@ function makeContext(
   return {
     session: null,
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
     db: findMany ? { user: { findMany } } : {},
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
   } as any

--- a/packages/core/src/access/relationship-label-filter.test.ts
+++ b/packages/core/src/access/relationship-label-filter.test.ts
@@ -46,7 +46,7 @@ function makeContext(): AccessContext {
   return {
     session: null,
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
     db: {},
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
   } as any

--- a/packages/core/src/access/types.ts
+++ b/packages/core/src/access/types.ts
@@ -290,12 +290,19 @@ export interface AccessContext<TPrisma extends PrismaClientLike = PrismaClientLi
   plugins: Record<string, unknown>
   _isSudo: boolean
   /**
-   * Internal mutable counter to track resolveOutput hook depth.
-   * When depth > 0, we skip auto-including relationships to prevent infinite loops
-   * when hooks make database queries that include relationships back to the original entity.
-   * We use a mutable object so that spreading the context preserves the reference.
+   * The resolve chain: the ordered sequence of `resolveOutput` hook
+   * `(listKey, fieldKey)` pairs a read has entered on the way to here. A
+   * top-level read starts with an empty chain. Each hook invocation is given
+   * a NEW context whose chain extends this one by its own pair — the chain is
+   * never mutated in place, so concurrent hook invocations (e.g. sibling rows
+   * in a to-many relation processed via `Promise.all`) never observe each
+   * other's chain. A hook that would re-enter a pair already on its own chain
+   * is refused (`ResolveOutputCycleError`) rather than left to recurse
+   * forever; a chain longer than `RESOLVE_CHAIN_MAX_LENGTH` is a separate,
+   * non-fatal cost limit. See ADR-0023 and the "Resolve chain" glossary entry
+   * in CONTEXT.md.
    */
-  _resolveOutputCounter: { depth: number }
+  _resolveOutputChain: readonly { listKey: string; fieldKey: string }[]
 }
 
 /**

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -434,7 +434,7 @@ export function getContext<
     // client, otherwise start empty and populate via plugin runtimes below.
     plugins: _sharedPlugins ?? {},
     _isSudo,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
 
   // Create access-controlled operations for each list, populating `db` in place.

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -297,9 +297,10 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
  * construction, so the request-time `context.db` is bound to the ORIGINAL
  * client. We rebuild the delegates against `tx` via {@link buildDbDelegate},
  * reusing the request context's `session`, `storage`, `plugins`, `_isSudo`, and
- * the shared `_resolveOutputCounter` reference (so resolveOutput depth tracking
- * is preserved). Plugin runtimes are NOT re-executed; the existing
- * `plugins` object is reused as-is.
+ * the current `_resolveOutputChain` value (carried through unchanged, so a
+ * write issued from inside a `resolveOutput` hook keeps that hook's chain).
+ * Plugin runtimes are NOT re-executed; the existing `plugins` object is
+ * reused as-is.
  */
 function bindContextToTransaction<TPrisma extends PrismaClientLike>(
   args: WritePipelineArgs<TPrisma>,
@@ -313,7 +314,7 @@ function bindContextToTransaction<TPrisma extends PrismaClientLike>(
     storage: context.storage,
     plugins: context.plugins,
     _isSudo: context._isSudo,
-    _resolveOutputCounter: context._resolveOutputCounter,
+    _resolveOutputChain: context._resolveOutputChain,
   }
   // Rebuild the db delegate against `tx`, pointing back at `txContext` so hooks
   // reached through it also see the transactional context.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,11 @@ export { ValidationError } from './hooks/index.js'
 // a user-input validation failure.
 export { AccessScopeDepthExceededError } from './access/index.js'
 
+// Thrown by a `resolveOutput` hook whose own read cycles back into a
+// `(list, field)` pair already on its resolve chain (see ADR-0023). Distinct
+// from `ValidationError` for the same reason as `AccessScopeDepthExceededError`.
+export { ResolveOutputCycleError } from './access/index.js'
+
 // Field self-containment validation — checks each field implements the
 // generation contract (getPrismaType / getTypeScriptType / getZodSchema, or
 // getPrismaRelation for relationships) so a misimplemented field fails early

--- a/packages/core/tests/access-relationships.test.ts
+++ b/packages/core/tests/access-relationships.test.ts
@@ -23,7 +23,7 @@ describe('Relationship Access Control', () => {
     },
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
 
   describe('getRelatedListConfig', () => {

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1430,7 +1430,7 @@ describe('getContext', () => {
       // Regression for issue #830: a read issued from inside a `resolveOutput`
       // hook used to lose relation row scoping ENTIRELY — `buildIncludeWithAccessControl`
       // returned a whole-object `undefined` for the inner read (any
-      // `_resolveOutputCounter.depth > 0`), which `mergeIncludeWithAccessControl`
+      // `_resolveOutputChain.length > 0`), which `mergeIncludeWithAccessControl`
       // treated as "nothing to merge against" and passed the caller's include
       // through completely unscoped. The fix scopes each immediate relation with
       // its own access `where` while still not auto-EXPANDING into that
@@ -1439,7 +1439,7 @@ describe('getContext', () => {
       describe('scopes (without expanding) a caller include used inside a resolveOutput hook (#830)', () => {
         // Build an Author config with a virtual field whose resolveOutput issues a
         // read WITH an explicit include. While that hook runs,
-        // _resolveOutputCounter.depth > 0.
+        // _resolveOutputChain.length > 0.
         function configWithResolveOutputProbe(
           callerInclude: Record<string, unknown>,
           capture: (include: unknown) => void,

--- a/packages/core/tests/default-value-create.test.ts
+++ b/packages/core/tests/default-value-create.test.ts
@@ -33,7 +33,7 @@ function makeContext(): AccessContext {
     storage: {} as any,
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
 }
 

--- a/packages/core/tests/hook-pipeline.test.ts
+++ b/packages/core/tests/hook-pipeline.test.ts
@@ -37,7 +37,7 @@ function makeContext(): AccessContext {
     storage: {} as any,
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
 }
 

--- a/packages/core/tests/nav-count.test.ts
+++ b/packages/core/tests/nav-count.test.ts
@@ -43,7 +43,7 @@ function makeContext(counts: Record<string, number>): {
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   } as unknown as AccessContext
   return { context, spies }
 }
@@ -168,7 +168,7 @@ describe('resolveNavCounts', () => {
       storage: {},
       plugins: {},
       _isSudo: false,
-      _resolveOutputCounter: { depth: 0 },
+      _resolveOutputChain: [],
     } as unknown as AccessContext
 
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/packages/core/tests/resolve-chain.test.ts
+++ b/packages/core/tests/resolve-chain.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import { virtual, text, relationship } from '../src/fields/index.js'
+import { ResolveOutputCycleError } from '../src/access/index.js'
+import { RESOLVE_CHAIN_MAX_LENGTH } from '../src/access/depth-limits.js'
+import type { OpenSaasConfig } from '../src/config/types.js'
+
+/**
+ * Regression coverage for issue #844 / ADR-0023: a `resolveOutput` hook that
+ * issues its own read used to be able to recurse without bound, because the
+ * only guard was a boolean read of a mutable counter shared by the whole
+ * request. The fix is a resolve chain — an ordered list of `(list, field)`
+ * pairs, extended by deriving a NEW context per hook invocation rather than
+ * mutating one shared value — with a cycle guard that refuses to re-enter a
+ * pair already on the chain, and a separate, non-fatal cost cap.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeModel(): any {
+  return { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn(), count: vi.fn() }
+}
+
+describe('resolve chain — cycle guard terminates hook-issued reads (#844)', () => {
+  it('two lists with no relationship fields, whose virtual hooks read each other, throw the cycle error instead of recursing', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        Ping: {
+          fields: {
+            label: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ context }) => {
+                  await context.db.pong.findMany({})
+                  return 'ping'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        Pong: {
+          fields: {
+            label: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ context }) => {
+                  await context.db.ping.findMany({})
+                  return 'pong'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = { ping: makeModel(), pong: makeModel() }
+    prisma.ping.findMany.mockResolvedValue([{ id: 'p1' }])
+    prisma.pong.findMany.mockResolvedValue([{ id: 'q1' }])
+
+    const context = await getContext(config, prisma, null)
+
+    await expect(context.db.ping.findMany({})).rejects.toThrow(ResolveOutputCycleError)
+
+    // The cycle must be caught within a handful of hops, never left to grow
+    // toward the hundreds of queries the un-bounded chain produced (#844).
+    const totalCalls =
+      prisma.ping.findMany.mock.calls.length + prisma.pong.findMany.mock.calls.length
+    expect(totalCalls).toBeLessThan(10)
+  })
+
+  it('names every (list, field) pair on the chain in order, including the repeat', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        Ping: {
+          fields: {
+            label: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ context }) => {
+                  await context.db.pong.findMany({})
+                  return 'ping'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        Pong: {
+          fields: {
+            label: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ context }) => {
+                  await context.db.ping.findMany({})
+                  return 'pong'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = { ping: makeModel(), pong: makeModel() }
+    prisma.ping.findMany.mockResolvedValue([{ id: 'p1' }])
+    prisma.pong.findMany.mockResolvedValue([{ id: 'q1' }])
+
+    const context = await getContext(config, prisma, null)
+
+    let caught: unknown
+    try {
+      await context.db.ping.findMany({})
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(ResolveOutputCycleError)
+    const err = caught as ResolveOutputCycleError
+    expect(err.chain).toEqual([
+      { listKey: 'Ping', fieldKey: 'label' },
+      { listKey: 'Pong', fieldKey: 'label' },
+      { listKey: 'Ping', fieldKey: 'label' },
+    ])
+    expect(err.message).toBe(
+      'resolveOutput cycle detected: Ping.label → Pong.label → Ping.label. A hook that ' +
+        're-enters a (list, field) pair already on its own resolve chain cannot terminate, so ' +
+        'the read is refused rather than left to recurse until the process runs out of memory. ' +
+        'Restructure the hooks so the read does not loop back into itself.',
+    )
+  })
+
+  it("reproduces the reporter's 3-list cyclic schema (User → Account → Student) within a bounded query budget", async () => {
+    // Sketch matches the issue's minimal reproduction: User.name reads
+    // Account, whose Student rows' own virtual field reads Account again.
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        User: {
+          fields: {
+            accounts: relationship({ ref: 'Account.user', many: true }),
+            name: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ item, context }) => {
+                  const [a] = await context.db.account.findMany({
+                    where: { userId: item.id },
+                    take: 1,
+                  })
+                  return `${(a as { firstName?: string } | undefined)?.firstName}`
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        Account: {
+          fields: {
+            firstName: text(),
+            user: relationship({ ref: 'User.accounts' }),
+            students: relationship({ ref: 'Student.account', many: true }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        Student: {
+          fields: {
+            account: relationship({ ref: 'Account.students' }),
+            label: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ item, context }) => {
+                  const a = await context.db.account.findUnique({
+                    where: { id: item.accountId },
+                  })
+                  return `${(a as { firstName?: string } | undefined)?.firstName}`
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = { user: makeModel(), account: makeModel(), student: makeModel() }
+    prisma.user.findMany.mockResolvedValue([{ id: 'u1' }])
+    // Account rows returned to a hook-issued read embed their (row-scoped,
+    // one-level) relations directly — deliberately WITHOUT `user`, so the
+    // walk goes through `students` → `Student.label`, matching the trace in
+    // the issue rather than short-circuiting through the `user` back-edge.
+    prisma.account.findMany.mockResolvedValue([
+      { id: 'a1', firstName: 'Ann', students: [{ id: 's1', accountId: 'a1' }] },
+    ])
+    // `context.db.<list>.findUnique` is implemented via the Prisma model's
+    // `findFirst` (see `createFindUnique` in `context/index.ts`), not its
+    // `findUnique` — mock the method actually called.
+    prisma.account.findFirst.mockResolvedValue({
+      id: 'a1',
+      firstName: 'Ann',
+      students: [{ id: 's1', accountId: 'a1' }],
+    })
+
+    const context = await getContext(config, prisma, null)
+
+    // Must settle (not hang), and must not have driven an unbounded number of
+    // queries before doing so — this is the actual OOM mechanism from #844.
+    await expect(context.db.user.findMany({})).rejects.toThrow(ResolveOutputCycleError)
+
+    const totalCalls =
+      prisma.user.findMany.mock.calls.length +
+      prisma.account.findMany.mock.calls.length +
+      prisma.account.findFirst.mock.calls.length
+    expect(totalCalls).toBeLessThan(20)
+  })
+})
+
+describe('resolve chain — cost cap is a warning, not a denial (#844)', () => {
+  it('an acyclic chain longer than RESOLVE_CHAIN_MAX_LENGTH omits the field and warns once, without throwing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    // A straight-line chain of distinct lists L0 → L1 → … so no (list, field)
+    // pair ever repeats — this chain is acyclic and would terminate on its
+    // own; it only needs to be capped as a cost limit.
+    const listCount = RESOLVE_CHAIN_MAX_LENGTH + 3
+    const lists: OpenSaasConfig['lists'] = {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = {}
+    for (let i = 0; i < listCount; i++) {
+      const listKey = `L${i}`
+      const dbKey = `l${i}`
+      const nextDbKey = `l${i + 1}`
+      lists[listKey] = {
+        fields: {
+          next: virtual({
+            type: 'string',
+            hooks: {
+              resolveOutput:
+                i < listCount - 1
+                  ? async ({ context }) => {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      await (context.db as any)[nextDbKey].findMany({})
+                      return 'ok'
+                    }
+                  : () => 'leaf',
+            },
+          }),
+        },
+        access: { operation: { query: () => true } },
+      }
+      prisma[dbKey] = makeModel()
+      prisma[dbKey].findMany.mockResolvedValue([{ id: `${dbKey}-row` }])
+    }
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists,
+    }
+
+    const context = await getContext(config, prisma, null)
+
+    // Does NOT throw — a cap hit is a cost limit, never a correctness denial.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await (context.db as any).l0.findMany({})
+    expect(result).toBeTruthy()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('RESOLVE_CHAIN_MAX_LENGTH')
+
+    // Nothing past the cap is ever queried — the chain simply stops growing.
+    for (let i = RESOLVE_CHAIN_MAX_LENGTH + 1; i < listCount; i++) {
+      expect(prisma[`l${i}`].findMany).not.toHaveBeenCalled()
+    }
+
+    warnSpy.mockRestore()
+  })
+})
+
+describe('resolve chain — concurrent hook invocations are isolated (#844)', () => {
+  it('sibling rows in a to-many read each observe their own chain of length 1, not a racing shared counter', async () => {
+    const observedLengths: number[] = []
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        Widget: {
+          fields: {
+            tag: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async ({ context }) => {
+                  // Stagger completion so the three hook invocations
+                  // genuinely interleave rather than running back-to-back.
+                  await new Promise((resolve) => setTimeout(resolve, Math.random() * 5))
+                  observedLengths.push(context._resolveOutputChain.length)
+                  return 'tag'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = { widget: makeModel() }
+    prisma.widget.findMany.mockResolvedValue([{ id: 'w1' }, { id: 'w2' }, { id: 'w3' }])
+
+    const context = await getContext(config, prisma, null)
+    await context.db.widget.findMany({})
+
+    expect(observedLengths.sort()).toEqual([1, 1, 1])
+  })
+
+  it('an unrelated top-level read in flight alongside a hook still gets its full nested auto-include', async () => {
+    let releaseSlowHook: () => void = () => {}
+
+    const config: OpenSaasConfig = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        Slow: {
+          fields: {
+            tag: virtual({
+              type: 'string',
+              hooks: {
+                resolveOutput: async () => {
+                  await new Promise<void>((resolve) => {
+                    releaseSlowHook = resolve
+                  })
+                  return 'tag'
+                },
+              },
+            }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        Fast: {
+          fields: {
+            name: text(),
+            child: relationship({ ref: 'FastChild' }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        FastChild: {
+          fields: {
+            label: text(),
+            grandchild: relationship({ ref: 'FastGrandchild' }),
+          },
+          access: { operation: { query: () => true } },
+        },
+        FastGrandchild: {
+          fields: { value: text() },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prisma: any = { slow: makeModel(), fast: makeModel() }
+    prisma.slow.findMany.mockResolvedValue([{ id: 'sl1' }])
+    prisma.fast.findMany.mockResolvedValue([{ id: 'f1' }])
+
+    const context = await getContext(config, prisma, null)
+
+    // Start the slow read — it blocks inside Slow.tag's hook until released.
+    const slowPromise = context.db.slow.findMany({})
+
+    // Let the slow hook actually start (and derive its context) before racing
+    // the unrelated read against it.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // While the slow hook is still in flight, issue a plain top-level read
+    // that has nothing to do with it.
+    const fastPromise = context.db.fast.findMany({})
+
+    await fastPromise
+    releaseSlowHook()
+    await slowPromise
+
+    // The unrelated read's auto-include must still descend two levels deep
+    // (child → grandchild), not collapse to a bare `{ child: true }` because
+    // it happened to run while a totally different read's hook was active.
+    expect(prisma.fast.findMany.mock.calls[0][0].include).toEqual({
+      child: { include: { grandchild: true } },
+    })
+  })
+})

--- a/packages/core/tests/write-pipeline.test.ts
+++ b/packages/core/tests/write-pipeline.test.ts
@@ -88,7 +88,7 @@ function makeContext(opts?: { isSudo?: boolean }): AccessContext {
     storage: {} as any,
     plugins: {},
     _isSudo: opts?.isSudo ?? false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
 }
 

--- a/packages/rag/src/storage/storage.test.ts
+++ b/packages/rag/src/storage/storage.test.ts
@@ -15,7 +15,7 @@ function createMockContext(dbOverrides: Record<string, unknown> = {}): AccessCon
     storage: {} as unknown,
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   } as AccessContext<unknown>
 }
 

--- a/packages/ui/tests/components/AdminUIListView.test.tsx
+++ b/packages/ui/tests/components/AdminUIListView.test.tsx
@@ -31,7 +31,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }

--- a/packages/ui/tests/components/AdminUINavigationSlot.test.tsx
+++ b/packages/ui/tests/components/AdminUINavigationSlot.test.tsx
@@ -35,7 +35,7 @@ function makeContext(delegates: Record<string, DelegateStub> = {}): AccessContex
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }

--- a/packages/ui/tests/components/AdminUISingleton.test.tsx
+++ b/packages/ui/tests/components/AdminUISingleton.test.tsx
@@ -63,7 +63,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   // Cast: this is a stub for rendering tests, not a full Prisma-backed context.
   return context as unknown as AccessContext<unknown>

--- a/packages/ui/tests/components/AdminUISingletonSuppress.test.tsx
+++ b/packages/ui/tests/components/AdminUISingletonSuppress.test.tsx
@@ -66,7 +66,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   // Cast: this is a stub for rendering tests, not a full Prisma-backed context.
   return context as unknown as AccessContext<unknown>

--- a/packages/ui/tests/components/ItemFormCountStrip.test.tsx
+++ b/packages/ui/tests/components/ItemFormCountStrip.test.tsx
@@ -34,7 +34,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   // Cast: this is a stub for pipeline tests, not a full Prisma-backed context.
   return context as unknown as AccessContext<unknown>

--- a/packages/ui/tests/components/ListView.test.tsx
+++ b/packages/ui/tests/components/ListView.test.tsx
@@ -30,7 +30,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }

--- a/packages/ui/tests/components/NavigationActiveState.test.tsx
+++ b/packages/ui/tests/components/NavigationActiveState.test.tsx
@@ -38,7 +38,7 @@ const context = {
   storage: {},
   plugins: {},
   _isSudo: false,
-  _resolveOutputCounter: { depth: 0 },
+  _resolveOutputChain: [],
 } as unknown as AccessContext<unknown>
 
 describe('Navigation active state', () => {

--- a/packages/ui/tests/components/NavigationChildrenRegion.test.tsx
+++ b/packages/ui/tests/components/NavigationChildrenRegion.test.tsx
@@ -35,7 +35,7 @@ const context = {
   storage: {},
   plugins: {},
   _isSudo: false,
-  _resolveOutputCounter: { depth: 0 },
+  _resolveOutputChain: [],
 } as unknown as AccessContext<unknown>
 
 describe('Navigation children region (ADR-0021)', () => {

--- a/packages/ui/tests/components/NavigationNavCounts.test.tsx
+++ b/packages/ui/tests/components/NavigationNavCounts.test.tsx
@@ -35,7 +35,7 @@ const context = {
   storage: {},
   plugins: {},
   _isSudo: false,
-  _resolveOutputCounter: { depth: 0 },
+  _resolveOutputChain: [],
 } as unknown as AccessContext<unknown>
 
 /**

--- a/packages/ui/tests/components/RelationshipTableEditableColumns.test.ts
+++ b/packages/ui/tests/components/RelationshipTableEditableColumns.test.ts
@@ -14,7 +14,7 @@ function makeContext(): AccessContext<unknown> {
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }

--- a/packages/ui/tests/components/SingletonNavDashboard.test.tsx
+++ b/packages/ui/tests/components/SingletonNavDashboard.test.tsx
@@ -53,7 +53,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   // Cast: this is a stub for rendering tests, not a full Prisma-backed context.
   return context as unknown as AccessContext<unknown>

--- a/packages/ui/tests/lib/getRelationshipOptions.test.ts
+++ b/packages/ui/tests/lib/getRelationshipOptions.test.ts
@@ -14,7 +14,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }

--- a/packages/ui/tests/lib/prepareItemForm.test.ts
+++ b/packages/ui/tests/lib/prepareItemForm.test.ts
@@ -14,7 +14,7 @@ function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unk
     storage: {},
     plugins: {},
     _isSudo: false,
-    _resolveOutputCounter: { depth: 0 },
+    _resolveOutputChain: [],
   }
   return context as unknown as AccessContext<unknown>
 }


### PR DESCRIPTION
## Summary

Implements the fix designed in ADR-0023 (merged in #845) for the unbounded `resolveOutput` recursion reported in #844: a `resolveOutput` hook that issues its own read could return rows whose own `resolveOutput` hooks issued further reads with no bound, driving the process to the V8 heap limit on a cyclic readable-relationship graph.

- **Resolve chain replaces the depth counter.** `AccessContext`'s `_resolveOutputCounter: { depth: number }` is replaced by `_resolveOutputChain: readonly { listKey: string; fieldKey: string }[]` — the ordered sequence of `resolveOutput` hooks a read has entered. The chain is never mutated in place: each hook invocation gets a **new, derived context** (with its `db` delegate rebuilt against that derived context, so a hook-issued read's own nested hooks actually see the extended chain rather than silently falling back to the top-level one).
- **Cycle guard throws.** A hook that would re-enter a `(list, field)` pair already on its own chain throws the new `ResolveOutputCycleError`, naming every pair on the chain in order (including the repeat), instead of recursing until the process runs out of memory.
- **Cost cap warns, never throws.** `RESOLVE_CHAIN_MAX_LENGTH` (alongside `READ_INCLUDE_MAX_DEPTH`) is a separate, non-fatal limit — an acyclic chain that legitimately runs deep (e.g. a virtual field reading another virtual field several hops down) omits the field and logs one `console.warn` rather than being denied.
- **Fixes a second, independent concurrency bug as a side effect.** Because the old counter was a single mutable value shared by the whole request, a plain top-level read running concurrently with an unrelated in-flight hook could observe "inside a hook" and silently collapse its own nested auto-include. Deriving a new context per hook invocation makes that check accurate under concurrency.
- Corrected the stale code comment in `access-filter.ts` that claimed the include-side guard alone prevents infinite loops (it doesn't — the loop runs through the hook↔read boundary, which is what the resolve chain now bounds).

## Changes

- `packages/core/src/access/types.ts` — `_resolveOutputCounter` → `_resolveOutputChain`
- `packages/core/src/access/depth-limits.ts` — new `RESOLVE_CHAIN_MAX_LENGTH` cost cap
- `packages/core/src/access/errors.ts` — new `ResolveOutputCycleError`
- `packages/core/src/access/field-visibility.ts` — cycle guard, cost cap, per-hook derived context + rebuilt `db` delegate
- `packages/core/src/access/access-filter.ts` — `insideResolveOutput` reads the chain; stale comment corrected
- `packages/core/src/context/index.ts`, `write-pipeline.ts` — chain initialization/threading through transaction rebinding
- `packages/core/src/access/index.ts`, `packages/core/src/index.ts` — export `ResolveOutputCycleError`
- Mechanical mock migration (`_resolveOutputCounter` → `_resolveOutputChain`) across `packages/core`, `packages/rag`, `packages/ui` test suites
- New regression coverage: `packages/core/tests/resolve-chain.test.ts` (cycle detection, chain naming, the reporter's 3-list cyclic schema terminating within a bounded query budget, the cost cap warning without throwing, sibling-row concurrency isolation, and the unrelated-concurrent-read auto-include fix)
- `.changeset/curly-otters-bound.md` — minor bump for `@opensaas/stack-core`

## Test plan

- [x] `pnpm test` in `packages/core` — 917 passed (911 pre-existing + 6 new), including the four #830 regression tests (unmodified assertions, mechanically updated mocks) exercised end-to-end through `getContext` with a mock Prisma client
- [x] `pnpm test` in `packages/rag` — 356 passed
- [x] `pnpm test` in `packages/ui` — 559 passed
- [x] `pnpm build` in `packages/core`, `packages/rag`, `packages/ui`
- [x] `pnpm lint` — clean (only pre-existing unrelated warnings)
- [x] `pnpm manypkg fix` — no-op
- [x] `pnpm format` — clean
- [x] Changeset added via the `pr-changeset` skill

Closes #844

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GX2uQea8awTF7qpsa8JuBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX2uQea8awTF7qpsa8JuBp)_