### PR TITLE
fix(core): a bare read fetches scalars, not relations (#848)

### DIFF
--- a/.changeset/silent-relations-detour.md
+++ b/.changeset/silent-relations-detour.md
@@ -1,0 +1,47 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
+---
+
+**This break is silent.** A `context.db` read with no `include` (and no fragment `query`) used to auto-include every readable relationship of the list, recursing up to 5 levels deep. It now returns the row's own columns plus its virtual fields only — matching Prisma's own semantics for a bare read — and relations arrive only when you name them. A read that used to return `post.author` now returns no `author` key at all: no error, no warning, just less data (ADR-0024). This applies uniformly to `findUnique`, `findMany`, and a singleton's `get()`, under sudo and under a session alike. Foreign-key columns (e.g. `authorId`) are unaffected and always returned, so a relation stays reachable by id without an `include`.
+
+**Detect call sites that need updating:**
+
+- Grep for bare reads: `context.db.*.find*` calls (or a singleton's `.get()`) with no `include` and no `query` argument, whose result is later used to access a relationship field.
+- Grep for `resolveOutput` hooks on `virtual` fields that read a relation off `item` (e.g. `item.author`, `item.posts`) — these silently degrade the same way, since a hook's own `context.db` read is subject to the same rule.
+
+**Migrate** by naming the relation explicitly, either via `include`:
+
+```typescript
+// Before — relied on the auto-include
+const post = await context.db.post.findUnique({ where: { id } })
+post.author // used to be populated
+
+// After — name it
+const post = await context.db.post.findUnique({
+  where: { id },
+  include: { author: true },
+})
+post.author // populated
+```
+
+or via a fragment `query`:
+
+```typescript
+const post = await context.db.post.findUnique({
+  where: { id },
+  query: postWithAuthorFragment,
+})
+```
+
+A `resolveOutput` hook that read `item.<relation>` should instead read through `context.db` with an explicit `include`, or its caller should pass one.
+
+**Singleton `get()` gains caller-`include` support** it never had — it can now be narrowed and widened like any other read:
+
+```typescript
+const settings = await context.db.settings.get({ include: { homepage: true } })
+```
+
+Bare reads also stop evaluating operation-level `query` access on related lists (that walk previously ran for every relation at every level before fetching anything), so an access function relied on for a side effect will no longer fire on a bare read.
+
+See `docs/adr/0024-a-read-with-no-include-fetches-scalars-not-relations.md` for the full rationale.

--- a/docs/content/concepts/access-control.md
+++ b/docs/content/concepts/access-control.md
@@ -23,7 +23,7 @@ Two defaults set the tone:
 
 Writes check operation-level access, filter writable fields, then persist. Reads are a **two-phase** pipeline:
 
-1. **Access Filter** (pre-query): the engine evaluates operation-level `query` access and merges the resulting filter into the Prisma `where`/`include` — rows and relations a session can't see never leave the database.
+1. **Access Filter** (pre-query): the engine evaluates operation-level `query` access and merges the resulting filter into the Prisma `where`/`include` — rows and relations a session can't see never leave the database. This only runs for relations the caller actually asked for: a read with no `include` (and no fragment `query`) fetches the row's own columns and virtual fields only, matching Prisma's own semantics — see [Queries & Fragments](/docs/concepts/queries).
 2. **Field Visibility** (post-query): on the returned rows, fields the session can't read are removed, `resolveOutput` hooks run, and virtual fields are computed.
 
 In order:

--- a/docs/content/concepts/queries.md
+++ b/docs/content/concepts/queries.md
@@ -97,6 +97,10 @@ if (!post) return notFound()
 `context.db` reads do **not** honour Prisma's `select` argument. Narrow a read with `include` (for relationships) or a fragment `query` instead. Passing `select` to `findUnique`/`findMany` is a no-op: it logs a runtime warning and the full, access-filtered record is still returned (field-level visibility is always enforced by [access control](/docs/concepts/access-control), regardless of `select`).
 {% /callout %}
 
+{% callout type="info" %}
+A `context.db` read with **no** `include` and **no** fragment `query` returns the row's own columns and virtual fields only — never relations, matching Prisma's own default. `post.author` is `undefined` on a bare `findUnique`/`findMany` unless you name it via `include` or a fragment. This also applies to a `virtual` field's `resolveOutput` hook issuing its own bare `context.db` read — it won't see relations either, so read through `context.db` for what you need or pass an `include`.
+{% /callout %}
+
 ### Via `runQuery` / `runQueryOne` (standalone helpers)
 
 When you don't have direct access to `context.db` (for example inside a hook or a shared utility), use the standalone helpers. They take the `context`, the PascalCase list key, the fragment, and query args:

--- a/docs/content/reference/context-api.md
+++ b/docs/content/reference/context-api.md
@@ -316,6 +316,10 @@ export async function getContext(session: Session = null) {
 
 All database operations are access-controlled and execute hooks in the correct order.
 
+{% callout type="warning" %}
+A read with no `include` (and no fragment `query`) returns the row's own columns plus its virtual fields — **never relations**, matching Prisma's own semantics for the same call. Name a relation explicitly via `include` (or a fragment `query`, see [Queries & Fragments](/docs/concepts/queries)) to fetch it. Foreign-key columns (e.g. `authorId`) are always returned, so a relation stays reachable by id without an `include`.
+{% /callout %}
+
 ### `findUnique()`
 
 Find a single record by unique field (typically ID).

--- a/examples/blog/test-context-nested-virtual.ts
+++ b/examples/blog/test-context-nested-virtual.ts
@@ -1,6 +1,11 @@
 /**
  * Test context.db operations with nested virtual fields
  * This demonstrates that virtual fields work in actual database operations
+ *
+ * A bare read (no `include`, no fragment `query`) returns the row's own
+ * columns plus its virtual fields — never relations (ADR-0024). `select` is
+ * also a documented no-op on `context.db` reads. So fetching `author` here
+ * requires an explicit `include`.
  */
 
 import type { Context } from './.opensaas/types'
@@ -10,17 +15,8 @@ async function testNestedVirtualFields(context: Context) {
   // This should type-check correctly with the fix
   const post = await context.db.post.findUnique({
     where: { id: '123' },
-    select: {
-      id: true,
-      title: true,
-      author: {
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          displayName: true, // Virtual field - should work now!
-        },
-      },
+    include: {
+      author: true,
     },
   })
 
@@ -32,14 +28,8 @@ async function testNestedVirtualFields(context: Context) {
 
   // Test findMany with nested virtual fields
   const posts = await context.db.post.findMany({
-    select: {
-      id: true,
-      title: true,
-      author: {
-        select: {
-          displayName: true, // Virtual field in nested relationship
-        },
-      },
+    include: {
+      author: true,
     },
   })
 
@@ -51,20 +41,15 @@ async function testNestedVirtualFields(context: Context) {
     }
   })
 
-  // Test create with nested select including virtual field
+  // Test create with nested include including virtual field
   const newPost = await context.db.post.create({
     data: {
       title: 'New Post',
       slug: 'new-post',
       content: 'Content here',
     },
-    select: {
-      id: true,
-      author: {
-        select: {
-          displayName: true, // Virtual field
-        },
-      },
+    include: {
+      author: true,
     },
   })
 

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -909,6 +909,34 @@ export type ${listName}FindFirstArgs = Omit<Prisma.${listName}FindFirstArgs, 'se
 }
 
 /**
+ * Generate custom GetArgs type for a singleton list's `get()` method — the same
+ * include/query narrowing as FindUniqueArgs, minus `where` (a singleton has no
+ * unique selector; there is exactly one row).
+ */
+function generateGetArgsType(listName: string, fields: Record<string, FieldConfig>): string {
+  const hasRelationships = Object.values(fields).some((field) => field.type === 'relationship')
+
+  if (hasRelationships) {
+    return `/**
+ * Custom Args for ${listName}.get() with virtual field support in nested relationships
+ */
+export type ${listName}GetArgs = {
+  select?: ${listName}Select | null
+  include?: ${listName}Include | null
+  query?: Fragment<${listName}Output, FieldSelection<${listName}Output>>
+}`
+  } else {
+    return `/**
+ * Custom Args for ${listName}.get() with virtual field support
+ */
+export type ${listName}GetArgs = {
+  select?: ${listName}Select | null
+  query?: Fragment<${listName}Output, FieldSelection<${listName}Output>>
+}`
+  }
+}
+
+/**
  * Generate custom CreateArgs type that uses our extended Select/Include
  */
 function generateCreateArgsType(listName: string, fields: Record<string, FieldConfig>): string {
@@ -1133,9 +1161,12 @@ function generateCustomDBType(config: OpenSaasConfig): string {
     lines.push(`      args: Prisma.SelectSubset<T, ${listName}UpdateManyArgs>`)
     lines.push(`    ) => Promise<Array<${listName}GetPayload<T>>>`)
 
-    // get - only for singleton lists
+    // get - only for singleton lists; accepts the same include/query narrowing
+    // as findUnique (minus `where` — a singleton has exactly one row).
     if (isSingleton) {
-      lines.push(`    get: () => Promise<${listName}GetPayload<{}> | null>`)
+      lines.push(`    get: <T extends ${listName}GetArgs>(`)
+      lines.push(`      args?: Prisma.SelectSubset<T, ${listName}GetArgs>`)
+      lines.push(`    ) => Promise<${listName}GetPayload<T> | null>`)
     }
 
     lines.push(`  }`)
@@ -1323,6 +1354,10 @@ export function generateTypes(config: OpenSaasConfig): string {
     lines.push('')
     lines.push(generateFindFirstArgsType(listName, listConfig.fields))
     lines.push('')
+    if (listConfig.isSingleton) {
+      lines.push(generateGetArgsType(listName, listConfig.fields))
+      lines.push('')
+    }
     lines.push(generateCreateArgsType(listName, listConfig.fields))
     lines.push('')
     lines.push(generateUpdateArgsType(listName, listConfig.fields))

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -247,6 +247,10 @@ Reads run no `afterOperation` (list or field):
 
 `context.db` reads (`findUnique`, `findMany`) do **not** apply Prisma's `select` semantics. Narrow a read with `include` (for relationships) or a fragment `query` instead. Passing `select` is a visible no-op: the op logs a one-time `console.warn` and still returns the full, access-filtered record. Field-level visibility is always enforced by access control regardless of `select`, so there is no leak — only a correctness/perf footgun the warning surfaces.
 
+### A Bare Read Fetches Scalars, Not Relations (ADR-0024)
+
+A read with no `include` and no fragment `query` returns the row's own columns plus its virtual fields — **never relations** — matching Prisma's own default. `findUnique`, `findMany`, and a singleton's `get()` all follow this rule uniformly, under sudo and under a session alike. Relations are fetched only when a caller names them via `include` or a fragment `query`, at which point the existing merge-with-access-control path (`mergeIncludeWithAccessControl`) applies exactly as before (#566/#830 unaffected). Foreign-key columns (e.g. `authorId`) are unaffected and always returned, so a relation stays reachable by id without an `include`. A `resolveOutput` hook that issues its own bare `context.db` read is subject to the same rule — reading `item.<relation>` inside such a hook silently returns `undefined` unless the hook's own read names that relation. See `docs/adr/0024-a-read-with-no-include-fetches-scalars-not-relations.md`.
+
 ### Context Type Safety
 
 Context uses generic typing to preserve Prisma types:

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -7,7 +7,6 @@ import {
   buildIncludeWithAccessControl,
   mergeIncludeWithAccessControl,
   stripVirtualFieldsFromInclude,
-  toPrismaInclude,
 } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
@@ -978,8 +977,13 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       // Sudo bypasses access control entirely — the caller's include is trusted
       // and used as-is (matching the prior behaviour); no per-relation filtering.
       include = args.include
-    } else {
-      // Build include with access control filters
+    } else if (args.include) {
+      // Caller named relations to fetch — build the access-controlled include
+      // and MERGE (not replace) it with the caller's: the caller selects WHICH
+      // relations to fetch, access control decides WHETHER and WITH WHAT
+      // filter (#566). A caller include naming a relation past the depth the
+      // engine can scope throws `AccessScopeDepthExceededError` (issue #830)
+      // rather than being returned unscoped.
       const accessControlledInclude = await buildIncludeWithAccessControl(
         listConfig.fields,
         {
@@ -992,22 +996,19 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
         // to it (self-referential or longer) stops re-descending.
         [listName],
       )
-      // MERGE (not replace) a caller-supplied include with the access-controlled
-      // include: the caller selects WHICH relations to fetch, access control
-      // decides WHETHER and WITH WHAT filter (#566). A bare auto-include (no
-      // caller include) still uses the access-controlled include directly. A
-      // caller include naming a relation past the depth the engine can scope
-      // throws `AccessScopeDepthExceededError` (issue #830) rather than being
-      // returned unscoped.
-      include = args.include
-        ? mergeIncludeWithAccessControl(
-            args.include,
-            accessControlledInclude,
-            listConfig.fields,
-            config,
-            listName,
-          )
-        : toPrismaInclude(accessControlledInclude)
+      include = mergeIncludeWithAccessControl(
+        args.include,
+        accessControlledInclude,
+        listConfig.fields,
+        config,
+        listName,
+      )
+    } else {
+      // A bare read (no caller `include`) fetches the row's own columns only,
+      // matching Prisma's semantics for the same call (ADR-0024). Relations
+      // are fetched only when a caller names them. This also means no related
+      // list's operation-level `query` access is evaluated on a bare read.
+      include = undefined
     }
 
     // Virtual fields have no database column. Whichever path produced
@@ -1116,8 +1117,13 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       // Sudo bypasses access control entirely — the caller's include is trusted
       // and used as-is (matching the prior behaviour); no per-relation filtering.
       include = args?.include
-    } else {
-      // Build include with access control filters
+    } else if (args?.include) {
+      // Caller named relations to fetch — build the access-controlled include
+      // and MERGE (not replace) it with the caller's: the caller selects WHICH
+      // relations to fetch, access control decides WHETHER and WITH WHAT
+      // filter (#566). A caller include naming a relation past the depth the
+      // engine can scope throws `AccessScopeDepthExceededError` (issue #830)
+      // rather than being returned unscoped.
       const accessControlledInclude = await buildIncludeWithAccessControl(
         listConfig.fields,
         {
@@ -1130,22 +1136,19 @@ function createFindMany<TPrisma extends PrismaClientLike>(
         // to it (self-referential or longer) stops re-descending.
         [listName],
       )
-      // MERGE (not replace) a caller-supplied include with the access-controlled
-      // include: the caller selects WHICH relations to fetch, access control
-      // decides WHETHER and WITH WHAT filter (#566). A bare auto-include (no
-      // caller include) still uses the access-controlled include directly. A
-      // caller include naming a relation past the depth the engine can scope
-      // throws `AccessScopeDepthExceededError` (issue #830) rather than being
-      // returned unscoped.
-      include = args?.include
-        ? mergeIncludeWithAccessControl(
-            args.include,
-            accessControlledInclude,
-            listConfig.fields,
-            config,
-            listName,
-          )
-        : toPrismaInclude(accessControlledInclude)
+      include = mergeIncludeWithAccessControl(
+        args.include,
+        accessControlledInclude,
+        listConfig.fields,
+        config,
+        listName,
+      )
+    } else {
+      // A bare read (no caller `include`) fetches each row's own columns only,
+      // matching Prisma's semantics for the same call (ADR-0024). Relations
+      // are fetched only when a caller names them. This also means no related
+      // list's operation-level `query` access is evaluated on a bare read.
+      include = undefined
     }
 
     // Virtual fields have no database column. Whichever path produced
@@ -1412,7 +1415,16 @@ function createGet<TPrisma extends PrismaClientLike>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createFn: any,
 ) {
-  return async () => {
+  return async (args?: {
+    include?: Record<string, unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query?: any
+    // `select` is not honoured — accepted only so the no-op can be made visible.
+    select?: Record<string, unknown>
+  }) => {
+    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
+    warnIfSelectIgnored(args, listName, 'get')
+
     // First try to find the existing record
     // Access Prisma model dynamically - required because model names are generated at runtime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1437,24 +1449,54 @@ function createGet<TPrisma extends PrismaClientLike>(
       }
     }
 
-    // Build include with access control filters
-    const accessControlledInclude = await buildIncludeWithAccessControl(
-      listConfig.fields,
-      {
-        session: context.session,
-        context,
-      },
-      config,
-      0,
-      // Seed the cycle guard with the root list so a relationship cycle back
-      // to it (self-referential or longer) stops re-descending.
-      [listName],
-    )
+    // When a query fragment is provided, build the include from the fragment
+    // instead of the access-controlled include. Access control still runs via
+    // filterReadableFields; the fragment then narrows to only the requested fields.
+    const fragment = isFragment(args?.query) ? args.query : null
+    let include: Record<string, unknown> | undefined
+
+    if (fragment) {
+      include = buildInclude(fragment._fields) ?? undefined
+    } else if (context._isSudo) {
+      // Sudo bypasses access control entirely — the caller's include is trusted
+      // and used as-is; no per-relation filtering.
+      include = args?.include
+    } else if (args?.include) {
+      // Caller named relations to fetch — build the access-controlled include
+      // and MERGE (not replace) it with the caller's, exactly like the other
+      // read ops (#566/#830).
+      const accessControlledInclude = await buildIncludeWithAccessControl(
+        listConfig.fields,
+        {
+          session: context.session,
+          context,
+        },
+        config,
+        0,
+        // Seed the cycle guard with the root list so a relationship cycle back
+        // to it (self-referential or longer) stops re-descending.
+        [listName],
+      )
+      include = mergeIncludeWithAccessControl(
+        args.include,
+        accessControlledInclude,
+        listConfig.fields,
+        config,
+        listName,
+      )
+    } else {
+      // A bare read (no caller `include`) fetches the row's own columns only,
+      // matching Prisma's semantics for the same call (ADR-0024).
+      include = undefined
+    }
+
+    // Virtual fields have no database column and must never reach Prisma (#628).
+    include = stripVirtualFieldsFromInclude(include, listConfig.fields, config)
 
     // Try to find the record
     const item = await model.findFirst({
       where,
-      include: toPrismaInclude(accessControlledInclude),
+      include,
     })
 
     // If record exists, return it
@@ -1471,6 +1513,10 @@ function createGet<TPrisma extends PrismaClientLike>(
         0,
         listName,
       )
+      // When a fragment is provided, pick only the requested fields from the result
+      if (fragment) {
+        return pickFields(filtered, fragment._fields)
+      }
       return filtered
     }
 

--- a/packages/core/tests/bare-read-scalars.test.ts
+++ b/packages/core/tests/bare-read-scalars.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import { config, list } from '../src/config/index.js'
+import { text, relationship, virtual } from '../src/fields/index.js'
+
+/**
+ * Regression coverage for issue #848 / ADR-0024: a `context.db` read with no
+ * `include` (and no fragment `query`) used to auto-include every readable
+ * relationship of the list, recursing to `READ_INCLUDE_MAX_DEPTH` and
+ * evaluating every related list's operation-level `query` access along the
+ * way. It now returns the row's own columns plus its virtual fields — nothing
+ * more — matching Prisma's own semantics for a bare read. Relations are
+ * fetched only when a caller names them via `include` (covered, unmodified,
+ * by the #566/#830 regression suites in `context.test.ts`).
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockPrisma(): any {
+  return {
+    author: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    post: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  }
+}
+
+function buildTestConfig(authorQuerySpy: ReturnType<typeof vi.fn>) {
+  return config({
+    db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+    lists: {
+      Author: list({
+        fields: {
+          name: text(),
+        },
+        access: { operation: { query: authorQuerySpy } },
+      }),
+      Post: list({
+        fields: {
+          title: text(),
+          // List-only ref keeps the schema minimal — the relation still owns
+          // an `authorId` foreign-key column, which is what matters here.
+          author: relationship({ ref: 'Author' }),
+          shout: virtual({
+            type: 'string',
+            hooks: {
+              resolveOutput: ({ item }) => `${(item as { title?: string }).title}!`,
+            },
+          }),
+        },
+        access: { operation: { query: () => true } },
+      }),
+    },
+  })
+}
+
+describe('a bare read fetches scalars, not relations (#848, ADR-0024)', () => {
+  it('findUnique with no include sends no include to the ORM and evaluates no related query access', async () => {
+    const authorQuerySpy = vi.fn(() => true)
+    const testConfig = await buildTestConfig(authorQuerySpy)
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findFirst.mockResolvedValue({ id: '1', title: 'Hello', authorId: 'a1' })
+
+    const context = getContext(testConfig, mockPrisma, null)
+    const result = await context.db.post.findUnique({ where: { id: '1' } })
+
+    expect(mockPrisma.post.findFirst).toHaveBeenCalledWith({
+      where: { id: '1' },
+      include: undefined,
+    })
+    // Related list's operation-level `query` access is never invoked — a bare
+    // read never even considers whether the relation is fetchable.
+    expect(authorQuerySpy).not.toHaveBeenCalled()
+
+    // Own columns (including the FK column) and the computed virtual field
+    // are present; the relation key is absent entirely.
+    expect(result).toEqual({ id: '1', title: 'Hello', authorId: 'a1', shout: 'Hello!' })
+    expect(result).not.toHaveProperty('author')
+  })
+
+  it('findMany with no include sends no include to the ORM and evaluates no related query access', async () => {
+    const authorQuerySpy = vi.fn(() => true)
+    const testConfig = await buildTestConfig(authorQuerySpy)
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findMany.mockResolvedValue([{ id: '1', title: 'Hello', authorId: 'a1' }])
+
+    const context = getContext(testConfig, mockPrisma, null)
+    const result = await context.db.post.findMany({})
+
+    expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ include: undefined }),
+    )
+    expect(authorQuerySpy).not.toHaveBeenCalled()
+
+    expect(result).toEqual([{ id: '1', title: 'Hello', authorId: 'a1', shout: 'Hello!' }])
+    expect(result[0]).not.toHaveProperty('author')
+  })
+
+  it('a caller-supplied include still evaluates the related query access (unchanged)', async () => {
+    const authorQuerySpy = vi.fn(() => true)
+    const testConfig = await buildTestConfig(authorQuerySpy)
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findFirst.mockResolvedValue({
+      id: '1',
+      title: 'Hello',
+      authorId: 'a1',
+      author: { id: 'a1', name: 'Ann' },
+    })
+
+    const context = getContext(testConfig, mockPrisma, null)
+    const result = await context.db.post.findUnique({
+      where: { id: '1' },
+      include: { author: true },
+    })
+
+    expect(authorQuerySpy).toHaveBeenCalled()
+    expect(result?.author).toEqual({ id: 'a1', name: 'Ann' })
+  })
+
+  it('sudo bare read also sends no include (behaviour already matched Prisma; unaffected by this change)', async () => {
+    const authorQuerySpy = vi.fn(() => true)
+    const testConfig = await buildTestConfig(authorQuerySpy)
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findFirst.mockResolvedValue({ id: '1', title: 'Hello', authorId: 'a1' })
+
+    const context = getContext(testConfig, mockPrisma, null).sudo()
+    const result = await context.db.post.findUnique({ where: { id: '1' } })
+
+    expect(mockPrisma.post.findFirst).toHaveBeenCalledWith({
+      where: { id: '1' },
+      include: undefined,
+    })
+    expect(authorQuerySpy).not.toHaveBeenCalled()
+    expect(result).toEqual({ id: '1', title: 'Hello', authorId: 'a1', shout: 'Hello!' })
+  })
+})

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -397,8 +397,12 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       const context = getContext(await testConfig, mockPrisma, null)
 
+      // A caller-supplied `include` is required to fetch `posts` at all — a
+      // bare read returns scalars only (ADR-0024) — so name it explicitly to
+      // exercise the per-relation access `where` merge.
       await context.db.user.findUnique({
         where: { id: '1' },
+        include: { posts: true },
       })
 
       // Verify findFirst was called with access filter
@@ -469,8 +473,11 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       const context = getContext(await testConfig, mockPrisma, null)
 
+      // `author` must be named explicitly — a bare read returns scalars only
+      // (ADR-0024).
       const result = await context.db.post.findUnique({
         where: { id: '1' },
+        include: { author: true },
       })
 
       // Email should be filtered out
@@ -522,8 +529,11 @@ describe('Nested Operations - Access Control and Hooks', () => {
 
       const context = getContext(await testConfig, mockPrisma, null)
 
+      // `author` must be named explicitly to exercise the access-denied drop —
+      // a bare read never requests it at all (ADR-0024).
       await context.db.post.findUnique({
         where: { id: '1' },
+        include: { author: true },
       })
 
       // Verify include does NOT include author (access denied)

--- a/packages/core/tests/resolve-chain.test.ts
+++ b/packages/core/tests/resolve-chain.test.ts
@@ -136,9 +136,12 @@ describe('resolve chain — cycle guard terminates hook-issued reads (#844)', ()
     )
   })
 
-  it("reproduces the reporter's 3-list cyclic schema (User → Account → Student) within a bounded query budget", async () => {
+  it("no longer reproduces the reporter's 3-list cyclic schema (User → Account → Student) on a bare hook-issued read (#848, ADR-0024)", async () => {
     // Sketch matches the issue's minimal reproduction: User.name reads
-    // Account, whose Student rows' own virtual field reads Account again.
+    // Account, whose Student rows' own virtual field reads Account again. The
+    // hook's read is BARE (no `include`), so under ADR-0024 it fetches
+    // Account's own columns only — `students` is never fetched, the walk into
+    // `Student.label` never happens, and the cycle cannot form.
     const config: OpenSaasConfig = {
       db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
       lists: {
@@ -191,33 +194,42 @@ describe('resolve chain — cycle guard terminates hook-issued reads (#844)', ()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prisma: any = { user: makeModel(), account: makeModel(), student: makeModel() }
     prisma.user.findMany.mockResolvedValue([{ id: 'u1' }])
-    // Account rows returned to a hook-issued read embed their (row-scoped,
-    // one-level) relations directly — deliberately WITHOUT `user`, so the
-    // walk goes through `students` → `Student.label`, matching the trace in
-    // the issue rather than short-circuiting through the `user` back-edge.
-    prisma.account.findMany.mockResolvedValue([
-      { id: 'a1', firstName: 'Ann', students: [{ id: 's1', accountId: 'a1' }] },
-    ])
+    // Mirrors real Prisma semantics: a relation key is only present on the
+    // returned row when the caller actually asked for it via `include`. The
+    // hook's read never does, so `students` (and `user`) never appear here —
+    // that is the mechanism that breaks the cycle under ADR-0024.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prisma.account.findMany.mockImplementation((args: any = {}) => {
+      const row: Record<string, unknown> = { id: 'a1', firstName: 'Ann' }
+      if (args.include?.students) row.students = [{ id: 's1', accountId: 'a1' }]
+      if (args.include?.user) row.user = { id: 'u1' }
+      return Promise.resolve([row])
+    })
     // `context.db.<list>.findUnique` is implemented via the Prisma model's
     // `findFirst` (see `createFindUnique` in `context/index.ts`), not its
     // `findUnique` — mock the method actually called.
-    prisma.account.findFirst.mockResolvedValue({
-      id: 'a1',
-      firstName: 'Ann',
-      students: [{ id: 's1', accountId: 'a1' }],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prisma.account.findFirst.mockImplementation((args: any = {}) => {
+      const row: Record<string, unknown> = { id: 'a1', firstName: 'Ann' }
+      if (args.include?.students) row.students = [{ id: 's1', accountId: 'a1' }]
+      if (args.include?.user) row.user = { id: 'u1' }
+      return Promise.resolve(row)
     })
 
     const context = await getContext(config, prisma, null)
 
-    // Must settle (not hang), and must not have driven an unbounded number of
-    // queries before doing so — this is the actual OOM mechanism from #844.
-    await expect(context.db.user.findMany({})).rejects.toThrow(ResolveOutputCycleError)
+    // Must settle (not hang or throw) — the bare hook-issued read never
+    // fetches `students`, so `Student.label` never fires and there is no
+    // cycle to detect.
+    const result = await context.db.user.findMany({})
+    expect(result).toEqual([{ id: 'u1', name: 'Ann' }])
 
+    // Only the two reads the hook actually issues — no unbounded recursion.
     const totalCalls =
       prisma.user.findMany.mock.calls.length +
       prisma.account.findMany.mock.calls.length +
       prisma.account.findFirst.mock.calls.length
-    expect(totalCalls).toBeLessThan(20)
+    expect(totalCalls).toBe(2)
   })
 })
 
@@ -319,7 +331,7 @@ describe('resolve chain — concurrent hook invocations are isolated (#844)', ()
     expect(observedLengths.sort()).toEqual([1, 1, 1])
   })
 
-  it('an unrelated top-level read in flight alongside a hook still gets its full nested auto-include', async () => {
+  it('an unrelated top-level read in flight alongside a hook still gets its full explicit include scoped', async () => {
     let releaseSlowHook: () => void = () => {}
 
     const config: OpenSaasConfig = {
@@ -377,16 +389,21 @@ describe('resolve chain — concurrent hook invocations are isolated (#844)', ()
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     // While the slow hook is still in flight, issue a plain top-level read
-    // that has nothing to do with it.
-    const fastPromise = context.db.fast.findMany({})
+    // that has nothing to do with it. A bare read fetches scalars only
+    // (ADR-0024), so name `child` explicitly — a caller include naming a
+    // relation BARE (`true`, no nested include of its own) still picks up the
+    // access-controlled include for whatever lies beneath it.
+    const fastPromise = context.db.fast.findMany({ include: { child: true } })
 
     await fastPromise
     releaseSlowHook()
     await slowPromise
 
-    // The unrelated read's auto-include must still descend two levels deep
-    // (child → grandchild), not collapse to a bare `{ child: true }` because
-    // it happened to run while a totally different read's hook was active.
+    // The unrelated read's access-controlled scoping must still descend two
+    // levels deep (child → grandchild), not collapse to a bare `{ child: true }`
+    // because it happened to run while a totally different read's hook was
+    // active — `insideResolveOutput` must stay scoped to the hook's OWN
+    // derived context, never leak into a concurrently-running, unrelated one.
     expect(prisma.fast.findMany.mock.calls[0][0].include).toEqual({
       child: { include: { grandchild: true } },
     })

--- a/packages/core/tests/singleton.test.ts
+++ b/packages/core/tests/singleton.test.ts
@@ -205,6 +205,89 @@ describe('Singleton Lists', () => {
     })
   })
 
+  describe('get() with a caller include (#848, ADR-0024)', () => {
+    // A singleton read gains the same caller-`include` handling as findUnique
+    // and findMany: bare fetches scalars only, and a caller include is merged
+    // with the access-controlled include (row-scoped per relation).
+    it("a bare get() sends no include and does not evaluate the related list's query access", async () => {
+      const homeAuthorQuerySpy = vi.fn(() => true)
+      const relConfig: OpenSaasConfig = {
+        db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+        lists: {
+          HomePage: {
+            fields: {
+              title: { type: 'text' },
+              featuredAuthor: { type: 'relationship', ref: 'Author' },
+            },
+            access: { operation: { query: () => true, create: () => true } },
+            isSingleton: true,
+          },
+          Author: {
+            fields: { name: { type: 'text' } },
+            access: { operation: { query: homeAuthorQuerySpy } },
+          },
+        },
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const relPrisma: any = {
+        homePage: { findFirst: vi.fn(), create: vi.fn(), count: vi.fn() },
+        author: { findFirst: vi.fn(), findMany: vi.fn() },
+      }
+      relPrisma.homePage.findFirst.mockResolvedValue({
+        id: 1,
+        title: 'Home',
+        featuredAuthorId: 'a1',
+      })
+
+      const context = getContext(relConfig, relPrisma, null)
+      const result = await context.db.homePage.get()
+
+      expect(relPrisma.homePage.findFirst).toHaveBeenCalledWith({ where: {}, include: undefined })
+      expect(homeAuthorQuerySpy).not.toHaveBeenCalled()
+      expect(result).toEqual({ id: 1, title: 'Home', featuredAuthorId: 'a1' })
+      expect(result).not.toHaveProperty('featuredAuthor')
+    })
+
+    it('a caller include on get() is merged with the access-controlled include, row-scoped like any other read', async () => {
+      const homeAuthorQuerySpy = vi.fn(() => ({ published: { equals: true } }))
+      const relConfig: OpenSaasConfig = {
+        db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+        lists: {
+          HomePage: {
+            fields: {
+              title: { type: 'text' },
+              featuredAuthor: { type: 'relationship', ref: 'Author' },
+            },
+            access: { operation: { query: () => true, create: () => true } },
+            isSingleton: true,
+          },
+          Author: {
+            fields: { name: { type: 'text' } },
+            access: { operation: { query: homeAuthorQuerySpy } },
+          },
+        },
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const relPrisma: any = {
+        homePage: { findFirst: vi.fn(), create: vi.fn(), count: vi.fn() },
+        author: { findFirst: vi.fn(), findMany: vi.fn() },
+      }
+      relPrisma.homePage.findFirst.mockResolvedValue({
+        id: 1,
+        title: 'Home',
+        featuredAuthorId: 'a1',
+        featuredAuthor: { id: 'a1', name: 'Ann' },
+      })
+
+      const context = getContext(relConfig, relPrisma, null)
+      const result = await context.db.homePage.get({ include: { featuredAuthor: true } })
+
+      const call = relPrisma.homePage.findFirst.mock.calls[0][0]
+      expect(call.include.featuredAuthor).toEqual({ where: { published: { equals: true } } })
+      expect(result?.featuredAuthor).toEqual({ id: 'a1', name: 'Ann' })
+    })
+  })
+
   describe('delete operation', () => {
     it('should block delete on singleton lists', async () => {
       mockPrisma.settings.findUnique.mockResolvedValue({


### PR DESCRIPTION
## Summary

- A `context.db` read with no `include` (and no fragment `query`) used to auto-include **every** readable relationship of the list, recursing up to `READ_INCLUDE_MAX_DEPTH` (5) and evaluating every related list's operation-level `query` access along the way — Prisma's own semantics for the same call are "scalars only." This is identified as the shared root cause behind #566, #830, and #844.
- A bare read now returns the row's own columns plus its virtual fields only, matching Prisma, for `findUnique`, `findMany`, and a singleton's `.get()` alike — under sudo and under a session, uniformly. `.get()` also gains caller-`include` support it never had.
- Relations are still fetched, and access-scoped exactly as before, whenever a caller names them via `include` or a fragment `query` — the `mergeIncludeWithAccessControl` / `buildIncludeWithAccessControl` machinery (and the #566/#830 fixes it carries) is untouched; it's simply no longer invoked unprompted.
- Follows the decision recorded in ADR-0024 (`docs/adr/0024-a-read-with-no-include-fetches-scalars-not-relations.md`, #849, already merged).

### Implementation

- `packages/core/src/context/index.ts`: `createFindUnique`, `createFindMany`, and `createGet` (singleton) only call `buildIncludeWithAccessControl` when the caller supplied an `include`; a bare read sends `include: undefined` straight through. `createGet` gains the same fragment/`include`/sudo handling the other two reads already had.
- `packages/cli/src/generator/types.ts`: generates a `<List>GetArgs` type for singleton lists and types `get()` to accept it (`include`/`query`/`select`), mirroring `FindUniqueArgs`.
- Docs (`docs/content/concepts/{queries,access-control}.md`, `docs/content/reference/context-api.md`, `packages/core/CLAUDE.md`) updated to describe the new default; one example (`examples/blog/test-context-nested-virtual.ts`) fixed to pass an explicit `include` instead of relying on the old auto-include.
- Existing regression coverage for #566 and #830 (caller-supplied-`include` behavior) is **unmodified** — only bare-read call sites in tests were updated. The `#844` cycle-guard reproduction now demonstrates the cycle no longer occurs on the reporter's bare hook-issued read (with the mock's return value made to actually respect the `include` argument, so it faithfully models Prisma); the genuine two-list cycle regression is untouched and still throws.
- New test coverage: `packages/core/tests/bare-read-scalars.test.ts` (bare vs. explicit-include behavior, including "no related `query` access is evaluated on a bare read") and a new describe block in `packages/core/tests/singleton.test.ts` for `.get()`'s new `include` support.

## Test plan

- [x] `pnpm test` in `packages/core` — 923/923 passing
- [x] `pnpm test` in `packages/cli` — 323/323 passing
- [x] `pnpm build` for `@opensaas/stack-core` and `@opensaas/stack-cli` — clean
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm manypkg fix` — no changes
- [x] `pnpm format` — clean
- [x] Generated `examples/blog` types and typechecked the fixed example script against them
- [x] Changeset added (`.changeset/silent-relations-detour.md`, minor) leading with the silent nature of the break, both detection strategies, and the migration

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PifFTifspW7ud4ptUGK4Mx


---
_Generated by [Claude Code](https://claude.ai/code/session_01234uq5m5nrBAB6cQa95m9M)_