### PR TITLE
fix(core): emit @@index for isIndexed: true, not an invalid inline @index

### DIFF
--- a/.changeset/swift-moons-gather.md
+++ b/.changeset/swift-moons-gather.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-core': patch
+'@opensaas/stack-cli': patch
+---
+
+Fix `isIndexed: true` on `text`, `decimal` and `calendarDay` emitting an invalid inline `@index` attribute, producing a schema Prisma rejects with "Attribute not known: @index".
+Non-unique indexes are now emitted as block-level `@@index([field])`; `isIndexed: 'unique'` is unchanged.

--- a/examples/blog/opensaas.config.ts
+++ b/examples/blog/opensaas.config.ts
@@ -118,6 +118,10 @@ export default config({
       fields: {
         title: text({
           validation: { isRequired: true },
+          // Non-unique index: titles are looked up and sorted on, but are not
+          // required to be distinct. Emitted as `@@index([title])` on the model
+          // — Prisma has no field-level `@index` attribute.
+          isIndexed: true,
           access: {
             read: () => true,
             create: isSignedIn,

--- a/examples/blog/prisma/schema.prisma
+++ b/examples/blog/prisma/schema.prisma
@@ -42,5 +42,6 @@ model Post {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @default(now()) @updatedAt
 
+  @@index([title])
   @@index([authorId])
 }

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -10,6 +10,8 @@ import {
   timestamp,
   select,
   json,
+  decimal,
+  calendarDay,
 } from '@opensaas/stack-core/fields'
 
 describe('Prisma Schema Generator', () => {
@@ -995,6 +997,98 @@ describe('Prisma Schema Generator', () => {
       // Should not have index
       expect(schema).not.toContain('@@index([authorId])')
       expect(schema).not.toContain('@@unique([authorId])')
+    })
+
+    // Prisma has no field-level `@index` attribute — `@id`, `@unique`,
+    // `@default`, `@map`, `@relation`, `@updatedAt` and `@ignore` are the whole
+    // field-level set. A non-unique index exists ONLY as the model-level
+    // `@@index([...])`, so emitting an inline `@index` produces a schema Prisma
+    // refuses to parse ("Attribute not known: @index").
+    it('should generate @@index for a scalar field with isIndexed: true', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          Post: {
+            fields: {
+              title: text({ isIndexed: true }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@@index([title])')
+      // The index must NOT ride along on the field line.
+      expect(schema).not.toMatch(/\s@index\b/)
+    })
+
+    it('should generate @@index for every scalar type that accepts isIndexed', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+        },
+        lists: {
+          Reading: {
+            fields: {
+              label: text({ isIndexed: true }),
+              amount: decimal({ isIndexed: true }),
+              takenOn: calendarDay({ isIndexed: true }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@@index([label])')
+      expect(schema).toContain('@@index([amount])')
+      expect(schema).toContain('@@index([takenOn])')
+      expect(schema).not.toMatch(/\s@index\b/)
+    })
+
+    it('should keep isIndexed: "unique" as an inline @unique on scalar fields', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          User: {
+            fields: {
+              email: text({ isIndexed: 'unique' }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      // A unique index has a valid field-level form, so it stays inline —
+      // unchanged from every schema this generator has ever produced.
+      expect(schema).toMatch(/email\s+String\??\s+@unique/)
+      expect(schema).not.toContain('@@unique([email])')
+    })
+
+    it('should not generate an index for a scalar without isIndexed', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          Post: {
+            fields: {
+              title: text(),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).not.toContain('@@index([title])')
+      expect(schema).not.toContain('@@unique([title])')
     })
 
     it('should generate @@map for a list-level db.map', () => {

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -84,6 +84,28 @@ function getFieldModifiers(
 }
 
 /**
+ * Get the block-level index a field asks for, if any.
+ *
+ * Prisma has no field-level `@index` attribute, so a non-unique index cannot
+ * ride along in the field's modifiers — the field requests it out-of-line and
+ * the generator emits `@@index([...])` on the model, exactly as it already does
+ * for relationship foreign keys via `getPrismaRelation`.
+ */
+function getFieldIndex(
+  fieldName: string,
+  field: FieldConfig,
+  provider?: string,
+  listName?: string,
+  keystoneCompat?: boolean,
+): boolean | 'unique' | undefined {
+  if (field.getPrismaType) {
+    return field.getPrismaType(fieldName, provider, listName, keystoneCompat).index
+  }
+
+  return undefined
+}
+
+/**
  * Generate Prisma schema from OpenSaas config
  *
  * @param prismaClientOutput - Module specifier for the patched Prisma client's
@@ -234,6 +256,9 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
     // Track relationship field names (in declaration order) for later processing
     const relationshipFieldNames: string[] = []
 
+    // Block-level indexes requested by scalar fields (see getFieldIndex)
+    const scalarIndexes: { field: string; indexType: boolean | 'unique' }[] = []
+
     // Add regular fields
     for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
       // Skip virtual fields - they don't create database columns
@@ -295,6 +320,17 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
       const nullPart = modStr.startsWith('?') ? '?' : ''
       const attrPart = modStr.startsWith('?') ? modStr.slice(1).trimStart() : modStr
       lines.push(`  ${paddedName} ${prismaType}${nullPart}${attrPart ? ' ' + attrPart : ''}`)
+
+      const index = getFieldIndex(
+        fieldName,
+        fieldConfig,
+        config.db.provider,
+        listName,
+        keystoneCompat,
+      )
+      if (index !== undefined && index !== false) {
+        scalarIndexes.push({ field: fieldName, indexType: index })
+      }
     }
 
     // Add relationship fields (lines + foreign key indexes) from the precomputed results
@@ -324,6 +360,17 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
     }
     if (timestamps.updatedAt) {
       lines.push('  updatedAt DateTime @default(now()) @updatedAt')
+    }
+
+    // Add block-level indexes for scalar fields. Emitted before the foreign-key
+    // indexes so the order follows field declaration order (scalars are written
+    // above relationships in the model).
+    for (const index of scalarIndexes) {
+      if (index.indexType === 'unique') {
+        lines.push(`  @@unique([${index.field}])`)
+      } else if (index.indexType === true) {
+        lines.push(`  @@index([${index.field}])`)
+      }
     }
 
     // Add indexes for foreign key fields

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -640,7 +640,8 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
    * @param keystoneCompat - Whether Keystone-compat mode is enabled (db.keystoneCompat).
    *   When true, non-null text columns without an explicit defaultValue emit
    *   `@default("")` to match Keystone 6's implicit empty-string text default.
-   * @returns Prisma type string, optional modifiers, and optional enum values
+   * @returns Prisma type string, optional modifiers, optional enum values, and
+   *   an optional block-level index request
    */
   getPrismaType?: (
     fieldName: string,
@@ -655,6 +656,26 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
      * The enum name is the value of `type`.
      */
     enumValues?: string[]
+    /**
+     * If set, this field requires a block-level index on the owning model:
+     * `@@index([fieldName])` for `true`, `@@unique([fieldName])` for
+     * `'unique'`. `false` and `undefined` both mean "no index".
+     *
+     * Prisma has no field-level `@index` attribute — a non-unique index can
+     * ONLY be expressed as the model-level `@@index([...])` — so a field that
+     * wants one has to ask for it out-of-line rather than appending to
+     * {@link modifiers}. (A unique index has both forms available; the
+     * built-in scalars keep emitting the inline `@unique` modifier for that
+     * case, so this channel carries only what cannot be written inline.)
+     *
+     * Same shape as {@link PrismaRelationResult.foreignKeyIndex}, which is how
+     * relationship fields have always emitted their foreign-key indexes. The
+     * generator handles both through one emit pass, so the field stays the
+     * authority on whether it can be indexed by name at all — a multi-column
+     * field (see {@link getPrismaColumns}) has no single column matching its
+     * field name and can decline, or name a real column of its own.
+     */
+    index?: boolean | 'unique'
   }
   /**
    * Get TypeScript type information for type generation

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -144,11 +144,11 @@ export function text<
         modifiers += ` @default(${defaultLiteral})`
       }
 
-      // Unique/index modifiers
+      // Unique modifier. A non-unique index has no field-level form in Prisma,
+      // so it is requested out-of-line via `index` below and emitted by the
+      // generator as `@@index([...])` on the model.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
-      } else if (options?.isIndexed === true) {
-        modifiers += ' @index'
       }
 
       // Map modifier
@@ -159,6 +159,7 @@ export function text<
       return {
         type: 'String',
         modifiers: modifiers.trimStart() || undefined,
+        index: options?.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {
@@ -402,16 +403,17 @@ export function decimal<
         modifiers += ` @map("${db.map}")`
       }
 
-      // Unique/index modifiers
+      // Unique modifier. A non-unique index has no field-level form in Prisma,
+      // so it is requested out-of-line via `index` below and emitted by the
+      // generator as `@@index([...])` on the model.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
-      } else if (options?.isIndexed === true) {
-        modifiers += ' @index'
       }
 
       return {
         type: 'Decimal',
         modifiers: modifiers.trimStart() || undefined,
+        index: options?.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {
@@ -747,16 +749,17 @@ export function calendarDay<
         modifiers += ` @map("${db.map}")`
       }
 
-      // Unique/index modifiers
+      // Unique modifier. A non-unique index has no field-level form in Prisma,
+      // so it is requested out-of-line via `index` below and emitted by the
+      // generator as `@@index([...])` on the model.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
-      } else if (options?.isIndexed === true) {
-        modifiers += ' @index'
       }
 
       return {
         type: 'DateTime',
         modifiers: modifiers.trimStart() || undefined,
+        index: options?.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {

--- a/packages/core/tests/field-types.test.ts
+++ b/packages/core/tests/field-types.test.ts
@@ -103,12 +103,16 @@ describe('Field Types', () => {
         expect(prismaType.modifiers).toContain('@unique')
       })
 
-      test('includes @index modifier', () => {
+      test('requests a block-level index rather than an inline modifier', () => {
         const field = text({ isIndexed: true })
         const prismaType = field.getPrismaType('slug')
 
         expect(prismaType.type).toBe('String')
-        expect(prismaType.modifiers).toContain('@index')
+        // Prisma has no field-level `@index` attribute — emitting one produces a
+        // schema Prisma refuses to parse. A non-unique index is requested
+        // out-of-line and lands as `@@index([slug])` on the model.
+        expect(prismaType.index).toBe(true)
+        expect(prismaType.modifiers ?? '').not.toContain('@index')
       })
 
       test('db.isNullable: true makes optional field explicitly nullable', () => {


### PR DESCRIPTION
## The bug

Prisma has no field-level `@index` attribute. `@id`, `@unique`, `@default`, `@map`, `@relation`, `@updatedAt` and `@ignore` are the entire field-level set — a non-unique index exists **only** as the model-level `@@index([...])`.

The `text()`, `decimal()` and `calendarDay()` builders appended ` @index` to their field modifiers, so any config using `isIndexed: true` on a scalar produced a schema Prisma refuses to parse:

```
error: Attribute not known: "@index".
  -->  prisma/schema.prisma:567
   |
567 |   twilioSid    String @index
```

`isIndexed: 'unique'` was unaffected — inline `@unique` is valid.

`relationship()` has always got this right, emitting `@@index([authorId])` via `getPrismaRelation()`. Only the scalar path was broken.

## The fix

A field's index request now travels out-of-line. `getPrismaType()` gains an optional `index?: boolean | 'unique'`, sitting beside the existing `enumValues` — already the channel by which a field asks for emission outside its own line. The generator collects these per list and emits them through the same pass that has always handled relationship foreign keys, so `@@index([...])` for scalars and FKs is one code path.

Keeping the field the authority — rather than having the generator sniff `isIndexed` itself — preserves field self-containment, and lets a multi-column field (`getPrismaColumns`, ADR-0006), which has no single column matching its field name, decline rather than emit a fresh broken index.

`isIndexed: 'unique'` keeps emitting the inline `@unique` modifier. It has a valid field-level form and every schema generated to date contains it, so this channel carries only what cannot be written inline. Output for existing configs is byte-identical.

## Why the tests didn't catch it

`packages/core/tests/field-types.test.ts:106` asserted our own return value against our own convention, so it went green on output Prisma rejects — and a replacement asserting `index: true` would have the identical blind spot.

CI already has real Prisma gates (the scaffold `generate` → `db:push` guard, and the nightly per-example run). They never fired because **no config in the repo used `isIndexed: true` on a scalar** — the gate existed, the fixture didn't. `Post.title` in `examples/blog` now carries the option, so the nightly gate exercises a real scalar index, and the regenerated schema is committed as a visible artifact.

Verified end-to-end locally: `pnpm generate` (which runs `prisma format` and `prisma generate`, both of which parse the schema) → `pnpm db:push` → `Post_title_idx` present in the SQLite database.

## Scope

Fixes the three builders that emit the broken attribute. `integer`, `timestamp` and `select` don't accept `isIndexed` at all — that's a compile error rather than a broken schema, and closing that gap is additive with its own design questions, so it's tracked separately rather than riding along in a fix.

No doc changes: the prose at `docs/content/reference/fields-api.md:59`/`:623` already described `@@index` semantics correctly — the docs were ahead of the code, and the copy-pasteable examples at `docs/content/concepts/field-types.md:100`/`:221` become valid as of this change.

## Testing

- Repointed `field-types.test.ts` to assert the index request and the absence of an inline attribute
- Four generator tests: `@@index` for a scalar, for all three affected types, `'unique'` still inline, and no index without the option
- Confirmed the new tests are load-bearing by reintroducing the bug in the built core — they fail while the other 108 generator tests pass, reproducing the original blind spot exactly
- Full suite green: 2,634 tests across 9 packages; `pnpm lint` 0 errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q142a6D7WsLJ39noXqrkN6)_