### PR TITLE
fix(auth): base-model plugin schema extension no longer clobbers derived Auth list db/access

### DIFF
--- a/.changeset/tame-otters-listen.md
+++ b/.changeset/tame-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+Fix a better-auth plugin's schema extension of a base model (`user`/`session`/`account`/`verification`) silently dropping the derived Auth list's `db` (`map`/`schema`/`timestamps`) and `access` config.

--- a/packages/auth/src/config/plugin.ts
+++ b/packages/auth/src/config/plugin.ts
@@ -62,7 +62,45 @@ export function authPlugin(config: AuthConfig): Plugin {
         verification: normalized.models.verification.modelName,
       }
 
-      // Extract additional lists from Better Auth plugins
+      // Add all auth lists FIRST, before any better-auth plugin schema
+      // extension is processed. This must happen before the betterAuthPlugins
+      // loop below so a base-model extension (e.g. a plugin's `schema: {
+      // user: { fields: … } }`) always finds the real derived list already
+      // registered under its key and takes the merge (`extendList`) path
+      // against it — instead of pre-empting that key with a bare
+      // `list({ fields })` that carries no `db`/`access` (see #861).
+      //
+      // The plugin only ever touches its OWN derived keys. When a developer
+      // renames the auth user model (e.g. user.modelName: 'AuthUser'), the
+      // derived key is 'AuthUser' and an app's separate 'User' list is left
+      // untouched — the plugin never extends/overwrites a list it didn't
+      // derive. Extending only kicks in when an existing list shares the
+      // derived key (e.g. the default 'User'), which is the intended
+      // "merge auth fields into my User" behaviour.
+      for (const [listName, listConfig] of Object.entries(authLists)) {
+        if (context.config.lists[listName]) {
+          // A list already exists under this derived key — merge auth fields
+          // in only. Access control belongs to whoever owns the list (the
+          // application declared it first), so the plugin never forwards its
+          // own access here — see ADR-0013.
+          context.extendList(listName, {
+            fields: listConfig.fields,
+            hooks: listConfig.hooks,
+            mcp: listConfig.mcp,
+          })
+        } else {
+          // Otherwise, add the auth list
+          context.addList(listName, listConfig)
+        }
+      }
+
+      // Extract additional lists from Better Auth plugins. Because the auth
+      // lists above are already registered, a schema extension of a base
+      // model (user/session/account/verification) always finds its resolved
+      // key occupied by the real derived list and merges via `extendList` —
+      // its `db`/`access` are preserved. Non-base plugin tables (e.g.
+      // `oauth_application`, `passkey`) still register as new lists via
+      // `addList`, same as before.
       for (const plugin of normalized.betterAuthPlugins) {
         if (plugin && typeof plugin === 'object' && 'schema' in plugin) {
           // Plugin has schema property - convert to OpenSaaS lists
@@ -86,32 +124,6 @@ export function authPlugin(config: AuthConfig): Plugin {
               context.addList(listName, listConfig)
             }
           }
-        }
-      }
-
-      // Add all auth lists.
-      //
-      // The plugin only ever touches its OWN derived keys. When a developer
-      // renames the auth user model (e.g. user.modelName: 'AuthUser'), the
-      // derived key is 'AuthUser' and an app's separate 'User' list is left
-      // untouched — the plugin never extends/overwrites a list it didn't
-      // derive. Extending only kicks in when an existing list shares the
-      // derived key (e.g. the default 'User'), which is the intended
-      // "merge auth fields into my User" behaviour.
-      for (const [listName, listConfig] of Object.entries(authLists)) {
-        if (context.config.lists[listName]) {
-          // A list already exists under this derived key — merge auth fields
-          // in only. Access control belongs to whoever owns the list (the
-          // application declared it first), so the plugin never forwards its
-          // own access here — see ADR-0013.
-          context.extendList(listName, {
-            fields: listConfig.fields,
-            hooks: listConfig.hooks,
-            mcp: listConfig.mcp,
-          })
-        } else {
-          // Otherwise, add the auth list
-          context.addList(listName, listConfig)
         }
       }
 

--- a/packages/auth/tests/plugin-derived-keys.test.ts
+++ b/packages/auth/tests/plugin-derived-keys.test.ts
@@ -161,6 +161,54 @@ describe('authPlugin - add-vs-extend with derived keys', () => {
     expect(appUser.access?.operation?.update?.({} as any)).toBe(false)
     expect(appUser.access?.operation?.update).toBe(hostUserUpdate)
   })
+
+  it('preserves the derived Auth list db (map/schema/timestamps) and access when a better-auth plugin extends a base model (#861)', async () => {
+    // A better-auth provider plugin (e.g. the `anonymous` plugin) that ships a
+    // schema extension for the base `user` model — the exact shape adoptBetterAuthTables()
+    // + betterAuthPlugins produces in the field. Before the #861 fix, the
+    // plugin's schema loop ran BEFORE the derived Auth lists were added, so it
+    // pre-empted `AuthUser` with a bare `list({ fields })` (no `db`, no
+    // `access`) — and the real derived list then lost to the field-only
+    // `extendList` merge, silently dropping `@@map`/`@@schema`/timestamps/access.
+    const anonymousBetterAuthPlugin = {
+      id: 'anonymous',
+      schema: {
+        user: {
+          fields: {
+            isAnonymous: { type: 'boolean', required: false },
+          },
+        },
+      },
+    }
+
+    const userQuery = vi.fn(() => true)
+    const result = await config({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          schema: 'auth',
+          user: { modelName: 'AuthUser' },
+          session: { modelName: 'AuthSession' },
+          account: { modelName: 'AuthAccount' },
+          verification: { modelName: 'AuthVerification' },
+          betterAuthPlugins: [anonymousBetterAuthPlugin],
+          access: { user: { operation: { query: userQuery } } },
+        }),
+      ],
+      lists: {},
+    })
+
+    const authUser = result.lists.AuthUser
+
+    // The plugin's schema extension is merged in...
+    expect(authUser.fields).toHaveProperty('isAnonymous')
+    // ...without displacing the derived list's own db config...
+    expect(authUser.db?.map).toBe('AuthUser')
+    expect(authUser.db?.schema).toBe('auth')
+    expect(authUser.db?.timestamps).toBe(true)
+    // ...or its access config.
+    expect(authUser.access?.operation?.query).toBe(userQuery)
+  })
 })
 
 describe('authPlugin - runtime user-key resolution', () => {


### PR DESCRIPTION
## Summary

- `authPlugin`'s `init` processed `betterAuthPlugins` schema extensions **before** registering the derived Auth lists. When a better-auth plugin declared a schema extension for a base model (`user`/`session`/`account`/`verification`), it resolved to the derived list key (e.g. `AuthUser`) and pre-empted it with a bare `list({ fields })` via `addList` — no `db`, no `access`. The real derived list, added moments later, then lost to the field-only `extendList` merge, silently dropping its `@@map`/`@@schema`/`timestamps` and `access` config.
- For an app adopting a separate-schema better-auth install (`adoptBetterAuthTables({ schema: 'auth' })`), this relocated the auth user table out of its Postgres schema and dropped the timestamp columns — a destructive migration produced purely by adding a plugin like `anonymous()`.
- Fixed by registering the derived Auth lists **before** processing the `betterAuthPlugins` schema loop, so a base-model extension always finds its key already occupied by the real derived list and takes the `extendList` (merge) path against it. Non-base plugin tables (`oauth_application`, `passkey`, …) still register via `addList` exactly as before.

## Test plan

- [x] Added a regression test (`packages/auth/tests/plugin-derived-keys.test.ts`) asserting that a base-model-extending better-auth plugin leaves the derived Auth list's `db.map`/`db.schema`/`db.timestamps` and `access` unchanged, while still merging in the plugin's fields
- [x] Verified the new test fails against the pre-fix code and passes after the fix (TDD red/green)
- [x] `pnpm --filter @opensaas/stack-auth test` — 147 tests pass
- [x] `pnpm --filter @opensaas/stack-auth build` — type-checks clean
- [x] `pnpm lint` — no new errors
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed
- [x] Changeset added (`@opensaas/stack-auth`, patch)

Closes #861


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVFf2Y9j9eByjLyo2aiVGT)_