### PR TITLE
fix(auth): derived expiresAt and the session/account user FK are required

### DIFF
--- a/.changeset/tiny-plums-relax.md
+++ b/.changeset/tiny-plums-relax.md
@@ -1,0 +1,19 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-auth': minor
+---
+
+A relationship field's foreign key can now be declared non-nullable via `db.isNullable: false` — the generated FK column and its relation field lose their `?` together. Omitting the option leaves every existing relationship unchanged (still nullable by default).
+
+```typescript
+user: relationship({
+  ref: 'User.sessions',
+  db: { isNullable: false },
+})
+// Generates: userId String  (was String?)
+//            user   User    @relation(...)  (was User?)
+```
+
+`@opensaas/stack-auth`'s derived Auth lists now use this to match better-auth's own Prisma schema: `Session.expiresAt`, `Verification.expiresAt`, and the `Session.user`/`Account.user` foreign keys generate as required instead of nullable.
+
+**Migration note:** this changes the generated schema for existing greenfield apps. Running `opensaas generate` followed by `prisma db push`/`prisma migrate dev` will produce a migration that adds `NOT NULL` to `Session.expiresAt`, `Verification.expiresAt`, `Session.userId`, and `Account.userId`. Since better-auth's own adapter always writes these columns, no existing row should violate the new constraint — but back up production data before applying, as with any schema migration.

--- a/docs/content/reference/fields-api.md
+++ b/docs/content/reference/fields-api.md
@@ -921,6 +921,7 @@ relationship(options: {
   many?: boolean
   db?: {
     foreignKey?: boolean
+    isNullable?: boolean
   }
   ui?: {
     displayMode?: 'select' | 'cards'
@@ -1045,6 +1046,40 @@ The `db.foreignKey` option is only needed for one-to-one relationships where you
 {% callout type="warning" %}
 Setting `db.foreignKey: true` on both sides of a one-to-one relationship will cause a validation error. Only one side can store the foreign key.
 {% /callout %}
+
+##### `db.isNullable`
+
+Controls DB-level nullability of the foreign key column and its relation field, together — they can never disagree.
+
+**Type:** `boolean`
+**Default:** `true` (nullable, matching every relationship generated before this option existed)
+
+**Constraints:**
+
+- Only valid on the FK-owning (single) side of a relationship — the many side has no foreign key column of its own and rejects this option
+
+**Example:**
+
+```typescript
+Session: list({
+  fields: {
+    // Every session genuinely belongs to a user — make the FK required
+    user: relationship({
+      ref: 'User.sessions',
+      db: { isNullable: false },
+    }),
+  },
+})
+```
+
+**Generated Prisma schema:**
+
+```prisma
+model Session {
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+}
+```
 
 ##### `ui.displayMode`
 

--- a/examples/starter-auth/prisma/schema.prisma
+++ b/examples/starter-auth/prisma/schema.prisma
@@ -48,15 +48,15 @@ model User {
 }
 
 model Session {
-  id        String    @id @default(cuid())
-  token     String    @unique
-  expiresAt DateTime?
+  id        String   @id @default(cuid())
+  token     String   @unique
+  expiresAt DateTime
   ipAddress String?
   userAgent String?
-  userId    String?   @map("user")
-  user      User?     @relation(onDelete: Cascade, fields: [userId], references: [id])
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(now()) @updatedAt
+  userId    String   @map("user")
+  user      User     @relation(onDelete: Cascade, fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Account {
@@ -70,17 +70,17 @@ model Account {
   scope                 String?
   idToken               String?
   password              String?
-  userId                String?   @map("user")
-  user                  User?     @relation(onDelete: Cascade, fields: [userId], references: [id])
+  userId                String    @map("user")
+  user                  User      @relation(onDelete: Cascade, fields: [userId], references: [id])
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @default(now()) @updatedAt
 }
 
 model Verification {
-  id         String    @id @default(cuid())
+  id         String   @id @default(cuid())
   identifier String
   value      String
-  expiresAt  DateTime?
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @default(now()) @updatedAt
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @default(now()) @updatedAt
 }

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -110,14 +110,18 @@ function fieldDb(fieldName: string, fields: Record<string, string>): { map: stri
  * Build the `db` config for a `user` relationship (`Session.user` /
  * `Account.user`), honouring a `userId` column override from the better-auth
  * `fields` map and mirroring better-auth's own FK shape: no separate FK index
- * — the index is applied at the field level via `isIndexed: false` — and
- * `onDelete: Cascade`, so a generated Auth schema diffs clean against a live
- * better-auth database on both dimensions instead of showing a spurious index
- * drop and a referential-action change (issue #679).
+ * — the index is applied at the field level via `isIndexed: false` —
+ * `onDelete: Cascade`, and a required (non-nullable) foreign key, since
+ * better-auth's adapter always writes a `userId` on every session/account row
+ * it creates. This means a generated Auth schema diffs clean against a live
+ * better-auth database on all three dimensions instead of showing a spurious
+ * index drop, a referential-action change, and a `DROP NOT NULL` (issues #679,
+ * #863).
  */
 function userRelationshipDb(fields: Record<string, string>): NonNullable<RelationshipField['db']> {
   const column = fields.userId
   return {
+    isNullable: false,
     ...(column ? { foreignKey: { map: column } } : {}),
     extendPrismaSchema: ({ fkLine, relationLine }) => ({
       fkLine,
@@ -187,7 +191,9 @@ function createSessionList(
         isIndexed: 'unique',
         db: fieldDb('token', f),
       }),
-      expiresAt: timestamp({ db: fieldDb('expiresAt', f) }),
+      expiresAt: timestamp({
+        db: { isNullable: false, ...fieldDb('expiresAt', f) },
+      }),
       ipAddress: text({ db: fieldDb('ipAddress', f) }),
       userAgent: text({ db: fieldDb('userAgent', f) }),
       user: relationship({
@@ -252,7 +258,9 @@ function createVerificationList(
     fields: {
       identifier: text({ validation: { isRequired: true }, db: fieldDb('identifier', f) }),
       value: text({ validation: { isRequired: true }, db: fieldDb('value', f) }),
-      expiresAt: timestamp({ db: fieldDb('expiresAt', f) }),
+      expiresAt: timestamp({
+        db: { isNullable: false, ...fieldDb('expiresAt', f) },
+      }),
     },
     db: listDb(model, DEFAULT_MODEL_NAMES.verification),
     access,

--- a/packages/auth/tests/derive-auth-lists.test.ts
+++ b/packages/auth/tests/derive-auth-lists.test.ts
@@ -44,6 +44,13 @@ describe('deriveAuthLists - default behaviour (no overrides)', () => {
     expect(lists.User.fields.accounts.ref).toBe('Account.user')
   })
 
+  it('marks Session/Verification expiresAt as DB-required, matching better-auth (issue #863)', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+
+    expect(lists.Session.fields.expiresAt.db?.isNullable).toBe(false)
+    expect(lists.Verification.fields.expiresAt.db?.isNullable).toBe(false)
+  })
+
   it('emits no table @@map and no scalar @map for default keys', () => {
     const { lists } = deriveAuthLists(defaultModels)
 
@@ -106,6 +113,13 @@ describe('deriveAuthLists - user FK shape mirrors better-auth (issue #679)', () 
       // The FK line itself is untouched by the cascade rewrite.
       expect(result.fkLine).toBe('  userId       String?')
     }
+  })
+
+  it('marks the user FK non-nullable, matching better-auth (issue #863)', () => {
+    const { lists } = deriveAuthLists(defaultModels)
+
+    expect(lists.Session.fields.user.db?.isNullable).toBe(false)
+    expect(lists.Account.fields.user.db?.isNullable).toBe(false)
   })
 
   it('keeps the cascade extendPrismaSchema alongside a userId column override', () => {

--- a/packages/auth/tests/generated-fk-shape.test.ts
+++ b/packages/auth/tests/generated-fk-shape.test.ts
@@ -79,3 +79,37 @@ describe('generated auth schema — Session/Account user FK mirrors better-auth 
     expect(widget).toContain('@@index([ownerId])')
   })
 })
+
+describe('generated auth schema — required columns mirror better-auth (issue #863)', () => {
+  it('emits a required (non-nullable) userId FK and user relation on Session and Account', async () => {
+    const schema = await generateSchema({
+      db: { provider: 'sqlite' },
+      plugins: [authPlugin({ emailAndPassword: { enabled: true } })],
+      lists: {},
+    })
+
+    for (const model of ['Session', 'Account']) {
+      const block = modelBlock(schema, model)
+
+      expect(block).toMatch(/userId\s+String\s/)
+      expect(block).not.toMatch(/userId\s+String\?/)
+      expect(block).toMatch(/user\s+User\s+@relation/)
+      expect(block).not.toMatch(/user\s+User\?/)
+    }
+  })
+
+  it('emits a required (non-nullable) expiresAt on Session and Verification', async () => {
+    const schema = await generateSchema({
+      db: { provider: 'sqlite' },
+      plugins: [authPlugin({ emailAndPassword: { enabled: true } })],
+      lists: {},
+    })
+
+    for (const model of ['Session', 'Verification']) {
+      const block = modelBlock(schema, model)
+
+      expect(block).toMatch(/expiresAt\s+DateTime\s/)
+      expect(block).not.toMatch(/expiresAt\s+DateTime\?/)
+    }
+  })
+})

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -978,6 +978,36 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toContain('user         User? // Back reference')
     })
 
+    it('should throw when db.isNullable is set on the non-FK-owning side of a one-to-one relationship', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+              profile: relationship({
+                ref: 'Profile.user',
+                db: { foreignKey: true },
+              }),
+            },
+          },
+          Profile: {
+            fields: {
+              bio: text(),
+              // Wrong side: User.profile owns the FK, not Profile.user.
+              user: relationship({ ref: 'User.profile', db: { isNullable: false } }),
+            },
+          },
+        },
+      }
+
+      expect(() => generatePrismaSchema(config)).toThrow(
+        'db.isNullable can only be used on the foreign-key-owning side',
+      )
+    })
+
     it('should generate @@index for foreign keys by default (matching Keystone behavior)', () => {
       const config: OpenSaasConfig = {
         db: {

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -750,6 +750,93 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toContain('categoryId   String? @map("category")')
     })
 
+    it('should generate a required FK column and relation field with db.isNullable: false', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+              posts: relationship({ ref: 'Post.author', many: true }),
+            },
+          },
+          Post: {
+            fields: {
+              title: text(),
+              author: relationship({
+                ref: 'User.posts',
+                db: { isNullable: false },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('authorId     String @map("author")')
+      expect(schema).not.toContain('authorId     String?')
+      expect(schema).toContain('author       User  @relation(fields: [authorId], references: [id])')
+      expect(schema).not.toContain('author       User?')
+    })
+
+    it('should default the FK column and relation field to nullable without db.isNullable', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          User: {
+            fields: {
+              name: text(),
+              posts: relationship({ ref: 'Post.author', many: true }),
+            },
+          },
+          Post: {
+            fields: {
+              title: text(),
+              author: relationship({ ref: 'User.posts' }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('authorId     String?')
+      expect(schema).toContain(
+        'author       User?  @relation(fields: [authorId], references: [id])',
+      )
+    })
+
+    it('should generate a required FK for a list-only relationship with db.isNullable: false', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          Category: {
+            fields: {
+              name: text(),
+            },
+          },
+          Post: {
+            fields: {
+              title: text(),
+              category: relationship({ ref: 'Category', db: { isNullable: false } }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('categoryId   String @map("category")')
+      expect(schema).not.toContain('categoryId   String?')
+    })
+
     it('should apply extendPrismaSchema to self-referential relationship with onDelete', () => {
       const config: OpenSaasConfig = {
         db: {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1110,6 +1110,28 @@ export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =
     isIndexed?: boolean | 'unique'
     db?: {
       /**
+       * Controls DB-level nullability of the foreign key column (and its
+       * relation field) independently of the many side's own shape. Only
+       * meaningful on the FK-owning (single) side of a relationship — the
+       * many side has no column of its own to make non-nullable and rejects
+       * this option.
+       *
+       * @default true (nullable, matching every relationship generated before
+       * this option existed)
+       *
+       * @example
+       * ```typescript
+       * // Every session genuinely belongs to a user — make the FK required
+       * user: relationship({
+       *   ref: 'User.sessions',
+       *   db: { isNullable: false },
+       * })
+       * // Generates: userId String  (was String?)
+       * //            user   User    @relation(...)  (was User?)
+       * ```
+       */
+      isNullable?: boolean
+      /**
        * Controls foreign key placement and column name for bidirectional relationships
        * Can be a boolean or an object with a map property
        * Only valid on single (non-many) relationships

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1411,7 +1411,21 @@ function getPrismaRelation(
     return { modelLines: [fkLine, relationLine], foreignKeyIndex, backRelation }
   }
 
-  // Non-FK side of a one-to-one relationship: just the relation field
+  // Non-FK side of a one-to-one relationship: just the relation field. This
+  // side has no foreign key column, so `db.isNullable` (which only makes
+  // sense paired with a column) cannot be honoured here — reject rather than
+  // silently ignore a developer's stated intent (the FK-owning side is
+  // determined by `db.foreignKey`/alphabetical ordering, not by which field
+  // declares `isNullable`).
+  if (field.db?.isNullable === false) {
+    throw new Error(
+      `db.isNullable can only be used on the foreign-key-owning side of a relationship. ` +
+        `"${listKey}.${fieldName}" does not own the foreign key for this one-to-one relationship — ` +
+        `set db.isNullable on "${targetList}.${targetField}" instead, or make this side own the ` +
+        `foreign key via db.foreignKey.`,
+    )
+  }
+
   let relationLine = `  ${paddedName} ${targetList}?`
   if (field.db?.extendPrismaSchema) {
     relationLine = field.db.extendPrismaSchema({ relationLine }).relationLine

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1387,10 +1387,16 @@ function getPrismaRelation(
         ? ` @map("${field.db.foreignKey.map}")`
         : ` @map("${fieldName}")`
 
-    let fkLine = `  ${fkPaddedName} String?${uniqueModifier}${mapModifier}`
+    // Nullability: explicit db.isNullable overrides the default (nullable),
+    // matching the scalar fields' `db.isNullable` convention. It moves the FK
+    // column and its relation field together — they can never disagree.
+    const isNullable = field.db?.isNullable ?? true
+    const nullModifier = isNullable ? '?' : ''
+
+    let fkLine = `  ${fkPaddedName} String${nullModifier}${uniqueModifier}${mapModifier}`
     let relationLine = targetField
-      ? `  ${paddedName} ${targetList}?  @relation(fields: [${foreignKeyField}], references: [id])`
-      : `  ${paddedName} ${targetList}?  @relation("${listKey}_${fieldName}", fields: [${foreignKeyField}], references: [id])`
+      ? `  ${paddedName} ${targetList}${nullModifier}  @relation(fields: [${foreignKeyField}], references: [id])`
+      : `  ${paddedName} ${targetList}${nullModifier}  @relation("${listKey}_${fieldName}", fields: [${foreignKeyField}], references: [id])`
 
     if (field.db?.extendPrismaSchema) {
       const extended = field.db.extendPrismaSchema({ fkLine, relationLine })
@@ -1449,6 +1455,16 @@ export function relationship<
           'List-only refs (ref: "ListName") always create foreign keys automatically.',
       )
     }
+  }
+
+  // Validate db.isNullable usage: only the FK-owning (single) side of a
+  // relationship has a column to make non-nullable — the many side always
+  // generates an array field with no nullability of its own.
+  if (options.db?.isNullable !== undefined && options.many) {
+    throw new Error(
+      'db.isNullable can only be used on single relationships (many: false or undefined). ' +
+        'Many-side of a relationship has no foreign key column to make non-nullable.',
+    )
   }
 
   const field: RelationshipField<TTypeInfo> = {

--- a/packages/core/tests/field-types.test.ts
+++ b/packages/core/tests/field-types.test.ts
@@ -761,6 +761,18 @@ describe('Field Types', () => {
         expect(field.ref).toBe('Post.author')
         expect(field.many).toBe(true)
       })
+
+      test('accepts db.isNullable on a single relationship', () => {
+        const field = relationship({ ref: 'User.posts', db: { isNullable: false } })
+
+        expect(field.db?.isNullable).toBe(false)
+      })
+
+      test('throws error when db.isNullable is used with many: true', () => {
+        expect(() => {
+          relationship({ ref: 'Post.author', many: true, db: { isNullable: false } })
+        }).toThrow('db.isNullable can only be used on single relationships')
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- Core: relationship fields gain `db.isNullable` on the FK-owning (single) side — when set to `false`, the generated FK column and its relation field lose their `?` together. Omitting it leaves every existing relationship byte-for-byte unchanged (still nullable by default). Misusing it on a `many: true` field throws at field-definition time, mirroring the existing `db.foreignKey` validation.
- Auth: the derived Auth lists now use `db.isNullable: false` so `Session.expiresAt`, `Verification.expiresAt`, and the `Session.user`/`Account.user` foreign keys generate as **required**, matching better-auth's own Prisma schema. Previously these four columns were nullable with no config seam to correct them, so a generated Auth schema could never match a live better-auth database on these columns.
- Regenerated `examples/starter-auth/prisma/schema.prisma` to reflect the new required columns.
- Docs: documented the new `db.isNullable` relationship option in `docs/content/reference/fields-api.md`.
- Added a changeset (minor on both `@opensaas/stack-core` and `@opensaas/stack-auth`) with a migration note — existing greenfield adopters will see a migration that adds `NOT NULL` to these four columns after regenerating.

## Test plan

- [x] Unit tests: `relationship()` constructor accepts `db.isNullable` on a single relationship and throws when combined with `many: true` (`packages/core/tests/field-types.test.ts`)
- [x] Generator tests: FK column/relation field emit without `?` when `db.isNullable: false`, for both bidirectional and list-only refs; default (omitted) behavior unchanged (`packages/cli/src/generator/prisma.test.ts`)
- [x] Auth unit tests: derived `Session`/`Account`/`Verification` fields carry `db.isNullable: false` (`packages/auth/tests/derive-auth-lists.test.ts`)
- [x] Auth end-to-end schema tests: the fully assembled generated schema emits required `userId`/`user` and `expiresAt` columns (`packages/auth/tests/generated-fk-shape.test.ts`)
- [x] `pnpm build`, `pnpm -w exec turbo run test` (core, cli, auth, ui) all pass
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` — no changes needed beyond what's committed
- [x] Docs link-check passes

Closes #863

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD1mhmPMEZFxWWjpRToN2C)_