### PR TITLE
auth: separate a model's tableName (@@map) from its modelName

### DIFF
--- a/.changeset/tame-jars-adopt.md
+++ b/.changeset/tame-jars-adopt.md
@@ -1,0 +1,22 @@
+---
+'@opensaas/stack-auth': minor
+---
+
+Add a per-model `tableName` option, independent of `modelName`, so a renamed Auth list key can still adopt a differently-named live table — most commonly better-auth's own default lowercase table names (`user`, `session`, `account`, `verification`).
+
+```typescript
+authPlugin({
+  user: { modelName: 'AuthUser', tableName: 'user' },
+  session: { modelName: 'AuthSession', tableName: 'session' },
+})
+```
+
+`adoptBetterAuthTables()` gains matching `useBetterAuthTableNames` and `tableNames` options:
+
+```typescript
+adoptBetterAuthTables({ useBetterAuthTableNames: true })
+// or explicitly:
+adoptBetterAuthTables({ tableNames: { user: 'user', session: 'session' } })
+```
+
+With no `tableName` set, behaviour is unchanged: the table name still follows `modelName` when it differs from the better-auth default, otherwise no `@@map` is emitted.

--- a/docs/content/how-to/authentication.md
+++ b/docs/content/how-to/authentication.md
@@ -1024,6 +1024,59 @@ The recipe is just a convenience over the plugin's own `schema` / per-model
 `modelName` / `fields` options — anything it sets you can also set directly on
 `authPlugin`, or override after spreading it in.
 
+### Adopting better-auth's default table names
+
+The most common migration shape isn't the renamed-table one above — it's a
+project that ran better-auth **before** adding Stack, so its tables are
+still better-auth's own default lowercase names (`user`, `session`,
+`account`, `verification`). Your app almost always also has its own domain
+`User`, so the Auth identity still needs a prefixed list key (`AuthUser`) to
+avoid a collision — but that prefixed key must map to the _unprefixed_ live
+table, not a table named `AuthUser`.
+
+`modelName` and the physical table name are independent for exactly this
+reason: `modelName` sets the list key, and a separate `tableName` pins the
+`@@map`. Pass `useBetterAuthTableNames: true` to point every model's table
+name at better-auth's own defaults while keeping the `Auth`-prefixed list
+keys:
+
+```typescript
+authPlugin({
+  ...adoptBetterAuthTables({ schema: 'auth', useBetterAuthTableNames: true }),
+  emailAndPassword: { enabled: true },
+})
+// List keys: AuthUser / AuthSession / AuthAccount / AuthVerification
+// Live tables: user / session / account / verification (via @@map)
+```
+
+For a mix — most tables use better-auth's defaults but one was renamed — use
+the per-model `tableNames` escape hatch instead (it takes precedence over
+`useBetterAuthTableNames` for any model it names):
+
+```typescript
+adoptBetterAuthTables({
+  useBetterAuthTableNames: true,
+  tableNames: { user: 'app_users' }, // only the user table was renamed
+})
+```
+
+The same knob is available directly on `authPlugin` without the recipe, for a
+single model:
+
+```typescript
+authPlugin({
+  user: { modelName: 'AuthUser', tableName: 'user' },
+  session: { modelName: 'AuthSession', tableName: 'session' },
+  account: { modelName: 'AuthAccount', tableName: 'account' },
+  verification: { modelName: 'AuthVerification', tableName: 'verification' },
+})
+```
+
+With no `tableName` set, behaviour is unchanged from before this option
+existed: the table name follows `modelName` whenever it differs from the
+better-auth default, so a renamed-table install (the `adoptBetterAuthTables()`
+default from the previous section) keeps working without any changes.
+
 ### Linking your app User to the Auth identity
 
 Because the Auth identity (`AuthUser`) and your domain `User` are separate

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -71,13 +71,16 @@ developer writes — not hardcoded. The pure derivation lives in
 `src/config/derive-auth-lists.ts` (`deriveAuthLists`), which `getAuthLists`
 and the plugin's add-vs-extend logic consume:
 
-- per-model `modelName` → list key + table `@@map`
+- per-model `modelName` → list key (and Prisma model name)
+- per-model `tableName` → table `@@map`, **independent of `modelName`**
+  (defaults to `modelName` when it differs from the better-auth default,
+  otherwise unset — i.e. unchanged output when `tableName` isn't set)
 - per-model `fields` (better-auth field → column) → field-level `@map`
 - the `userId` column override → the `user` relationship foreign-key `@map`
 - relationship refs between the Auth lists follow the derived keys
   (e.g. `Session.user → AuthUser.sessions`)
 
-With no `modelName`/`fields` overrides the output is unchanged
+With no `modelName`/`tableName`/`fields` overrides the output is unchanged
 (`User`/`Session`/`Account`/`Verification`, original field shapes, no `@@map`).
 
 ```typescript
@@ -87,6 +90,15 @@ authPlugin({
   session: { modelName: 'AuthSession', fields: { userId: 'user_id' } },
 })
 // Adds AuthUser/AuthSession/... and leaves an app's own `User` untouched.
+```
+
+```typescript
+// modelName sets the list key; tableName independently pins the live table —
+// e.g. a prefixed list key adopting better-auth's own default lowercase table.
+authPlugin({
+  user: { modelName: 'AuthUser', tableName: 'user' },
+  session: { modelName: 'AuthSession', tableName: 'session' },
+})
 ```
 
 Because the plugin only ever adds/extends its **derived** keys, an app's own
@@ -164,10 +176,10 @@ How it wires up (Postgres multi-schema):
 
 `adoptBetterAuthTables()` (`src/config/adopt-better-auth-tables.ts`) is a thin
 recipe that returns the `AuthConfig` adoption knobs — the plugin-level `schema`
-plus a per-model `modelName` (and optional column `fields` maps) — preset to the
-conventions of a standard separate-schema better-auth install. It ties together
-the keys/field derivation and schema placement so a migrator doesn't rebuild the
-config by hand. Spread it into `authPlugin`:
+plus a per-model `modelName` (and optional column `fields`/`tableName` maps) —
+preset to the conventions of a standard separate-schema better-auth install. It
+ties together the keys/field derivation and schema placement so a migrator
+doesn't rebuild the config by hand. Spread it into `authPlugin`:
 
 ```typescript
 import { authPlugin, adoptBetterAuthTables } from '@opensaas/stack-auth'
@@ -176,7 +188,23 @@ authPlugin({
   ...adoptBetterAuthTables(), // schema: 'auth', AuthUser/AuthSession/AuthAccount/AuthVerification
   emailAndPassword: { enabled: true },
 })
-// Options: adoptBetterAuthTables({ schema, modelNamePrefix, fields })
+// Options: adoptBetterAuthTables({ schema, modelNamePrefix, fields, useBetterAuthTableNames, tableNames })
+```
+
+The most common adoption shape is a project that ran better-auth **before**
+Stack, so its live tables are still better-auth's own default lowercase names
+(`user`/`session`/`account`/`verification`) even though the derived list keys
+need an `Auth` prefix to avoid colliding with the app's own domain `User`.
+`useBetterAuthTableNames: true` sets every model's `tableName` to that
+default; the per-model `tableNames` map is the escape hatch for a mix (it
+wins over `useBetterAuthTableNames` for any model it names):
+
+```typescript
+authPlugin({
+  ...adoptBetterAuthTables({ useBetterAuthTableNames: true }),
+  // → AuthUser/AuthSession/AuthAccount/AuthVerification list keys,
+  //   @@map("user")/@@map("session")/@@map("account")/@@map("verification")
+})
 ```
 
 It is pure config (no side effects): everything it sets can also be written

--- a/packages/auth/src/config/adopt-better-auth-tables.ts
+++ b/packages/auth/src/config/adopt-better-auth-tables.ts
@@ -28,6 +28,22 @@
  * auth migration. The recipe never touches the application's own domain `User`:
  * its model names are `Auth`-prefixed by default and the plugin only ever
  * adds/extends its *derived* keys.
+ *
+ * The single most common adoption shape is a project that ran better-auth
+ * *before* adding Stack: its live tables are still better-auth's own default
+ * lowercase names (`user`/`session`/`account`/`verification`), even though the
+ * derived list keys need the `Auth` prefix to avoid colliding with the app's
+ * own domain `User`. Pass `useBetterAuthTableNames: true` to point every
+ * model's physical table at that default while keeping the prefixed list keys
+ * (or `tableNames` for an explicit per-model override):
+ *
+ * ```typescript
+ * authPlugin({
+ *   ...adoptBetterAuthTables({ useBetterAuthTableNames: true }),
+ *   // AuthUser/AuthSession/AuthAccount/AuthVerification list keys,
+ *   // @@map("user")/@@map("session")/@@map("account")/@@map("verification")
+ * })
+ * ```
  */
 
 import type { AuthConfig, AuthModelConfig } from './types.js'
@@ -89,6 +105,39 @@ export type AdoptBetterAuthTablesOptions = {
     account?: Record<string, string>
     verification?: Record<string, string>
   }
+
+  /**
+   * Set every model's physical table name to better-auth's own default
+   * lowercase table name (`user`, `session`, `account`, `verification`) —
+   * independent of the prefixed list key/`modelName`.
+   *
+   * This is the single most common adoption shape: a project that ran
+   * better-auth before adding the stack has exactly these tables, and the
+   * default `modelNamePrefix: 'Auth'` alone would otherwise pin the table
+   * name to the prefixed model name (`AuthUser`, ...), which `prisma migrate
+   * diff` reads as a rename against the live `user` table.
+   *
+   * Ignored for a model with an explicit entry in {@link tableNames}.
+   *
+   * @default false
+   */
+  useBetterAuthTableNames?: boolean
+
+  /**
+   * Per-model explicit table name overrides, keyed by model. Takes
+   * precedence over `useBetterAuthTableNames` for that model.
+   *
+   * @example
+   * ```typescript
+   * adoptBetterAuthTables({ tableNames: { user: 'users' } })
+   * ```
+   */
+  tableNames?: {
+    user?: string
+    session?: string
+    account?: string
+    verification?: string
+  }
 }
 
 /** The four better-auth models and their default (unprefixed) model names. */
@@ -97,6 +146,14 @@ const MODEL_DEFAULT_NAMES = {
   session: 'Session',
   account: 'Account',
   verification: 'Verification',
+} as const
+
+/** better-auth's own default lowercase table names, per model. */
+const BETTER_AUTH_DEFAULT_TABLE_NAMES = {
+  user: 'user',
+  session: 'session',
+  account: 'account',
+  verification: 'verification',
 } as const
 
 /**
@@ -123,11 +180,23 @@ export type AdoptBetterAuthTablesConfig = Pick<
 export function adoptBetterAuthTables(
   options: AdoptBetterAuthTablesOptions = {},
 ): AdoptBetterAuthTablesConfig {
-  const { schema = 'auth', modelNamePrefix = 'Auth', fields = {} } = options
+  const {
+    schema = 'auth',
+    modelNamePrefix = 'Auth',
+    fields = {},
+    useBetterAuthTableNames = false,
+    tableNames = {},
+  } = options
 
   const buildModel = (model: keyof typeof MODEL_DEFAULT_NAMES): AuthModelConfig => {
     const config: AuthModelConfig = {
       modelName: `${modelNamePrefix}${MODEL_DEFAULT_NAMES[model]}`,
+    }
+    const tableName =
+      tableNames[model] ??
+      (useBetterAuthTableNames ? BETTER_AUTH_DEFAULT_TABLE_NAMES[model] : undefined)
+    if (tableName !== undefined) {
+      config.tableName = tableName
     }
     const fieldMap = fields[model]
     if (fieldMap && Object.keys(fieldMap).length > 0) {

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -2,13 +2,15 @@
  * Pure `better-auth config → Auth lists` derivation.
  *
  * This module is intentionally free of side effects and plugin/runtime
- * concerns: given the resolved better-auth model config (per-model `modelName`
- * and `fields` column maps) plus any custom User fields, it produces the four
- * OpenSaaS Auth lists (user/session/account/verification) with:
+ * concerns: given the resolved better-auth model config (per-model `modelName`,
+ * `tableName`, and `fields` column maps) plus any custom User fields, it
+ * produces the four OpenSaaS Auth lists (user/session/account/verification)
+ * with:
  *
  *  - list keys taken from each model's `modelName`
- *  - a table `@@map` (list-level `db.map`) when the key differs from the
- *    default better-auth model name
+ *  - a table `@@map` (list-level `db.map`) taken from each model's resolved
+ *    `tableName` — independent of `modelName`, so a renamed list key can still
+ *    adopt a differently-named live table
  *  - field-level `@map` (`db.map`) for any better-auth field → column override
  *  - relationship refs between the auth lists wired to the *derived* keys
  *    (e.g. `Session.user → AuthUser.sessions`)
@@ -30,17 +32,6 @@ import type { ListConfig } from '@opensaas/stack-core'
 import type { RelationshipField } from '@opensaas/stack-core/fields'
 import type { ExtendUserListConfig } from '../lists/index.js'
 import type { AuthAccessConfig, NormalizedAuthModelConfig, NormalizedAuthModels } from './types.js'
-
-/**
- * Default better-auth model names — used to decide whether a `@@map` is needed
- * (only when the configured `modelName` differs from the default).
- */
-const DEFAULT_MODEL_NAMES = {
-  user: 'User',
-  session: 'Session',
-  account: 'Account',
-  verification: 'Verification',
-} as const
 
 /**
  * The derived Auth list set together with the keys each list was placed under.
@@ -71,24 +62,24 @@ export type DerivedAuthLists = {
  * Auth list must opt back in so the generated models keep those columns and
  * better-auth keeps working.
  *
- * When the developer renames the model (e.g. `modelName: 'AuthUser'`), we also
- * pin the physical table name to that model name via `@@map("AuthUser")` so the
- * generated list adopts the developer's live table exactly. When a `schema` is
- * configured (plugin-level or per-model), the list is placed in that Postgres
- * schema via `@@schema(...)`.
+ * The physical table name (`@@map`) comes from the model's resolved
+ * `tableName` — independent of the list key/`modelName` — so a renamed list
+ * key can still adopt a differently-named live table (e.g. better-auth's own
+ * default lowercase table names). When a `schema` is configured (plugin-level
+ * or per-model), the list is placed in that Postgres schema via `@@schema(...)`.
  *
- * With no `modelName`/`schema` overrides we emit only `timestamps: true`,
+ * With no `tableName`/`schema` overrides we emit only `timestamps: true`,
  * leaving the default `User`/`Session`/... table/schema output unchanged.
  */
-function listDb(
-  model: NormalizedAuthModelConfig,
-  defaultModelName: string,
-): { timestamps: true; map?: string; schema?: string } {
-  const map = model.modelName !== defaultModelName ? model.modelName : undefined
+function listDb(model: NormalizedAuthModelConfig): {
+  timestamps: true
+  map?: string
+  schema?: string
+} {
   const schema = model.schema
   return {
     timestamps: true,
-    ...(map !== undefined ? { map } : {}),
+    ...(model.tableName !== undefined ? { map: model.tableName } : {}),
     ...(schema !== undefined ? { schema } : {}),
   }
 }
@@ -165,7 +156,7 @@ function createUserList(
       // Custom fields from user config
       ...(userConfig.fields || {}),
     },
-    db: listDb(model, DEFAULT_MODEL_NAMES.user),
+    db: listDb(model),
     access: userConfig.access || access,
     hooks: userConfig.hooks,
   })
@@ -202,7 +193,7 @@ function createSessionList(
         db: userRelationshipDb(f),
       }),
     },
-    db: listDb(model, DEFAULT_MODEL_NAMES.session),
+    db: listDb(model),
     access,
   })
 }
@@ -237,7 +228,7 @@ function createAccountList(
       idToken: text({ db: fieldDb('idToken', f) }),
       password: text({ db: fieldDb('password', f) }),
     },
-    db: listDb(model, DEFAULT_MODEL_NAMES.account),
+    db: listDb(model),
     access,
   })
 }
@@ -262,7 +253,7 @@ function createVerificationList(
         db: { isNullable: false, ...fieldDb('expiresAt', f) },
       }),
     },
-    db: listDb(model, DEFAULT_MODEL_NAMES.verification),
+    db: listDb(model),
     access,
   })
 }

--- a/packages/auth/src/config/index.ts
+++ b/packages/auth/src/config/index.ts
@@ -26,14 +26,24 @@ const DEFAULT_MODEL_NAMES = {
  * falling back to the better-auth default model name and an empty column map.
  * The model's Postgres schema is the per-model `schema` override when present,
  * otherwise the plugin-level `schema` default (or `undefined` for `public`).
+ *
+ * `tableName` defaults to today's behaviour when not explicitly set: it
+ * follows `modelName` when that differs from the better-auth default (so a
+ * renamed list still pins its table via `@@map`), otherwise it stays unset.
+ * An explicit `tableName` is independent of `modelName` — it lets a renamed
+ * list key adopt a differently-named live table (e.g. better-auth's own
+ * default lowercase table names).
  */
 function normalizeModelConfig(
   config: AuthModelConfig | undefined,
   defaultModelName: string,
   defaultSchema: string | undefined,
 ): NormalizedAuthModelConfig {
+  const modelName = config?.modelName || defaultModelName
+  const tableName = config?.tableName ?? (modelName !== defaultModelName ? modelName : undefined)
   return {
-    modelName: config?.modelName || defaultModelName,
+    modelName,
+    tableName,
     fields: config?.fields || {},
     schema: config?.schema ?? defaultSchema,
   }

--- a/packages/auth/src/config/types.ts
+++ b/packages/auth/src/config/types.ts
@@ -150,10 +150,30 @@ export type AuthAccessConfig = {
 export type AuthModelConfig = {
   /**
    * The table/list name for this model.
-   * Becomes the OpenSaaS list key (and Prisma model name) and the table `@@map`.
+   * Becomes the OpenSaaS list key and Prisma model name.
    * @default the default better-auth model name (e.g. 'User', 'Session')
    */
   modelName?: string
+  /**
+   * The physical database table name for this model, independent of
+   * `modelName`. Generates a `@@map("...")` on the derived list.
+   *
+   * Lets a renamed list key (e.g. `modelName: 'AuthUser'`, to avoid colliding
+   * with an app's own domain `User`) still adopt a live table under a
+   * different name — most commonly better-auth's own default lowercase
+   * table names (`user`, `session`, `account`, `verification`).
+   *
+   * @default `modelName` when it differs from the better-auth default model
+   *   name, otherwise unset (no `@@map`) — i.e. today's behaviour when this
+   *   option is not set.
+   *
+   * @example
+   * ```typescript
+   * // List key AuthUser, but the live table is still called `user`.
+   * user: { modelName: 'AuthUser', tableName: 'user' }
+   * ```
+   */
+  tableName?: string
   /**
    * Map better-auth field names to database column names.
    * Each entry generates a `@map("column")` on the derived field.
@@ -369,12 +389,15 @@ export type AuthConfig = {
 /**
  * Resolved per-model auth configuration after normalization.
  * Always carries a concrete `modelName` (the developer's override or the
- * better-auth default) and a (possibly empty) `fields` column map. `schema`
- * carries the resolved Postgres schema for the model (per-model override, else
- * the plugin-level schema, else `undefined` for the default `public` schema).
+ * better-auth default) and a (possibly empty) `fields` column map. `tableName`
+ * is the resolved physical table name — `undefined` means no `@@map` is
+ * emitted (the list key doubles as the table name). `schema` carries the
+ * resolved Postgres schema for the model (per-model override, else the
+ * plugin-level schema, else `undefined` for the default `public` schema).
  */
 export type NormalizedAuthModelConfig = {
   modelName: string
+  tableName?: string
   fields: Record<string, string>
   schema?: string
 }

--- a/packages/auth/tests/adopt-better-auth-tables.test.ts
+++ b/packages/auth/tests/adopt-better-auth-tables.test.ts
@@ -76,6 +76,105 @@ describe('adoptBetterAuthTables - recipe defaults', () => {
   })
 })
 
+describe('adoptBetterAuthTables - table names (issue #862)', () => {
+  it('sets no tableName by default (prefixed modelName also pins the table, as before)', () => {
+    const fragment = adoptBetterAuthTables()
+
+    expect(fragment.user).toEqual({ modelName: 'AuthUser' })
+    expect(fragment.session).toEqual({ modelName: 'AuthSession' })
+  })
+
+  it('useBetterAuthTableNames sets every model tableName to the better-auth default lowercase name', () => {
+    const fragment = adoptBetterAuthTables({ useBetterAuthTableNames: true })
+
+    expect(fragment.user).toEqual({ modelName: 'AuthUser', tableName: 'user' })
+    expect(fragment.session).toEqual({ modelName: 'AuthSession', tableName: 'session' })
+    expect(fragment.account).toEqual({ modelName: 'AuthAccount', tableName: 'account' })
+    expect(fragment.verification).toEqual({
+      modelName: 'AuthVerification',
+      tableName: 'verification',
+    })
+  })
+
+  it('tableNames sets explicit per-model table names', () => {
+    const fragment = adoptBetterAuthTables({
+      tableNames: { user: 'users', session: 'user_sessions' },
+    })
+
+    expect(fragment.user).toEqual({ modelName: 'AuthUser', tableName: 'users' })
+    expect(fragment.session).toEqual({ modelName: 'AuthSession', tableName: 'user_sessions' })
+    // Models without an explicit tableName entry stay unset.
+    expect(fragment.account).toEqual({ modelName: 'AuthAccount' })
+  })
+
+  it('tableNames takes precedence over useBetterAuthTableNames for the same model', () => {
+    const fragment = adoptBetterAuthTables({
+      useBetterAuthTableNames: true,
+      tableNames: { user: 'custom_user_table' },
+    })
+
+    expect(fragment.user?.tableName).toBe('custom_user_table')
+    // Other models still fall back to the better-auth default.
+    expect(fragment.session?.tableName).toBe('session')
+  })
+
+  it('combines tableName with a field column map on the same model', () => {
+    const fragment = adoptBetterAuthTables({
+      useBetterAuthTableNames: true,
+      fields: { user: { name: 'full_name' } },
+    })
+
+    expect(fragment.user).toEqual({
+      modelName: 'AuthUser',
+      tableName: 'user',
+      fields: { name: 'full_name' },
+    })
+  })
+})
+
+describe('adoptBetterAuthTables - clean-diff adoption with better-auth default table names', () => {
+  it('produces Auth lists that @@map to the live lowercase tables under prefixed list keys', async () => {
+    const result = await generationConfig({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          ...adoptBetterAuthTables({ useBetterAuthTableNames: true }),
+          emailAndPassword: { enabled: true },
+        }),
+      ],
+      lists: {
+        User: list({
+          fields: { subjectId: text({ validation: { isRequired: true } }) },
+        }),
+      },
+    })
+
+    // List keys stay prefixed (no collision with the app's own User)...
+    expect(result.lists).toHaveProperty('AuthUser')
+    // ...but the physical table is better-auth's own default lowercase name.
+    expect(result.lists.AuthUser.db).toEqual({ timestamps: true, map: 'user', schema: 'auth' })
+    expect(result.lists.AuthSession.db).toEqual({
+      timestamps: true,
+      map: 'session',
+      schema: 'auth',
+    })
+    expect(result.lists.AuthAccount.db).toEqual({
+      timestamps: true,
+      map: 'account',
+      schema: 'auth',
+    })
+    expect(result.lists.AuthVerification.db).toEqual({
+      timestamps: true,
+      map: 'verification',
+      schema: 'auth',
+    })
+
+    // The app's own domain User is untouched.
+    expect(result.lists.User.fields).toHaveProperty('subjectId')
+    expect(result.lists.User.fields).not.toHaveProperty('email')
+  })
+})
+
 describe('adoptBetterAuthTables - composes with authPlugin', () => {
   it('spreads into authPlugin alongside the rest of the auth config', async () => {
     const result = await config({

--- a/packages/auth/tests/config.test.ts
+++ b/packages/auth/tests/config.test.ts
@@ -165,6 +165,44 @@ describe('normalizeAuthConfig', () => {
     expect(result.access.user).toBe(userAccess)
     expect(result.access.session).toBe(sessionAccess)
   })
+
+  describe('models.tableName (issue #862)', () => {
+    it('defaults tableName to undefined for unrenamed models', () => {
+      const result = normalizeAuthConfig({})
+
+      expect(result.models.user.tableName).toBeUndefined()
+      expect(result.models.session.tableName).toBeUndefined()
+      expect(result.models.account.tableName).toBeUndefined()
+      expect(result.models.verification.tableName).toBeUndefined()
+    })
+
+    it('defaults tableName to the renamed modelName, matching pre-#862 behaviour', () => {
+      const result = normalizeAuthConfig({
+        user: { modelName: 'AuthUser' },
+      })
+
+      expect(result.models.user.modelName).toBe('AuthUser')
+      expect(result.models.user.tableName).toBe('AuthUser')
+    })
+
+    it('resolves an explicit tableName independent of modelName', () => {
+      const result = normalizeAuthConfig({
+        user: { modelName: 'AuthUser', tableName: 'user' },
+      })
+
+      expect(result.models.user.modelName).toBe('AuthUser')
+      expect(result.models.user.tableName).toBe('user')
+    })
+
+    it('honours an explicit tableName even when modelName is left at its default', () => {
+      const result = normalizeAuthConfig({
+        session: { tableName: 'sessions' },
+      })
+
+      expect(result.models.session.modelName).toBe('Session')
+      expect(result.models.session.tableName).toBe('sessions')
+    })
+  })
 })
 
 describe('authPlugin', () => {

--- a/packages/auth/tests/derive-auth-lists.test.ts
+++ b/packages/auth/tests/derive-auth-lists.test.ts
@@ -140,11 +140,16 @@ describe('deriveAuthLists - user FK shape mirrors better-auth (issue #679)', () 
 })
 
 describe('deriveAuthLists - custom modelName overrides', () => {
+  // `deriveAuthLists` is the pure derivation step: it consumes an already-
+  // resolved `tableName` rather than re-deriving one from `modelName`. That
+  // default derivation (tableName follows modelName when it differs from the
+  // better-auth default) lives in `normalizeModelConfig` (config/index.ts) —
+  // mirror its output here since these fixtures bypass normalization.
   const customModels: NormalizedAuthModels = {
-    user: { modelName: 'AuthUser', fields: {} },
-    session: { modelName: 'AuthSession', fields: {} },
-    account: { modelName: 'AuthAccount', fields: {} },
-    verification: { modelName: 'AuthVerification', fields: {} },
+    user: { modelName: 'AuthUser', tableName: 'AuthUser', fields: {} },
+    session: { modelName: 'AuthSession', tableName: 'AuthSession', fields: {} },
+    account: { modelName: 'AuthAccount', tableName: 'AuthAccount', fields: {} },
+    verification: { modelName: 'AuthVerification', tableName: 'AuthVerification', fields: {} },
   }
 
   it('derives list keys from modelName', () => {
@@ -190,6 +195,61 @@ describe('deriveAuthLists - custom modelName overrides', () => {
     expect(lists.AuthSession.db?.timestamps).toBe(true)
     expect(lists.AuthAccount.db?.timestamps).toBe(true)
     expect(lists.AuthVerification.db?.timestamps).toBe(true)
+  })
+})
+
+describe('deriveAuthLists - tableName independent of modelName (issue #862)', () => {
+  it('emits @@map from tableName even though modelName is unchanged', () => {
+    const models: NormalizedAuthModels = {
+      user: { modelName: 'User', tableName: 'users', fields: {} },
+      session: { modelName: 'Session', fields: {} },
+      account: { modelName: 'Account', fields: {} },
+      verification: { modelName: 'Verification', fields: {} },
+    }
+
+    const { keys, lists } = deriveAuthLists(models)
+
+    // The list key follows modelName, unaffected by tableName.
+    expect(keys.user).toBe('User')
+    expect(lists.User.db?.map).toBe('users')
+  })
+
+  it('adopts a better-auth default lowercase table under a prefixed list key', () => {
+    // The shape issue #862 exists for: a prefixed list key (to avoid
+    // colliding with the app's own domain User) whose live table is still
+    // better-auth's own default lowercase name.
+    const models: NormalizedAuthModels = {
+      user: { modelName: 'AuthUser', tableName: 'user', fields: {} },
+      session: { modelName: 'AuthSession', tableName: 'session', fields: {} },
+      account: { modelName: 'AuthAccount', tableName: 'account', fields: {} },
+      verification: { modelName: 'AuthVerification', tableName: 'verification', fields: {} },
+    }
+
+    const { keys, lists } = deriveAuthLists(models)
+
+    expect(keys).toEqual({
+      user: 'AuthUser',
+      session: 'AuthSession',
+      account: 'AuthAccount',
+      verification: 'AuthVerification',
+    })
+    expect(lists.AuthUser.db?.map).toBe('user')
+    expect(lists.AuthSession.db?.map).toBe('session')
+    expect(lists.AuthAccount.db?.map).toBe('account')
+    expect(lists.AuthVerification.db?.map).toBe('verification')
+  })
+
+  it('emits no @@map when tableName is unset, even with a renamed modelName', () => {
+    const models: NormalizedAuthModels = {
+      user: { modelName: 'AuthUser', fields: {} },
+      session: { modelName: 'Session', fields: {} },
+      account: { modelName: 'Account', fields: {} },
+      verification: { modelName: 'Verification', fields: {} },
+    }
+
+    const { lists } = deriveAuthLists(models)
+
+    expect(lists.AuthUser.db?.map).toBeUndefined()
   })
 })
 
@@ -243,7 +303,7 @@ describe('deriveAuthLists - schema placement', () => {
 
   it('carries both @@map and @@schema for renamed + relocated lists', () => {
     const models: NormalizedAuthModels = {
-      user: { modelName: 'AuthUser', fields: {}, schema: 'auth' },
+      user: { modelName: 'AuthUser', tableName: 'AuthUser', fields: {}, schema: 'auth' },
       session: { modelName: 'AuthSession', fields: {}, schema: 'auth' },
       account: { modelName: 'AuthAccount', fields: {}, schema: 'auth' },
       verification: { modelName: 'AuthVerification', fields: {}, schema: 'auth' },

--- a/packages/auth/tests/generated-fk-shape.test.ts
+++ b/packages/auth/tests/generated-fk-shape.test.ts
@@ -113,3 +113,34 @@ describe('generated auth schema — required columns mirror better-auth (issue #
     }
   })
 })
+
+describe('generated auth schema — tableName independent of modelName (issue #862)', () => {
+  it('emits a prefixed model name with a @@map to a better-auth default lowercase table', async () => {
+    const schema = await generateSchema({
+      db: { provider: 'postgresql' },
+      plugins: [
+        authPlugin({
+          user: { modelName: 'AuthUser', tableName: 'user' },
+          session: { modelName: 'AuthSession', tableName: 'session' },
+          account: { modelName: 'AuthAccount', tableName: 'account' },
+          verification: { modelName: 'AuthVerification', tableName: 'verification' },
+          emailAndPassword: { enabled: true },
+        }),
+      ],
+      lists: {},
+    })
+
+    for (const [model, table] of [
+      ['AuthUser', 'user'],
+      ['AuthSession', 'session'],
+      ['AuthAccount', 'account'],
+      ['AuthVerification', 'verification'],
+    ]) {
+      const block = modelBlock(schema, model)
+      // The generated model keeps the prefixed name but maps to the live
+      // lowercase table — no DROP/CREATE rename against a real better-auth
+      // install using its own default table names.
+      expect(block).toContain(`@@map("${table}")`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- `AuthModelConfig` gains a per-model `tableName`, independent of `modelName`, forwarded straight to the derived list's `db.map` (`@@map`)
- `adoptBetterAuthTables()` gains matching `useBetterAuthTableNames` (set every model's table to better-auth's own default lowercase name) and `tableNames` (per-model explicit override, wins over `useBetterAuthTableNames`) options
- Default behaviour is unchanged when `tableName` is not set: it still follows `modelName` when that differs from the better-auth default, otherwise no `@@map` is emitted — byte-for-byte identical generator output for existing configs

This unblocks the single most common better-auth adoption shape: a project that ran better-auth *before* adding the stack has live tables named `user`/`session`/`account`/`verification`, but still needs `Auth`-prefixed list keys (`AuthUser`, ...) to avoid colliding with its own domain `User`. Previously `modelName` controlled both the list key and the `@@map`, so there was no way to get a prefixed key on an unprefixed table — `prisma migrate diff` read every renamed model as a destructive rename.

```typescript
authPlugin({
  ...adoptBetterAuthTables({ schema: 'auth', useBetterAuthTableNames: true }),
  emailAndPassword: { enabled: true },
})
// List keys: AuthUser / AuthSession / AuthAccount / AuthVerification
// Live tables (@@map): user / session / account / verification
```

## Test plan

- [x] Unit tests: `tableName` independent of `modelName` (`derive-auth-lists.test.ts`)
- [x] Unit tests: normalization defaults (`config.test.ts` — unchanged default, `tableName` follows renamed `modelName`, explicit `tableName` independent of `modelName`)
- [x] Unit tests: `adoptBetterAuthTables` `useBetterAuthTableNames` / `tableNames` / precedence / composition with `fields` (`adopt-better-auth-tables.test.ts`)
- [x] End-to-end generated-schema test asserting `@@map("user")` etc. under prefixed model names (`generated-fk-shape.test.ts`)
- [x] `pnpm test` (packages/auth): 165/165 passing
- [x] `pnpm lint` passes (pre-existing unrelated warnings only)
- [x] `pnpm build` (core, cli, auth) passes
- [x] Docs: auth how-to guide adoption walkthrough covers the default-table-names case; `packages/auth/CLAUDE.md` updated

Closes #862


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmNGm4kjLxMutG3GaszE37)_