### PR TITLE
auth: add betterAuthOptions passthrough and buildBetterAuthOptions builder

### DIFF
--- a/.changeset/tidy-frogs-jump.md
+++ b/.changeset/tidy-frogs-jump.md
@@ -1,0 +1,32 @@
+---
+'@opensaas/stack-auth': minor
+---
+
+Add a `betterAuthOptions` escape hatch on `AuthConfig` for better-auth options the stack doesn't model, plus an exported `buildBetterAuthOptions()` builder for apps that still need to hand-wire their own `betterAuth()` instance.
+
+`betterAuthOptions` is deep-merged onto the options `createAuth()` builds, applied last — a plain-object value merges recursively alongside sibling keys the stack already set (e.g. `session: { cookieCache }` doesn't clobber `session.expiresIn`), and wins on any genuine key collision:
+
+```typescript
+authPlugin({
+  betterAuthOptions: {
+    databaseHooks: { user: { create: { after: syncDomainUser } } },
+    session: { cookieCache: { enabled: true, maxAge: 300 } },
+    verification: { storeIdentifier: 'hashed' },
+    baseURL: process.env.BETTER_AUTH_URL,
+  },
+})
+```
+
+`database`, `plugins`, and `additionalFields` under `user`/`session`/`account`/`verification` are rejected — they already have dedicated seams (`db` config, `betterAuthPlugins`), or have schema consequences a passthrough can't also apply to the generated Prisma schema.
+
+`buildBetterAuthOptions(config, context)` returns the exact same options object `createAuth()` uses, for apps that need a resolved `betterAuth()` instance rather than `createAuth()`'s lazy proxy:
+
+```typescript
+import { betterAuth } from 'better-auth'
+import { buildBetterAuthOptions } from '@opensaas/stack-auth/server'
+
+export const auth = betterAuth({
+  ...(await buildBetterAuthOptions(config, rawOpensaasContext)),
+  databaseHooks: { user: { create: { after: syncDomainUser } } },
+})
+```

--- a/docs/content/reference/auth.md
+++ b/docs/content/reference/auth.md
@@ -271,6 +271,29 @@ authPlugin({
 
 The auth plugin automatically converts Better Auth plugin schemas to OpenSaaS lists.
 
+### `betterAuthOptions`
+
+Escape hatch for any better-auth option the stack doesn't model as its own config field. Deep-merged into the options `createAuth()` builds, applied **last** — a plain-object value at a given key merges recursively with what the stack already set there (so a nested addition like `session.cookieCache` adds alongside the stack's own `session.expiresIn`/`updateAge` rather than replacing them), and on a genuine key collision `betterAuthOptions` wins. Arrays and any other value type replace the stack's value outright.
+
+```typescript
+authPlugin({
+  betterAuthOptions: {
+    // Sync a domain user row for every better-auth user
+    databaseHooks: { user: { create: { after: syncDomainUser } } },
+    // 5-minute session cookie cache
+    session: { cookieCache: { enabled: true, maxAge: 300 } },
+    // Keep PII out of the verification table
+    verification: { storeIdentifier: 'hashed' },
+    // Derive the base URL instead of relying on env vars
+    baseURL: process.env.BETTER_AUTH_URL,
+  },
+})
+```
+
+`database` and `plugins` are rejected — they're already the dedicated seams (the stack's `db` config, and `betterAuthPlugins` above) and accepting them here would create two unranked ways to set the same thing. So is `additionalFields` under `user`/`session`/`account`/`verification`: it has schema consequences (new columns) that a passthrough can't also apply to the generated Prisma schema, so add fields to the derived list instead — `extendUserList` for the user model, or declare the list yourself in your own `lists` config for the others.
+
+The same options object is available standalone via `buildBetterAuthOptions()` — see [Escape hatch: hand-wiring `betterAuth()`](#escape-hatch-hand-wiring-betterauth) below.
+
 ## Auto-Generated Lists
 
 The auth plugin automatically generates the following lists:
@@ -346,6 +369,34 @@ Then create the API route:
 // app/api/auth/[...all]/route.ts
 export { GET, POST } from '@/lib/auth'
 ```
+
+### Escape hatch: hand-wiring `betterAuth()`
+
+`createAuth()` covers the common case. If you need to construct `betterAuth()`
+yourself — e.g. a third-party contract that requires a resolved instance
+rather than `createAuth()`'s lazy proxy — `buildBetterAuthOptions()` gives you
+the exact same options object `createAuth()` passes to `betterAuth()`, so your
+hand-wired instance derives from the stack config instead of duplicating it:
+
+```typescript
+// lib/auth.ts
+import { betterAuth } from 'better-auth'
+import { buildBetterAuthOptions } from '@opensaas/stack-auth/server'
+import config from '../opensaas.config'
+import { rawOpensaasContext } from '@/.opensaas/context'
+
+export const auth = betterAuth({
+  ...(await buildBetterAuthOptions(config, rawOpensaasContext)),
+  // Local additions on top of the stack-derived options
+  databaseHooks: { user: { create: { after: syncDomainUser } } },
+})
+```
+
+This keeps the auth plugin authoritative for everything it models (providers,
+session expiry, password policy, the plugin array) while your additions stay
+an explicit, reviewable diff. It also gives an incremental migration path onto
+`createAuth()`: adopt the builder first, then move options into
+[`betterAuthOptions`](#betterauthoptions) as the stack grows knobs for them.
 
 ## Client Setup
 

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -29,6 +29,7 @@ Auto-generated lists:
 ### Server (`src/server/index.ts`)
 
 - `createAuth(config, rawContext?)` - Creates Better-auth instance with MCP plugin support
+- `buildBetterAuthOptions(config, rawContext?)` - Returns the same `BetterAuthOptions` `createAuth()` builds, without constructing an instance — for apps that need to hand-wire their own `betterAuth()`
 - Returns `{ handler, signIn, signOut, ... }` - Better-auth methods
 
 ### Client (`src/client/index.ts`)
@@ -321,6 +322,74 @@ authPlugin({
   },
 })
 ```
+
+### Escape hatch for unmodelled better-auth options (`betterAuthOptions`)
+
+`AuthConfig` models a deliberately closed set of better-auth options. For
+anything the stack doesn't model — database hooks, `session.cookieCache`,
+`baseURL`, `verification.storeIdentifier`, and so on — pass it through
+`betterAuthOptions`, typed as better-auth's own `BetterAuthOptions` so it
+tracks better-auth's surface without the stack re-declaring it:
+
+```typescript
+authPlugin({
+  betterAuthOptions: {
+    databaseHooks: { user: { create: { after: syncDomainUser } } },
+    session: { cookieCache: { enabled: true, maxAge: 300 } },
+    verification: { storeIdentifier: 'hashed' },
+    baseURL: process.env.BETTER_AUTH_URL,
+  },
+})
+```
+
+`createAuth()` (`src/server/index.ts`) deep-merges `betterAuthOptions` onto
+the options it builds from the rest of `AuthConfig`, applied **last**:
+plain-object values merge recursively per key (so `session: { cookieCache }`
+lands alongside the stack's own `session.expiresIn`/`updateAge` instead of
+replacing the whole `session` block), arrays and other value types replace
+outright, and `betterAuthOptions` wins on any genuine key collision. The
+merge and the option-building it merges onto both live in
+`buildBetterAuthOptions()`, the single place `createAuth()` and the exported
+builder share — they cannot drift from each other because `createAuth()`
+calls it directly rather than reimplementing it.
+
+`database` and `plugins` are rejected outright (`assertNoUnsupportedPassthroughKeys`
+in `src/server/index.ts`): they already have dedicated seams (`db` in the
+stack config, and `betterAuthPlugins` respectively), and accepting them here
+would create two unranked ways to set the same thing — worse for `plugins`,
+since the stack must append `nextCookies()` last (see "Auth forms submit
+through server actions" below). `additionalFields` under `user`/`session`/
+`account`/`verification` is rejected too — it adds columns with no
+corresponding change to the generated Prisma schema, which is exactly the
+silent-divergence failure mode this passthrough exists to avoid elsewhere.
+Add fields to the derived list instead: `extendUserList` for the user model,
+or declare the list yourself in your own `lists` config for the others (the
+auth plugin's `addList`-vs-`extendList` logic — see "Deriving Auth lists from
+better-auth config" above — merges in field additions for any list matching
+one of its derived keys).
+
+### Hand-wiring `betterAuth()` from the stack config (`buildBetterAuthOptions`)
+
+An app that needs a resolved `betterAuth()` instance at module-init time
+(rather than `createAuth()`'s lazy proxy) can derive its options from the
+stack config instead of duplicating them:
+
+```typescript
+import { betterAuth } from 'better-auth'
+import { buildBetterAuthOptions } from '@opensaas/stack-auth/server'
+
+export const auth = betterAuth({
+  ...(await buildBetterAuthOptions(config, rawOpensaasContext)),
+  databaseHooks: { user: { create: { after: syncDomainUser } } }, // not yet in betterAuthOptions
+})
+```
+
+This is the same async-resolve-then-construct step `createAuth()` performs
+internally, exported standalone — see ADR-0014 and root `CLAUDE.md`'s
+"Getting the ORM client outside a request" for why `createAuth()` itself
+can't be synchronous. It gives an incremental path onto `createAuth()`: adopt
+the builder first, then fold options into `betterAuthOptions` above as the
+stack grows first-class config for them.
 
 ## Integration Points
 

--- a/packages/auth/src/config/index.ts
+++ b/packages/auth/src/config/index.ts
@@ -158,6 +158,7 @@ export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
     access: config.access || {},
     betterAuthPlugins: config.betterAuthPlugins || [],
     rateLimit: config.rateLimit,
+    betterAuthOptions: config.betterAuthOptions || {},
   }
 }
 

--- a/packages/auth/src/config/types.ts
+++ b/packages/auth/src/config/types.ts
@@ -1,5 +1,5 @@
 import type { ListConfig } from '@opensaas/stack-core'
-import type { User } from 'better-auth'
+import type { BetterAuthOptions, User } from 'better-auth'
 import type { ExtendUserListConfig } from '../lists/index.js'
 
 /**
@@ -429,6 +429,44 @@ export type AuthConfig = {
      */
     max?: number
   }
+
+  /**
+   * Escape hatch for better-auth options the stack doesn't model — typed as
+   * better-auth's own `BetterAuthOptions` so it stays in step with
+   * better-auth's surface without the stack re-declaring it. Deep-merged into
+   * the options `createAuth()` builds, applied LAST: a plain-object value at a
+   * given key merges recursively with whatever the stack already set there
+   * (so e.g. `session: { cookieCache: {...} }` adds alongside the stack's own
+   * `session.expiresIn`/`updateAge` rather than clobbering them); any other
+   * value (including arrays) replaces the stack's value outright. On a genuine
+   * key collision, this option wins.
+   *
+   * `database` and `plugins` are rejected — they're already the dedicated
+   * seams (the stack's `db` config, and `betterAuthPlugins` respectively) and
+   * accepting them here would create two unranked ways to set the same thing.
+   * So is `additionalFields` under `user`/`session`/`account`/`verification` —
+   * it has schema consequences (new columns) that a passthrough can't also
+   * apply to the generated Prisma schema; add fields to the derived list
+   * instead (`extendUserList` for the user model, or declare the list
+   * yourself for the others — see `packages/auth/CLAUDE.md`).
+   *
+   * The same options object is available standalone via
+   * `buildBetterAuthOptions()` (`@opensaas/stack-auth/server`) for apps that
+   * still need to hand-wire their own `betterAuth()` instance.
+   *
+   * @example
+   * ```typescript
+   * authPlugin({
+   *   betterAuthOptions: {
+   *     databaseHooks: { user: { create: { after: syncDomainUser } } },
+   *     session: { cookieCache: { enabled: true, maxAge: 300 } },
+   *     verification: { storeIdentifier: 'hashed' },
+   *     baseURL: process.env.BETTER_AUTH_URL,
+   *   },
+   * })
+   * ```
+   */
+  betterAuthOptions?: Partial<BetterAuthOptions>
 }
 
 /**

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -34,6 +34,240 @@ function toBetterAuthModelOptions(
   return Object.keys(options).length > 0 ? options : undefined
 }
 
+const MODELS_WITH_NO_ADDITIONAL_FIELDS_PASSTHROUGH = [
+  'user',
+  'session',
+  'account',
+  'verification',
+] as const
+
+/**
+ * Reject `betterAuthOptions` keys that already have a dedicated, non-passthrough
+ * seam — accepting them here would create two unranked ways to set the same
+ * thing, or (for `additionalFields`) silently diverge from the generated
+ * Prisma schema. See the `betterAuthOptions` doc comment on `AuthConfig`.
+ */
+function assertNoUnsupportedPassthroughKeys(betterAuthOptions: Record<string, unknown>): void {
+  if ('database' in betterAuthOptions) {
+    throw new Error(
+      '[@opensaas/stack-auth] `betterAuthOptions.database` is not supported — the stack ' +
+        'derives the database adapter from your `db` config and the running context. ' +
+        'Configure the database through `db` in `opensaas.config.ts` instead.',
+    )
+  }
+
+  if ('plugins' in betterAuthOptions) {
+    throw new Error(
+      '[@opensaas/stack-auth] `betterAuthOptions.plugins` is not supported — better-auth ' +
+        'plugins are added through `authPlugin({ betterAuthPlugins: [...] })`, which the stack ' +
+        'appends `nextCookies()` after. Use `betterAuthPlugins` instead.',
+    )
+  }
+
+  for (const model of MODELS_WITH_NO_ADDITIONAL_FIELDS_PASSTHROUGH) {
+    const modelOptions = betterAuthOptions[model]
+    if (
+      modelOptions &&
+      typeof modelOptions === 'object' &&
+      !Array.isArray(modelOptions) &&
+      'additionalFields' in modelOptions
+    ) {
+      throw new Error(
+        `[@opensaas/stack-auth] \`betterAuthOptions.${model}.additionalFields\` is not ` +
+          'supported — it adds columns that would not be reflected in the generated Prisma ' +
+          'schema. Add fields to the derived list instead: ' +
+          (model === 'user'
+            ? '`extendUserList`, or declare the list yourself in your own `lists` config.'
+            : 'declare the derived list yourself in your own `lists` config (the auth plugin ' +
+              'merges in field additions for the models it derives).'),
+      )
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+/**
+ * Deep-merge `overrides` onto `base`, recursing into plain-object values so a
+ * nested addition (one database hook, one session sub-option) merges
+ * alongside sibling keys the stack already set there rather than replacing
+ * the whole branch. Arrays and any other value type replace outright.
+ * `overrides` wins on every key collision.
+ */
+function mergeBetterAuthOptions(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+  for (const [key, value] of Object.entries(overrides)) {
+    const baseValue = result[key]
+    result[key] =
+      isPlainObject(baseValue) && isPlainObject(value)
+        ? mergeBetterAuthOptions(baseValue, value)
+        : value
+  }
+  return result
+}
+
+/**
+ * Build the `BetterAuthOptions` a better-auth instance for this OpenSaas
+ * config should be constructed with — the same options `createAuth()` uses
+ * internally, available standalone for an app that still needs to hand-wire
+ * its own `betterAuth()` instance (e.g. a third-party contract that requires
+ * a resolved instance at module-init time). Keeps the auth plugin
+ * authoritative for everything it models; the app's additions on top become
+ * an explicit, reviewable diff instead of a parallel, hand-duplicated config.
+ *
+ * @example
+ * ```typescript
+ * import { betterAuth } from 'better-auth'
+ * import { buildBetterAuthOptions } from '@opensaas/stack-auth/server'
+ *
+ * export const auth = betterAuth({
+ *   ...(await buildBetterAuthOptions(config, context)),
+ *   databaseHooks: { user: { create: { after: syncDomainUser } } },
+ * })
+ * ```
+ */
+export async function buildBetterAuthOptions(
+  opensaasConfig: OpenSaasConfig | Promise<OpenSaasConfig>,
+  context: AccessContext | Promise<AccessContext>,
+): Promise<BetterAuthOptions> {
+  const resolvedConfig = await Promise.resolve(opensaasConfig)
+  const resolvedContext = await Promise.resolve(context)
+
+  // Extract auth config from plugin data
+  const authConfig = resolvedConfig._pluginData?.auth as NormalizedAuthConfig | undefined
+
+  if (!authConfig) {
+    throw new Error(
+      'Auth config not found. Make sure to use authPlugin() in your opensaas.config.ts',
+    )
+  }
+
+  // `requireConfirmation` has no better-auth equivalent — it's a UI-only
+  // concern the pre-built forms already take as their own
+  // `requirePasswordConfirmation` prop. Warn rather than silently drop it,
+  // since setting it here looks like it should do something.
+  if (
+    authConfig.emailAndPassword.enabled &&
+    authConfig.emailAndPassword.requireConfirmation !== true
+  ) {
+    console.warn(
+      '[@opensaas/stack-auth] `emailAndPassword.requireConfirmation` has no effect here — ' +
+        'createAuth() has no better-auth option to forward it to. Pass ' +
+        '`requirePasswordConfirmation` directly to <SignUpForm> / <ResetPasswordForm> instead.',
+    )
+  }
+
+  // `passwordReset` is wired through better-auth's `emailAndPassword` config
+  // (there's no password to reset without a password-based account), so it
+  // silently has no effect if email/password auth itself isn't enabled.
+  if (authConfig.passwordReset.enabled && !authConfig.emailAndPassword.enabled) {
+    console.warn(
+      '[@opensaas/stack-auth] `passwordReset.enabled` has no effect here — ' +
+        '`emailAndPassword.enabled` is false, so there is no password-based account to reset.',
+    )
+  }
+
+  assertNoUnsupportedPassthroughKeys(authConfig.betterAuthOptions as Record<string, unknown>)
+
+  // Build better-auth configuration
+  const betterAuthConfig: BetterAuthOptions = {
+    database: getDatabaseConfig(resolvedConfig.db, resolvedContext),
+
+    // Mirror the per-model config (modelName + field column maps) back to
+    // better-auth so the running auth instance reads/writes the same
+    // tables/columns the OpenSaaS Auth lists were derived from.
+    user: toBetterAuthModelOptions(authConfig.models.user),
+    session: {
+      ...toBetterAuthModelOptions(authConfig.models.session),
+      expiresIn: authConfig.session.expiresIn || 604800,
+      // better-auth treats `updateAge: 0` as "refresh on every request", not
+      // "never refresh" — disabling refresh entirely requires its separate
+      // `disableSessionRefresh` flag regardless of `updateAge`.
+      ...(authConfig.session.updateAge === false
+        ? { disableSessionRefresh: true }
+        : { updateAge: authConfig.session.updateAge }),
+    },
+    account: toBetterAuthModelOptions(authConfig.models.account),
+    verification: toBetterAuthModelOptions(authConfig.models.verification),
+
+    // Enable email and password if configured
+    emailAndPassword: authConfig.emailAndPassword.enabled
+      ? {
+          enabled: true,
+          requireEmailVerification: authConfig.emailVerification.enabled,
+          minPasswordLength: authConfig.emailAndPassword.minPasswordLength,
+          ...(authConfig.passwordReset.enabled
+            ? {
+                sendResetPassword: authConfig.emailAndPassword.sendResetPassword,
+                resetPasswordTokenExpiresIn: authConfig.passwordReset.tokenExpiration,
+              }
+            : {}),
+        }
+      : undefined,
+
+    // Email verification (independent of emailAndPassword — also covers
+    // e.g. a social-provider account whose email isn't yet verified)
+    emailVerification: authConfig.emailVerification.enabled
+      ? {
+          sendVerificationEmail: authConfig.emailVerification.sendVerificationEmail,
+          sendOnSignUp: authConfig.emailVerification.sendOnSignUp,
+          expiresIn: authConfig.emailVerification.tokenExpiration,
+        }
+      : undefined,
+
+    // Trust host (required for production)
+    trustedOrigins: process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',') || [],
+
+    // Social providers
+    socialProviders: Object.entries(authConfig.socialProviders)
+      .filter(([_, config]) => config?.enabled !== false)
+      .reduce(
+        (acc, [provider, config]) => {
+          if (config) {
+            acc[provider] = {
+              clientId: config.clientId,
+              clientSecret: config.clientSecret,
+            }
+          }
+          return acc
+        },
+        {} as Record<string, { clientId: string; clientSecret: string }>,
+      ),
+
+    // Rate limiting configuration
+    rateLimit: authConfig.rateLimit
+      ? {
+          enabled: authConfig.rateLimit.enabled,
+          window: authConfig.rateLimit.window,
+          max: authConfig.rateLimit.max,
+        }
+      : undefined,
+
+    // Pass through any additional Better Auth plugins, then append
+    // nextCookies LAST so it can write the Set-Cookie headers produced by
+    // any auth.api.* call made inside a Next.js server action into Next's
+    // cookie store. This is what makes the server-action auth forms (which
+    // call auth.api.signInEmail/signUpEmail/etc. server-side) actually
+    // persist a session. It must be the final plugin in the array.
+    plugins: [...(authConfig.betterAuthPlugins || []), nextCookies()],
+  }
+
+  return mergeBetterAuthOptions(
+    betterAuthConfig as unknown as Record<string, unknown>,
+    authConfig.betterAuthOptions as Record<string, unknown>,
+  ) as BetterAuthOptions
+}
+
 /**
  * Create a better-auth instance from OpenSaas config
  * This should be called once at app startup
@@ -65,126 +299,7 @@ export function createAuth(
 
     if (!authPromise) {
       authPromise = (async () => {
-        const resolvedConfig = await configPromise
-        const resolvedContext = await contextPromise
-
-        // Extract auth config from plugin data
-        const authConfig = resolvedConfig._pluginData?.auth as NormalizedAuthConfig | undefined
-
-        if (!authConfig) {
-          throw new Error(
-            'Auth config not found. Make sure to use authPlugin() in your opensaas.config.ts',
-          )
-        }
-
-        // `requireConfirmation` has no better-auth equivalent — it's a UI-only
-        // concern the pre-built forms already take as their own
-        // `requirePasswordConfirmation` prop. Warn rather than silently drop it,
-        // since setting it here looks like it should do something.
-        if (
-          authConfig.emailAndPassword.enabled &&
-          authConfig.emailAndPassword.requireConfirmation !== true
-        ) {
-          console.warn(
-            '[@opensaas/stack-auth] `emailAndPassword.requireConfirmation` has no effect here — ' +
-              'createAuth() has no better-auth option to forward it to. Pass ' +
-              '`requirePasswordConfirmation` directly to <SignUpForm> / <ResetPasswordForm> instead.',
-          )
-        }
-
-        // `passwordReset` is wired through better-auth's `emailAndPassword` config
-        // (there's no password to reset without a password-based account), so it
-        // silently has no effect if email/password auth itself isn't enabled.
-        if (authConfig.passwordReset.enabled && !authConfig.emailAndPassword.enabled) {
-          console.warn(
-            '[@opensaas/stack-auth] `passwordReset.enabled` has no effect here — ' +
-              '`emailAndPassword.enabled` is false, so there is no password-based account to reset.',
-          )
-        }
-
-        // Build better-auth configuration
-        const betterAuthConfig: BetterAuthOptions = {
-          database: getDatabaseConfig(resolvedConfig.db, resolvedContext),
-
-          // Mirror the per-model config (modelName + field column maps) back to
-          // better-auth so the running auth instance reads/writes the same
-          // tables/columns the OpenSaaS Auth lists were derived from.
-          user: toBetterAuthModelOptions(authConfig.models.user),
-          session: {
-            ...toBetterAuthModelOptions(authConfig.models.session),
-            expiresIn: authConfig.session.expiresIn || 604800,
-            // better-auth treats `updateAge: 0` as "refresh on every request", not
-            // "never refresh" — disabling refresh entirely requires its separate
-            // `disableSessionRefresh` flag regardless of `updateAge`.
-            ...(authConfig.session.updateAge === false
-              ? { disableSessionRefresh: true }
-              : { updateAge: authConfig.session.updateAge }),
-          },
-          account: toBetterAuthModelOptions(authConfig.models.account),
-          verification: toBetterAuthModelOptions(authConfig.models.verification),
-
-          // Enable email and password if configured
-          emailAndPassword: authConfig.emailAndPassword.enabled
-            ? {
-                enabled: true,
-                requireEmailVerification: authConfig.emailVerification.enabled,
-                minPasswordLength: authConfig.emailAndPassword.minPasswordLength,
-                ...(authConfig.passwordReset.enabled
-                  ? {
-                      sendResetPassword: authConfig.emailAndPassword.sendResetPassword,
-                      resetPasswordTokenExpiresIn: authConfig.passwordReset.tokenExpiration,
-                    }
-                  : {}),
-              }
-            : undefined,
-
-          // Email verification (independent of emailAndPassword — also covers
-          // e.g. a social-provider account whose email isn't yet verified)
-          emailVerification: authConfig.emailVerification.enabled
-            ? {
-                sendVerificationEmail: authConfig.emailVerification.sendVerificationEmail,
-                sendOnSignUp: authConfig.emailVerification.sendOnSignUp,
-                expiresIn: authConfig.emailVerification.tokenExpiration,
-              }
-            : undefined,
-
-          // Trust host (required for production)
-          trustedOrigins: process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',') || [],
-
-          // Social providers
-          socialProviders: Object.entries(authConfig.socialProviders)
-            .filter(([_, config]) => config?.enabled !== false)
-            .reduce(
-              (acc, [provider, config]) => {
-                if (config) {
-                  acc[provider] = {
-                    clientId: config.clientId,
-                    clientSecret: config.clientSecret,
-                  }
-                }
-                return acc
-              },
-              {} as Record<string, { clientId: string; clientSecret: string }>,
-            ),
-
-          // Rate limiting configuration
-          rateLimit: authConfig.rateLimit
-            ? {
-                enabled: authConfig.rateLimit.enabled,
-                window: authConfig.rateLimit.window,
-                max: authConfig.rateLimit.max,
-              }
-            : undefined,
-
-          // Pass through any additional Better Auth plugins, then append
-          // nextCookies LAST so it can write the Set-Cookie headers produced by
-          // any auth.api.* call made inside a Next.js server action into Next's
-          // cookie store. This is what makes the server-action auth forms (which
-          // call auth.api.signInEmail/signUpEmail/etc. server-side) actually
-          // persist a session. It must be the final plugin in the array.
-          plugins: [...(authConfig.betterAuthPlugins || []), nextCookies()],
-        }
-
+        const betterAuthConfig = await buildBetterAuthOptions(configPromise, contextPromise)
         authInstance = betterAuth(betterAuthConfig)
         return authInstance
       })()

--- a/packages/auth/tests/config.test.ts
+++ b/packages/auth/tests/config.test.ts
@@ -18,6 +18,15 @@ describe('normalizeAuthConfig', () => {
     expect(result.sessionFields).toEqual(['userId', 'email', 'name'])
     expect(result.socialProviders).toEqual({})
     expect(result.betterAuthPlugins).toEqual([])
+    expect(result.betterAuthOptions).toEqual({})
+  })
+
+  it('should pass through betterAuthOptions unchanged', () => {
+    const result = normalizeAuthConfig({
+      betterAuthOptions: { baseURL: 'https://example.com' },
+    })
+
+    expect(result.betterAuthOptions).toEqual({ baseURL: 'https://example.com' })
   })
 
   it('should normalize email and password config', () => {

--- a/packages/auth/tests/server.test.ts
+++ b/packages/auth/tests/server.test.ts
@@ -19,7 +19,8 @@ vi.mock('better-auth/next-js', () => ({
   nextCookies: nextCookiesMock,
 }))
 
-const { createAuth, getSessionFromAuth } = await import('../src/server/index.js')
+const { createAuth, buildBetterAuthOptions, getSessionFromAuth } =
+  await import('../src/server/index.js')
 
 function makeAuthConfig(overrides: Partial<NormalizedAuthConfig> = {}): NormalizedAuthConfig {
   return {
@@ -49,6 +50,7 @@ function makeAuthConfig(overrides: Partial<NormalizedAuthConfig> = {}): Normaliz
     access: {},
     betterAuthPlugins: [],
     rateLimit: undefined,
+    betterAuthOptions: {},
     ...overrides,
   }
 }
@@ -302,6 +304,182 @@ describe('createAuth', () => {
 
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('passwordReset'))
     warnSpy.mockRestore()
+  })
+})
+
+describe('betterAuthOptions passthrough', () => {
+  beforeEach(() => {
+    betterAuthMock.mockClear()
+    prismaAdapterMock.mockClear()
+    nextCookiesMock.mockClear()
+  })
+
+  it('produces byte-for-byte identical options to today when unused', async () => {
+    // `normalizeAuthConfig` is what actually defaults a config without
+    // `betterAuthOptions` to `{}` (see config.test.ts) — reproduce that
+    // realistic normalized shape here rather than an AuthConfig missing a
+    // required NormalizedAuthConfig field.
+    const authConfig = makeAuthConfig({ betterAuthOptions: {} })
+
+    const built = await buildBetterAuthConfig(authConfig)
+
+    expect(built).toEqual({
+      database: { client: { __mockPrisma: true }, opts: { provider: 'sqlite' } },
+      user: { modelName: 'User' },
+      session: { modelName: 'Session', expiresIn: 604800, updateAge: 86400 },
+      account: { modelName: 'Account' },
+      verification: { modelName: 'Verification' },
+      emailAndPassword: {
+        enabled: true,
+        requireEmailVerification: false,
+        minPasswordLength: 8,
+      },
+      emailVerification: undefined,
+      trustedOrigins: [],
+      socialProviders: {},
+      rateLimit: undefined,
+      plugins: [{ id: 'next-cookies' }],
+    })
+  })
+
+  it('surfaces a top-level option the stack does not model (e.g. baseURL)', async () => {
+    const config = await buildBetterAuthConfig(
+      makeAuthConfig({ betterAuthOptions: { baseURL: 'https://example.com' } }),
+    )
+
+    expect(config.baseURL).toBe('https://example.com')
+  })
+
+  it('merges a nested database hook without clobbering sibling top-level keys', async () => {
+    const after = vi.fn()
+    const config = await buildBetterAuthConfig(
+      makeAuthConfig({
+        session: { expiresIn: 604800, updateAge: 86400 },
+        betterAuthOptions: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only shape
+          databaseHooks: { user: { create: { after } } } as any,
+        },
+      }),
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- narrow test-only access
+    expect((config as any).databaseHooks.user.create.after).toBe(after)
+    // The stack's own session config survives — passthrough added a sibling
+    // top-level key, it didn't replace the whole options object.
+    expect(config.session?.expiresIn).toBe(604800)
+  })
+
+  it('merges a nested session option without clobbering the stack-set session keys', async () => {
+    const config = await buildBetterAuthConfig(
+      makeAuthConfig({
+        session: { expiresIn: 604800, updateAge: 3600 },
+        betterAuthOptions: {
+          session: { cookieCache: { enabled: true, maxAge: 300 } },
+        },
+      }),
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- narrow test-only access
+    expect((config.session as any).cookieCache).toEqual({ enabled: true, maxAge: 300 })
+    expect(config.session?.expiresIn).toBe(604800)
+    expect(config.session?.updateAge).toBe(3600)
+  })
+
+  it('lets the passthrough win on a genuine key collision', async () => {
+    const config = await buildBetterAuthConfig(
+      makeAuthConfig({
+        session: { expiresIn: 604800, updateAge: 3600 },
+        betterAuthOptions: {
+          session: { expiresIn: 999 },
+        },
+      }),
+    )
+
+    expect(config.session?.expiresIn).toBe(999)
+  })
+
+  it('replaces an array outright instead of concatenating (e.g. trustedOrigins)', async () => {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = 'https://env-origin.com'
+    try {
+      const config = await buildBetterAuthConfig(
+        makeAuthConfig({
+          betterAuthOptions: { trustedOrigins: ['https://config-origin.com'] },
+        }),
+      )
+
+      expect(config.trustedOrigins).toEqual(['https://config-origin.com'])
+    } finally {
+      delete process.env.BETTER_AUTH_TRUSTED_ORIGINS
+    }
+  })
+
+  it('rejects betterAuthOptions.database', async () => {
+    await expect(
+      buildBetterAuthOptions(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only shape
+        makeOpensaasConfig(makeAuthConfig({ betterAuthOptions: { database: {} as any } })),
+        makeContext(),
+      ),
+    ).rejects.toThrow(/betterAuthOptions\.database/)
+  })
+
+  it('rejects betterAuthOptions.plugins', async () => {
+    await expect(
+      buildBetterAuthOptions(
+        makeOpensaasConfig(makeAuthConfig({ betterAuthOptions: { plugins: [] } })),
+        makeContext(),
+      ),
+    ).rejects.toThrow(/betterAuthOptions\.plugins/)
+  })
+
+  it.each(['user', 'session', 'account', 'verification'] as const)(
+    'rejects betterAuthOptions.%s.additionalFields',
+    async (model) => {
+      await expect(
+        buildBetterAuthOptions(
+          makeOpensaasConfig(
+            makeAuthConfig({
+              betterAuthOptions: {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only shape
+                [model]: { additionalFields: { foo: { type: 'string' } } } as any,
+              },
+            }),
+          ),
+          makeContext(),
+        ),
+      ).rejects.toThrow(new RegExp(`betterAuthOptions\\.${model}\\.additionalFields`))
+    },
+  )
+
+  it('does not reject additionalFields nested under an unrelated model key', async () => {
+    // A plain object at `user` with no `additionalFields` key must not trip the guard.
+    const config = await buildBetterAuthConfig(
+      makeAuthConfig({ betterAuthOptions: { user: { modelName: 'CustomUser' } } }),
+    )
+
+    expect(config.user).toMatchObject({ modelName: 'CustomUser' })
+  })
+})
+
+describe('buildBetterAuthOptions / createAuth parity', () => {
+  beforeEach(() => {
+    betterAuthMock.mockClear()
+  })
+
+  it('createAuth constructs betterAuth with exactly what buildBetterAuthOptions returns', async () => {
+    const authConfig = makeAuthConfig({
+      betterAuthOptions: { baseURL: 'https://example.com' },
+    })
+    const opensaasConfig = makeOpensaasConfig(authConfig)
+    const context = makeContext()
+
+    const built = await buildBetterAuthOptions(opensaasConfig, context)
+
+    const auth = createAuth(opensaasConfig, context)
+    await auth.api.getSession({})
+
+    expect(betterAuthMock).toHaveBeenCalledTimes(1)
+    expect(betterAuthMock.mock.calls[0][0]).toEqual(built)
   })
 })
 


### PR DESCRIPTION
## Summary

- Add `betterAuthOptions` on `AuthConfig` — an escape hatch for any better-auth option the stack doesn't model. Deep-merged onto the options `createAuth()` builds, applied **last**: a plain-object value at a given key merges recursively with what the stack already set there (e.g. `session: { cookieCache }` doesn't clobber `session.expiresIn`/`updateAge`), any other value type (including arrays) replaces outright, and `betterAuthOptions` wins on a genuine key collision.
- Extract the options-building logic in `createAuth()` into an exported `buildBetterAuthOptions(config, context)`, returning the exact `BetterAuthOptions` object `createAuth()` uses — so an app that still needs to hand-wire its own `betterAuth()` instance (e.g. a third-party contract requiring a resolved instance at module-init time) can derive its options from the stack config instead of duplicating them. `createAuth()` now calls this builder directly, so the two cannot drift.
- Reject `database`, `plugins`, and `additionalFields` under `user`/`session`/`account`/`verification` in the passthrough — the first two already have dedicated seams (`db` config, `betterAuthPlugins`), and `additionalFields` has schema consequences (new columns) a passthrough can't also apply to the generated Prisma schema. Each rejection's error message names the supported alternative.
- Docs: `docs/content/reference/auth.md` (new `betterAuthOptions` config section + "Escape hatch: hand-wiring `betterAuth()`" section) and `packages/auth/CLAUDE.md`.
- Changeset (minor) for `@opensaas/stack-auth`.

## Test plan

- [x] New tests in `packages/auth/tests/server.test.ts`: passthrough reaches the built options (top-level and nested), nested merge doesn't clobber sibling keys, collision precedence (passthrough wins), arrays replace rather than concatenate, each rejected key throws naming the alternative, `createAuth()` and `buildBetterAuthOptions()` produce byte-identical output (parity), unused passthrough produces the same options as before this change.
- [x] New test in `packages/auth/tests/config.test.ts`: `normalizeAuthConfig` defaults `betterAuthOptions` to `{}` and passes a configured value through unchanged.
- [x] `pnpm test` (packages/auth): 198/198 passing
- [x] `pnpm build` (packages/core, packages/cli, packages/auth): clean
- [x] `pnpm lint`: no new warnings/errors
- [x] `pnpm manypkg fix` / `pnpm format`: clean

Closes #866


---
_Generated by [Claude Code](https://claude.ai/code/session_01EU6QfvFgE4oU93N5w9rWaA)_