### PR TITLE
fix(ci): give the nightly published-create e2e a pnpm version to resolve

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # This job deliberately scaffolds outside the workspace, so it needs no
+      # repo checkout of its own — but `pnpm/action-setup` resolves the pnpm
+      # version from the workspace `package.json`'s `packageManager`, and with
+      # nothing checked out it fails with "No pnpm version is specified".
+      # Sparse-check-out just that file: it keeps the runner's pnpm in lockstep
+      # with the repo (a pinned `version:` here would silently drift), and the
+      # scaffold below still runs in a temp dir against the PUBLISHED package.
+      - name: Check out package.json for the pnpm version
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
The Nightly workflow's `published-create-e2e` job has failed on every scheduled run. This unblocks it.

## The failure

```
Error: No pnpm version is specified.
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

The job deliberately has **no `actions/checkout`** — by design, since it tests the *published* package in a `mktemp -d` rather than the workspace. But `pnpm/action-setup` resolves the pnpm version from the workspace `package.json`'s `packageManager`, and with nothing checked out there is no `package.json` to read.

The repo does declare `"packageManager": "pnpm@10.29.1"`. The job simply cannot see it.

Every other job in the repo checks out first and goes through the local composite `.github/actions/setup`. This job is the only one calling `pnpm/action-setup` directly, with no checkout — which is why it is the only one affected.

## This is not a regression, and the gap is real

`nightly.yml` has exactly one commit in its history — the one that introduced it, already in this shape. The job has therefore never passed.

That matters more than the red badge. Per ADR-0002 this job is the *true* end-to-end: a real networked install of the published `create-opensaas-app`, then the documented first-run flow. The PR-gate scaffold guard only proxies it, borrowing the workspace toolchain offline. The failure happens at toolchain setup, **before** `npx create-opensaas-app@latest` ever runs, so the published artifact has never been exercised by CI at all.

The sibling `examples-build` job is unaffected and passes.

## The fix

Sparse-check-out just `package.json` before the pnpm setup step.

Rejected the alternative of pinning `version:` in the action config: it would drift from `packageManager` silently, and the next pnpm bump would leave the nightly testing a version the repo no longer uses. The sparse checkout keeps the two in lockstep.

It does not weaken what the job tests. The scaffold still happens in a temp dir against the published package; the pnpm binary driving it was never part of the artifact under test.

## What this does not prove

**The job is unblocked, not verified.** It has never run past its first step, so everything downstream — the networked scaffold, `generate`, `db:push`, `build` — is still unproven and may surface its own failures on the first real run. Expect this to need a follow-up.

Worth triggering via `workflow_dispatch` rather than waiting for 03:17 UTC, so the next failure (if any) surfaces now.

## Notes for review

- CI config only — no package code, so no changeset.
- Aligning this job's `pnpm/action-setup@v6` with the `@v4` used by the composite setup action is worth doing, but it is cleanup rather than part of this fix, so it is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGHcWLZbyo2sEjpBxJPFt6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGHcWLZbyo2sEjpBxJPFt6)_