### PR TITLE
fix(core): reject undeclared where/orderBy keys on findMany and count

### DIFF
--- a/.changeset/thick-rats-doubt.md
+++ b/.changeset/thick-rats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+`findMany`/`count` now reject an undeclared `where`/`orderBy` key (including nested inside `AND`/`OR`/`NOT` or a relation filter), closing the same back-relation surface #564 closed on writes. `sudo` still bypasses.

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -21,6 +21,9 @@ export {
 } from './engine.js'
 // Canonical field-level access evaluation (shared by read and write paths).
 export { checkFieldAccess, filterWritableFields } from './field-access.js'
+// Read-path key validation — the `findMany`/`count` counterpart to the write
+// path's #564 undeclared-key reject.
+export { validateQueryKeys } from './query-validation.js'
 // Phase 1 — Access Filter (pre-query row/relation scoping).
 export { buildAccessScopedInclude, stripVirtualFieldsFromInclude } from './access-filter.js'
 // Phase 2 — Field Visibility (post-query field stripping + resolveOutput).

--- a/packages/core/src/access/query-validation.ts
+++ b/packages/core/src/access/query-validation.ts
@@ -128,7 +128,7 @@ function walkWhere(
     // Scalar field filters use Prisma's own operator vocabulary (`equals`,
     // `contains`, `in`, …) and never nest another field name — trusted as-is,
     // no further walk needed. Only a relationship field's filter nests a
-    // WHERE clause for another list, via a relation quantifier.
+    // WHERE clause for another list.
     if (
       resolved.isRelationship &&
       value !== null &&
@@ -137,14 +137,27 @@ function walkWhere(
     ) {
       const related = getRelatedListConfig(resolved.fieldConfig.ref, config)
       if (!related) continue
-      for (const [quantifier, quantifierValue] of Object.entries(
-        value as Record<string, unknown>,
-      )) {
-        if (RELATION_QUANTIFIERS.has(quantifier)) {
-          walkWhere(quantifierValue, related.listConfig, related.listName, config, isSudo)
+
+      const relationEntries = Object.entries(value as Record<string, unknown>)
+      const hasQuantifier = relationEntries.some(([k]) => RELATION_QUANTIFIERS.has(k))
+
+      if (hasQuantifier) {
+        // Wrapped form: `{ author: { is: {...} } }` / `{ posts: { some: {...} } }`.
+        // Only the quantifier's own value is a nested WHERE clause for the
+        // related list.
+        for (const [quantifier, quantifierValue] of relationEntries) {
+          if (RELATION_QUANTIFIERS.has(quantifier)) {
+            walkWhere(quantifierValue, related.listConfig, related.listName, config, isSudo)
+          }
         }
-        // Other keys under a relation field (e.g. `equals: null` for a to-one
-        // nullability check) are not nested WHERE clauses — nothing to walk.
+      } else {
+        // Direct-nesting form: Prisma's documented default for a to-one
+        // relation filter nests the related list's own fields with no `is`
+        // wrapper at all (`{ author: { email: { contains: '...' } } }`). The
+        // whole value object IS the nested WHERE clause here — walk it
+        // directly, or an undeclared key reached exactly this way (one hop
+        // through a to-one relation) would pass through unchecked.
+        walkWhere(value, related.listConfig, related.listName, config, isSudo)
       }
     }
   }

--- a/packages/core/src/access/query-validation.ts
+++ b/packages/core/src/access/query-validation.ts
@@ -1,0 +1,206 @@
+import type { ListConfig, OpenSaasConfig } from '../config/types.js'
+import { getRelatedListConfig } from './engine.js'
+import { ValidationError } from '../hooks/index.js'
+
+/**
+ * #912 — read-path key validation.
+ *
+ * The write path settled #564: an undeclared key in `data` throws, because the
+ * generated Prisma model has strictly more fields than the config declares (most
+ * notably back-relations — Prisma emits one for every inbound foreign key, whether
+ * or not the list config declares the reverse relationship). Reads had no
+ * equivalent — a caller's `where`/`orderBy` reached Prisma unchanged, so an
+ * anonymous caller could filter or order by a relation the config never exposed.
+ *
+ * This module is the read-path counterpart: every key named in a caller's `where`
+ * or `orderBy` is resolved against the list config before the query runs. A key
+ * with no entry in the config throws, naming the list and the key. `sudo` is the
+ * single trusted bypass, mirroring the write path.
+ *
+ * Deliberately NOT walked: the access filter produced by the list's own `query`
+ * access control. That filter is trusted config authored by the same person who
+ * declares the fields — walking it would make this an access-control decision
+ * (that's #915/#916), not the key-existence seam this ticket establishes.
+ */
+
+// Prisma's logical combinators for a WHERE clause — never field names.
+const LOGICAL_OPERATORS = new Set(['AND', 'OR', 'NOT'])
+
+// Prisma's relation quantifiers. The value nested under one of these is itself a
+// WHERE clause for the RELATED list, and is walked against that list's fields.
+const RELATION_QUANTIFIERS = new Set(['some', 'every', 'none', 'is', 'isNot'])
+
+// Always present, never declared in a list's `fields` — the write path
+// (`filterWritableFields`) excludes the same three names from `fieldConfigs`.
+const SYSTEM_FIELDS = new Set(['id', 'createdAt', 'updatedAt'])
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- field configs are heterogeneous across field types
+type FieldConfigMap = Record<string, any>
+
+interface ResolvedQueryField {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- field configs are heterogeneous across field types
+  fieldConfig: any
+  isRelationship: boolean
+}
+
+/**
+ * Resolve a `where`/`orderBy` key against a list's declared fields.
+ *
+ * A key is valid when it is:
+ * - a system field (`id`, `createdAt`, `updatedAt`) — always present, and never
+ *   declared in `fields` (the write path excludes them from `fieldConfigs` the
+ *   same way), or
+ * - a field declared directly in the list config, or
+ * - the foreign-key scalar a to-one `relationship` field implies (e.g. `authorId`
+ *   for `author: relationship(...)`) — the config never names this column
+ *   directly, but Prisma always generates it, and the write path
+ *   (`filterWritableFields`) grants it the same pass, or
+ * - a raw per-part column a multi-column field's `splitColumns` contributes (e.g.
+ *   storage `image()`/`file()` in Keystone-parity mode) — undeclared by design,
+ *   mirroring the write path's `splitColumnOwners` allowance (#568/#789).
+ *
+ * Anything else — most importantly a Prisma-generated back-relation the config
+ * never declares — resolves to `undefined` and is rejected by the caller.
+ */
+function resolveQueryField(key: string, fields: FieldConfigMap): ResolvedQueryField | undefined {
+  if (SYSTEM_FIELDS.has(key)) {
+    return { fieldConfig: undefined, isRelationship: false }
+  }
+
+  const fieldConfig = fields[key]
+  if (fieldConfig) {
+    return { fieldConfig, isRelationship: fieldConfig.type === 'relationship' }
+  }
+
+  if (key.endsWith('Id')) {
+    const baseField = fields[key.slice(0, -2)]
+    if (baseField && baseField.type === 'relationship' && !baseField.many) {
+      return { fieldConfig: baseField, isRelationship: false }
+    }
+  }
+
+  for (const [ownerName, owner] of Object.entries(fields)) {
+    if (owner && typeof owner.getColumnNames === 'function') {
+      const columns: string[] = owner.getColumnNames(ownerName)
+      if (columns.includes(key)) {
+        return { fieldConfig: owner, isRelationship: false }
+      }
+    }
+  }
+
+  return undefined
+}
+
+function rejectUndeclaredKey(listName: string, key: string, kind: 'where' | 'orderBy'): never {
+  throw new ValidationError([
+    `Cannot query "${listName}" — "${key}" is not a field of this list. ` +
+      `Undeclared ${kind} keys are rejected (use sudo to bypass).`,
+  ])
+}
+
+function walkWhere(
+  where: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listName: string,
+  config: OpenSaasConfig,
+  isSudo: boolean,
+): void {
+  if (where === null || typeof where !== 'object') return
+
+  if (Array.isArray(where)) {
+    for (const entry of where) walkWhere(entry, listConfig, listName, config, isSudo)
+    return
+  }
+
+  for (const [key, value] of Object.entries(where as Record<string, unknown>)) {
+    if (LOGICAL_OPERATORS.has(key)) {
+      walkWhere(value, listConfig, listName, config, isSudo)
+      continue
+    }
+
+    const resolved = resolveQueryField(key, listConfig.fields)
+    if (!resolved) {
+      if (isSudo) continue
+      rejectUndeclaredKey(listName, key, 'where')
+    }
+
+    // Scalar field filters use Prisma's own operator vocabulary (`equals`,
+    // `contains`, `in`, …) and never nest another field name — trusted as-is,
+    // no further walk needed. Only a relationship field's filter nests a
+    // WHERE clause for another list, via a relation quantifier.
+    if (
+      resolved.isRelationship &&
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      const related = getRelatedListConfig(resolved.fieldConfig.ref, config)
+      if (!related) continue
+      for (const [quantifier, quantifierValue] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        if (RELATION_QUANTIFIERS.has(quantifier)) {
+          walkWhere(quantifierValue, related.listConfig, related.listName, config, isSudo)
+        }
+        // Other keys under a relation field (e.g. `equals: null` for a to-one
+        // nullability check) are not nested WHERE clauses — nothing to walk.
+      }
+    }
+  }
+}
+
+function walkOrderBy(
+  orderBy: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listName: string,
+  config: OpenSaasConfig,
+  isSudo: boolean,
+): void {
+  if (orderBy === null || typeof orderBy !== 'object') return
+
+  if (Array.isArray(orderBy)) {
+    for (const entry of orderBy) walkOrderBy(entry, listConfig, listName, config, isSudo)
+    return
+  }
+
+  for (const [key, value] of Object.entries(orderBy as Record<string, unknown>)) {
+    const resolved = resolveQueryField(key, listConfig.fields)
+    if (!resolved) {
+      if (isSudo) continue
+      rejectUndeclaredKey(listName, key, 'orderBy')
+    }
+
+    if (resolved.isRelationship && value !== null && typeof value === 'object') {
+      // `{ relation: { _count: 'asc' } }` orders by an aggregate — no nested
+      // field name to resolve. `{ relation: { name: 'asc' } }` orders by a
+      // field on a to-one related list — walk it against that list's fields.
+      if ('_count' in (value as Record<string, unknown>)) continue
+
+      const related = getRelatedListConfig(resolved.fieldConfig.ref, config)
+      if (related) walkOrderBy(value, related.listConfig, related.listName, config, isSudo)
+    }
+  }
+}
+
+/**
+ * Validate a caller-supplied `where`/`orderBy` against the list config,
+ * recursing into logical operators (`AND`/`OR`/`NOT`) and relation filters.
+ * Throws a `ValidationError` naming the list and the offending key on the
+ * first undeclared key found. `isSudo` bypasses the check entirely, matching
+ * the write path's `sudo` escape hatch.
+ */
+export function validateQueryKeys(args: {
+  where?: unknown
+  orderBy?: unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>
+  listName: string
+  config: OpenSaasConfig
+  isSudo: boolean
+}): void {
+  const { where, orderBy, listConfig, listName, config, isSudo } = args
+  if (where !== undefined) walkWhere(where, listConfig, listName, config, isSudo)
+  if (orderBy !== undefined) walkOrderBy(orderBy, listConfig, listName, config, isSudo)
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -7,6 +7,7 @@ import {
   buildAccessScopedInclude,
   stripVirtualFieldsFromInclude,
   foldDeclaredDependencies,
+  validateQueryKeys,
 } from '../access/index.js'
 import type { DeclaredOnlyTree } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
@@ -875,7 +876,7 @@ export function populateDbDelegate<TPrisma extends PrismaClientLike>(
       create: createOp,
       update: updateOp,
       delete: createDelete(listName, listConfig, prisma, context, config),
-      count: createCount(listName, listConfig, prisma, context),
+      count: createCount(listName, listConfig, prisma, context, config),
       createMany: createCreateMany(listName, listConfig, prisma, context, config, createOp),
       updateMany: createUpdateMany(
         listName,
@@ -1133,6 +1134,18 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       )
     }
 
+    // #912 — reject a `where`/`orderBy` key the list config doesn't declare
+    // (e.g. a Prisma-generated back-relation) before it ever reaches the
+    // access filter merge below. `sudo` bypasses, matching the write path.
+    validateQueryKeys({
+      where: args?.where,
+      orderBy: args?.orderBy,
+      listConfig,
+      listName,
+      config,
+      isSudo: context._isSudo === true,
+    })
+
     // Check query access (skip if sudo mode)
     let where: Record<string, unknown> | undefined = args?.where
     if (!context._isSudo) {
@@ -1388,8 +1401,21 @@ function createCount<TPrisma extends PrismaClientLike>(
   listConfig: ListConfig<any>,
   prisma: TPrisma,
   context: AccessContext<TPrisma>,
+  config: OpenSaasConfig,
 ) {
   return async (args?: { where?: Record<string, unknown> }) => {
+    // #912 — reject a `where` key the list config doesn't declare (e.g. a
+    // Prisma-generated back-relation), same as findMany. `count` leaks the
+    // most cleanly of any read op — a bare count answers a predicate with no
+    // rows returned at all — so it gets the same reject, not a lesser one.
+    validateQueryKeys({
+      where: args?.where,
+      listConfig,
+      listName,
+      config,
+      isSudo: context._isSudo === true,
+    })
+
     // Check query access (skip if sudo mode)
     let where: Record<string, unknown> | undefined = args?.where
     if (!context._isSudo) {

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1255,6 +1255,173 @@ describe('getContext', () => {
       })
     })
 
+    describe('read-path key validation (#912)', () => {
+      it('throws on an undeclared `where` key on findMany, naming the list and the key', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(context.db.post.findMany({ where: { bogusKey: 'x' } })).rejects.toThrow(/Post/)
+        await expect(context.db.post.findMany({ where: { bogusKey: 'x' } })).rejects.toThrow(
+          /bogusKey/,
+        )
+        expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+      })
+
+      it('throws on an undeclared `where` key on count', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(context.db.user.count({ where: { bogusKey: 'x' } })).rejects.toThrow(
+          /bogusKey/,
+        )
+        expect(mockPrisma.user.count).not.toHaveBeenCalled()
+      })
+
+      it('throws on an undeclared `orderBy` key on findMany', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(context.db.post.findMany({ orderBy: { bogusKey: 'asc' } })).rejects.toThrow(
+          /bogusKey/,
+        )
+        expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+      })
+
+      it('throws on an undeclared key nested inside a logical operator (AND/OR/NOT)', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(
+          context.db.post.findMany({
+            where: { OR: [{ title: { contains: 'a' } }, { bogusKey: 'x' }] },
+          }),
+        ).rejects.toThrow(/bogusKey/)
+
+        await expect(
+          context.db.post.findMany({
+            where: { AND: [{ NOT: { bogusKey: 'x' } }] },
+          }),
+        ).rejects.toThrow(/bogusKey/)
+      })
+
+      it('throws on an undeclared key nested inside a relation filter, naming the RELATED list', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(
+          context.db.post.findMany({ where: { author: { is: { bogusKey: 'x' } } } }),
+        ).rejects.toThrow(/User/)
+        await expect(
+          context.db.post.findMany({ where: { author: { is: { bogusKey: 'x' } } } }),
+        ).rejects.toThrow(/bogusKey/)
+      })
+
+      it('rejects a Prisma-generated back-relation the list config never declares (the regression that matters most)', async () => {
+        // Organisation declares no relationship back to Document — mirrors a
+        // list whose Prisma model gets a `from_Document_organisation`
+        // back-relation purely because Document holds an FK pointing at it.
+        const backRelationPrisma = {
+          organisation: { findMany: vi.fn(), count: vi.fn() },
+        }
+        const backRelationConfig: OpenSaasConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            Organisation: {
+              fields: { name: { type: 'text' } },
+              access: { operation: { query: () => true } },
+            },
+          },
+        }
+
+        const context = await getContext(backRelationConfig, backRelationPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { from_Document_organisation: { some: {} } },
+          }),
+        ).rejects.toThrow(/from_Document_organisation/)
+        await expect(
+          context.db.organisation.count({
+            where: { from_Document_organisation: { some: {} } },
+          }),
+        ).rejects.toThrow(/from_Document_organisation/)
+
+        expect(backRelationPrisma.organisation.findMany).not.toHaveBeenCalled()
+        expect(backRelationPrisma.organisation.count).not.toHaveBeenCalled()
+      })
+
+      it('never mistakes a Prisma filter operator (equals/contains/startsWith/in/is/isNot) for a field name', async () => {
+        mockPrisma.post.findMany.mockResolvedValue([
+          { id: '1', title: 'Test Post', content: 'x', authorId: 'u1' },
+        ])
+
+        const context = await getContext(config, mockPrisma, null)
+        const where = {
+          title: { equals: 'Test Post', contains: 'Test', startsWith: 'T', in: ['Test Post'] },
+          author: { is: { name: 'John' }, isNot: null },
+        }
+
+        await context.db.post.findMany({ where })
+
+        expect(mockPrisma.post.findMany).toHaveBeenCalledWith(expect.objectContaining({ where }))
+      })
+
+      it('passes all of the above through under sudo (the single trusted bypass)', async () => {
+        mockPrisma.post.findMany.mockResolvedValue([])
+
+        const context = (await getContext(config, mockPrisma, null)).sudo()
+        await context.db.post.findMany({
+          where: { bogusKey: 'x', OR: [{ alsoBogus: 'y' }] },
+          orderBy: { alsoOrderByBogus: 'asc' },
+        })
+
+        expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { bogusKey: 'x', OR: [{ alsoBogus: 'y' }] },
+            orderBy: { alsoOrderByBogus: 'asc' },
+          }),
+        )
+      })
+
+      it('keeps an implied foreign-key scalar filterable (authorId for author: relationship(...))', async () => {
+        mockPrisma.post.findMany.mockResolvedValue([])
+
+        const context = await getContext(config, mockPrisma, null)
+        await context.db.post.findMany({ where: { authorId: 'user-1' } })
+
+        expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({ where: { authorId: 'user-1' } }),
+        )
+      })
+
+      it('findFirst inherits the check through findMany, with no second copy', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(context.db.post.findFirst({ where: { bogusKey: 'x' } })).rejects.toThrow(
+          /bogusKey/,
+        )
+        expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+      })
+
+      it('updateMany inherits the check through findMany, with no second copy', async () => {
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(
+          context.db.user.updateMany({ where: { bogusKey: 'x' }, data: { name: 'y' } }),
+        ).rejects.toThrow(/bogusKey/)
+        expect(mockPrisma.user.findMany).not.toHaveBeenCalled()
+        expect(mockPrisma.user.update).not.toHaveBeenCalled()
+      })
+
+      it('an ordinary read using only declared keys is unaffected', async () => {
+        const mockUsers = [{ id: '1', name: 'John', email: 'john@example.com' }]
+        mockPrisma.user.findMany.mockResolvedValue(mockUsers)
+
+        const context = await getContext(config, mockPrisma, null)
+        const result = await context.db.user.findMany({
+          where: { name: 'John' },
+          orderBy: { name: 'asc' },
+        })
+
+        expect(result).toEqual(mockUsers)
+      })
+    })
+
     describe('explicit include merges with access control (#566)', () => {
       // Author has many Posts; Post.query access scopes to published posts only.
       // A caller-supplied `include` must NOT bypass that per-relation filter.

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1311,6 +1311,33 @@ describe('getContext', () => {
         ).rejects.toThrow(/bogusKey/)
       })
 
+      it("throws on an undeclared key reached via Prisma's direct-nesting to-one filter (no `is` wrapper)", async () => {
+        // Prisma's documented default for filtering a to-one relation nests the
+        // related list's fields directly, with no `is`/`isNot` wrapper at all —
+        // e.g. `{ author: { email: { contains: '...' } } }`. An undeclared key
+        // reached this way (one hop through a to-one relation, rather than at
+        // the root) must be rejected exactly like the wrapped `is` form.
+        const context = await getContext(config, mockPrisma, null)
+
+        await expect(
+          context.db.post.findMany({ where: { author: { bogusKey: 'x' } } }),
+        ).rejects.toThrow(/User/)
+        await expect(
+          context.db.post.findMany({ where: { author: { bogusKey: 'x' } } }),
+        ).rejects.toThrow(/bogusKey/)
+        expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+      })
+
+      it('accepts a declared field on the direct-nesting to-one filter form', async () => {
+        mockPrisma.post.findMany.mockResolvedValue([])
+
+        const context = await getContext(config, mockPrisma, null)
+        const where = { author: { name: { equals: 'John' } } }
+        await context.db.post.findMany({ where })
+
+        expect(mockPrisma.post.findMany).toHaveBeenCalledWith(expect.objectContaining({ where }))
+      })
+
       it('rejects a Prisma-generated back-relation the list config never declares (the regression that matters most)', async () => {
         // Organisation declares no relationship back to Document — mirrors a
         // list whose Prisma model gets a `from_Document_organisation`


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/access/query-validation.ts`: a recursive walk (`validateQueryKeys`) that validates a caller-supplied `where`/`orderBy` against the list config before the query reaches Prisma, mirroring the write path's #564 undeclared-key reject.
- Wires the validation into `createFindMany` and `createCount` in `packages/core/src/context/index.ts` (the only two operations the issue identifies as the real surface — `findUnique` already validates its unique `where`, and `findFirst`/`updateMany` inherit for free by delegating to the same validated `findMany`).
- The walk recurses into logical operators (`AND`/`OR`/`NOT`) and relation quantifiers (`some`/`every`/`none`/`is`/`isNot`), switching to the *related* list's fields when it crosses a relationship — so a nested key is checked against the right list.
- Prisma's own filter operator vocabulary (`equals`, `contains`, `startsWith`, `in`, …) and aggregate ordering (`_count`) are never mistaken for field names.
- System fields (`id`, `createdAt`, `updatedAt`), implied foreign-key scalars (e.g. `authorId` for `author: relationship(...)`), and multi-column field sub-columns (`getColumnNames`) remain filterable, matching the same allowances the write path already grants.
- `sudo` bypasses the check entirely, matching the write path's escape hatch.
- Only the caller-supplied `where`/`orderBy` is walked — the access filter produced by the list's own `query` access control is trusted config and is never walked (that's out of scope here, and belongs to #915/#916).

## Test plan

- [x] New `describe('read-path key validation (#912)')` block in `packages/core/tests/context.test.ts` covering: undeclared `where` key on `findMany`/`count`, undeclared `orderBy` key, nested `AND`/`OR`/`NOT`, nested relation filter (naming the *related* list), the back-relation regression case from the issue (`from_Document_organisation`), operator-vs-field-name disambiguation, `sudo` bypass, implied FK scalar filterability, `findFirst`/`updateMany` inheriting the check, and an ordinary read remaining unaffected.
- [x] `pnpm test` (core package): 970/970 passing, no regressions in the existing suite.
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` all clean.
- [x] `tsc --noEmit` clean.
- [x] Changeset added (`@opensaas/stack-core`: patch).

Closes #912


---
_Generated by [Claude Code](https://claude.ai/code/session_01YD1qbFLq2BhYgVcqAP1j7G)_