### PR TITLE
fix(auth): getSessionFromAuth accepts both createAuth() overloads

### DIFF
--- a/.changeset/tame-otters-jump.md
+++ b/.changeset/tame-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+`getSessionFromAuth()` now accepts an auth instance from either `createAuth()` overload — including the plugin-narrowed one — without a cast.

--- a/packages/auth/src/server/get-session-from-auth.test.ts
+++ b/packages/auth/src/server/get-session-from-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expectTypeOf } from 'vitest'
+import type { OpenSaasConfig, AccessContext, Session } from '@opensaas/stack-core'
+import { emailOTP } from 'better-auth/plugins'
+import { createAuth, getSessionFromAuth } from './index.js'
+
+// Type-level regression coverage for #906: `getSessionFromAuth` must accept
+// an auth instance from either `createAuth()` overload — the widened
+// `Auth<BetterAuthOptions>` returned with no plugin tuple, and the narrowed
+// `Auth<ResolvedBetterAuthOptions<TPlugins>>` returned when one is passed —
+// with no cast and no intermediate widening assignment. `Parameters<typeof
+// createAuth>` on the overloaded export resolves against its last (generic)
+// signature rather than the call-site-selected one, so each call shape is
+// wrapped in its own ordinary function and read back via `typeof`, mirroring
+// `build-better-auth-options.test.ts`.
+type TestPlugins = [ReturnType<typeof emailOTP>]
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced only via `typeof` below
+function callWithNoPlugins(
+  config: OpenSaasConfig | Promise<OpenSaasConfig>,
+  context: AccessContext | Promise<AccessContext>,
+) {
+  return createAuth(config, context)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced only via `typeof` below
+function callWithPlugins(
+  config: OpenSaasConfig | Promise<OpenSaasConfig>,
+  context: AccessContext | Promise<AccessContext>,
+  plugins: TestPlugins,
+) {
+  return createAuth(config, context, plugins)
+}
+
+type WidenedAuth = ReturnType<typeof callWithNoPlugins>
+type NarrowedAuth = ReturnType<typeof callWithPlugins>
+
+describe('getSessionFromAuth accepts either createAuth() overload (#906)', () => {
+  it('accepts the widened Auth<BetterAuthOptions> instance with no cast', () => {
+    expectTypeOf<WidenedAuth>().toExtend<Parameters<typeof getSessionFromAuth>[0]>()
+  })
+
+  it('accepts the narrowed, plugin-typed Auth instance with no cast', () => {
+    // This is the exact case #906 reported as a type error: a `createAuth`
+    // instance narrowed by a plugin tuple, passed straight into
+    // `getSessionFromAuth` without widening it back to `Auth<BetterAuthOptions>`.
+    expectTypeOf<NarrowedAuth>().toExtend<Parameters<typeof getSessionFromAuth>[0]>()
+  })
+
+  it('return type stays Promise<Session | null>, unchanged by the widened/narrowed instance', () => {
+    expectTypeOf(getSessionFromAuth).returns.toEqualTypeOf<Promise<Session | null>>()
+  })
+})

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -565,9 +565,19 @@ function resolveSessionField(
  * await headers() })`. Exported as the single reusable implementation; pass
  * the caller's request headers (e.g. Next.js `await headers()` in a Server
  * Component/action) so a session cookie can actually be resolved.
+ *
+ * `auth` is typed structurally over just the one member this function reads
+ * — `api.getSession` — rather than a single concrete `Auth<Options>`
+ * instantiation, so it accepts an instance from either `createAuth()`
+ * overload: the widened `Auth<BetterAuthOptions>`, or the narrowed
+ * `Auth<ResolvedBetterAuthOptions<TPlugins>>` returned when a plugin tuple is
+ * passed. `TResolvedSession` is inferred from whatever `auth.api.getSession`
+ * actually returns (the default `{ session, user }` shape, or a
+ * `customSession` plugin's replaced shape) — it is not constrained, so no
+ * `any`/`unknown` is introduced at the call boundary.
  */
-export async function getSessionFromAuth(
-  auth: ReturnType<typeof betterAuth>,
+export async function getSessionFromAuth<TResolvedSession>(
+  auth: { api: { getSession: (args: { headers: Headers }) => Promise<TResolvedSession> } },
   sessionFields: string[],
   headers: Headers,
 ): Promise<Session | null> {


### PR DESCRIPTION
## Summary

- `getSessionFromAuth()`'s `auth` parameter is now generic, typed structurally over the one member it actually reads (`api.getSession`), instead of the single concrete `ReturnType<typeof betterAuth>` (i.e. the widened `Auth<BetterAuthOptions>`).
- This means an instance returned from either `createAuth()` overload — the widened `Auth<BetterAuthOptions>` (no plugin tuple) or the narrowed `Auth<ResolvedBetterAuthOptions<TPlugins>>` (plugin tuple passed) — is now accepted with no cast and no intermediate widening assignment. Previously the narrowed instance was a type error, forcing apps to choose between typed plugin endpoints and the shared session projection.
- The projection behavior (resolution precedence, `userId` special-casing, the unresolved-field warning) and the `Promise<Session | null>` return type are unchanged.
- No `any`/`unknown` introduced in the exported signature — the new type parameter is inferred, not constrained.
- Left `StackContext`/`AccessContext` and `createAuth`'s overloads untouched, as scoped by the issue.

## Test plan

- [x] Added a type-level regression test (`packages/auth/src/server/get-session-from-auth.test.ts`) covering both `createAuth()` overloads — verified it fails to compile against the old signature (reverted locally to confirm), and compiles clean against the fix.
- [x] `pnpm vitest run` in `packages/auth` — 217 passed, including existing `getSessionFromAuth` behavior tests unchanged.
- [x] `tsc --noEmit` clean for `packages/auth`.
- [x] `pnpm lint` clean on changed files.
- [x] `pnpm format` (prettier --check) clean on changed files.
- [x] Changeset added (patch — input type loosening only).

Closes #906


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMy1ZJwfbt7YvkJm19YhAH)_