### PR TITLE
fix(core): FieldAccess['read'] types item as present, matching Field Visibility

### DIFF
--- a/.changeset/tame-hounds-wave.md
+++ b/.changeset/tame-hounds-wave.md
@@ -1,0 +1,19 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Fix `FieldAccess['read']` typing `item` as absent when Field Visibility always passes the fetched row. A field `read` rule that reads a property off `item` now compiles without a cast, `any`, or non-null assertion:
+
+```ts
+// Before (required a cast/assertion — `item` was typed `undefined`)
+internalNotes: text({
+  access: { read: ({ item, session }) => item!.ownerId === session?.userId } as FieldAccessControl,
+})
+
+// After (compiles as written — `item` is typed as the row)
+internalNotes: text({
+  access: { read: ({ item, session }) => item.ownerId === session?.userId },
+})
+```
+
+`FieldAccess['read']` now accepts only the single `operation: 'read'` call shape (rather than the full `read | create | update` union `FieldAccess['create']`/`FieldAccess['update']` still accept), so a rule written for the `read` slot never needs to narrow on `operation` to use `item`. The `create` branch — where there genuinely is no row yet — is unchanged.

--- a/packages/core/src/access/field-access.test.ts
+++ b/packages/core/src/access/field-access.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, expectTypeOf } from 'vitest'
 import { checkFieldAccess, filterWritableFields } from './field-access.js'
 import { InvalidFieldAccessResultError } from './errors.js'
 import { ValidationError } from '../hooks/index.js'
+import type { FieldAccess, FieldAccessControl } from './types.js'
 
 // A non-sudo access context. The cast is localized to test setup (mirrors the
 // existing sudo-context casts in this file): the runtime AccessContext carries
@@ -21,6 +22,50 @@ function sudoContext() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
+
+// ── #914: `FieldAccess['read']`'s `item` must type as present, matching what
+// Field Visibility (field-visibility.ts) actually passes ──
+
+describe("FieldAccess['read'] item typing (issue #914)", () => {
+  type Item = { ownerId: string }
+
+  it('types item as present for a read rule that reads a property off it — no cast, no `any`', () => {
+    const fieldAccess: FieldAccess<Item> = {
+      read: ({ session, item }) => item.ownerId === session?.userId,
+    }
+    expect(typeof fieldAccess.read).toBe('function')
+  })
+
+  it('still compiles a read rule that ignores item entirely', () => {
+    const fieldAccess: FieldAccess<Item> = {
+      read: () => true,
+    }
+    expect(typeof fieldAccess.read).toBe('function')
+  })
+
+  it('leaves the create branch unchanged — item is still absent, there genuinely is no row yet', () => {
+    // Pinned against `FieldAccessControl`'s discriminated union directly
+    // (rather than `FieldAccess['create']`'s destructured callback), because
+    // `create`/`update` — unlike `read` — are untouched by this fix and keep
+    // accepting the full `FieldAccessControl` union in `FieldAccess`.
+    type CreateArgs = Extract<Parameters<FieldAccessControl<Item>>[0], { operation: 'create' }>
+    expectTypeOf<CreateArgs['item']>().toEqualTypeOf<undefined>()
+  })
+
+  // Type-level pin: `resolveReadableFieldValue` (field-visibility.ts) is the
+  // sole caller of `checkFieldAccess` for `operation: 'read'`, and always
+  // supplies `item: accessItem` — a full row, never `undefined`. This
+  // assertion has no runtime effect (`expectTypeOf` is a no-op outside
+  // `vitest --typecheck`); its value is that `pnpm build`/`tsc` fails on this
+  // file the moment `FieldAccess['read']`'s `item` type drifts back to
+  // optional/absent, so the declared type and the call site cannot silently
+  // diverge again.
+  it("pins FieldAccess['read']'s item type against the field-visibility.ts call site", () => {
+    type ReadArgs = Parameters<NonNullable<FieldAccess<Item>['read']>>[0]
+    expectTypeOf<ReadArgs['item']>().toEqualTypeOf<Item>()
+    expectTypeOf<ReadArgs['operation']>().toEqualTypeOf<'read'>()
+  })
+})
 
 // ── #913: a field rule returning a filter must not be granted blanket access ──
 

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -1,5 +1,5 @@
 import type { Session, AccessContext } from './types.js'
-import type { FieldAccess } from './types.js'
+import type { FieldAccess, FieldAccessControl } from './types.js'
 // `ValidationError` is referenced only inside function bodies (call-time), never
 // at module-evaluation time, so the field-access ⇄ hooks import cycle is safe
 // under ESM live bindings.
@@ -49,7 +49,15 @@ export async function checkFieldAccess(
     return true // No field access means allow
   }
 
-  const accessControl = fieldAccess[operation]
+  // `FieldAccess['read']` is narrower than `FieldAccess['create'/'update']` (it
+  // only accepts the single `operation: 'read'` call shape, see `types.ts`),
+  // so indexing by a not-yet-narrowed `operation` union produces a callable
+  // whose effective parameter type collapses to an intersection TypeScript
+  // can't satisfy generically here. Widen back to the general
+  // `FieldAccessControl` — the same shape this function has always built and
+  // passed below — since by construction the args object always matches
+  // whichever operation is actually requested.
+  const accessControl = fieldAccess[operation] as FieldAccessControl | undefined
   if (!accessControl) {
     return true // No specific access control means allow
   }

--- a/packages/core/src/access/types.ts
+++ b/packages/core/src/access/types.ts
@@ -324,6 +324,43 @@ export type AccessControl<T = Record<string, unknown>> = (args: {
 }) => boolean | PrismaFilter<T> | Promise<boolean | PrismaFilter<T>>
 
 /**
+ * The per-operation argument shapes a `FieldAccessControl` function is called
+ * with — the discriminated union `FieldAccessControl` wraps, and the source
+ * of truth `FieldAccess`'s individual `read`/`create`/`update` members are
+ * picked from (via `Extract`) below. Keeping this as its own named type is
+ * what lets both sides reference the exact same three call shapes instead of
+ * two independently-maintained descriptions drifting apart.
+ */
+type FieldAccessControlArgs<TItem, TCreateInput, TUpdateInput> =
+  | {
+      session: Session | null
+      // Field Visibility (phase 2 of the two-phase read) always evaluates
+      // `read` rules against an already-fetched row — see
+      // `resolveReadableFieldValue` in `field-visibility.ts`, the sole
+      // caller of `checkFieldAccess` for this operation. Unlike `create`
+      // (where no row exists yet), there is no case where `item` is absent
+      // here, so it is required rather than optional.
+      item: TItem
+      context: AccessContext
+      inputData?: undefined
+      operation: 'read'
+    }
+  | {
+      session: Session | null
+      item?: undefined
+      context: AccessContext
+      inputData: TCreateInput
+      operation: 'create'
+    }
+  | {
+      session: Session | null
+      item: TItem
+      context: AccessContext
+      inputData: TUpdateInput
+      operation: 'update'
+    }
+
+/**
  * Field-level access control function.
  * For create/update operations, receives inputData to validate incoming values.
  *
@@ -337,45 +374,40 @@ export type AccessControl<T = Record<string, unknown>> = (args: {
  * evaluator (`checkFieldAccess`) enforces this: a rule that somehow returns
  * anything other than `true`/`false` (bypassing this type) throws rather than
  * defaulting to allow.
+ *
+ * This is the general, all-operations union — useful for a single function
+ * reused across more than one of `FieldAccess`'s `read`/`create`/`update`
+ * slots, narrowing on `operation` to tell the call shapes apart. A function
+ * written for exactly one slot doesn't need to: `FieldAccess` picks each
+ * slot's own single-operation shape out of this union (see below), so e.g. a
+ * `read`-only rule sees `item` as always present with no narrowing required.
  */
 export type FieldAccessControl<
   TItem = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
   TUpdateInput = Record<string, unknown>,
-> = (
-  args:
-    | {
-        session: Session | null
-        item?: undefined
-        context: AccessContext
-        inputData?: undefined
-        operation: 'read'
-      }
-    | {
-        session: Session | null
-        item?: undefined
-        context: AccessContext
-        inputData: TCreateInput
-        operation: 'create'
-      }
-    | {
-        session: Session | null
-        item: TItem
-        context: AccessContext
-        inputData: TUpdateInput
-        operation: 'update'
-      },
-) => boolean | Promise<boolean>
+> = (args: FieldAccessControlArgs<TItem, TCreateInput, TUpdateInput>) => boolean | Promise<boolean>
 
 /**
  * Field-level access control
+ *
+ * `read` is typed from the single `operation: 'read'` member of
+ * `FieldAccessControlArgs`, not the full `FieldAccessControl` union — so a
+ * rule written directly for this slot sees `item` as always present (never
+ * `TItem | undefined`) with no narrowing, cast, or `any` needed. A function
+ * typed as the broader `FieldAccessControl` union remains assignable here
+ * (and to `create`/`update`) — accepting more call shapes than the slot
+ * requires is a valid substitute, same as anywhere else function parameters
+ * are contravariant.
  */
 export type FieldAccess<
   TItem = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
   TUpdateInput = Record<string, unknown>,
 > = {
-  read?: FieldAccessControl<TItem, TCreateInput, TUpdateInput>
+  read?: (
+    args: Extract<FieldAccessControlArgs<TItem, TCreateInput, TUpdateInput>, { operation: 'read' }>,
+  ) => boolean | Promise<boolean>
   create?: FieldAccessControl<TItem, TCreateInput, TUpdateInput>
   update?: FieldAccessControl<TItem, TCreateInput, TUpdateInput>
 }


### PR DESCRIPTION
## Summary

- `FieldAccessControl`'s `read` branch declared `item?: undefined`, but Field Visibility (`field-visibility.ts`) — the sole caller for `operation: 'read'` — always evaluates the rule against the already-fetched row. A field `read` rule that read a property off `item` (the "most natural thing an author would write", per the issue) failed to compile with `TS18048: 'item' is possibly 'undefined'`, pushing authors toward a cast/`any`/non-null assertion in the one place losing type safety costs the most.
- Fixed the `read` branch of the discriminated union to type `item` as required (`TItem`), matching the `update` branch and the runtime call site.
- Restructured `FieldAccess['read']` to pick only the single `operation: 'read'` shape out of the union (via `Extract`) — not the full `read | create | update` union `FieldAccess['create']`/`FieldAccess['update']` still accept — so a rule assigned directly to the `read` slot sees `item` as always present with **no narrowing, cast, or `any` needed**. (Simply widening the `read` union member alone wasn't sufficient — I verified with a live `tsc` repro that the `create` member's `item?: undefined` still contaminated the destructured type across the shared `FieldAccessControl` union.)
- `create` is unchanged — there's genuinely no row yet, so `item?: undefined` stays.
- `checkFieldAccess` (the internal evaluator in `field-access.ts`) widens back to `FieldAccessControl` when indexing `fieldAccess[operation]` by a not-yet-narrowed `operation`, since a union of differently-shaped callables collapses to an unsatisfiable intersection at the call site otherwise.
- Added type-level tests (`field-access.test.ts`) pinning `FieldAccess['read']`'s `item` type against the `field-visibility.ts` call site, and covering: the natural read rule compiling with no cast, a rule that ignores `item` still compiling, and the `create` branch staying unchanged.

## Test plan

- [x] `pnpm build` (tsc) passes for `packages/core` and all downstream workspace packages (`auth`, `ui`, `storage`, `storage-s3`, `storage-vercel`, `rag`, `tiptap`)
- [x] `pnpm test` — 987/987 tests pass in `packages/core` (4 new type-level tests added)
- [x] Verified the new type-level test actually catches the regression: reverting `types.ts` alone reproduces the original `TS18048` error plus two new pin-test failures
- [x] `pnpm eslint packages/core` — clean
- [x] `pnpm format` / `pnpm manypkg fix` — no changes
- [x] Changeset added (`.changeset/tame-hounds-wave.md`, minor — narrowing a public type, per the precedent set in #913/#919)

Closes #914

---
_Generated by [Claude Code](https://claude.ai/code/session_015dzH7Zr2ZpawsojPQkL7Ji)_