### PR TITLE
fix(core,ui): field read access gates where/orderBy, not just returned rows

### DIFF
--- a/.changeset/soft-eagles-jog.md
+++ b/.changeset/soft-eagles-jog.md
@@ -1,0 +1,20 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': minor
+---
+
+Fix a field-level `read` gate withholding a field's VALUE but leaving its PREDICATE unconstrained: a read-denied field could still be named in a `where`/`orderBy`, letting its value (or relative order) be recovered by probing — `count()` is the cleanest instrument, since it answers a predicate while returning no rows at all. `findMany`/`count` now reject a `where`/`orderBy` key naming a field the session cannot read (including nested inside `AND`/`OR`/`NOT`), throwing instead of returning a silently narrowed or empty result. A `read` rule that depends on the fetched row (`item`) cannot be evaluated before the query runs and now resolves to a denial rather than being skipped — see `docs/adr/0031-a-predicate-cannot-name-a-field-the-session-cannot-read.md`. `sudo` is unaffected.
+
+This was independently reachable through the admin UI's own list view: `collectFilterSpecs`, `buildListFilterWhere`, and `collectFilterSuggestions` (`@opensaas/stack-core`) now take a required `{ session, context }` argument and return a `Promise`, excluding a read-denied field from the collected Filter specs so the UI never suggests, autocompletes, or submits a filter the engine is going to reject — a `field:value` token for such a field now degrades to free text instead. The list view's sort validation (`@opensaas/stack-ui`) excludes the same fields from what a `?sort=` URL param may activate.
+
+```ts
+// Before
+const specs = collectFilterSpecs(listConfig, listKey, config)
+const where = buildListFilterWhere(query, listConfig, listKey, config)
+const suggestions = collectFilterSuggestions(listConfig, listKey, config)
+
+// After — pass the session/context the field's `read` access is checked against
+const specs = await collectFilterSpecs(listConfig, listKey, config, { session, context })
+const where = await buildListFilterWhere(query, listConfig, listKey, config, { session, context })
+const suggestions = await collectFilterSuggestions(listConfig, listKey, config, { session, context })
+```

--- a/.changeset/soft-eagles-jog.md
+++ b/.changeset/soft-eagles-jog.md
@@ -16,5 +16,8 @@ const suggestions = collectFilterSuggestions(listConfig, listKey, config)
 // After — pass the session/context the field's `read` access is checked against
 const specs = await collectFilterSpecs(listConfig, listKey, config, { session, context })
 const where = await buildListFilterWhere(query, listConfig, listKey, config, { session, context })
-const suggestions = await collectFilterSuggestions(listConfig, listKey, config, { session, context })
+const suggestions = await collectFilterSuggestions(listConfig, listKey, config, {
+  session,
+  context,
+})
 ```

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,10 @@ _Avoid_: list access, row access
 A check that gates whether a session may read or write a single field, returning a boolean only. Cannot scope rows — a denied field is removed, not used to exclude records.
 _Avoid_: column access, property access
 
+**Predicate-time read check**:
+A field-level `read` rule evaluated BEFORE the query runs, against a key named in a caller's `where`/`orderBy`, rather than against an already-fetched row — the check that stops a field's withheld value or relative order from being recovered by probing a query that returns no rows containing it (e.g. `count()`). There is no row yet at this point, so a rule that depends on one (dereferences `item`) cannot be answered and resolves to a denial rather than being skipped (ADR-0031).
+_Avoid_: filter access check, where validation
+
 **Access Filter** (pre-query phase):
 The first pass of a read, run before the database is hit. Uses operation-level access to build the access-scoped `include`/`where` so the database only returns rows and relations the session is allowed to see. It scopes the relations a read asked for; it does not choose them (see Bare read). Failing to compute a scope is a **denial**, never a passthrough: a caller-supplied `include` nested deeper than the phase can scope throws rather than returning unscoped rows (ADR-0022). This is distinct from having nothing to scope — a list with no relationships — which passes through unchanged.
 _Avoid_: query builder, include builder

--- a/docs/adr/0031-a-predicate-cannot-name-a-field-the-session-cannot-read.md
+++ b/docs/adr/0031-a-predicate-cannot-name-a-field-the-session-cannot-read.md
@@ -1,0 +1,31 @@
+# A predicate cannot name a field the session cannot read
+
+Status: accepted
+
+Field-level `read` access has always been a post-query check: Field Visibility strips a denied key from a row the database has already returned. Nothing constrained which fields a caller's `where`/`orderBy` could _name_. Since the access filter is ANDed onto the caller's `where` rather than replacing it, a constant access filter does not stop the result from varying with the caller's own predicate — so a read-denied field's value could be recovered by probing: `count({ where: { billingAddress: { startsWith: '12 ' } } })` differs from the same query with `'99 '` one character at a time, and `orderBy` leaks relative ordering across the whole table without naming a single value. This was independently reachable through the admin UI's own list view (filtering and sorting), not only by an application that forwards a caller-supplied `where` (#915).
+
+We decided a field the session cannot read cannot be _named_ in a predicate either, checked before the query runs (`findMany`/`count`, the read seam #912 established), using the same evaluator Field Visibility already uses — `checkFieldAccess` — so there is exactly one place a field's `read` rule is interpreted, not two that could drift apart.
+
+## The row-dependent case
+
+The evaluator's `read` slot is typed with `item` always present (ADR the #914 fix established), because Field Visibility always has a fetched row to hand it. Predicate-time evaluation has no such row — the query has not run yet. A rule that depends on one (`item.ownerId === session?.userId`, the shape `InvalidFieldAccessResultError`'s own message recommends) cannot be answered here at all.
+
+## Considered options
+
+- **Skip the check for a row-dependent rule (i.e., let it through).** Rejected outright: it reopens exactly this hole for the fields most likely to be worth gating — a field whose visibility depends on ownership is a more sensitive field than one gated by a static role check, not a less sensitive one. An unanswerable check must not silently mean "allowed".
+- **Deny at predicate time — chosen.** A rule that cannot be evaluated before the query resolves to `false`: the field simply cannot be named in a `where`/`orderBy`, regardless of what the same rule would have decided post-query for a specific row. This is knowable statically from the rule's shape (whether it dereferences `item`) so it degrades gracefully — a rule written to check only `session` (the common case for a field meant to be filterable/sortable) evaluates normally and returns its real answer.
+- **Throw a distinct error for the row-dependent case**, forcing the field author to explicitly declare it as non-predicable. Rejected for now as unnecessary ceremony: the loud `ValidationError` the caller already gets ("cannot query — field denied by read access") communicates the same fact, and a config that never puts a row-dependent field in a filterable position never observes the distinction. Revisit if that proves to be a poor developer experience in practice.
+
+## How "row-dependent" is detected
+
+Detection is intentionally black-box rather than static analysis of the rule's source: the rule is called with a **poisoned `item`** — a `Proxy` whose `get`/`has`/`ownKeys` traps throw the moment anything touches it, including through optional chaining (`item?.x` still performs the property read once `item` itself is non-nullish, which the Proxy always is). A rule that never reaches into `item` completes normally; one that does throws, which `isFieldReadableForPredicate` catches and turns into `false`. A plain `item: undefined` was considered and rejected — it only catches a _non-optional_ dereference (`item.x`, which the type system already discourages by typing `item` as always present for `read`), and would silently misevaluate the officially-recommended `item?.ownerId === session?.userId` idiom into `undefined === undefined` for an anonymous session, which is `true`.
+
+`InvalidFieldAccessResultError` (#913 — a rule returning a non-boolean) is deliberately **not** folded into this `false`: it propagates unchanged, so a config bug that would otherwise silently read as "field denied by policy" stays visibly a config bug.
+
+## Consequences
+
+- **The admin UI's own filter/sort affordances had to close alongside the engine, not after it.** `collectFilterSpecs` (and the `buildListFilterWhere`/`collectFilterSuggestions` built on it) now takes the session/context and excludes a field the session cannot read from the collected specs — a denied field's Filter spec is simply absent, so a `field:value` token degrades to free text (the engine's existing "unknown field" path) rather than ever reaching `context.db`. The list view's sort validation excludes the same fields from what a `?sort=` URL param may activate. Both were reachable independent of any caller-supplied `where` — see the issue for the reproduction through ordinary list-view filtering and sorting.
+- **This narrows two public function signatures.** `collectFilterSpecs`, `buildListFilterWhere`, and `collectFilterSuggestions` (`@opensaas/stack-core`) now take a required `{ session, context }` argument and return a `Promise`, matching the shape `resolveRelationshipCountFilters`/`resolveRelationshipLabelFilters` already established for the same reason (#732, #749).
+- **Scoped to the current list only.** The predicate walk checks whether a relationship field on _this_ list may be named at all (its own `read` access), but does not recurse into a related list's fields nested inside a relation filter (`{ author: { is: { email: ... } } }`) — that is #916's separate change. A field on a related list is unaffected by this record.
+- **`sudo` is unaffected**, matching every other access seam — `checkFieldAccess` (and so `isFieldReadableForPredicate`) short-circuits to allow before a sudo context ever calls a field rule.
+- **Denial is an error, not a narrowed or empty result** — a caller can never mistake "you may not ask that" for "nothing matched", which is the property that closes the probing oracle: the `count()` for a matching and a non-matching prefix now throws identically instead of differing.

--- a/packages/core/src/access/field-access.test.ts
+++ b/packages/core/src/access/field-access.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, expectTypeOf } from 'vitest'
-import { checkFieldAccess, filterWritableFields } from './field-access.js'
+import {
+  checkFieldAccess,
+  filterWritableFields,
+  isFieldReadableForPredicate,
+} from './field-access.js'
 import { InvalidFieldAccessResultError } from './errors.js'
 import { ValidationError } from '../hooks/index.js'
 import type { FieldAccess, FieldAccessControl } from './types.js'
@@ -205,6 +209,80 @@ describe('checkFieldAccess', () => {
       context: sudoContext(),
     })
     expect(allowed).toBe(true)
+  })
+})
+
+describe('isFieldReadableForPredicate (#915)', () => {
+  it('allows when there is no field access configured', async () => {
+    const readable = await isFieldReadableForPredicate(undefined, {
+      session: null,
+      context: nonSudoContext(),
+    })
+    expect(readable).toBe(true)
+  })
+
+  it('allows when the rule only inspects session (never touches item)', async () => {
+    const readable = await isFieldReadableForPredicate(
+      { read: ({ session }) => session?.userId === 'admin' },
+      { session: { userId: 'admin' }, context: nonSudoContext() },
+    )
+    expect(readable).toBe(true)
+  })
+
+  it('denies when the rule returns false', async () => {
+    const readable = await isFieldReadableForPredicate(
+      { read: () => false },
+      { session: null, context: nonSudoContext() },
+    )
+    expect(readable).toBe(false)
+  })
+
+  it('denies a row-dependent rule that dereferences `item` directly', async () => {
+    const readable = await isFieldReadableForPredicate(
+      { read: ({ item, session }) => item.ownerId === session?.userId },
+      { session: { userId: 'user-1' }, context: nonSudoContext() },
+    )
+    expect(readable).toBe(false)
+  })
+
+  it('denies a row-dependent rule even when it reads `item` via optional chaining', async () => {
+    // This is the exact idiom `InvalidFieldAccessResultError`'s own message
+    // recommends (`item?.ownerId === session?.userId`) — it must still deny,
+    // not silently misevaluate `undefined === session?.userId` against a
+    // poisoned `item`.
+    const readable = await isFieldReadableForPredicate(
+      { read: ({ item, session }) => item?.ownerId === session?.userId },
+      { session: null, context: nonSudoContext() },
+    )
+    expect(readable).toBe(false)
+  })
+
+  it('denies a row-dependent rule that only enumerates `item`s keys', async () => {
+    const readable = await isFieldReadableForPredicate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { read: ({ item }) => Object.keys(item as any).length > 0 },
+      { session: null, context: nonSudoContext() },
+    )
+    expect(readable).toBe(false)
+  })
+
+  it('propagates InvalidFieldAccessResultError instead of folding it into a denial', async () => {
+    const fieldAccess = {
+      read: () => ({ ownerId: { equals: 'someone-else' } }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    await expect(
+      isFieldReadableForPredicate(fieldAccess, { session: null, context: nonSudoContext() }),
+    ).rejects.toThrow(InvalidFieldAccessResultError)
+  })
+
+  it('sudo bypasses the rule entirely, so a row-dependent rule never denies', async () => {
+    const readable = await isFieldReadableForPredicate(
+      { read: ({ item, session }) => item.ownerId === session?.userId },
+      { session: null, context: sudoContext() },
+    )
+    expect(readable).toBe(true)
   })
 })
 

--- a/packages/core/src/access/field-access.test.ts
+++ b/packages/core/src/access/field-access.test.ts
@@ -277,6 +277,24 @@ describe('isFieldReadableForPredicate (#915)', () => {
     ).rejects.toThrow(InvalidFieldAccessResultError)
   })
 
+  it('propagates a genuine error the rule throws for its own reasons, not just non-boolean results', async () => {
+    // The rule never touches `item` — it throws for a reason of its own.
+    // This must NOT be folded into an ordinary `false` denial (that would
+    // mask a real bug in the rule as "field not readable"), matching how the
+    // post-query path (`filterReadableFields`) already lets such a throw
+    // propagate unchanged.
+    const fieldAccess: FieldAccess = {
+      read: ({ session }) => {
+        if (session === null) throw new Error('unexpected anonymous access')
+        return true
+      },
+    }
+
+    await expect(
+      isFieldReadableForPredicate(fieldAccess, { session: null, context: nonSudoContext() }),
+    ).rejects.toThrow('unexpected anonymous access')
+  })
+
   it('sudo bypasses the rule entirely, so a row-dependent rule never denies', async () => {
     const readable = await isFieldReadableForPredicate(
       { read: ({ item, session }) => item.ownerId === session?.userId },

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -7,6 +7,44 @@ import { ValidationError } from '../hooks/index.js'
 import { InvalidFieldAccessResultError } from './errors.js'
 
 /**
+ * Marks a throw caused by touching {@link createPoisonedItem}'s `item`, as
+ * opposed to some other error a field rule legitimately raises. Not exported
+ * — callers only ever see its effect (a `false` from
+ * `isFieldReadableForPredicate`), never the class itself.
+ */
+class PredicateTimeItemAccessError extends Error {}
+
+/**
+ * An `item` that throws {@link PredicateTimeItemAccessError} on ANY attempt to
+ * read a property off it — including via optional chaining (`item?.x`),
+ * since the Proxy itself is a truthy object and optional chaining still
+ * performs the property read once its base is non-nullish. Used by
+ * `isFieldReadableForPredicate` to detect a read rule that depends on the
+ * fetched row: there is no row yet at predicate-evaluation time (see that
+ * function's doc), so any rule that reaches into `item` at all cannot be
+ * answered here.
+ */
+function createPoisonedItem(): Record<string, unknown> {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        throw new PredicateTimeItemAccessError(String(prop))
+      },
+      has(_target, prop) {
+        throw new PredicateTimeItemAccessError(String(prop))
+      },
+      ownKeys() {
+        throw new PredicateTimeItemAccessError('ownKeys')
+      },
+      getOwnPropertyDescriptor(_target, prop) {
+        throw new PredicateTimeItemAccessError(String(prop))
+      },
+    },
+  ) as Record<string, unknown>
+}
+
+/**
  * Shared field-level access evaluation.
  *
  * This module is the single, canonical home for field-level access checks. Both
@@ -89,6 +127,57 @@ export async function checkFieldAccess(
   // available, so `create` (which has no `item` to evaluate a filter against)
   // needs no separate answer: neither operation ever honours a non-boolean.
   throw new InvalidFieldAccessResultError(operation, result)
+}
+
+/**
+ * Whether a field's `read` access allows it to be NAMED in a `where`/`orderBy`
+ * predicate, evaluated BEFORE the query runs (#915).
+ *
+ * Field-level `read` access has always been a post-query check (Field
+ * Visibility, `field-visibility.ts`): it strips a denied key from a row that
+ * has already been fetched. That leaves the predicate itself unconstrained —
+ * a caller can still filter or sort by a field whose value they could never
+ * read, and recover it (or its relative order) by probing. This function is
+ * the pre-query counterpart, called from `query-validation.ts`'s `where`/
+ * `orderBy` walk for every key that resolves to a declared field.
+ *
+ * It delegates to the SAME evaluator Field Visibility uses
+ * (`checkFieldAccess`) — there is no second, parallel field-access evaluator
+ * for predicates, matching this module's own rule for every other caller.
+ * The one difference is the `item` it hands the rule: there is no fetched row
+ * yet, so a rule that depends on one (the shape `FieldAccess['read']`
+ * documents as the norm, e.g. `item?.ownerId === session?.userId`) cannot be
+ * answered here. Rather than skip the check for such a rule — which would
+ * reopen exactly the hole this closes for the fields most likely to be
+ * sensitive — it is handed a poisoned `item` that throws on any property
+ * read, and that throw is caught and resolved to `false`: a row-dependent
+ * `read` rule always denies at predicate time, documented and deliberate
+ * (see docs/adr/0031). A rule that never touches `item` (checking only
+ * `session`, the common case for a field meant to be filterable/sortable at
+ * all) evaluates normally and returns its real answer.
+ *
+ * A rule that returns a non-boolean is a distinct, louder failure (#913,
+ * ADR-0030) — `InvalidFieldAccessResultError` — and is deliberately NOT
+ * folded into the `false` here; it propagates so the config bug it signals is
+ * never mistaken for an ordinary field-level denial.
+ */
+export async function isFieldReadableForPredicate(
+  fieldAccess: FieldAccess | undefined,
+  args: {
+    session: Session | null
+    context: AccessContext & { _isSudo?: boolean }
+  },
+): Promise<boolean> {
+  try {
+    return await checkFieldAccess(fieldAccess, 'read', {
+      session: args.session,
+      context: args.context,
+      item: createPoisonedItem(),
+    })
+  } catch (err) {
+    if (err instanceof InvalidFieldAccessResultError) throw err
+    return false
+  }
 }
 
 /**

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -175,8 +175,12 @@ export async function isFieldReadableForPredicate(
       item: createPoisonedItem(),
     })
   } catch (err) {
-    if (err instanceof InvalidFieldAccessResultError) throw err
-    return false
+    // Only the poisoned-item signal means "row-dependent, deny". Anything
+    // else — including `InvalidFieldAccessResultError` and a genuine bug in
+    // the rule itself — propagates unchanged rather than being silently
+    // folded into an ordinary denial (found in review of #925).
+    if (err instanceof PredicateTimeItemAccessError) return false
+    throw err
   }
 }
 

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -20,10 +20,17 @@ export {
   getRelatedListConfig,
 } from './engine.js'
 // Canonical field-level access evaluation (shared by read and write paths).
-export { checkFieldAccess, filterWritableFields } from './field-access.js'
+export {
+  checkFieldAccess,
+  filterWritableFields,
+  isFieldReadableForPredicate,
+} from './field-access.js'
 // Read-path key validation — the `findMany`/`count` counterpart to the write
 // path's #564 undeclared-key reject.
 export { validateQueryKeys } from './query-validation.js'
+// Read-path field-level access on `where`/`orderBy` keys — a field the
+// session cannot read cannot be named in a predicate either (#915).
+export { validateQueryFieldReadAccess } from './query-validation.js'
 // Phase 1 — Access Filter (pre-query row/relation scoping).
 export { buildAccessScopedInclude, stripVirtualFieldsFromInclude } from './access-filter.js'
 // Phase 2 — Field Visibility (post-query field stripping + resolveOutput).

--- a/packages/core/src/access/query-validation.ts
+++ b/packages/core/src/access/query-validation.ts
@@ -1,5 +1,7 @@
 import type { ListConfig, OpenSaasConfig } from '../config/types.js'
+import type { Session, AccessContext } from './types.js'
 import { getRelatedListConfig } from './engine.js'
+import { isFieldReadableForPredicate } from './field-access.js'
 import { ValidationError } from '../hooks/index.js'
 
 /**
@@ -21,6 +23,15 @@ import { ValidationError } from '../hooks/index.js'
  * access control. That filter is trusted config authored by the same person who
  * declares the fields — walking it would make this an access-control decision
  * (that's #915/#916), not the key-existence seam this ticket establishes.
+ *
+ * `validateQueryFieldReadAccess` below is that access-control decision for
+ * #915: it re-walks `where`/`orderBy` (reusing `resolveQueryField`) and checks
+ * each resolved field's `read` access via the canonical evaluator, so a field
+ * the session cannot read cannot be named in a predicate either. It runs
+ * strictly after this module's key-existence check — an undeclared key is
+ * #912's rejection, not a field-access decision — and stays scoped to the
+ * CURRENT list, deliberately not recursing into a related list's fields
+ * nested inside a relation filter (that's #916).
  */
 
 // Prisma's logical combinators for a WHERE clause — never field names.
@@ -37,7 +48,7 @@ const SYSTEM_FIELDS = new Set(['id', 'createdAt', 'updatedAt'])
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- field configs are heterogeneous across field types
 type FieldConfigMap = Record<string, any>
 
-interface ResolvedQueryField {
+export interface ResolvedQueryField {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- field configs are heterogeneous across field types
   fieldConfig: any
   isRelationship: boolean
@@ -62,7 +73,10 @@ interface ResolvedQueryField {
  * Anything else — most importantly a Prisma-generated back-relation the config
  * never declares — resolves to `undefined` and is rejected by the caller.
  */
-function resolveQueryField(key: string, fields: FieldConfigMap): ResolvedQueryField | undefined {
+export function resolveQueryField(
+  key: string,
+  fields: FieldConfigMap,
+): ResolvedQueryField | undefined {
   if (SYSTEM_FIELDS.has(key)) {
     return { fieldConfig: undefined, isRelationship: false }
   }
@@ -216,4 +230,108 @@ export function validateQueryKeys(args: {
   const { where, orderBy, listConfig, listName, config, isSudo } = args
   if (where !== undefined) walkWhere(where, listConfig, listName, config, isSudo)
   if (orderBy !== undefined) walkOrderBy(orderBy, listConfig, listName, config, isSudo)
+}
+
+/**
+ * #915 — the predicate-time counterpart to `checkFieldAccess`'s post-query
+ * check: reject a `where`/`orderBy` key that names a field the session cannot
+ * read, BEFORE the query runs. See this module's top doc comment for how this
+ * relates to `validateQueryKeys` (#912) and `isFieldReadableForPredicate`'s
+ * doc (in `field-access.ts`) for how a row-dependent `read` rule is handled.
+ *
+ * A key `resolveQueryField` cannot resolve is skipped here — #912 has already
+ * rejected it (or, under `sudo`, deliberately let it through) by the time
+ * this runs. A system field (`id`/`createdAt`/`updatedAt`) resolves with no
+ * `fieldConfig` and carries no field-level access control, so it is always
+ * readable and skipped too.
+ */
+async function checkKeyReadableOrThrow(
+  key: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listName: string,
+  args: { session: Session | null; context: AccessContext & { _isSudo?: boolean } },
+  kind: 'where' | 'orderBy',
+): Promise<void> {
+  const resolved = resolveQueryField(key, listConfig.fields)
+  if (!resolved || resolved.fieldConfig === undefined) return
+
+  const readable = await isFieldReadableForPredicate(resolved.fieldConfig.access, args)
+  if (!readable) {
+    throw new ValidationError([
+      `Cannot query "${listName}" — "${key}" is denied by field-level read access. ` +
+        `A field the session cannot read cannot be named in a ${kind} (use sudo to bypass).`,
+    ])
+  }
+}
+
+async function walkWhereReadAccess(
+  where: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listName: string,
+  args: { session: Session | null; context: AccessContext & { _isSudo?: boolean } },
+): Promise<void> {
+  if (where === null || typeof where !== 'object') return
+
+  if (Array.isArray(where)) {
+    for (const entry of where) await walkWhereReadAccess(entry, listConfig, listName, args)
+    return
+  }
+
+  for (const [key, value] of Object.entries(where as Record<string, unknown>)) {
+    if (LOGICAL_OPERATORS.has(key)) {
+      await walkWhereReadAccess(value, listConfig, listName, args)
+      continue
+    }
+    // Deliberately does not recurse into a relationship field's own nested
+    // value: it checks whether THIS list's relationship field may be named
+    // (its own `read` access), but a field on the RELATED list nested inside
+    // it is #916's scope, not this one.
+    await checkKeyReadableOrThrow(key, listConfig, listName, args, 'where')
+  }
+}
+
+async function walkOrderByReadAccess(
+  orderBy: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  listName: string,
+  args: { session: Session | null; context: AccessContext & { _isSudo?: boolean } },
+): Promise<void> {
+  if (orderBy === null || typeof orderBy !== 'object') return
+
+  if (Array.isArray(orderBy)) {
+    for (const entry of orderBy) await walkOrderByReadAccess(entry, listConfig, listName, args)
+    return
+  }
+
+  for (const key of Object.keys(orderBy as Record<string, unknown>)) {
+    await checkKeyReadableOrThrow(key, listConfig, listName, args, 'orderBy')
+  }
+}
+
+/**
+ * Validate a caller-supplied `where`/`orderBy` against field-level `read`
+ * access, recursing into logical operators (`AND`/`OR`/`NOT`) the same way
+ * `validateQueryKeys` does. Throws a `ValidationError` naming the list and
+ * the offending key on the first read-denied field found. `isSudo` bypasses
+ * the check entirely, matching `validateQueryKeys` and the write path's
+ * `sudo` escape hatch.
+ */
+export async function validateQueryFieldReadAccess(args: {
+  where?: unknown
+  orderBy?: unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>
+  listName: string
+  session: Session | null
+  context: AccessContext & { _isSudo?: boolean }
+  isSudo: boolean
+}): Promise<void> {
+  const { where, orderBy, listConfig, listName, session, context, isSudo } = args
+  if (isSudo) return
+  const evalArgs = { session, context }
+  if (where !== undefined) await walkWhereReadAccess(where, listConfig, listName, evalArgs)
+  if (orderBy !== undefined) await walkOrderByReadAccess(orderBy, listConfig, listName, evalArgs)
 }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1135,35 +1135,8 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       )
     }
 
-    // #912 — reject a `where`/`orderBy` key the list config doesn't declare
-    // (e.g. a Prisma-generated back-relation) before it ever reaches the
-    // access filter merge below. `sudo` bypasses, matching the write path.
-    validateQueryKeys({
-      where: args?.where,
-      orderBy: args?.orderBy,
-      listConfig,
-      listName,
-      config,
-      isSudo: context._isSudo === true,
-    })
-
-    // #915 — reject a `where`/`orderBy` key naming a field this session
-    // cannot READ, so a field-level `read` gate can't be probed via a
-    // predicate (a `count()` that varies with the withheld value, an
-    // `orderBy` that leaks relative ordering). Runs after the #912 check
-    // above so an undeclared key is always #912's rejection, never this
-    // one's. `sudo` bypasses, matching #912.
-    await validateQueryFieldReadAccess({
-      where: args?.where,
-      orderBy: args?.orderBy,
-      listConfig,
-      listName,
-      session: context.session,
-      context,
-      isSudo: context._isSudo === true,
-    })
-
-    // Check query access (skip if sudo mode)
+    // Check query access first (skip if sudo mode) — this MUST run before the
+    // #912/#915 where/orderBy validation below. See the comment there for why.
     let where: Record<string, unknown> | undefined = args?.where
     if (!context._isSudo) {
       const queryAccess = listConfig.access?.operation?.query
@@ -1175,6 +1148,35 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       if (accessResult === false) {
         return []
       }
+
+      // #912 — reject a `where`/`orderBy` key the list config doesn't declare
+      // (e.g. a Prisma-generated back-relation), and #915 — reject one naming
+      // a field this session cannot READ (closing a probe via a `count()`
+      // that varies with the withheld value, or an `orderBy` that leaks
+      // relative ordering). Both run only now that the caller is known to
+      // have SOME access to the list (`accessResult !== false`): the thrown
+      // errors name the offending key, and running them before the access
+      // check above would let a caller with ZERO access to the list learn a
+      // field's name and read-gating status from the error message alone —
+      // turning the validation itself into the kind of oracle #915 closes.
+      // `sudo` bypasses this whole branch, matching the write path.
+      validateQueryKeys({
+        where: args?.where,
+        orderBy: args?.orderBy,
+        listConfig,
+        listName,
+        config,
+        isSudo: false,
+      })
+      await validateQueryFieldReadAccess({
+        where: args?.where,
+        orderBy: args?.orderBy,
+        listConfig,
+        listName,
+        session: context.session,
+        context,
+        isSudo: false,
+      })
 
       // Merge access filter with where clause
       const mergedWhere = mergeFilters(args?.where, accessResult)
@@ -1421,32 +1423,8 @@ function createCount<TPrisma extends PrismaClientLike>(
   config: OpenSaasConfig,
 ) {
   return async (args?: { where?: Record<string, unknown> }) => {
-    // #912 — reject a `where` key the list config doesn't declare (e.g. a
-    // Prisma-generated back-relation), same as findMany. `count` leaks the
-    // most cleanly of any read op — a bare count answers a predicate with no
-    // rows returned at all — so it gets the same reject, not a lesser one.
-    validateQueryKeys({
-      where: args?.where,
-      listConfig,
-      listName,
-      config,
-      isSudo: context._isSudo === true,
-    })
-
-    // #915 — same predicate-time field-read check as `findMany`, and for the
-    // same reason count matters most: a bare count answers a predicate while
-    // returning no rows at all, the cleanest instrument for probing a
-    // read-denied field's withheld value.
-    await validateQueryFieldReadAccess({
-      where: args?.where,
-      listConfig,
-      listName,
-      session: context.session,
-      context,
-      isSudo: context._isSudo === true,
-    })
-
-    // Check query access (skip if sudo mode)
+    // Check query access first (skip if sudo mode) — this MUST run before the
+    // #912/#915 where validation below. See the comment there for why.
     let where: Record<string, unknown> | undefined = args?.where
     if (!context._isSudo) {
       const queryAccess = listConfig.access?.operation?.query
@@ -1458,6 +1436,33 @@ function createCount<TPrisma extends PrismaClientLike>(
       if (accessResult === false) {
         return 0
       }
+
+      // #912 — reject a `where` key the list config doesn't declare (e.g. a
+      // Prisma-generated back-relation), and #915 — reject one naming a field
+      // this session cannot READ. `count` leaks the most cleanly of any read
+      // op — a bare count answers a predicate with no rows returned at all —
+      // so it gets the same reject, not a lesser one. Both run only now that
+      // the caller is known to have SOME access to the list (`accessResult
+      // !== false`) — see the identical comment in `createFindMany` for why
+      // that ordering matters: running them before the access check would
+      // let a fully-denied caller learn a field's name and read-gating
+      // status from the thrown error alone. `sudo` bypasses this whole
+      // branch, matching the write path.
+      validateQueryKeys({
+        where: args?.where,
+        listConfig,
+        listName,
+        config,
+        isSudo: false,
+      })
+      await validateQueryFieldReadAccess({
+        where: args?.where,
+        listConfig,
+        listName,
+        session: context.session,
+        context,
+        isSudo: false,
+      })
 
       // Merge access filter with where clause
       const mergedWhere = mergeFilters(args?.where, accessResult)

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -8,6 +8,7 @@ import {
   stripVirtualFieldsFromInclude,
   foldDeclaredDependencies,
   validateQueryKeys,
+  validateQueryFieldReadAccess,
 } from '../access/index.js'
 import type { DeclaredOnlyTree } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
@@ -1146,6 +1147,22 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       isSudo: context._isSudo === true,
     })
 
+    // #915 — reject a `where`/`orderBy` key naming a field this session
+    // cannot READ, so a field-level `read` gate can't be probed via a
+    // predicate (a `count()` that varies with the withheld value, an
+    // `orderBy` that leaks relative ordering). Runs after the #912 check
+    // above so an undeclared key is always #912's rejection, never this
+    // one's. `sudo` bypasses, matching #912.
+    await validateQueryFieldReadAccess({
+      where: args?.where,
+      orderBy: args?.orderBy,
+      listConfig,
+      listName,
+      session: context.session,
+      context,
+      isSudo: context._isSudo === true,
+    })
+
     // Check query access (skip if sudo mode)
     let where: Record<string, unknown> | undefined = args?.where
     if (!context._isSudo) {
@@ -1413,6 +1430,19 @@ function createCount<TPrisma extends PrismaClientLike>(
       listConfig,
       listName,
       config,
+      isSudo: context._isSudo === true,
+    })
+
+    // #915 — same predicate-time field-read check as `findMany`, and for the
+    // same reason count matters most: a bare count answers a predicate while
+    // returning no rows at all, the cleanest instrument for probing a
+    // read-denied field's withheld value.
+    await validateQueryFieldReadAccess({
+      where: args?.where,
+      listConfig,
+      listName,
+      session: context.session,
+      context,
       isSudo: context._isSudo === true,
     })
 

--- a/packages/core/src/filter/collect.ts
+++ b/packages/core/src/filter/collect.ts
@@ -45,13 +45,21 @@ export async function collectFilterSpecs(
   args: FilterAccessArgs,
 ): Promise<Record<string, FilterSpec>> {
   const specs: Record<string, FilterSpec> = {}
-  for (const [fieldName, field] of Object.entries(listConfig.fields)) {
-    if (typeof field.getFilterSpec !== 'function') continue
-    const readable = await isFieldReadableForPredicate(field.access, args)
-    if (!readable) continue
-    const spec = field.getFilterSpec(fieldName, listKey, config)
+  const filterableFields = Object.entries(listConfig.fields).filter(
+    ([, field]) => typeof field.getFilterSpec === 'function',
+  )
+  // Each field's read-access check is independent of every other's — run
+  // them concurrently rather than serially, since a `read` rule that does
+  // async work (e.g. a DB lookup) would otherwise add per-field latency to
+  // every list-view page render (found in review of #925).
+  const readableFlags = await Promise.all(
+    filterableFields.map(([, field]) => isFieldReadableForPredicate(field.access, args)),
+  )
+  filterableFields.forEach(([fieldName, field], index) => {
+    if (!readableFlags[index]) return
+    const spec = field.getFilterSpec!(fieldName, listKey, config)
     if (spec) specs[fieldName] = spec
-  }
+  })
   return specs
 }
 

--- a/packages/core/src/filter/collect.ts
+++ b/packages/core/src/filter/collect.ts
@@ -1,7 +1,19 @@
 import type { ListConfig, OpenSaasConfig } from '../config/types.js'
+import type { Session, AccessContext } from '../access/types.js'
+import { isFieldReadableForPredicate } from '../access/field-access.js'
 import { parseFilterQuery } from './parse.js'
 import { buildFilterWhere } from './map.js'
 import type { FilterCondition, FilterFieldSuggestion, FilterSpec } from './types.js'
+
+/**
+ * The session/context a field's `read` access is evaluated against — the same
+ * shape every other access-scoped admin-UI helper takes (e.g.
+ * `resolveRelationshipCountFilters`, `resolveRelationshipLabelFilters`).
+ */
+export type FilterAccessArgs = {
+  session: Session | null
+  context: AccessContext & { _isSudo?: boolean }
+}
 
 /**
  * Resolve every field's {@link FilterSpec} for a list by delegating to each
@@ -9,20 +21,34 @@ import type { FilterCondition, FilterFieldSuggestion, FilterSpec } from './types
  * whose method returns `undefined`) is simply not filterable — the absence
  * degrades gracefully so third-party fields keep working.
  *
+ * A field the session cannot READ is excluded here too (#915), evaluated the
+ * same predicate-time way `context.db.*`'s `findMany`/`count` now enforce
+ * (`isFieldReadableForPredicate` — no fetched row exists yet, so a
+ * row-dependent `read` rule resolves to "not filterable"). This is what keeps
+ * the admin UI from ever suggesting, autocompleting, or submitting a filter
+ * the engine is going to reject: excluding the spec here means a token
+ * naming that field degrades to free text (`buildFilterWhere`'s existing
+ * "unknown field" path) rather than reaching `context.db` at all.
+ *
  * @param listConfig The list whose fields to inspect.
  * @param listKey    The list's key (passed through to each field's spec).
  * @param config     The full config (relationship specs resolve their target
  *   list's label field from it).
+ * @param args       The session/context to evaluate field-level `read` access
+ *   against.
  */
-export function collectFilterSpecs(
+export async function collectFilterSpecs(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   listConfig: ListConfig<any>,
   listKey: string,
   config: OpenSaasConfig,
-): Record<string, FilterSpec> {
+  args: FilterAccessArgs,
+): Promise<Record<string, FilterSpec>> {
   const specs: Record<string, FilterSpec> = {}
   for (const [fieldName, field] of Object.entries(listConfig.fields)) {
     if (typeof field.getFilterSpec !== 'function') continue
+    const readable = await isFieldReadableForPredicate(field.access, args)
+    if (!readable) continue
     const spec = field.getFilterSpec(fieldName, listKey, config)
     if (spec) specs[fieldName] = spec
   }
@@ -38,14 +64,15 @@ export function collectFilterSpecs(
  *
  * @returns A `where` fragment, or `undefined` when the query filters nothing.
  */
-export function buildListFilterWhere(
+export async function buildListFilterWhere(
   query: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   listConfig: ListConfig<any>,
   listKey: string,
   config: OpenSaasConfig,
-): FilterCondition | undefined {
-  const specs = collectFilterSpecs(listConfig, listKey, config)
+  args: FilterAccessArgs,
+): Promise<FilterCondition | undefined> {
+  const specs = await collectFilterSpecs(listConfig, listKey, config, args)
   const tokens = parseFilterQuery(query)
   return buildFilterWhere(tokens, specs)
 }
@@ -56,13 +83,14 @@ export function buildListFilterWhere(
  * search). Carries no functions, so it can cross the server/client boundary to
  * drive the Filter builder's autocomplete.
  */
-export function collectFilterSuggestions(
+export async function collectFilterSuggestions(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   listConfig: ListConfig<any>,
   listKey: string,
   config: OpenSaasConfig,
-): FilterFieldSuggestion[] {
-  const specs = collectFilterSpecs(listConfig, listKey, config)
+  args: FilterAccessArgs,
+): Promise<FilterFieldSuggestion[]> {
+  const specs = await collectFilterSpecs(listConfig, listKey, config, args)
   return Object.entries(specs).map(([field, spec]) => ({
     field,
     operators: spec.operators,

--- a/packages/core/src/filter/filter.test.ts
+++ b/packages/core/src/filter/filter.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect } from 'vitest'
 import { parseFilterQuery } from './parse.js'
 import { buildFilterWhere } from './map.js'
-import { buildListFilterWhere, collectFilterSpecs, collectFilterSuggestions } from './collect.js'
+import {
+  buildListFilterWhere,
+  collectFilterSpecs,
+  collectFilterSuggestions,
+  type FilterAccessArgs,
+} from './collect.js'
 import type { FilterSpec } from './types.js'
 import { list } from '../config/index.js'
 import { text, integer, select, checkbox, timestamp, relationship } from '../fields/index.js'
 import type { OpenSaasConfig } from '../config/types.js'
+import type { AccessContext } from '../access/types.js'
+
+// A permissive session/context — no field on any list under test declares
+// field-level `read` access unless a test says so, so every field is
+// filterable/sortable by default (matching `checkFieldAccess`'s own
+// allow-by-default for a field with no rule).
+const noAccessArgs: FilterAccessArgs = {
+  session: null,
+  context: { _isSudo: false } as unknown as AccessContext,
+}
 
 // ─────────────────────────────────────────────────────────────
 // parseFilterQuery — the pure query-string → tokens boundary (ADR-0017)
@@ -250,8 +265,8 @@ describe('core field Filter specs', () => {
   const config = makeConfig()
   const postConfig = config.lists.Post
 
-  it('collectFilterSpecs resolves a spec for every filterable core field', () => {
-    const collected = collectFilterSpecs(postConfig, 'Post', config)
+  it('collectFilterSpecs resolves a spec for every filterable core field', async () => {
+    const collected = await collectFilterSpecs(postConfig, 'Post', config, noAccessArgs)
     expect(Object.keys(collected).sort()).toEqual(
       ['author', 'featured', 'publishedAt', 'status', 'title', 'views'].sort(),
     )
@@ -309,23 +324,68 @@ describe('core field Filter specs', () => {
     })
   })
 
-  it('does not produce specs for password/json/virtual (absence degrades gracefully)', () => {
+  it('does not produce specs for password/json/virtual (absence degrades gracefully)', async () => {
     // A list of non-filterable fields yields no specs at all.
-    const specsForUser = collectFilterSpecs(config.lists.User, 'User', config)
+    const specsForUser = await collectFilterSpecs(config.lists.User, 'User', config, noAccessArgs)
     // User only has `name` (text) → exactly one spec, proving non-text absence.
     expect(Object.keys(specsForUser)).toEqual(['name'])
+  })
+
+  it('excludes a field the session cannot read (#915)', async () => {
+    const gatedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        Organisation: list({
+          fields: {
+            name: text(),
+            billingAddress: text({ access: { read: () => false } }),
+          },
+        }),
+      },
+    }
+    const collected = await collectFilterSpecs(
+      gatedConfig.lists.Organisation,
+      'Organisation',
+      gatedConfig,
+      noAccessArgs,
+    )
+    expect(Object.keys(collected)).toEqual(['name'])
+  })
+
+  it('excludes a row-dependent read rule too — no row exists at predicate time (#915)', async () => {
+    const gatedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        Organisation: list({
+          fields: {
+            name: text(),
+            billingAddress: text({
+              access: { read: ({ item, session }) => item.ownerId === session?.userId },
+            }),
+          },
+        }),
+      },
+    }
+    const collected = await collectFilterSpecs(
+      gatedConfig.lists.Organisation,
+      'Organisation',
+      gatedConfig,
+      noAccessArgs,
+    )
+    expect(Object.keys(collected)).toEqual(['name'])
   })
 })
 
 describe('buildListFilterWhere (end-to-end over a real list config)', () => {
   const config = makeConfig()
 
-  it('composes parse + specs into a merged where', () => {
-    const where = buildListFilterWhere(
+  it('composes parse + specs into a merged where', async () => {
+    const where = await buildListFilterWhere(
       'status:Published views:>10 author:"Ada" hello',
       config.lists.Post,
       'Post',
       config,
+      noAccessArgs,
     )
     expect(where).toEqual({
       AND: [
@@ -339,8 +399,35 @@ describe('buildListFilterWhere (end-to-end over a real list config)', () => {
     })
   })
 
-  it('returns undefined for an all-whitespace query', () => {
-    expect(buildListFilterWhere('   ', config.lists.Post, 'Post', config)).toBeUndefined()
+  it('returns undefined for an all-whitespace query', async () => {
+    expect(
+      await buildListFilterWhere('   ', config.lists.Post, 'Post', config, noAccessArgs),
+    ).toBeUndefined()
+  })
+
+  it('a read-denied field degrades to free text instead of reaching the engine (#915)', async () => {
+    const gatedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        Organisation: list({
+          fields: {
+            name: text(),
+            billingAddress: text({ access: { read: () => false } }),
+          },
+        }),
+      },
+    }
+    // `billingAddress:12` never produces `{ billingAddress: { contains: '12' } }`
+    // — the spec is excluded, so the token degrades to a free-text search for
+    // "12" across `name` (the only remaining free-text field) instead.
+    const where = await buildListFilterWhere(
+      'billingAddress:12',
+      gatedConfig.lists.Organisation,
+      'Organisation',
+      gatedConfig,
+      noAccessArgs,
+    )
+    expect(where).toEqual({ name: { contains: '12' } })
   })
 })
 
@@ -379,22 +466,54 @@ describe('to-many relationship Filter spec (count comparisons — issue #732)', 
     expect(spec.suggestions.valueSource).toEqual({ kind: 'none' })
   })
 
-  it('end-to-end: buildListFilterWhere carries a count marker for `posts:>5`', () => {
+  it('end-to-end: buildListFilterWhere carries a count marker for `posts:>5`', async () => {
     const config = countConfig()
-    const where = buildListFilterWhere('posts:>5', config.lists.User, 'User', config)
+    const where = await buildListFilterWhere(
+      'posts:>5',
+      config.lists.User,
+      'User',
+      config,
+      noAccessArgs,
+    )
     expect(where).toEqual({ posts: { _countFilter: { operator: 'gt', value: 5 } } })
   })
 })
 
 describe('collectFilterSuggestions', () => {
-  it('returns serializable, function-free suggestion metadata', () => {
+  it('returns serializable, function-free suggestion metadata', async () => {
     const config = makeConfig()
-    const suggestions = collectFilterSuggestions(config.lists.Post, 'Post', config)
+    const suggestions = await collectFilterSuggestions(
+      config.lists.Post,
+      'Post',
+      config,
+      noAccessArgs,
+    )
     // No functions anywhere → JSON round-trips cleanly.
     expect(JSON.parse(JSON.stringify(suggestions))).toEqual(suggestions)
     const status = suggestions.find((s) => s.field === 'status')!
     expect(status.valueSource.kind).toBe('enum')
     const author = suggestions.find((s) => s.field === 'author')!
     expect(author.valueSource).toEqual({ kind: 'relationship', listKey: 'User', many: false })
+  })
+
+  it('excludes a read-denied field from the suggestion metadata (#915)', async () => {
+    const gatedConfig: OpenSaasConfig = {
+      db: { provider: 'sqlite', prismaClientConstructor: () => null as never },
+      lists: {
+        Organisation: list({
+          fields: {
+            name: text(),
+            billingAddress: text({ access: { read: () => false } }),
+          },
+        }),
+      },
+    }
+    const suggestions = await collectFilterSuggestions(
+      gatedConfig.lists.Organisation,
+      'Organisation',
+      gatedConfig,
+      noAccessArgs,
+    )
+    expect(suggestions.map((s) => s.field)).toEqual(['name'])
   })
 })

--- a/packages/core/src/filter/index.ts
+++ b/packages/core/src/filter/index.ts
@@ -13,6 +13,7 @@ export { parseFilterQuery } from './parse.js'
 export { serializeFilterQuery } from './serialize.js'
 export { buildFilterWhere } from './map.js'
 export { collectFilterSpecs, buildListFilterWhere, collectFilterSuggestions } from './collect.js'
+export type { FilterAccessArgs } from './collect.js'
 export { RELATIONSHIP_COUNT_FILTER_KEY } from './types.js'
 export type {
   FilterOperator,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,6 +135,7 @@ export type {
   FilterValueSource,
   FilterFieldSuggestion,
   RelationshipCountFilterMarker,
+  FilterAccessArgs,
 } from './filter/index.js'
 
 // Access-scoped to-many relationship counts for the admin list view (#732):

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -41,6 +41,11 @@ export { validateWithZod, generateZodSchema } from './validation/schema.js'
 // This is the single field-access evaluator — the UI must not re-implement it.
 export { checkFieldAccess } from './access/index.js'
 
+// Predicate-time field-read evaluator (#915), reused by @opensaas/stack-ui to
+// keep the admin list view's sort validation in lockstep with the engine: a
+// field the session cannot read cannot seed an `orderBy` either.
+export { isFieldReadableForPredicate } from './access/index.js'
+
 // Config-shape sub-types consumed by sibling packages (not part of the consumer surface)
 export type {
   DatabaseConfig,

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -1645,6 +1645,47 @@ describe('getContext', () => {
         )
       })
 
+      it('a caller with zero list access gets the ordinary silent denial, not a validation error naming the field (found in review of #925)', async () => {
+        // Operation-level `query` access is fully denied for this session.
+        // The #912/#915 where/orderBy validation must never run in that case
+        // — the thrown ValidationError names the offending key, which would
+        // let a caller with NO access to the list at all learn a field's
+        // name and its read-gating status purely from the error message.
+        // That is itself the kind of oracle #915 exists to close, just
+        // pointed at "does this field exist and is it read-gated" instead of
+        // "what is this field's value" — so a fully denied caller must see
+        // the SAME silent []/0 whether or not the where/orderBy names an
+        // undeclared or read-denied key.
+        const deniedConfig: OpenSaasConfig = {
+          ...orgConfig,
+          lists: {
+            Organisation: {
+              ...orgConfig.lists.Organisation,
+              access: { operation: { query: () => false } },
+            },
+          },
+        }
+        const context = await getContext(deniedConfig, orgPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { billingAddress: { startsWith: '12 ' } },
+          }),
+        ).resolves.toEqual([])
+        await expect(
+          context.db.organisation.findMany({ where: { bogusKey: 'x' } }),
+        ).resolves.toEqual([])
+        await expect(
+          context.db.organisation.count({
+            where: { billingAddress: { startsWith: '12 ' } },
+          }),
+        ).resolves.toBe(0)
+        await expect(context.db.organisation.count({ where: { bogusKey: 'x' } })).resolves.toBe(0)
+
+        expect(orgPrisma.organisation.findMany).not.toHaveBeenCalled()
+        expect(orgPrisma.organisation.count).not.toHaveBeenCalled()
+      })
+
       it('does not recurse into a related list nested inside a relation filter (#916 scope)', async () => {
         // #915 checks whether THIS list's relationship field may be named at
         // all; a field on the RELATED list reached through it is #916's

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getContext } from '../src/context/index.js'
 import { defineFragment } from '../src/query/index.js'
 import { virtual } from '../src/fields/index.js'
-import { AccessScopeDepthExceededError } from '../src/access/index.js'
+import {
+  AccessScopeDepthExceededError,
+  InvalidFieldAccessResultError,
+} from '../src/access/index.js'
 import { READ_INCLUDE_MAX_DEPTH } from '../src/access/depth-limits.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 
@@ -1446,6 +1449,238 @@ describe('getContext', () => {
         })
 
         expect(result).toEqual(mockUsers)
+      })
+    })
+
+    describe('predicate-time field-read access (#915)', () => {
+      // The exact shape from the issue: a public `query` gate with one
+      // field-level `read` gate. Without this fix, `billingAddress`'s withheld
+      // value can be recovered one character at a time via `count()`, and its
+      // relative order leaked via `orderBy`, despite no session ever being
+      // allowed to READ it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let orgPrisma: any
+      let orgConfig: OpenSaasConfig
+
+      beforeEach(() => {
+        orgPrisma = {
+          organisation: { findMany: vi.fn(), count: vi.fn() },
+        }
+        orgConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            Organisation: {
+              fields: {
+                name: { type: 'text' },
+                billingAddress: {
+                  type: 'text',
+                  access: { read: () => false },
+                },
+              },
+              access: { operation: { query: () => true } },
+            },
+          },
+        }
+      })
+
+      it('denies a `where` filter naming a read-denied field, on both findMany and count', async () => {
+        const context = await getContext(orgConfig, orgPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { billingAddress: { startsWith: '12 ' } },
+          }),
+        ).rejects.toThrow(/billingAddress/)
+        await expect(
+          context.db.organisation.count({
+            where: { billingAddress: { startsWith: '12 ' } },
+          }),
+        ).rejects.toThrow(/billingAddress/)
+
+        expect(orgPrisma.organisation.findMany).not.toHaveBeenCalled()
+        expect(orgPrisma.organisation.count).not.toHaveBeenCalled()
+      })
+
+      it('a count probe answers identically for a matching and a non-matching prefix (no oracle)', async () => {
+        // Before the fix, these two counts would differ (1 vs 0), letting the
+        // withheld value be recovered one character at a time. After the fix,
+        // both throw the SAME denial — there is no distinguishing signal left.
+        const context = await getContext(orgConfig, orgPrisma, null)
+
+        const matching = context.db.organisation
+          .count({ where: { billingAddress: { startsWith: '12 ' } } })
+          .catch((err: Error) => err.message)
+        const nonMatching = context.db.organisation
+          .count({ where: { billingAddress: { startsWith: '99 ' } } })
+          .catch((err: Error) => err.message)
+
+        expect(await matching).toEqual(await nonMatching)
+        expect(orgPrisma.organisation.count).not.toHaveBeenCalled()
+      })
+
+      it('denies ordering by a read-denied field', async () => {
+        const context = await getContext(orgConfig, orgPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({ orderBy: { billingAddress: 'asc' } }),
+        ).rejects.toThrow(/billingAddress/)
+        expect(orgPrisma.organisation.findMany).not.toHaveBeenCalled()
+      })
+
+      it('checks keys nested inside logical operators (AND/OR/NOT)', async () => {
+        const context = await getContext(orgConfig, orgPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { OR: [{ name: { contains: 'a' } }, { billingAddress: { contains: 'x' } }] },
+          }),
+        ).rejects.toThrow(/billingAddress/)
+        await expect(
+          context.db.organisation.findMany({
+            where: { AND: [{ NOT: { billingAddress: { contains: 'x' } } }] },
+          }),
+        ).rejects.toThrow(/billingAddress/)
+      })
+
+      it('a row-dependent read rule resolves to a denial, not a skipped check', async () => {
+        // `item` cannot be evaluated before the query runs — there is no row
+        // yet — so a rule that depends on it (the shape `FieldAccess['read']`
+        // documents as the norm) must deny here even though, post-query, the
+        // very same rule might have allowed this session to read the field.
+        const rowDependentConfig: OpenSaasConfig = {
+          ...orgConfig,
+          lists: {
+            Organisation: {
+              ...orgConfig.lists.Organisation,
+              fields: {
+                ...orgConfig.lists.Organisation.fields,
+                billingAddress: {
+                  type: 'text',
+                  access: {
+                    read: ({ item, session }: { item: { ownerId: string }; session: unknown }) =>
+                      item.ownerId === (session as { userId?: string } | null)?.userId,
+                  },
+                },
+              },
+            },
+          },
+        }
+
+        const context = await getContext(rowDependentConfig, orgPrisma, { userId: 'user-1' })
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { billingAddress: { contains: 'x' } },
+          }),
+        ).rejects.toThrow(/billingAddress/)
+        expect(orgPrisma.organisation.findMany).not.toHaveBeenCalled()
+      })
+
+      it('propagates InvalidFieldAccessResultError (#913), never folding it into a plain denial', async () => {
+        const filterReturningConfig: OpenSaasConfig = {
+          ...orgConfig,
+          lists: {
+            Organisation: {
+              ...orgConfig.lists.Organisation,
+              fields: {
+                ...orgConfig.lists.Organisation.fields,
+                billingAddress: {
+                  type: 'text',
+                  // Bypasses the FieldAccessControl boolean-only type on purpose —
+                  // this is the exact misconfiguration #913 closed.
+                  access: { read: (() => ({ ownerId: 'x' })) as unknown as () => boolean },
+                },
+              },
+            },
+          },
+        }
+
+        const context = await getContext(filterReturningConfig, orgPrisma, null)
+
+        await expect(
+          context.db.organisation.findMany({
+            where: { billingAddress: { contains: 'x' } },
+          }),
+        ).rejects.toThrow(InvalidFieldAccessResultError)
+      })
+
+      it('leaves a readable field filterable and sortable (no regression)', async () => {
+        orgPrisma.organisation.findMany.mockResolvedValue([])
+
+        const context = await getContext(orgConfig, orgPrisma, null)
+        await context.db.organisation.findMany({
+          where: { name: { contains: 'Acme' } },
+          orderBy: { name: 'asc' },
+        })
+
+        expect(orgPrisma.organisation.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { name: { contains: 'Acme' } },
+            orderBy: { name: 'asc' },
+          }),
+        )
+      })
+
+      it('sudo bypasses the check entirely, matching #912', async () => {
+        orgPrisma.organisation.findMany.mockResolvedValue([])
+        orgPrisma.organisation.count.mockResolvedValue(3)
+
+        const context = (await getContext(orgConfig, orgPrisma, null)).sudo()
+        await context.db.organisation.findMany({
+          where: { billingAddress: { startsWith: '12 ' } },
+          orderBy: { billingAddress: 'asc' },
+        })
+        await context.db.organisation.count({
+          where: { billingAddress: { startsWith: '12 ' } },
+        })
+
+        expect(orgPrisma.organisation.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { billingAddress: { startsWith: '12 ' } },
+            orderBy: { billingAddress: 'asc' },
+          }),
+        )
+        expect(orgPrisma.organisation.count).toHaveBeenCalledWith(
+          expect.objectContaining({ where: { billingAddress: { startsWith: '12 ' } } }),
+        )
+      })
+
+      it('does not recurse into a related list nested inside a relation filter (#916 scope)', async () => {
+        // #915 checks whether THIS list's relationship field may be named at
+        // all; a field on the RELATED list reached through it is #916's
+        // separate change, so it must not be rejected here — only #912's
+        // undeclared-key check (or #916, once it lands) governs that key.
+        const relPrisma = {
+          post: { findMany: vi.fn(), count: vi.fn() },
+        }
+        const relConfig: OpenSaasConfig = {
+          db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+          lists: {
+            User: {
+              fields: {
+                name: { type: 'text' },
+                secret: { type: 'text', access: { read: () => false } },
+              },
+              access: { operation: { query: () => true } },
+            },
+            Post: {
+              fields: {
+                title: { type: 'text' },
+                author: { type: 'relationship', ref: 'User.posts' },
+              },
+              access: { operation: { query: () => true } },
+            },
+          },
+        }
+        relPrisma.post.findMany.mockResolvedValue([])
+
+        const context = await getContext(relConfig, relPrisma, null)
+        // Names a field on the RELATED list (User.secret) nested inside the
+        // relation filter — not a key of Post itself, so #915's own check
+        // (which only inspects Post's own fields) does not deny it.
+        await context.db.post.findMany({ where: { author: { is: { secret: { contains: 'x' } } } } })
+
+        expect(relPrisma.post.findMany).toHaveBeenCalled()
       })
     })
 

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -24,6 +24,7 @@ import {
   resolveRelationshipLabelFilters,
 } from '@opensaas/stack-core'
 import type { FieldConfig } from '@opensaas/stack-core'
+import { isFieldReadableForPredicate } from '@opensaas/stack-core/internal'
 
 /**
  * Whether the list's delete access is NOT statically false (issue #733).
@@ -98,12 +99,23 @@ function toRelationshipLabel(
  * Virtual fields have no column to order by, and a to-one relationship has no
  * scalar to order by; a to-many relationship orders by its related `_count`, and
  * every scalar column orders by its own value.
+ *
+ * A field the session cannot READ is excluded too (#915) — evaluated the same
+ * predicate-time way `context.db.*`'s `findMany`/`count` now enforce, so a
+ * sort request naming a read-denied field is never honoured (it would only
+ * reach the engine's own #915 check and throw). `context.db` is still the
+ * real security boundary here; this is what keeps the admin UI's sort
+ * affordance from offering, and the URL param from silently no-op'ing on, a
+ * sort the engine is going to reject.
  */
-function isSortableField(field: FieldConfig | undefined): boolean {
+async function isSortableField(
+  field: FieldConfig | undefined,
+  args: { session: AccessContext<unknown>['session']; context: AccessContext<unknown> },
+): Promise<boolean> {
   if (!field) return false
   if (field.virtual === true) return false
-  if (field.type === 'relationship') return isToManyRelationshipField(field)
-  return true
+  if (field.type === 'relationship' && !isToManyRelationshipField(field)) return false
+  return isFieldReadableForPredicate(field.access, args)
 }
 
 /** Read a to-many relationship's access-scoped count off a fetched row's `_count`. */
@@ -185,10 +197,14 @@ export async function ListView({
   }
 
   // URL sort takes precedence over config initialSort, but only if the field is
-  // actually sortable — an unknown field, a virtual field, or a to-one
-  // relationship has no orderable column and would make Prisma throw (issue
-  // #732).
-  const validatedSort = sort && isSortableField(listConfig.fields[sort.field]) ? sort : undefined
+  // actually sortable — an unknown field, a virtual field, a to-one
+  // relationship, or a field this session cannot read (#915) has no orderable
+  // column and would make either Prisma or the engine's own predicate-time
+  // check throw (issue #732).
+  const sortFieldReadable =
+    sort &&
+    (await isSortableField(listConfig.fields[sort.field], { session: context.session, context }))
+  const validatedSort = sortFieldReadable ? sort : undefined
   const activeSort = validatedSort ?? initialSort
 
   // Fetch items using access-controlled context
@@ -210,7 +226,10 @@ export async function ListView({
     // filter can only ever narrow (never widen) what this session may see.
     const parsedWhere =
       search && search.trim()
-        ? buildListFilterWhere(search, listConfig, listKey, config)
+        ? await buildListFilterWhere(search, listConfig, listKey, config, {
+            session: context.session,
+            context,
+          })
         : undefined
 
     // Resolve any to-many relationship count-filter markers (`orders:>5`) into
@@ -331,7 +350,10 @@ export async function ListView({
   // server/client boundary; it mirrors the same specs the server-side
   // `buildListFilterWhere` above uses, so the builder can only produce queries
   // the engine understands.
-  const filterSuggestions = collectFilterSuggestions(listConfig, listKey, config)
+  const filterSuggestions = await collectFilterSuggestions(listConfig, listKey, config, {
+    session: context.session,
+    context,
+  })
 
   // When the list opts into avatars (issue #735), the label column renders with
   // an initials bubble ahead of the emphasized Item label. The label column is

--- a/packages/ui/tests/components/ListView.test.tsx
+++ b/packages/ui/tests/components/ListView.test.tsx
@@ -273,6 +273,92 @@ describe('ListView server-side filtering (filter engine, secured context)', () =
   })
 })
 
+describe('ListView excludes read-denied fields from filtering/sorting (#915)', () => {
+  const config: OpenSaasConfig = {
+    db: { provider: 'sqlite', url: 'file:./test.db' },
+    lists: {
+      Organisation: list({
+        fields: {
+          name: text(),
+          billingAddress: text({ access: { read: () => false } }),
+        },
+        access: { operation: { query: () => true } },
+      }),
+    },
+  }
+
+  it('drops a read-denied field from the collected filter suggestions', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ organisation: { findMany, count } })
+
+    const tree = await ListView({ context, config, listKey: 'Organisation', basePath: '/admin' })
+    const props = findListViewClientProps(tree)
+
+    expect(props.filterSuggestions.map((s) => s.field)).toEqual(['name'])
+  })
+
+  it('a `field:value` token for a read-denied field degrades to free text (never reaches context.db)', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ organisation: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'Organisation',
+      basePath: '/admin',
+      search: 'billingAddress:12',
+    })
+
+    // Never `{ billingAddress: { contains: '12' } }` — the spec was excluded,
+    // so the token falls back to a free-text search over `name`.
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { name: { contains: '12' } } }),
+    )
+  })
+
+  it('ignores a sort request naming a read-denied field (no orderBy, never reaches Prisma)', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ organisation: { findMany, count } })
+
+    await ListView({
+      context,
+      config,
+      listKey: 'Organisation',
+      basePath: '/admin',
+      sort: { field: 'billingAddress', direction: 'asc' },
+    })
+
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }))
+  })
+
+  it('leaves a readable field filterable and sortable (no regression)', async () => {
+    const findMany = vi.fn(async () => [])
+    const count = vi.fn(async () => 0)
+    const context = makeContext({ organisation: { findMany, count } })
+
+    const tree = await ListView({
+      context,
+      config,
+      listKey: 'Organisation',
+      basePath: '/admin',
+      search: 'name:Acme',
+      sort: { field: 'name', direction: 'asc' },
+    })
+    const props = findListViewClientProps(tree)
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { name: { contains: 'Acme' } },
+        orderBy: { name: 'asc' },
+      }),
+    )
+    expect(props.filterSuggestions.map((s) => s.field)).toEqual(['name'])
+  })
+})
+
 describe('ListView to-many relationship count sort & filter (issue #732)', () => {
   const config: OpenSaasConfig = {
     db: { provider: 'sqlite', url: 'file:./test.db' },


### PR DESCRIPTION
## Summary

A field-level `read` gate withheld the **value** but left the **predicate** entirely unconstrained: a read-denied field could still be named in a `where`/`orderBy`, so its value (or relative order) could be recovered by probing — `count()` is the cleanest instrument, since it answers a predicate while returning no rows at all. This was reachable through the stack's own admin UI (ordinary list-view filtering and sorting), not only via an application forwarding a caller-supplied `where`.

- `findMany`/`count` now reject a `where`/`orderBy` key naming a field the session cannot read, including keys nested inside `AND`/`OR`/`NOT` — throwing loudly (`ValidationError`) instead of returning a silently narrowed or empty result. `sudo` still bypasses, matching #912.
- A `read` rule that depends on the fetched row (`item`) cannot be evaluated before the query runs — there is no row yet. Rather than skip the check for such a rule (which would reopen the hole for exactly the fields most likely to be sensitive), it resolves to a denial. Detected by handing the rule a poisoned `item` Proxy that throws on any property access, including through optional chaining — see `docs/adr/0031`.
- A field rule returning a non-boolean (#913's `InvalidFieldAccessResultError`) propagates unchanged rather than being folded into a plain denial, so a config bug stays visibly a config bug.
- `collectFilterSpecs`/`buildListFilterWhere`/`collectFilterSuggestions` (`@opensaas/stack-core`) now take a required `{ session, context }` and exclude read-denied fields, so the admin UI never suggests, autocompletes, or submits a filter the engine is going to reject — a `field:value` token for such a field degrades to free text instead.
- The admin list view's sort validation (`@opensaas/stack-ui`, `ListView.tsx`) excludes the same fields from what a `?sort=` URL param may activate.
- Deliberately scoped to the **current list only** — a relationship field's own `read` access is checked, but a field on a *related* list reached through a relation filter is out of scope (tracked separately as #916), matching the issue's stated boundary.

## Test plan

- [x] `pnpm test` — core: 1008 passed (was 991); UI: 563 passed (was 559)
- [x] `pnpm exec tsc --noEmit` clean on both `@opensaas/stack-core` and `@opensaas/stack-ui`
- [x] `pnpm lint` — no new warnings/errors
- [x] New regression coverage:
  - `count()` probe returns the identical denial for a matching and a non-matching prefix (no oracle)
  - `orderBy` on a read-denied field is denied
  - keys nested inside `AND`/`OR`/`NOT` are checked
  - a row-dependent `read` rule (including one using `item?.x` optional chaining) resolves to denial
  - `InvalidFieldAccessResultError` propagates rather than being swallowed
  - `sudo` bypasses the check entirely
  - a readable field remains filterable/sortable (no regression)
  - a read-denied field is absent from collected Filter specs, from filter suggestions, and is excluded from the sortable set
  - a relation-filter key on a *related* list is unaffected (out of scope, #916)
- [x] Changeset added (`@opensaas/stack-core`, `@opensaas/stack-ui`, minor)
- [x] ADR added: `docs/adr/0031-a-predicate-cannot-name-a-field-the-session-cannot-read.md`

Closes #915


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6e4y65UkDMY7FayQ5jpQz)_