### PR TITLE
fix(cli): migration introspector maps Prisma Decimal to decimal()

### DIFF
--- a/.changeset/silent-plums-cheer.md
+++ b/.changeset/silent-plums-cheer.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix migration introspector mapping Prisma/Keystone `Decimal` columns to `text()` instead of `decimal()`. Declared `@db.Decimal(precision, scale)` attributes now carry through to the generated field.

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -522,6 +522,17 @@ control.
       options.push("isIndexed: 'unique'")
     }
 
+    // Carry a declared `@db.Decimal(precision, scale)` through to the decimal() builder
+    if (
+      field.type === 'Decimal' &&
+      field.nativeType?.name === 'Decimal' &&
+      field.nativeType.args.length === 2
+    ) {
+      const [precision, scale] = field.nativeType.args
+      options.push(`precision: ${precision}`)
+      options.push(`scale: ${scale}`)
+    }
+
     // Handle default values
     if (field.defaultValue) {
       if (field.type === 'DateTime' && field.defaultValue === 'now()') {
@@ -533,7 +544,7 @@ control.
     }
 
     // Generate unsupported type warning
-    if (['Decimal', 'Bytes'].includes(field.type)) {
+    if (field.type === 'Bytes') {
       warnings.push(
         `Field "${field.name}" uses unsupported type "${field.type}" - mapped to text()`,
       )

--- a/packages/cli/src/migration/introspectors/keystone-introspector.ts
+++ b/packages/cli/src/migration/introspectors/keystone-introspector.ts
@@ -246,6 +246,7 @@ export class KeystoneIntrospector {
       text: { type: 'text', import: 'text' },
       integer: { type: 'integer', import: 'integer' },
       float: { type: 'decimal', import: 'decimal' }, // No native float - mapped to decimal()
+      decimal: { type: 'decimal', import: 'decimal' },
       checkbox: { type: 'checkbox', import: 'checkbox' },
       timestamp: { type: 'timestamp', import: 'timestamp' },
       select: { type: 'select', import: 'select' },

--- a/packages/cli/src/migration/introspectors/prisma-introspector.ts
+++ b/packages/cli/src/migration/introspectors/prisma-introspector.ts
@@ -143,6 +143,21 @@ export class PrismaIntrospector {
       field.defaultValue = rest.substring(startIdx, endIdx)
     }
 
+    // Extract native type attribute (e.g. `@db.Decimal(10, 2)`)
+    const nativeTypeMatch = rest.match(/@db\.(\w+)(?:\(([^)]*)\))?/)
+    if (nativeTypeMatch) {
+      const [, nativeName, nativeArgs] = nativeTypeMatch
+      field.nativeType = {
+        name: nativeName,
+        args: nativeArgs
+          ? nativeArgs
+              .split(',')
+              .map((arg) => arg.trim())
+              .filter(Boolean)
+          : [],
+      }
+    }
+
     // Extract relation
     const relationMatch = rest.match(/@relation\(([^)]+)\)/)
     if (relationMatch) {
@@ -201,7 +216,7 @@ export class PrismaIntrospector {
       DateTime: { type: 'timestamp', import: 'timestamp' },
       Json: { type: 'json', import: 'json' },
       BigInt: { type: 'bigInt', import: 'bigInt' },
-      Decimal: { type: 'text', import: 'text' }, // No native support
+      Decimal: { type: 'decimal', import: 'decimal' },
       Bytes: { type: 'text', import: 'text' }, // No native support
     }
 
@@ -217,7 +232,7 @@ export class PrismaIntrospector {
     // Check for unsupported types
     for (const model of schema.models) {
       for (const field of model.fields) {
-        if (['Decimal', 'Bytes'].includes(field.type)) {
+        if (field.type === 'Bytes') {
           warnings.push(
             `Field "${model.name}.${field.name}" uses unsupported type "${field.type}" - will be mapped to text()`,
           )

--- a/packages/cli/src/migration/types.ts
+++ b/packages/cli/src/migration/types.ts
@@ -83,6 +83,15 @@ export interface IntrospectedField {
     fields: string[]
     references: string[]
   }
+  /**
+   * A Prisma native type attribute (e.g. `@db.Decimal(10, 2)`), if the field
+   * declared one. Generalised beyond `Decimal` so other native types
+   * (`@db.VarChar`, `@db.SmallInt`, ...) can reuse the same channel later.
+   */
+  nativeType?: {
+    name: string
+    args: string[]
+  }
 }
 
 export interface IntrospectedSchema {

--- a/packages/cli/tests/introspectors/keystone-introspector.test.ts
+++ b/packages/cli/tests/introspectors/keystone-introspector.test.ts
@@ -100,6 +100,13 @@ export default {
     })
   })
 
+  it('should map decimal to decimal() (issue #908)', () => {
+    expect(introspector.mapKeystoneTypeToOpenSaas('decimal')).toEqual({
+      type: 'decimal',
+      import: 'decimal',
+    })
+  })
+
   it('should handle file and image fields', () => {
     expect(introspector.mapKeystoneTypeToOpenSaas('image')).toEqual({
       type: 'image',

--- a/packages/cli/tests/introspectors/prisma-introspector.test.ts
+++ b/packages/cli/tests/introspectors/prisma-introspector.test.ts
@@ -199,6 +199,13 @@ model User {
     })
   })
 
+  it('should map Decimal to decimal() (issue #908)', () => {
+    expect(introspector.mapPrismaTypeToOpenSaas('Decimal')).toEqual({
+      type: 'decimal',
+      import: 'decimal',
+    })
+  })
+
   it('should warn when a Float column is mapped to decimal()', async () => {
     const schema = `
 datasource db {
@@ -221,7 +228,7 @@ model Product {
     expect(warnings[0]).toContain('decimal()')
   })
 
-  it('should generate warnings for unsupported types, but not for BigInt (issue #907)', async () => {
+  it('should generate warnings for unsupported types, but not for BigInt or Decimal (issue #907, #908)', async () => {
     const schema = `
 datasource db {
   provider = "postgresql"
@@ -240,10 +247,35 @@ model Data {
     const result = await introspector.introspect(tempDir)
     const warnings = introspector.getWarnings(result)
 
-    expect(warnings).toHaveLength(2)
-    expect(warnings[0]).toContain('Decimal')
-    expect(warnings[1]).toContain('Bytes')
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('Bytes')
     expect(warnings.some((w) => w.includes('BigInt'))).toBe(false)
+    expect(warnings.some((w) => w.includes('Decimal'))).toBe(false)
+  })
+
+  it('should capture @db.Decimal(precision, scale) as a native type attribute (issue #908)', async () => {
+    const schema = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id    String  @id @default(cuid())
+  price Decimal @db.Decimal(10, 2)
+  bare  Decimal
+}
+`
+    await fs.writeFile(path.join(tempDir, 'prisma', 'schema.prisma'), schema)
+
+    const result = await introspector.introspect(tempDir)
+    const product = result.models[0]
+
+    const priceField = product.fields.find((f) => f.name === 'price')
+    expect(priceField!.nativeType).toEqual({ name: 'Decimal', args: ['10', '2'] })
+
+    const bareField = product.fields.find((f) => f.name === 'bare')
+    expect(bareField!.nativeType).toBeUndefined()
   })
 
   it('should throw for missing schema', async () => {

--- a/packages/cli/tests/migration-generator.test.ts
+++ b/packages/cli/tests/migration-generator.test.ts
@@ -649,4 +649,102 @@ model Product {
       expect(output.warnings.some((w) => w.includes('Float') && w.includes('decimal()'))).toBe(true)
     })
   })
+
+  describe('Decimal Field Mapping (issue #908)', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'migration-decimal-'))
+      await fs.ensureDir(path.join(tempDir, 'prisma'))
+    })
+
+    afterEach(async () => {
+      await fs.remove(tempDir)
+    })
+
+    it('should carry precision/scale through for a declared @db.Decimal(p, s) column', async () => {
+      const schema = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id    String  @id @default(cuid())
+  price Decimal @db.Decimal(10, 2)
+}
+`
+      await fs.writeFile(path.join(tempDir, 'prisma', 'schema.prisma'), schema)
+
+      const session: MigrationSession = {
+        id: 'test',
+        projectType: 'prisma',
+        analysis: {
+          projectTypes: ['prisma'],
+          cwd: tempDir,
+          provider: 'postgresql',
+        },
+        currentQuestionIndex: 0,
+        answers: {
+          db_provider: 'postgresql',
+          enable_auth: false,
+          default_access: 'public-read-auth-write',
+        },
+        isComplete: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const output = await generator.generate(session)
+
+      expect(output.configContent).toContain(
+        'price: decimal({ validation: { isRequired: true }, precision: 10, scale: 2 })',
+      )
+      expect(output.configContent).toMatch(
+        /import \{[^}]*\bdecimal\b[^}]*\} from '@opensaas\/stack-core\/fields'/,
+      )
+      expect(output.warnings.some((w) => w.includes('Decimal'))).toBe(false)
+    })
+
+    it('should generate a bare decimal() with no precision/scale for a Decimal column without @db.Decimal', async () => {
+      const schema = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id    String   @id @default(cuid())
+  price Decimal?
+}
+`
+      await fs.writeFile(path.join(tempDir, 'prisma', 'schema.prisma'), schema)
+
+      const session: MigrationSession = {
+        id: 'test',
+        projectType: 'prisma',
+        analysis: {
+          projectTypes: ['prisma'],
+          cwd: tempDir,
+          provider: 'postgresql',
+        },
+        currentQuestionIndex: 0,
+        answers: {
+          db_provider: 'postgresql',
+          enable_auth: false,
+          default_access: 'public-read-auth-write',
+        },
+        isComplete: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const output = await generator.generate(session)
+
+      expect(output.configContent).toContain('price: decimal()')
+      expect(output.configContent).not.toContain('precision')
+      expect(output.configContent).not.toContain('scale')
+      expect(output.warnings.some((w) => w.includes('Decimal'))).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Prisma introspector now maps `Decimal` to the `decimal()` field builder instead of `text()` — the `// No native support` comment was stale; `decimal()` has existed as a first-class field type for a while.
- The Prisma field-line parser now captures a declared native type attribute (e.g. `@db.Decimal(10, 2)`) into a new, generalised `nativeType: { name, args }` channel on `IntrospectedField`, so other native types can reuse it later.
- The migration generator carries a declared `@db.Decimal(p, s)` through to `decimal({ precision: p, scale: s })`; a bare `Decimal` column (no native type attribute) generates a plain `decimal()` using the builder's defaults.
- Dropped `Decimal` from both unsupported-type warning sites (the introspector's warning collector and the migration generator's per-field warning), since it's now correctly supported. `Bytes` keeps its warning; `BigInt` was already handled correctly in #907.
- Added a `decimal` entry to the Keystone introspector's type-mapping table — it previously had none, so a Keystone `decimal()` field silently fell through to `text()` with no warning at all.

## Test plan

- [x] Added/updated tests in `prisma-introspector.test.ts`, `keystone-introspector.test.ts`, and `migration-generator.test.ts` covering: declared-precision Decimal, bare Decimal, Keystone `decimal`, and that no warning mentions `Decimal` anymore
- [x] `pnpm test` (packages/cli) — all 353 tests pass
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` run clean
- [x] `tsc --noEmit` (packages/cli) — clean
- [x] Changeset added (patch, `@opensaas/stack-cli`)

Closes #908


---
_Generated by [Claude Code](https://claude.ai/code/session_019hDCG87MKcaQ2NRP1Whfop)_