### PR TITLE
fix(core,cli): db.indexes supports single-field entries; new empty-array and isIndexed-collision errors

### DIFF
--- a/.changeset/tame-plums-heal.md
+++ b/.changeset/tame-plums-heal.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+`db.indexes` generation now fails with a descriptive error for an empty `fields` array, and for a single-field entry that duplicates a column already indexed by that field's own `isIndexed` — previously these silently produced invalid or duplicate Prisma.

--- a/.changeset/tiny-plums-listen.md
+++ b/.changeset/tiny-plums-listen.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Correct `ListIndex`/`db.indexes` doc comments, which wrongly claimed an entry must span two or more fields — a single-field entry is fully supported and now documented as such.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,9 +435,9 @@ The function receives:
 
 Field-level `extendPrismaSchema` is applied before the global `db.extendPrismaSchema`, allowing both granular and broad modifications.
 
-**Model-Level Composite Indexes (`db.indexes`):**
+**Model-Level Indexes (`db.indexes`):**
 
-Field-level `isIndexed` (on a scalar or relationship field) can only ever produce a single-column `@@unique`/`@@index`. A list's `db.indexes` is the multi-column case: each entry names two or more of the list's own OpenSaaS field names (not raw database column names) and the generator resolves each to its Prisma column — a scalar field's own name, or a relationship field's foreign key column (`<field>Id`) when this side owns it.
+Field-level `isIndexed` is the sugar for the unnamed single-column case. `db.indexes` is the full form — reach for it when a constraint needs a `name` (Prisma's `map:`, for adopting an existing live constraint), a `sort` direction, or spans more than one column. Arity is incidental: each entry names one or more of the list's own OpenSaaS field names (not raw database column names) and the generator resolves each to its Prisma column — a scalar field's own name, or a relationship field's foreign key column (`<field>Id`) when this side owns it. See the [reference docs](https://stack.opensaas.au/docs/reference/config-api#dbindexes) for the full rules.
 
 ```typescript
 Audition: list({
@@ -469,9 +469,20 @@ AuthVerification: list({
   },
 })
 // Generates: @@index([identifier, createdAt(sort: Desc)], map: "AuthVerification_identifier_createdAt_idx")
+
+RateLimit: list({
+  fields: { key: text() }, // no isIndexed here — db.indexes owns this column instead
+  db: {
+    // A single-field entry is as legitimate as a composite one — this is the
+    // form for adopting a live table's unique constraint under a name Prisma
+    // wouldn't derive on its own.
+    indexes: [{ fields: ['key'], unique: true, name: 'RateLimit_key_key' }],
+  },
+})
+// Generates: @@unique([key], map: "RateLimit_key_key")
 ```
 
-An entry naming a field the list doesn't have, a virtual field, a to-many relationship, or the non-FK side of a one-to-one relationship fails `pnpm generate` with an error naming the list, the entry, and the bad field — never silently dropped or emitted as invalid Prisma.
+An entry naming a field the list doesn't have, a virtual field, a to-many relationship, or the non-FK side of a one-to-one relationship fails `pnpm generate` with an error naming the list, the entry, and the bad field — never silently dropped or emitted as invalid Prisma. The same is true for an empty `fields` array, and for a single-field entry that indexes the exact column a field-level `isIndexed` on the same list already indexes (the error names both the field/`isIndexed` and the entry — remove one of them).
 
 ### Field Types
 

--- a/docs/content/reference/config-api.md
+++ b/docs/content/reference/config-api.md
@@ -347,6 +347,81 @@ Model Context Protocol configuration for this list.
 
 **Type:** [`ListMcpConfig`](#listmcpconfig)
 
+##### `db.indexes`
+
+Model-level `@@unique`/`@@index` constraints, spanning one or more of this list's own fields.
+
+**Type:** `ListIndex[]`
+
+```typescript
+type ListIndexFieldRef = string | { field: string; sort?: 'asc' | 'desc' }
+
+type ListIndex = {
+  fields: ListIndexFieldRef[]
+  unique?: boolean // default: false
+  name?: string // emitted as Prisma's `map:`
+}
+```
+
+Field-level [`isIndexed`](/docs/reference/fields-api#isindexed) is the sugar for the unnamed single-column case. `db.indexes` is the full form — reach for it when a constraint needs a `name` (for adopting an existing live constraint under a name Prisma wouldn't derive), a `sort` direction, or spans more than one column. Arity is incidental: an entry names **one or more** of the list's own OpenSaaS field names (not raw database column names). The generator resolves each to its Prisma column — a scalar field's own name (unaffected by `db.map`), or a relationship field's foreign key column (`<field>Id`) when this side owns it.
+
+**Example — composite unique (a database-level backstop a hook's existence check can't close on its own):**
+
+```typescript
+Audition: list({
+  fields: {
+    student: relationship({ ref: 'Student.auditions' }),
+    production: relationship({ ref: 'Production.auditions' }),
+  },
+  db: {
+    indexes: [{ fields: ['student', 'production'], unique: true }],
+  },
+})
+// Generates: @@unique([studentId, productionId])
+```
+
+**Example — single-field entry, naming an adopted constraint:**
+
+```typescript
+RateLimit: list({
+  fields: { key: text() }, // no isIndexed here — db.indexes owns this column instead
+  db: {
+    indexes: [{ fields: ['key'], unique: true, name: 'RateLimit_key_key' }],
+  },
+})
+// Generates: @@unique([key], map: "RateLimit_key_key")
+```
+
+**Example — sort direction and an adopted constraint name:**
+
+```typescript
+AuthVerification: list({
+  fields: {
+    identifier: text(),
+    createdAt: timestamp(),
+  },
+  db: {
+    indexes: [
+      {
+        fields: ['identifier', { field: 'createdAt', sort: 'desc' }],
+        name: 'AuthVerification_identifier_createdAt_idx',
+      },
+    ],
+  },
+})
+// Generates: @@index([identifier, createdAt(sort: Desc)], map: "AuthVerification_identifier_createdAt_idx")
+```
+
+**Errors at `pnpm generate` time** (each names the list and the entry):
+
+- An entry naming a field the list doesn't have, a virtual field, a to-many relationship, or the non-FK side of a one-to-one relationship.
+- An entry whose `fields` array is empty.
+- A single-field entry that indexes the exact column a field-level `isIndexed` on the same list already indexes — the error names both the field/`isIndexed` and the entry, since either one should be removed rather than both left producing the same constraint.
+
+No entry is ever silently dropped or emitted as invalid Prisma.
+
+**Deliberately not validated:** duplicate names across entries, and two entries covering the same column set — Prisma catches both with messages naming the columns, and all `db.indexes` entries live in one place.
+
 ---
 
 ### `OperationAccess`

--- a/docs/content/reference/fields-api.md
+++ b/docs/content/reference/fields-api.md
@@ -68,6 +68,8 @@ Database index configuration.
 - `'unique'` - Create unique index (enforces uniqueness)
 - `false` or omitted - No index
 
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
+
 **Example:**
 
 ```typescript
@@ -285,6 +287,8 @@ Database index configuration.
 - `'unique'` - Create unique index (enforces uniqueness)
 - `false` or omitted - No index
 
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
+
 #### Database Type
 
 Prisma: `BigInt`
@@ -473,6 +477,8 @@ Database index configuration.
 - `true` - Create non-unique index for faster queries
 - `'unique'` - Create unique index (enforces uniqueness)
 - `false` or omitted - No index
+
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
 
 **Example:**
 
@@ -743,6 +749,8 @@ Database index configuration.
 - `true` - Create non-unique index for faster date queries
 - `'unique'` - Create unique index (enforces uniqueness)
 - `false` or omitted - No index
+
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
 
 **Example:**
 

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1503,6 +1503,186 @@ describe('Prisma Schema Generator', () => {
       )
     })
 
+    describe('single-field entries (#918)', () => {
+      it('emits @@unique with map: for a single-field entry with unique and a name', () => {
+        const config: OpenSaasConfig = {
+          db: { provider: 'sqlite' },
+          lists: {
+            RateLimit: {
+              fields: { key: text() },
+              db: {
+                indexes: [{ fields: ['key'], unique: true, name: 'RateLimit_key_key' }],
+              },
+            },
+          },
+        }
+
+        const schema = generatePrismaSchema(config)
+
+        expect(schema).toContain('@@unique([key], map: "RateLimit_key_key")')
+      })
+
+      it('emits a bare @@unique for a single-field entry with unique and no name', () => {
+        const config: OpenSaasConfig = {
+          db: { provider: 'sqlite' },
+          lists: {
+            RateLimit: {
+              fields: { key: text() },
+              db: { indexes: [{ fields: ['key'], unique: true }] },
+            },
+          },
+        }
+
+        const schema = generatePrismaSchema(config)
+
+        expect(schema).toContain('@@unique([key])')
+      })
+
+      it('emits @@index for a single-field entry with unique absent', () => {
+        const config: OpenSaasConfig = {
+          db: { provider: 'sqlite' },
+          lists: {
+            Post: {
+              fields: { slug: text() },
+              db: { indexes: [{ fields: ['slug'] }] },
+            },
+          },
+        }
+
+        const schema = generatePrismaSchema(config)
+
+        expect(schema).toContain('@@index([slug])')
+        expect(schema).not.toContain('@@unique([slug])')
+      })
+
+      it('emits a sort direction on a single-field entry', () => {
+        const config: OpenSaasConfig = {
+          db: { provider: 'sqlite' },
+          lists: {
+            Post: {
+              fields: { createdAt: timestamp() },
+              db: { indexes: [{ fields: [{ field: 'createdAt', sort: 'desc' }] }] },
+            },
+          },
+        }
+
+        const schema = generatePrismaSchema(config)
+
+        expect(schema).toContain('@@index([createdAt(sort: Desc)])')
+      })
+
+      it("resolves a relationship field's foreign-key column through a single-field entry, same as the composite case", () => {
+        const config: OpenSaasConfig = {
+          db: { provider: 'sqlite' },
+          lists: {
+            User: { fields: { name: text() } },
+            Post: {
+              fields: {
+                title: text(),
+                // Field-level isIndexed disabled: db.indexes owns this column.
+                author: relationship({ ref: 'User', isIndexed: false }),
+              },
+              db: {
+                indexes: [{ fields: ['author'], unique: true, name: 'Post_authorId_key' }],
+              },
+            },
+          },
+        }
+
+        const schema = generatePrismaSchema(config)
+
+        expect(schema).toContain('@@unique([authorId], map: "Post_authorId_key")')
+      })
+    })
+
+    it('throws naming the list and entry for an empty fields array', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: { title: text() },
+            db: { indexes: [{ fields: [] }] },
+          },
+        },
+      }
+
+      expect(() => generatePrismaSchema(config)).toThrow(
+        /db\.indexes\[0\].*on list "Post".*empty "fields" array/,
+      )
+    })
+
+    it('throws naming the field, its isIndexed, and the entry when a single-field entry collides with a unique field-level isIndexed', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          RateLimit: {
+            fields: { key: text({ isIndexed: 'unique' }) },
+            db: { indexes: [{ fields: ['key'], unique: true, name: 'RateLimit_key_key' }] },
+          },
+        },
+      }
+
+      expect(() => generatePrismaSchema(config)).toThrow(
+        /db\.indexes\[0\].*on list "RateLimit".*field "key".*isIndexed: 'unique'/,
+      )
+    })
+
+    it('throws when a single-field entry collides with a plain (true) field-level isIndexed', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: { slug: text({ isIndexed: true }) },
+            db: { indexes: [{ fields: ['slug'] }] },
+          },
+        },
+      }
+
+      expect(() => generatePrismaSchema(config)).toThrow(
+        /db\.indexes\[0\].*on list "Post".*field "slug".*isIndexed: true/,
+      )
+    })
+
+    it("throws when a single-field entry collides with a relationship field's default (true) foreign-key index", () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          User: { fields: { name: text() } },
+          Post: {
+            fields: {
+              title: text(),
+              author: relationship({ ref: 'User' }), // isIndexed defaults to true for FKs
+            },
+            db: { indexes: [{ fields: ['author'] }] },
+          },
+        },
+      }
+
+      expect(() => generatePrismaSchema(config)).toThrow(
+        /db\.indexes\[0\].*on list "Post".*field "author".*isIndexed: true/,
+      )
+    })
+
+    it('does not flag a collision when the single-field entry and a field-level isIndexed target different columns', () => {
+      const config: OpenSaasConfig = {
+        db: { provider: 'sqlite' },
+        lists: {
+          Post: {
+            fields: {
+              slug: text({ isIndexed: 'unique' }),
+              category: text(),
+            },
+            db: { indexes: [{ fields: ['category'] }] },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@unique')
+      expect(schema).toContain('@@index([category])')
+    })
+
     it('generates byte-for-byte identical model output when no indexes are declared, matching pre-feature behaviour', () => {
       const config: OpenSaasConfig = {
         db: { provider: 'sqlite' },

--- a/packages/cli/src/generator/prisma.ts
+++ b/packages/cli/src/generator/prisma.ts
@@ -174,25 +174,102 @@ function resolveIndexFieldColumn(
 }
 
 /**
+ * A field-level `isIndexed` declaration that already produces a single-column
+ * `@@unique`/`@@index` line, keyed by the Prisma column it indexes. Used to
+ * detect a `db.indexes` single-field entry that would duplicate it (#918).
+ */
+type FieldLevelIndexColumn = { fieldName: string; indexType: boolean | 'unique' }
+
+/**
+ * Collect every field on the list carrying a field-level `isIndexed`
+ * declaration, keyed by the Prisma column it indexes — the column a
+ * single-field `db.indexes` entry must not also target (#918).
+ *
+ * Reads `isIndexed` generically (not every field type declares it, so the
+ * property is read via a narrow cast) rather than reusing the block-index
+ * bookkeeping the main generation loop builds for `@@index`/`@@unique`
+ * lines: a scalar field's `isIndexed: 'unique'` emits an inline field-level
+ * `@unique`, not a block line, but it still owns the column and still
+ * collides with a `db.indexes` entry naming it. A relationship field with no
+ * explicit `isIndexed` defaults to indexed (matching the FK auto-index
+ * default in the relationship field builder); a to-many relationship has no
+ * single foreign-key column and is skipped.
+ */
+function collectFieldLevelIndexColumns(
+  listName: string,
+  listConfig: ListConfig<TypeInfo>,
+  relationResults: Map<string, PrismaRelationResult>,
+): Map<string, FieldLevelIndexColumn> {
+  const columns = new Map<string, FieldLevelIndexColumn>()
+
+  for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
+    if (fieldConfig.virtual) continue
+
+    if (fieldConfig.type === 'relationship') {
+      const relField = fieldConfig as RelationshipField
+      if (relField.many) continue
+      const indexType = relField.isIndexed ?? true
+      if (indexType === false) continue
+      const relResult = relationResults.get(`${listName}.${fieldName}`)
+      if (relResult?.foreignKeyField) {
+        columns.set(relResult.foreignKeyField, { fieldName, indexType })
+      }
+      continue
+    }
+
+    const indexType = (fieldConfig as { isIndexed?: boolean | 'unique' }).isIndexed
+    if (indexType === undefined || indexType === false) continue
+    columns.set(fieldName, { fieldName, indexType })
+  }
+
+  return columns
+}
+
+/**
  * Generate the `@@unique([...])`/`@@index([...])` lines for a list's
  * model-level `db.indexes` (#864). Emitted after the existing field-level
  * scalar/foreign-key index lines, in declaration order, so a config with no
  * `db.indexes` produces byte-for-byte identical output to before this
  * feature existed.
+ *
+ * An entry spans one or more fields (#918) — arity is incidental; a named
+ * single-column constraint is as legitimate as a composite one. Two cases
+ * fail generation rather than silently producing nothing or invalid Prisma:
+ * an empty `fields` array, and a single-field entry that indexes the exact
+ * column a field-level `isIndexed` already indexes.
  */
 function generateModelIndexLines(
   listName: string,
   listConfig: ListConfig<TypeInfo>,
   relationResults: Map<string, PrismaRelationResult>,
+  fieldLevelIndexColumns: Map<string, FieldLevelIndexColumn>,
 ): string[] {
   const indexes = listConfig.db?.indexes
   if (!indexes || indexes.length === 0) return []
 
   return indexes.map((index, i) => {
     const entryDescription = `Model-level index db.indexes[${i}]`
+
+    if (index.fields.length === 0) {
+      throw new Error(
+        `${entryDescription} on list "${listName}" has an empty "fields" array — an index/constraint must name at least one field`,
+      )
+    }
+
     const resolved = index.fields.map((fieldRef) =>
       resolveIndexFieldColumn(listName, listConfig, relationResults, entryDescription, fieldRef),
     )
+
+    if (resolved.length === 1) {
+      const collision = fieldLevelIndexColumns.get(resolved[0].column)
+      if (collision) {
+        const isIndexedValue =
+          typeof collision.indexType === 'string' ? `'${collision.indexType}'` : 'true'
+        throw new Error(
+          `${entryDescription} on list "${listName}" duplicates the constraint already produced by field "${collision.fieldName}"'s isIndexed: ${isIndexedValue} — both would emit an index on "${resolved[0].column}"; remove one of them`,
+        )
+      }
+    }
 
     const fieldsList = resolved
       .map(({ column, sort }) =>
@@ -483,11 +560,20 @@ export function generatePrismaSchema(config: OpenSaasConfig, prismaClientOutput?
       }
     }
 
-    // Add model-level composite `@@unique`/`@@index` constraints declared via
-    // `db.indexes` (#864) — the multi-column case single-field `isIndexed`
-    // can't reach. Emitted last so a config with no `db.indexes` produces
-    // byte-for-byte identical output to before this feature existed.
-    lines.push(...generateModelIndexLines(listName, listConfig, relationResults))
+    // Add model-level `@@unique`/`@@index` constraints declared via
+    // `db.indexes` (#864, #918) — the full form when a name or a sort
+    // direction is needed; `isIndexed` above remains the sugar for the
+    // unnamed single-column case. Emitted last so a config with no
+    // `db.indexes` produces byte-for-byte identical output to before this
+    // feature existed.
+    lines.push(
+      ...generateModelIndexLines(
+        listName,
+        listConfig,
+        relationResults,
+        collectFieldLevelIndexColumns(listName, listConfig, relationResults),
+      ),
+    )
 
     // Map the model to a custom table name when configured (e.g. adopting
     // existing tables whose physical name differs from the list key).

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1867,14 +1867,20 @@ export type ListIndexFieldRef =
     }
 
 /**
- * A model-level composite `@@unique`/`@@index` constraint spanning two or
- * more of a list's own fields. See {@link ListConfig.db}'s `indexes` for the
- * full explanation and examples (#864).
+ * A model-level `@@unique`/`@@index` constraint spanning one or more of a
+ * list's own fields. See {@link ListConfig.db}'s `indexes` for the full
+ * explanation and examples (#864, #918).
  */
 export type ListIndex = {
   /**
    * The fields participating in this index/constraint, in declaration order.
    * OpenSaaS field names, not raw database column names.
+   *
+   * One or more fields — a named single-column constraint is as legitimate
+   * as a composite one, and is the form to reach for when a live table's
+   * constraint carries a name Prisma wouldn't derive on its own. Field-level
+   * `isIndexed` remains the sugar for the unnamed single-column case; this
+   * is the full form when a name or a sort direction is needed.
    */
   fields: ListIndexFieldRef[]
   /**
@@ -1968,31 +1974,40 @@ export type ListConfig<TTypeInfo extends TypeInfo> = {
      */
     timestamps?: boolean
     /**
-     * Model-level composite `@@unique`/`@@index` constraints spanning two or
-     * more of this list's own fields (#864).
+     * Model-level `@@unique`/`@@index` constraints spanning one or more of
+     * this list's own fields (#864, #918). See the [reference
+     * docs](https://stack.opensaas.au/docs/reference/config-api#dbindexes)
+     * for the full explanation, arity, and error conditions.
      *
-     * Field-level `isIndexed` (on a scalar or relationship field) can only
-     * ever produce a single-column index — it has no way to express a
-     * constraint or index that spans more than one column. `db.indexes` is
-     * that multi-column case: each entry names two or more of the list's own
-     * OpenSaaS field names, not raw database column names. The generator
-     * resolves each to its underlying Prisma column — a scalar field's own
-     * name (its Prisma field name is unaffected by `db.map`), or a
-     * relationship field's foreign key column (`<field>Id`) when this side
-     * owns it.
+     * Field-level `isIndexed` (on a scalar or relationship field) is the
+     * sugar for the unnamed single-column case. `db.indexes` is the full
+     * form — reach for it when a constraint needs a `name` (Prisma's `map:`,
+     * for adopting an existing live constraint), a `sort` direction, or spans
+     * more than one column. Arity is incidental: each entry names one or
+     * more of the list's own OpenSaaS field names, not raw database column
+     * names. The generator resolves each to its underlying Prisma column — a
+     * scalar field's own name (its Prisma field name is unaffected by
+     * `db.map`), or a relationship field's foreign key column (`<field>Id`)
+     * when this side owns it.
      *
-     * A composite **unique** is the load-bearing case: it's the
-     * database-level backstop for a business rule two concurrent writes could
-     * otherwise both slip past (e.g. "one booking per student per
-     * production") — something a hook's existence check cannot close on its
-     * own, and can't be retrofitted once duplicate rows exist. A composite
-     * **index** (non-unique) is the equivalent performance-only case (a hot
-     * multi-column lookup path).
+     * A **unique** entry is the load-bearing case: it's the database-level
+     * backstop for a business rule concurrent writes could otherwise both
+     * slip past (e.g. "one booking per student per production", or a
+     * single-column unique a live table already enforces under a name Prisma
+     * wouldn't derive) — something a hook's existence check cannot close on
+     * its own, and can't be retrofitted once duplicate rows exist. An
+     * **index** (non-unique) entry is the equivalent performance-only case
+     * (a hot lookup path).
      *
-     * An entry naming a field the list doesn't have, a virtual field, a
-     * to-many relationship, or the non-FK side of a one-to-one relationship
-     * fails `pnpm generate` with an error naming the list, the entry, and the
-     * bad field — it is never silently dropped or emitted as invalid Prisma.
+     * Two conditions fail `pnpm generate` with an error naming the list and
+     * the entry: an empty `fields` array, and a single-field entry that
+     * indexes the exact column a field-level `isIndexed` on the same list
+     * already indexes (the error also names that field and its `isIndexed`
+     * value — one of the two should be removed). An entry naming a field the
+     * list doesn't have, a virtual field, a to-many relationship, or the
+     * non-FK side of a one-to-one relationship fails the same way, naming
+     * the bad field too — no entry is ever silently dropped or emitted as
+     * invalid Prisma.
      *
      * @example One audition per student per production (composite unique)
      * ```typescript
@@ -2025,6 +2040,19 @@ export type ListConfig<TTypeInfo extends TypeInfo> = {
      *   },
      * })
      * // Generates: @@index([identifier, createdAt(sort: Desc)], map: "AuthVerification_identifier_createdAt_idx")
+     * ```
+     *
+     * @example Naming a single-column unique constraint (adopting a live table's existing name)
+     * ```typescript
+     * RateLimit: list({
+     *   fields: { key: text() }, // no isIndexed here — db.indexes owns this column instead
+     *   db: {
+     *     indexes: [{ fields: ['key'], unique: true, name: 'RateLimit_key_key' }],
+     *   },
+     * })
+     * // Generates: @@unique([key], map: "RateLimit_key_key")
+     * // Setting key's own isIndexed too would duplicate this constraint and
+     * // fail generation — one of the two must own the column.
      * ```
      */
     indexes?: ListIndex[]


### PR DESCRIPTION
## Summary

- Corrects the `ListIndex`/`db.indexes` doc comments (core `types.ts` and root `CLAUDE.md`), which wrongly claimed an entry must span **two or more** fields. A single-field entry already generated correct Prisma (including `map:`) on `main` — it was simply undocumented, untested, and forbidden by prose. Docs now describe the real rule: `isIndexed` is sugar for the unnamed single-column case, `db.indexes` is the full form for a name, a `sort` direction, or a composite constraint, and arity is incidental.
- Adds the two generation-time errors the surface was genuinely missing, each naming the list and the entry:
  - An entry whose `fields` array is empty (previously produced invalid Prisma, `@@unique([])`/`@@index([])`, surfaced only downstream by `prisma validate`).
  - A single-field entry that indexes the exact column a field-level `isIndexed` on the same list already indexes — the error also names the colliding field and its `isIndexed` value, since one of the two should be removed.
- Adds a `db.indexes` reference-docs section (`docs/content/reference/config-api.md`) and cross-links from every `isIndexed` reference entry (`docs/content/reference/fields-api.md`).
- No new API — no object form on `isIndexed`, no signature changes to `ListIndex`/`ListIndexFieldRef`/`isIndexed`.

## Test plan

- [x] New tests in `packages/cli/src/generator/prisma.test.ts`: single-field entry with `unique`+`name`, `unique` with no name, plain `@@index`, a `sort` direction, and a relationship field's FK column resolved through a single-field entry.
- [x] New tests for the empty-`fields` error, and for the `isIndexed` collision error covering both the `'unique'` and plain-`true` forms (scalar and relationship-FK-default cases), plus a non-collision control case.
- [x] Existing composite-index and error-path tests unchanged and passing.
- [x] `pnpm test` green in `packages/cli` (363 tests) and `packages/core` (1043 tests).
- [x] `pnpm build` green in `packages/core`, `packages/cli`, `packages/auth`.
- [x] `pnpm lint` clean (pre-existing unrelated warnings only) and `pnpm format` / `pnpm manypkg fix` applied.
- [x] Changesets added via the `pr-changeset` skill (patch on `@opensaas/stack-core`, patch on `@opensaas/stack-cli`).

Closes #918


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vag2xhpy1CViebAasA27Fx)_