### PR TITLE
fix(cli): resolve tsconfig.json path aliases when loading opensaas.config.ts

### DIFF
--- a/.changeset/tame-plums-relax.md
+++ b/.changeset/tame-plums-relax.md
@@ -1,0 +1,19 @@
+---
+'@opensaas/stack-cli': minor
+---
+
+Resolve `tsconfig.json` path aliases (`compilerOptions.paths`) when loading `opensaas.config.ts`, so a value import using an alias (e.g. `@/*`) works in the config and anywhere in its import closure, not just in type-only positions.
+
+```typescript
+// tsconfig.json
+{
+  "compilerOptions": {
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+
+// opensaas.config.ts
+import { lists } from '@/opensaas/lists' // now resolves
+```
+
+Only the single-trailing-`*`, single-target form of `paths` is translated; an entry with multiple candidate targets or an unsupported pattern shape logs a warning naming the pattern and is skipped rather than failing generation. Projects without a `tsconfig.json`, or without `paths`, are unaffected. The `opensaas migrate` command's Keystone config loader resolves aliases the same way.

--- a/examples/starter-auth/opensaas.config.ts
+++ b/examples/starter-auth/opensaas.config.ts
@@ -2,7 +2,7 @@ import { config, list } from '@opensaas/stack-core'
 import { text, relationship, select, timestamp, integer } from '@opensaas/stack-core/fields'
 import { authPlugin } from '@opensaas/stack-auth'
 import type { AccessControl } from '@opensaas/stack-core'
-import type { Lists } from '@/.opensaas/lists'
+import type { Lists } from './.opensaas/lists'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 
 /**

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -15,6 +15,7 @@ import {
   resolveOutputPaths,
   buildNodeBundle,
   formatNodeBuildDiagnostics,
+  resolveTsconfigAlias,
 } from '../generator/index.js'
 import {
   OpenSaasConfig,
@@ -73,9 +74,17 @@ export async function generateCommand() {
   const spinner = ora('Loading configuration...').start()
 
   try {
+    // Resolve tsconfig.json path aliases (e.g. "@/*") into jiti's alias
+    // option, so a value import in opensaas.config.ts (or anything it
+    // imports) can use the same aliases as the rest of the project (#905).
+    // A project with no tsconfig.json, or no `paths`, resolves to
+    // `alias: undefined`, which is identical to omitting the option.
+    const { alias, warnings: aliasWarnings } = resolveTsconfigAlias(cwd)
+
     // Load config using jiti (supports TypeScript)
     const jiti = createJiti(cwd, {
       interopDefault: true,
+      alias,
     })
 
     // Config may be async (if plugins are present)
@@ -93,6 +102,9 @@ export async function generateCommand() {
     }
 
     spinner.succeed(chalk.green('Configuration loaded'))
+    for (const warning of aliasWarnings) {
+      console.log(chalk.yellow(`⚠️  ${warning}`))
+    }
 
     // Execute beforeGenerate hooks if plugins are present
     if (config.plugins && config.plugins.length > 0) {

--- a/packages/cli/src/generator/index.ts
+++ b/packages/cli/src/generator/index.ts
@@ -18,3 +18,5 @@ export type {
 } from './output-paths.js'
 export { buildNodeBundle, formatNodeBuildDiagnostics } from './node-build.js'
 export type { BuildNodeBundleOptions, BuildNodeBundleResult } from './node-build.js'
+export { resolveTsconfigAlias } from './tsconfig-alias.js'
+export type { TsconfigAliasResult } from './tsconfig-alias.js'

--- a/packages/cli/src/generator/tsconfig-alias.test.ts
+++ b/packages/cli/src/generator/tsconfig-alias.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { createJiti } from 'jiti'
+import { resolveTsconfigAlias } from './tsconfig-alias.js'
+
+describe('resolveTsconfigAlias', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsconfig-alias-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function writeTsconfig(content: unknown | string) {
+    fs.writeFileSync(
+      path.join(tempDir, 'tsconfig.json'),
+      typeof content === 'string' ? content : JSON.stringify(content),
+    )
+  }
+
+  it('returns no alias when there is no tsconfig.json', () => {
+    expect(resolveTsconfigAlias(tempDir)).toEqual({ alias: undefined, warnings: [] })
+  })
+
+  it('returns no alias when tsconfig.json has no paths', () => {
+    writeTsconfig({ compilerOptions: { strict: true } })
+    expect(resolveTsconfigAlias(tempDir)).toEqual({ alias: undefined, warnings: [] })
+  })
+
+  it('translates a single-trailing-star alias against the default baseUrl (tsconfig dir)', () => {
+    writeTsconfig({ compilerOptions: { paths: { '@/*': ['./src/*'] } } })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(warnings).toEqual([])
+    expect(alias).toEqual({ '@/': path.join(tempDir, 'src') })
+  })
+
+  it('resolves the alias target against an explicit baseUrl', () => {
+    writeTsconfig({
+      compilerOptions: { baseUrl: './app', paths: { '@/*': ['./*'] } },
+    })
+
+    const { alias } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toEqual({ '@/': path.join(tempDir, 'app') })
+  })
+
+  it('handles multiple alias patterns in one tsconfig', () => {
+    writeTsconfig({
+      compilerOptions: {
+        paths: {
+          '@/*': ['./src/*'],
+          '@utils/*': ['./src/utils/*'],
+        },
+      },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(warnings).toEqual([])
+    expect(alias).toEqual({
+      '@/': path.join(tempDir, 'src'),
+      '@utils/': path.join(tempDir, 'src', 'utils'),
+    })
+  })
+
+  it('warns and skips a paths entry with more than one candidate target', () => {
+    writeTsconfig({
+      compilerOptions: { paths: { '@/*': ['./src/*', './lib/*'] } },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('@/*')
+    expect(warnings[0]).toContain('2 candidate target')
+  })
+
+  it('warns and skips a pattern with no wildcard', () => {
+    writeTsconfig({
+      compilerOptions: { paths: { config: ['./config.ts'] } },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('config')
+  })
+
+  it('warns and skips a pattern whose star is not the trailing character', () => {
+    writeTsconfig({
+      compilerOptions: { paths: { '@/*.css': ['./src/*.css'] } },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('mixes representable and unrepresentable entries: resolves one, warns on the other', () => {
+    writeTsconfig({
+      compilerOptions: {
+        paths: {
+          '@/*': ['./src/*'],
+          '@shared/*': ['./packages/a/*', './packages/b/*'],
+        },
+      },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toEqual({ '@/': path.join(tempDir, 'src') })
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('@shared/*')
+  })
+
+  it('tolerates JSONC comments and trailing commas (common in tsconfig.json)', () => {
+    writeTsconfig(`{
+      // path aliases
+      "compilerOptions": {
+        "paths": {
+          "@/*": ["./src/*"], /* trailing comma above, block comment here */
+        },
+      },
+    }`)
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(warnings).toEqual([])
+    expect(alias).toEqual({ '@/': path.join(tempDir, 'src') })
+  })
+
+  it('warns rather than throwing on unparseable JSON', () => {
+    writeTsconfig('{ this is not json')
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toBeUndefined()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('could not be parsed')
+  })
+})
+
+describe('resolveTsconfigAlias + jiti integration', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsconfig-alias-jiti-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('resolves a value import in the config through the alias', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { paths: { '@/*': ['./src/*'] } } }),
+    )
+    fs.mkdirSync(path.join(tempDir, 'src', 'opensaas'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'opensaas', 'lists.ts'),
+      "export const lists = { hello: 'world' }\n",
+    )
+    fs.writeFileSync(
+      path.join(tempDir, 'opensaas.config.ts'),
+      "import { lists } from '@/opensaas/lists'\nexport default { lists }\n",
+    )
+
+    const { alias } = resolveTsconfigAlias(tempDir)
+    const jiti = createJiti(tempDir, { interopDefault: true, alias })
+
+    const mod = (await jiti.import(path.join(tempDir, 'opensaas.config.ts'))) as {
+      default: { lists: { hello: string } }
+    }
+    expect(mod.default.lists).toEqual({ hello: 'world' })
+  })
+
+  it('resolves the alias transitively through the config’s own import closure', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { paths: { '@/*': ['./src/*'] } } }),
+    )
+    fs.mkdirSync(path.join(tempDir, 'src', 'opensaas'), { recursive: true })
+    // A module two hops deep also uses the alias — the config imports
+    // `helpers.ts`, which itself imports `lists.ts` via the alias.
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'opensaas', 'lists.ts'),
+      "export const lists = { hello: 'transitive' }\n",
+    )
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'opensaas', 'helpers.ts'),
+      "export { lists } from '@/opensaas/lists'\n",
+    )
+    fs.writeFileSync(
+      path.join(tempDir, 'opensaas.config.ts'),
+      "import { lists } from './src/opensaas/helpers'\nexport default { lists }\n",
+    )
+
+    const { alias } = resolveTsconfigAlias(tempDir)
+    const jiti = createJiti(tempDir, { interopDefault: true, alias })
+
+    const mod = (await jiti.import(path.join(tempDir, 'opensaas.config.ts'))) as {
+      default: { lists: { hello: string } }
+    }
+    expect(mod.default.lists).toEqual({ hello: 'transitive' })
+  })
+
+  it('fails to resolve the alias when no tsconfig.json is present (baseline without the fix)', async () => {
+    fs.mkdirSync(path.join(tempDir, 'src', 'opensaas'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tempDir, 'src', 'opensaas', 'lists.ts'),
+      "export const lists = { hello: 'world' }\n",
+    )
+    fs.writeFileSync(
+      path.join(tempDir, 'opensaas.config.ts'),
+      "import { lists } from '@/opensaas/lists'\nexport default { lists }\n",
+    )
+
+    const { alias } = resolveTsconfigAlias(tempDir)
+    expect(alias).toBeUndefined()
+
+    const jiti = createJiti(tempDir, { interopDefault: true, alias })
+    await expect(jiti.import(path.join(tempDir, 'opensaas.config.ts'))).rejects.toThrow()
+  })
+})

--- a/packages/cli/src/generator/tsconfig-alias.ts
+++ b/packages/cli/src/generator/tsconfig-alias.ts
@@ -1,0 +1,159 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Result of translating a project's `tsconfig.json` `compilerOptions.paths`
+ * into `jiti`'s `alias` option (issue #905).
+ */
+export interface TsconfigAliasResult {
+  /**
+   * Flat alias map for `createJiti`'s `alias` option, or `undefined` when
+   * there is nothing to alias (no `tsconfig.json`, no `paths`, or every
+   * `paths` entry was unrepresentable). Passing `undefined` through to
+   * `createJiti` is identical to omitting the option entirely.
+   */
+  alias: Record<string, string> | undefined
+  /**
+   * One message per `paths` entry that could not be translated, naming the
+   * pattern so the project owner knows which alias will not resolve.
+   */
+  warnings: string[]
+}
+
+/**
+ * `jiti` delegates alias resolution to `pathe`'s `resolveAlias`, which does
+ * plain prefix matching (`id.startsWith(key)` with a path-boundary check) —
+ * unlike `tsconfig` `paths`, which is a glob form allowing multiple candidate
+ * targets per pattern. This translation is therefore partial by design: it
+ * faithfully handles the common single-trailing-star, single-target case
+ * (`"@/*": ["./src/*"]`) by stripping the trailing `*` from both the pattern
+ * and its target and resolving the target against `baseUrl`. Any entry with
+ * more than one candidate target, or a pattern/target shape the alias model
+ * cannot represent (no star, a star that isn't the last character, multiple
+ * stars), is skipped and reported as a warning rather than silently dropped
+ * or faithfully reimplemented — full fidelity with TypeScript's resolver
+ * (`extends` chains, project references, conditional exports) is out of
+ * scope.
+ *
+ * A project with no `tsconfig.json`, or one with no `paths`, returns
+ * `{ alias: undefined, warnings: [] }` so callers behave exactly as they did
+ * before this translation existed.
+ */
+export function resolveTsconfigAlias(cwd: string): TsconfigAliasResult {
+  const tsconfigPath = path.join(cwd, 'tsconfig.json')
+  if (!fs.existsSync(tsconfigPath)) {
+    return { alias: undefined, warnings: [] }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripJsonComments(fs.readFileSync(tsconfigPath, 'utf-8')))
+  } catch {
+    return {
+      alias: undefined,
+      warnings: [
+        'tsconfig.json could not be parsed; path aliases in opensaas.config.ts will not be resolved.',
+      ],
+    }
+  }
+
+  const compilerOptions = getRecord(parsed, 'compilerOptions')
+  const paths = compilerOptions && getRecord(compilerOptions, 'paths')
+  if (!paths) {
+    return { alias: undefined, warnings: [] }
+  }
+
+  const baseUrl =
+    compilerOptions && typeof compilerOptions.baseUrl === 'string' ? compilerOptions.baseUrl : '.'
+  const baseDir = path.resolve(path.dirname(tsconfigPath), baseUrl)
+
+  const alias: Record<string, string> = {}
+  const warnings: string[] = []
+
+  for (const [pattern, targets] of Object.entries(paths)) {
+    if (!Array.isArray(targets) || targets.length !== 1 || typeof targets[0] !== 'string') {
+      warnings.push(
+        `tsconfig.json path "${pattern}" has ${Array.isArray(targets) ? targets.length : 0} candidate target(s); jiti's alias resolution only supports a single target, so this alias will not be resolved.`,
+      )
+      continue
+    }
+
+    const target = targets[0]
+    if (!isSingleTrailingStar(pattern) || !isSingleTrailingStar(target)) {
+      warnings.push(
+        `tsconfig.json path "${pattern}" -> "${target}" is not a single-trailing-"*" alias, which is the only form jiti's alias resolution can represent; this alias will not be resolved.`,
+      )
+      continue
+    }
+
+    const aliasKey = pattern.slice(0, -1)
+    const aliasTarget = path.resolve(baseDir, target.slice(0, -1))
+    alias[aliasKey] = aliasTarget
+  }
+
+  return { alias: Object.keys(alias).length > 0 ? alias : undefined, warnings }
+}
+
+/** True when `value` has exactly one `*`, and it is the final character. */
+function isSingleTrailingStar(value: string): boolean {
+  return value.length > 0 && value.indexOf('*') === value.length - 1
+}
+
+/** Read `obj[key]` as a plain record, or `undefined` if it isn't one. */
+function getRecord(obj: unknown, key: string): Record<string, unknown> | undefined {
+  if (typeof obj !== 'object' || obj === null || !(key in obj)) return undefined
+  const value = (obj as Record<string, unknown>)[key]
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+/**
+ * Strip `//` and `/* *‍/` comments and trailing commas from a JSONC string
+ * (tsconfig.json commonly contains both, which `JSON.parse` rejects).
+ * Comment-like sequences inside string literals are left untouched.
+ */
+function stripJsonComments(input: string): string {
+  let result = ''
+  let inString = false
+  let stringChar = ''
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+
+    if (inString) {
+      result += ch
+      if (ch === '\\') {
+        result += input[i + 1] ?? ''
+        i++
+        continue
+      }
+      if (ch === stringChar) inString = false
+      continue
+    }
+
+    if (ch === '"' || ch === "'") {
+      inString = true
+      stringChar = ch
+      result += ch
+      continue
+    }
+
+    if (ch === '/' && input[i + 1] === '/') {
+      while (i < input.length && input[i] !== '\n') i++
+      result += '\n'
+      continue
+    }
+
+    if (ch === '/' && input[i + 1] === '*') {
+      i += 2
+      while (i < input.length && !(input[i] === '*' && input[i + 1] === '/')) i++
+      i++ // land on the closing '/'
+      continue
+    }
+
+    result += ch
+  }
+
+  return result.replace(/,(\s*[}\]])/g, '$1')
+}

--- a/packages/cli/src/migration/introspectors/keystone-introspector.ts
+++ b/packages/cli/src/migration/introspectors/keystone-introspector.ts
@@ -8,6 +8,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import { createJiti } from 'jiti'
+import { resolveTsconfigAlias } from '../../generator/tsconfig-alias.js'
 import type { IntrospectedSchema, IntrospectedModel, IntrospectedField } from '../types.js'
 
 export interface KeystoneList {
@@ -57,10 +58,19 @@ export class KeystoneIntrospector {
     }
 
     try {
+      // Resolve tsconfig.json path aliases the same way the generate command
+      // does (#905), so an aliased value import in keystone.config.ts (or
+      // anything it imports) resolves here too.
+      const { alias, warnings } = resolveTsconfigAlias(cwd)
+      for (const warning of warnings) {
+        console.warn(`⚠️  ${warning}`)
+      }
+
       // Use jiti to load TypeScript config
       const jiti = createJiti(import.meta.url, {
         interopDefault: true,
         moduleCache: false,
+        alias,
       })
 
       const configModule = (await jiti.import(foundPath)) as { default?: unknown } | unknown


### PR DESCRIPTION
## Summary

- `opensaas generate` loaded `opensaas.config.ts` via `jiti` with no knowledge of the project's `tsconfig.json`, so a value import using a path alias (e.g. `@/*`) anywhere in the config's import closure failed with a bare `Cannot find module` error.
- Added `resolveTsconfigAlias()` (`packages/cli/src/generator/tsconfig-alias.ts`): reads the nearest `tsconfig.json`, and translates `compilerOptions.paths` into `jiti`'s flat, prefix-matching `alias` map (which itself delegates to `pathe`'s `resolveAlias`). Faithfully handles the common single-trailing-`*`, single-target case (`"@/*": ["./src/*"]`), resolved against `baseUrl`. A `paths` entry with multiple candidate targets, or a pattern shape the alias model can't represent, produces a warning naming the pattern and is skipped — generation continues.
- A project with no `tsconfig.json`, or no `paths`, resolves to `alias: undefined`, identical to omitting the option — no behavior change for existing projects.
- Wired the same resolution into `generate.ts`'s config loader and into the Keystone migration introspector (`keystone-introspector.ts`), which constructs its `jiti` loader the same way.
- `examples/starter-auth/opensaas.config.ts` no longer imports `Lists` through the `@/*` alias — switched to a relative specifier (`./.opensaas/lists`), since that aliased import only "worked" before because it was type-only and erased before `jiti` ever saw it; the template stops modelling a pattern that breaks the moment it becomes a value import.

## Test plan

- [x] New unit tests (`packages/cli/src/generator/tsconfig-alias.test.ts`): baseUrl handling, multiple patterns, multi-target warning, unsupported-pattern warning, mixed representable/unrepresentable entries, JSONC comments/trailing commas, unparseable JSON, no-tsconfig / no-paths cases
- [x] Integration tests using real `jiti` + a temp project: resolves a value import in the config through the alias, resolves the alias *transitively* through the config's own import closure, and confirms the same import fails without a `tsconfig.json` present (baseline)
- [x] `pnpm build` (core, auth, cli) and `pnpm test` for `packages/cli` (377 tests passing)
- [x] `pnpm lint` on changed files
- [x] Ran `opensaas generate` end-to-end against `examples/starter-auth` — succeeds; confirmed a pre-existing, unrelated Node-build diagnostic (staging dir doesn't include `.opensaas/lists.ts`) is unchanged before/after this PR
- [x] Changeset added (`@opensaas/stack-cli`: minor)

Closes #905


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5eAJvUVQUFHpdaf71tJo4)_