### PR TITLE
docs: default to no comments — add a Comments rule to CLAUDE.md and complete-issue

### DIFF
--- a/.claude/skills/complete-issue/SKILL.md
+++ b/.claude/skills/complete-issue/SKILL.md
@@ -27,6 +27,9 @@ Make a todo list for all the tasks below and work through them one at a time, ma
 - Use the `/tdd` skill for any non-trivial logic
 - Write failing tests first, then implement to make them pass
 - Keep changes focused on what the issue requires — no scope creep
+- **Write few comments.** See the "Comments" section of `CLAUDE.md` for the rule; the failure mode to watch for is specific to working this way. You will finish an issue holding a great deal of hard-won reasoning — why a threshold is 3 and not 5, which two options you weighed, what broke when you tried the obvious thing. The pull to write all of it down next to the code is strong, and it is the wrong destination. **That reasoning is what the PR body, the issue, the changeset and an ADR are for.** They are dated and reviewable; a docblock is neither, and it rots fastest beside the values most likely to change. If you catch yourself writing a paragraph to justify a line, move it to the PR body and leave the line bare.
+
+  Concretely, do not ship: a file header longer than a couple of lines, a docblock on a self-describing constant, a comment restating the line beneath it, or a note explaining why something is _absent_. If a comment would become false when someone edits the code below it, and no test would catch that, delete it. TSDoc on an exported config option, field builder, or plugin surface is the exception — that is the consumer's editor documentation, not narration.
 
 ### 4. Commit and Push
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1054,6 +1054,29 @@ model Teacher {
 - Prisma automatically creates join tables named `_relationName` when you use `@relation("relationName")`
 - For new projects, use the default Prisma naming unless you need Keystone compatibility or have specific naming requirements
 
+## Comments
+
+**Default to none.** The code says what it does; a good name says why it exists. A comment that restates either is a second copy of the truth that nothing keeps in sync — and prose is the only part of a file no test can falsify.
+
+A comment earns its place when it carries something the code **cannot**:
+
+- A constraint from outside the file — Prisma's behaviour, a Better-auth contract, a Next.js server/client boundary, a browser quirk, an upstream bug being worked around. Link it.
+- A warning where the obvious edit is the wrong one. `validation: { isRequired: true }` is an application-layer check and does **not** make the Prisma column non-null — that needs `db: { isNullable: false }`. The reader is about to make the mistake; the comment is the only thing in their way.
+- A **Known limits** block on a generator, migration script, or introspector, naming what it cannot handle. That is not derivable from the code — the code is precisely the part that does not handle those cases.
+
+Everything else that feels worth writing is **rationale, and rationale does not belong beside code.** Put it in an ADR (`docs/adr/`), the issue, the changeset, or the PR body. Those are dated, reviewed, and explicitly superseded when they stop being true. A docblock is none of those: it decays silently, and it decays fastest next to the values most likely to change.
+
+Two tests before keeping one:
+
+1. **Staleness.** If someone edits the line below, does the comment become false? If yes and no test would catch it, it is a liability, not documentation. `const MAX_BATCH = 3` annotated "Three, not 'a few'" becomes a lie the moment anyone writes `5`.
+2. **Restatement.** Does it say what the line already says? Delete the comment, not the line.
+
+**Never comment the absence of something.** No note explaining why there is no type annotation, no `// no-op`, no record of what the code used to be. Git holds that, and a reader who needs it can ask git.
+
+A file header should orient a reader in a line or two. If it needs a page, the explanation belongs in a doc or an ADR and the file should link to it — a nine-line docblock above `export const lists = {}` is the shape to avoid.
+
+**Public API docblocks are the deliberate exception.** Exported config options, field builders, and plugin surfaces carry TSDoc because it is what the consumer's editor shows — that is a contract, not a narration of the implementation beneath it.
+
 ## Development Workflow
 
 ### Making Changes to Core


### PR DESCRIPTION
## Summary

Stack code carries a lot of comments that restate the line beneath them, narrate absent code, or record rationale that would be better dated and reviewable somewhere else. This ports the Comments rule already in use in `enrolm8` (its `AGENTS.md` + `complete-issue` skill) into this repo, adapted to stack's surfaces.

- **`CLAUDE.md`** — a new top-level `## Comments` section: default to none; a comment earns its place only when it carries something the code cannot (an external constraint, a warning where the obvious edit is wrong, a Known-limits block on a generator or migration script). Rationale goes to an ADR, the issue, the changeset, or the PR body. Two tests before keeping a comment — staleness and restatement. Never comment the absence of something.
- **`.claude/skills/complete-issue/SKILL.md`** — a "Write few comments" bullet in the implementation step, naming the failure mode specific to finishing an issue: you end up holding a lot of hard-won reasoning and the pull to write it beside the code is strong, and wrong.

### Adapted for this repo

- The stack-specific "obvious edit is wrong" example is `validation: { isRequired: true }` (application-layer) vs `db: { isNullable: false }` (the column), rather than enrolm8's tenancy framing.
- Rationale destinations include **the changeset**, since that's a dated artefact this repo already requires per package change.
- Added an exception enrolm8 doesn't need: **TSDoc on exported config options, field builders and plugin surfaces stays.** That's the consumer's editor documentation and a public contract — this is a published library, so a blanket "default to none" without that carve-out would read as licence to strip the public API docs.

## Scope

Docs and agent guidance only — no `packages/*` changes (no changeset needed) and no `claude-plugins/*` changes (no plugin version bump). Prettier clean.

Applied to the `complete-issue` skill, which is the skill in this repo that writes code; there is no `create-issue` skill here.

## Test plan

- [x] `npx prettier --check` clean on both files
- [ ] N/A — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)