### PR TITLE
fix(core): afterTransaction hooks report the outermost transaction (ADR-0028)

### DIFF
--- a/.changeset/tame-goats-defer.md
+++ b/.changeset/tame-goats-defer.md
@@ -1,0 +1,33 @@
+---
+'@opensaas/stack-core': minor
+---
+
+`afterTransaction` now fires when the OUTERMOST transaction a write participates in settles, and can report `status: 'rolled-back'` where it always reported `'committed'` before (ADR-0028, fixes #899).
+
+A write that joins a transaction it did not open — inside `context.transaction()`, or a hook's own `context.db` write — used to fire its `afterTransaction` bracket optimistically as soon as its own write returned, even though the enclosing transaction was still open and could still roll back. It now defers that bracket until the transaction owner (`context.transaction()`, or the Write Pipeline when it opened the transaction) observes the real commit/rollback, then reports the outcome as a conjunction: `committed` if and only if the write itself succeeded **and** the enclosing transaction committed (the write's own error always wins over the transaction's outcome). `beforeTransaction` is unaffected — it still runs eagerly, before its write.
+
+```typescript
+User: list({
+  hooks: {
+    afterTransaction: async ({ status, item, error }) => {
+      if (status === 'rolled-back') {
+        // Now correctly fires even when this write itself succeeded but the
+        // OUTER context.transaction() callback later threw.
+        await billing.releaseSeat(error)
+      } else {
+        await billing.confirmSeat(item.seatId)
+      }
+    },
+  },
+})
+```
+
+Three behavior changes to be aware of when upgrading:
+
+- A `context.transaction()` call can now **reject** with `AfterTransactionError` even after its underlying transaction already committed, if a deferred `afterTransaction` hook throws. A transaction/serialization error (e.g. `P2034`) still takes precedence and propagates unwrapped, so an existing `P2034` retry loop is unaffected.
+- The deferred `item` a joined write's `afterTransaction` receives on commit is the row **as that write persisted it**, captured at write time — not re-read at flush — so it can be stale if a later write in the same transaction touches the same record.
+- Transaction-boundary hooks (`beforeTransaction`/`afterTransaction`) on a joined write now always receive a context bound to the base client, never the transaction client — matching what top-level writes already did.
+
+A write with no transaction owner at all (an app-managed `prisma.$transaction`, or a client that cannot open one, e.g. a bare test mock) is unaffected and still fires `afterTransaction` optimistically at write time.
+
+See `docs/adr/0028-a-transaction-boundary-hook-reports-the-outermost-transaction.md` and the "In-transaction vs transaction-boundary hooks" section of the hooks concept doc.

--- a/docs/content/concepts/hooks.md
+++ b/docs/content/concepts/hooks.md
@@ -161,6 +161,40 @@ hooks split into two families by where they run relative to that transaction:
     fires the bracket as a `create` involvement even though no row is written.
     Write your compensators to be **idempotent** so a no-op write is safe to
     compensate.
+  - **`afterTransaction` reports the OUTERMOST transaction, not the write's own
+    return (ADR-0028).** A write that joins a transaction it did not open — one
+    made inside `context.transaction()`, or a hook's own `context.db` write —
+    cannot itself observe when that enclosing transaction settles. Its
+    `afterTransaction` is deferred until the transaction owner
+    (`context.transaction()`, or the Write Pipeline when it opened the
+    transaction) observes the real settle, then fires with that outcome.
+    `beforeTransaction` stays eager in every case — only the paired
+    `afterTransaction` is deferred.
+    - **Status is a conjunction:** `committed` if and only if the write itself
+      succeeded **and** the enclosing transaction committed; otherwise
+      `rolled-back`. A write's own error always wins over the transaction's
+      outcome — a write that failed on its own reports `rolled-back` even if
+      everything else in the transaction went on to commit.
+    - **The deferred `item` is stale-safe, not stale-free.** It is the row as
+      that write persisted it, captured at write time — not re-read at flush —
+      so a later write to the same record in the same transaction leaves it
+      stale in what the compensator sees.
+    - **A rejected `context.transaction()` no longer implies rollback.** If the
+      transaction commits and a deferred `afterTransaction` then throws,
+      `context.transaction()` rejects with `AfterTransactionError` over data
+      that is already final. A transaction/serialization error (e.g. `P2034`)
+      still takes precedence and propagates unwrapped — a retry loop that
+      catches broadly should not treat every rejection as "not committed".
+    - **`beforeTransaction` can now run with the transaction already open.**
+      Under `context.transaction()` it runs on the write's way in, so it holds
+      that transaction open for its duration. Keep it fast, or hoist slow
+      external work above `context.transaction()` — a `context.db` write from
+      inside it can otherwise block on rows the transaction itself is writing.
+    - **A write with no transaction owner at all** (an application managing its
+      own `prisma.$transaction`, or a client that cannot open one — e.g. a bare
+      test mock, with no `context.transaction()` wrapping it) still fires
+      `afterTransaction` optimistically at write time, exactly as before — there
+      is no owner to defer to and no settle to wait for.
 
 ### Compensation pattern
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -170,6 +170,27 @@ Key points:
 - If the client cannot open an interactive transaction (e.g. a test mock, or you
   are already inside one), `fn` runs directly with identical hook/access
   semantics. See ADR-0012.
+- **A transaction-boundary `afterTransaction` reports the OUTERMOST transaction,
+  not its own write's return (ADR-0028).** A write nested in `context.transaction()`
+  (or a hook's own `context.db` write) cannot itself observe when the enclosing
+  transaction settles, so its `afterTransaction` is deferred until the owner —
+  `context.transaction()`, or the Write Pipeline when it opened the transaction —
+  observes the real commit/rollback. `beforeTransaction` stays eager in every
+  case, so under `context.transaction()` it runs with that transaction already
+  open (keep it fast; a `context.db` write from it can block on rows the
+  transaction itself is writing). Status is a conjunction — `committed` iff the
+  write itself succeeded AND the enclosing transaction committed, the write's
+  own error always winning otherwise — and the deferred `item` is the row as
+  that write persisted it, not re-read at flush (so a later same-record write in
+  the same transaction leaves it stale). Because of this, a **rejected
+  `context.transaction()` no longer implies rollback**: a deferred hook that
+  throws after a successful commit rejects the call with `AfterTransactionError`
+  over already-final data, though a transaction/serialization error (e.g.
+  `P2034`) still takes precedence and propagates unwrapped. A write with no
+  transaction owner at all (an app-managed `prisma.$transaction`, or a client —
+  e.g. a bare test mock — that cannot open one) still fires `afterTransaction`
+  optimistically at write time, unchanged. See ADR-0028 and the hooks concept
+  doc.
 
 ### Generators (`src/generator/`)
 

--- a/packages/core/src/access/transaction-registry.ts
+++ b/packages/core/src/access/transaction-registry.ts
@@ -1,0 +1,59 @@
+/**
+ * Deferral registry for transaction-boundary hooks on a JOINED write (ADR-0028,
+ * issue #899).
+ *
+ * A write that joins a transaction it did not open — because the client it was
+ * handed exposes no way to open one (a Prisma transaction client, or a plain
+ * write issued from a hook whose context is rebound to one) — cannot itself
+ * observe when the enclosing transaction settles. Instead of firing
+ * `afterTransaction` optimistically at write time, it enqueues a flush here.
+ * The transaction owner (`context.transaction()`, or the Write Pipeline when it
+ * actually opens the transaction) drains the queue, in enqueue (write) order,
+ * once it observes its own transaction settle — supplying the real
+ * committed/rolled-back outcome.
+ *
+ * This is internal plumbing with no public surface: it is threaded through the
+ * same context-rebind path ADR-0010/0012 already use for `plugins` and
+ * `_resolveOutputChain` (see `AccessContext['_transactionOwner']`), never
+ * exposed on the public `StackContext` type.
+ */
+
+/**
+ * The outcome the transaction OWNER observed for the transaction as a whole —
+ * distinct from a single write's own {@link import('../hooks/index.js').TransactionOutcome},
+ * which additionally carries that write's own persisted `item` or `error`.
+ */
+export interface TransactionSettleOutcome {
+  status: 'committed' | 'rolled-back'
+  error?: unknown
+}
+
+/**
+ * One deferred write's flush: given the owner's settle outcome, runs that
+ * write's `afterTransaction` bracket and appends any hook errors to `errors`.
+ */
+export type QueuedTransactionFlush = (
+  settle: TransactionSettleOutcome,
+  errors: unknown[],
+) => Promise<void>
+
+/**
+ * A FIFO queue of deferred transaction-boundary flushes, owned by whichever
+ * component opened the enclosing transaction. One registry per owned
+ * transaction; a nested `context.transaction()` joins its enclosing owner's
+ * registry rather than creating a second one.
+ */
+export class TransactionRegistry {
+  private readonly queue: QueuedTransactionFlush[] = []
+
+  enqueue(flush: QueuedTransactionFlush): void {
+    this.queue.push(flush)
+  }
+
+  /** Run every queued flush, in enqueue order, against the settled outcome. */
+  async drain(settle: TransactionSettleOutcome, errors: unknown[]): Promise<void> {
+    for (const flush of this.queue) {
+      await flush(settle, errors)
+    }
+  }
+}

--- a/packages/core/src/access/types.ts
+++ b/packages/core/src/access/types.ts
@@ -1,4 +1,5 @@
 import type { Fragment, FieldSelection, ResultOf } from '../query/index.js'
+import type { TransactionRegistry } from './transaction-registry.js'
 
 /**
  * Session interface - can be augmented by developers to add custom fields
@@ -303,6 +304,17 @@ export interface AccessContext<TPrisma extends PrismaClientLike = PrismaClientLi
    * in CONTEXT.md.
    */
   _resolveOutputChain: readonly { listKey: string; fieldKey: string }[]
+  /**
+   * Present when this context is JOINED into an enclosing transaction it did
+   * not open (ADR-0028, #899) — set by `context.transaction()`, or by the
+   * Write Pipeline when it opens the transaction the current write's hooks
+   * are rebound into. A write reached through a context carrying this defers
+   * its `afterTransaction` bracket to the registry instead of firing it at
+   * write time; `undefined` for a top-level context with no owner. Threaded
+   * through the same context-rebind path as `plugins`/`_resolveOutputChain`.
+   * @internal
+   */
+  _transactionOwner?: TransactionRegistry
 }
 
 /**

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -24,6 +24,9 @@ import {
   updateWriteStrategy,
   deleteWriteStrategy,
 } from './write-pipeline.js'
+import { AfterTransactionError } from './transaction-boundary.js'
+import { TransactionRegistry } from '../access/transaction-registry.js'
+import type { TransactionSettleOutcome } from '../access/transaction-registry.js'
 
 export type ServerActionProps =
   | { listKey: string; action: 'create'; data: Record<string, unknown> }
@@ -382,6 +385,36 @@ export interface StackContext<TPrisma extends PrismaClientLike = PrismaClientLik
 }
 
 /**
+ * Drain a `context.transaction()` owner's deferral registry once its callback
+ * (and any real underlying transaction) has settled (ADR-0028), then apply the
+ * existing error-precedence rule: a transaction/callback error always wins
+ * (compensators still all ran, but their errors are discarded in favor of
+ * re-surfacing the original — matching the Write Pipeline's `txError`
+ * precedence); otherwise, any deferred `afterTransaction` errors reject the
+ * call with {@link AfterTransactionError} even though the callback itself
+ * succeeded and the transaction committed.
+ */
+async function settleTransactionOwner<T>(
+  settled: Promise<T>,
+  registry: TransactionRegistry,
+): Promise<T> {
+  const errors: unknown[] = []
+  let result: T
+  try {
+    result = await settled
+  } catch (err) {
+    const outcome: TransactionSettleOutcome = { status: 'rolled-back', error: err }
+    await registry.drain(outcome, errors)
+    throw err
+  }
+  await registry.drain({ status: 'committed' }, errors)
+  if (errors.length > 0) {
+    throw new AfterTransactionError(errors)
+  }
+  return result
+}
+
+/**
  * Create an access-controlled context
  *
  * @param config - OpenSaas configuration
@@ -401,6 +434,10 @@ export function getContext<
   // Internal: when rebuilding the context against a transaction client, reuse the
   // already-initialised plugin services rather than re-running plugin runtimes.
   _sharedPlugins?: Record<string, unknown>,
+  // Internal (ADR-0028, #899): when rebuilding the context for a transaction
+  // owner's callback body, carry the deferral registry so writes reached
+  // through this context join it instead of firing afterTransaction eagerly.
+  _transactionOwner?: TransactionRegistry,
 ): StackContext<TPrisma> {
   // Initialize db object - will be populated with access-controlled operations
   // Type is intentionally broad to allow dynamic model access
@@ -439,6 +476,7 @@ export function getContext<
     plugins: _sharedPlugins ?? {},
     _isSudo,
     _resolveOutputChain: [],
+    _transactionOwner,
   }
 
   // Create access-controlled operations for each list, populating `db` in place.
@@ -806,31 +844,80 @@ export function getContext<
   // Sudo function - creates a new context that bypasses access control
   // but still executes all hooks and validation
   function sudo(): StackContext<TPrisma> {
-    return getContext(config, prisma, session, context.storage, true)
+    return getContext(
+      config,
+      prisma,
+      session,
+      context.storage,
+      true,
+      undefined,
+      // ADR-0028: a sudo write issued from inside an owned transaction (e.g.
+      // `tx.sudo().db.x.create()`) must still defer to that owner.
+      context._transactionOwner,
+    )
   }
 
-  // Interactive, hook-firing transaction (#614). Rebinds the access-controlled
-  // context to the transaction client so every `txContext.db.*` write runs its
-  // access checks + hooks but persists inside ONE transaction (atomic). The
-  // transaction `options` (e.g. `isolationLevel`) pass through to Prisma, and a
-  // serialization failure thrown inside the callback propagates to the caller
-  // for retry (it is never converted to a silent `null`).
+  // Interactive, hook-firing transaction (#614, ADR-0028 / #899). Rebinds the
+  // access-controlled context to the transaction client so every
+  // `txContext.db.*` write runs its access checks + hooks but persists inside
+  // ONE transaction (atomic). The transaction `options` (e.g. `isolationLevel`)
+  // pass through to Prisma, and a serialization failure thrown inside the
+  // callback propagates to the caller for retry (it is never converted to a
+  // silent `null`).
+  //
+  // This call OWNS a deferral registry for its callback's writes (ADR-0028):
+  // it always observes when its own callback settles — resolve/reject — even
+  // when the underlying client cannot open a real interactive transaction, so
+  // every `txContext.db.*` write defers its transaction-boundary bracket here
+  // instead of firing eagerly, and this call flushes them with the real
+  // outcome once the callback (and any real transaction) has settled. A
+  // `transaction()` nested inside another joins the outer owner's queue
+  // rather than creating a second one.
   function transaction<T>(
     fn: (txContext: StackContext<TPrisma>) => Promise<T>,
     options?: TransactionOptions,
   ): Promise<T> {
-    const client = prisma as unknown as TransactionCapable<TPrisma>
-    if (typeof client.$transaction !== 'function') {
-      // No interactive transaction available — either a plain client/mock or we
-      // are already inside a transaction (a Prisma tx client exposes no
-      // `$transaction`). Run directly: hook/access semantics are identical and
-      // atomicity is provided by any enclosing transaction.
+    if (context._transactionOwner) {
       return fn(returned)
     }
-    return client.$transaction(
-      (tx) => fn(getContext(config, tx, session, context.storage, _isSudo, context.plugins)),
-      options,
-    ) as Promise<T>
+
+    const registry = new TransactionRegistry()
+    const client = prisma as unknown as TransactionCapable<TPrisma>
+
+    const settled =
+      typeof client.$transaction !== 'function'
+        ? // No interactive transaction available — either a plain client/mock or
+          // we are already inside a transaction (a Prisma tx client exposes no
+          // `$transaction`). Run directly: hook/access semantics are identical
+          // and atomicity is provided by any enclosing transaction.
+          fn(
+            getContext(
+              config,
+              prisma,
+              session,
+              context.storage,
+              _isSudo,
+              context.plugins,
+              registry,
+            ),
+          )
+        : (client.$transaction(
+            (tx) =>
+              fn(
+                getContext(
+                  config,
+                  tx,
+                  session,
+                  context.storage,
+                  _isSudo,
+                  context.plugins,
+                  registry,
+                ),
+              ),
+            options,
+          ) as Promise<T>)
+
+    return settleTransactionOwner(settled, registry)
   }
 
   const returned: StackContext<TPrisma> = {

--- a/packages/core/src/context/transaction-boundary.ts
+++ b/packages/core/src/context/transaction-boundary.ts
@@ -9,6 +9,10 @@ import {
   type TransactionOutcome,
 } from '../hooks/index.js'
 import type { WriteOperation } from './write-pipeline.js'
+import type {
+  TransactionRegistry,
+  TransactionSettleOutcome,
+} from '../access/transaction-registry.js'
 
 /**
  * Transaction-boundary hooks (#590 / ADR-0010).
@@ -283,8 +287,12 @@ async function runBeforeTransactionForList<TPrisma extends PrismaClientLike>(
  * Run the list- and field-level `afterTransaction` hooks for one involved list
  * with the settled {@link TransactionOutcome}. Collects (does not throw) any
  * errors so the caller can keep running the remaining lists' compensators.
+ *
+ * Exported for {@link TransactionRegistry}-drained (deferred, joined-write)
+ * flushes, which run this same per-list logic once the transaction owner
+ * observes the real settle (ADR-0028).
  */
-async function runAfterTransactionForList<TPrisma extends PrismaClientLike>(
+export async function runAfterTransactionForList<TPrisma extends PrismaClientLike>(
   involved: InvolvedList,
   outcome: TransactionOutcome,
   context: AccessContext<TPrisma>,
@@ -401,29 +409,63 @@ export class AfterTransactionError extends Error {
 }
 
 /**
- * Bracket a write's transaction with the transaction-boundary hooks (#590).
+ * Compute a joined write's FINAL outcome once its owner's settle is known
+ * (ADR-0028): the write's own error always wins (it never fires early — see
+ * the ADR's provider-dependent-early-settle rejection); otherwise the write
+ * committed if and only if the owner's transaction also committed.
+ */
+function resolveDeferredOutcome(
+  writeOutcome: TransactionOutcome,
+  settle: TransactionSettleOutcome,
+): TransactionOutcome {
+  if (writeOutcome.status === 'rolled-back') return writeOutcome
+  if (settle.status === 'committed') return writeOutcome
+  return { status: 'rolled-back', error: settle.error }
+}
+
+/**
+ * Bracket a write's transaction with the transaction-boundary hooks (#590,
+ * ADR-0028 / #899).
  *
  * Sequence:
  *  1. Run every involved list's `beforeTransaction` in order, tracking which
- *     ran. A throw aborts: the transaction is NEVER opened; `afterTransaction`
- *     fires (status `rolled-back`, with the throw as `error`) ONLY for the lists
- *     whose `beforeTransaction` already ran (symmetric bracket), and the throw
- *     is then re-surfaced.
- *  2. Otherwise open the transaction via `runTransaction` (the existing #569
- *     machinery). On settle (commit or rollback) run `afterTransaction` for
- *     EVERY involved list (all of their `beforeTransaction` ran) with the
- *     outcome.
- *  3. If any `afterTransaction` throws, the rest still run; the collected
- *     errors are surfaced afterward as an {@link AfterTransactionError}.
+ *     ran (always eager — ADR-0028 keeps the symmetric bracket's "before" half
+ *     synchronous even for a joined write). A throw aborts: the transaction is
+ *     NEVER opened, and the throw is re-surfaced.
+ *  2. Otherwise run `runTransaction` (the existing #569 machinery — opens a
+ *     real transaction, joins one already open, or runs directly against a
+ *     client with no transaction support at all).
+ *  3. What happens to `afterTransaction` next depends on ownership:
+ *     - **Joined** (`args.joinedOwner` set — this write's context is nested in
+ *       a transaction it did not open): its bracket is DEFERRED — enqueued on
+ *       the owner's {@link TransactionRegistry} instead of firing now. The
+ *       owner drains it once it observes the real settle, at which point
+ *       {@link resolveDeferredOutcome} decides the final status.
+ *     - **Owner** (`args.ownedRegistry` set — this write just opened the
+ *       transaction every joined write below it shares): runs its own bracket
+ *       eagerly exactly as before, THEN drains `ownedRegistry` with the same
+ *       settle outcome so every write that joined this transaction gets its
+ *       deferred bracket flushed too.
+ *     - **Unowned** (neither set — no `context.transaction()` and no real
+ *       transaction to open, e.g. a bare test double): unchanged, fires
+ *       eagerly at write time (the "unowned join" case — there is no owner to
+ *       defer to and no settle signal to wait for).
+ *  4. If any `afterTransaction` throws, the rest still run; the collected
+ *     errors are surfaced afterward as an {@link AfterTransactionError} — for
+ *     a joined write this surfaces from the OWNER's promise, not this write's.
  *
  * Sudo does not affect these hooks — they always run; sudo only bypasses access.
  */
 export async function runWithTransactionBoundary<TPrisma extends PrismaClientLike>(args: {
   involvedLists: InvolvedList[]
   context: AccessContext<TPrisma>
+  /** Set when this write is nested in a transaction it did not open (ADR-0028). */
+  joinedOwner?: TransactionRegistry
+  /** Set when this write just opened the transaction joined writes below it share. */
+  ownedRegistry?: TransactionRegistry
   runTransaction: () => Promise<Record<string, unknown> | null>
 }): Promise<Record<string, unknown> | null> {
-  const { involvedLists, context, runTransaction } = args
+  const { involvedLists, context, joinedOwner, ownedRegistry, runTransaction } = args
 
   // Lists whose beforeTransaction ran (in order), for the symmetric bracket. A
   // list is marked as "ran" the moment its beforeTransaction BEGINS, so even a
@@ -446,14 +488,25 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
   // lists whose beforeTransaction ran, then surface the original error.
   if (beforeError !== undefined) {
     const outcome: TransactionOutcome = { status: 'rolled-back', error: beforeError }
-    const afterErrors: unknown[] = []
-    for (const involved of ran) {
-      await runAfterTransactionForList(involved, outcome, context, afterErrors)
+    if (joinedOwner) {
+      // Deferred: matches the eager branch below, which also discards any
+      // afterTransaction errors on this path (only beforeError propagates).
+      joinedOwner.enqueue(async (_settle, _errors) => {
+        const discarded: unknown[] = []
+        for (const involved of ran) {
+          await runAfterTransactionForList(involved, outcome, context, discarded)
+        }
+      })
+    } else {
+      const afterErrors: unknown[] = []
+      for (const involved of ran) {
+        await runAfterTransactionForList(involved, outcome, context, afterErrors)
+      }
     }
     throw beforeError
   }
 
-  // Open the transaction and capture the settle outcome.
+  // Open (or join) the transaction and capture THIS WRITE's own settle outcome.
   let outcome: TransactionOutcome
   let result: Record<string, unknown> | null = null
   let txError: unknown
@@ -465,6 +518,20 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
     outcome = { status: 'rolled-back', error: err }
   }
 
+  if (joinedOwner) {
+    // Deferred (ADR-0028): this write cannot observe the enclosing
+    // transaction's real settle, so its bracket is queued rather than fired.
+    // The write's own result/throw is unaffected — only afterTransaction waits.
+    joinedOwner.enqueue(async (settle, errors) => {
+      const finalOutcome = resolveDeferredOutcome(outcome, settle)
+      for (const involved of ran) {
+        await runAfterTransactionForList(involved, finalOutcome, context, errors)
+      }
+    })
+    if (txError !== undefined) throw txError
+    return result
+  }
+
   // afterTransaction always runs for every list whose beforeTransaction ran
   // (here: all involved lists). All compensators run even if one throws.
   const afterErrors: unknown[] = []
@@ -472,8 +539,17 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
     await runAfterTransactionForList(involved, outcome, context, afterErrors)
   }
 
+  // This write OWNS the transaction every joined write below it shares — drain
+  // their deferred brackets now, with the same settle outcome this write just
+  // observed (ADR-0028).
+  if (ownedRegistry) {
+    const settle: TransactionSettleOutcome =
+      txError !== undefined ? { status: 'rolled-back', error: txError } : { status: 'committed' }
+    await ownedRegistry.drain(settle, afterErrors)
+  }
+
   // Surface errors: the transaction's own error takes precedence (the write
-  // failed); otherwise any afterTransaction errors.
+  // failed); otherwise any afterTransaction errors (own + drained).
   if (txError !== undefined) throw txError
   if (afterErrors.length > 0) throw new AfterTransactionError(afterErrors)
 

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -19,6 +19,7 @@ import { hookPipeline } from './hook-pipeline.js'
 import { processNestedOperations, runAfterTasks } from './nested-operations.js'
 import type { AfterTask } from './nested-operations.js'
 import { enumerateInvolvedLists, runWithTransactionBoundary } from './transaction-boundary.js'
+import { TransactionRegistry } from '../access/transaction-registry.js'
 import { getDbKey } from '../lib/case-utils.js'
 // NOTE: `index.ts` imports from this module too — this is an intentional cyclic
 // dependency. It is safe because `buildDbDelegate` is only INVOKED at write
@@ -256,12 +257,30 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
     config,
   })
 
+  // ── Transaction ownership for the transaction-boundary hooks (ADR-0028) ────
+  // A write already reached through a context carrying `_transactionOwner` is
+  // itself JOINING an enclosing transaction it did not open (a nested
+  // `context.transaction()`, or a hook's own `context.db` write) — regardless
+  // of whether `prisma` here happens to still expose `$transaction`, it must
+  // defer to that owner rather than opening a second transaction. Otherwise,
+  // if `prisma` can open a real interactive transaction, THIS write becomes
+  // the owner: it creates the registry every joined write below it (including
+  // hook-issued writes reached via `bindContextToTransaction`) enqueues into.
+  const existingOwner = context._transactionOwner
+  const opensOwnTransaction =
+    !existingOwner && typeof (prisma as TransactionCapable).$transaction === 'function'
+  const ownedRegistry = opensOwnTransaction ? new TransactionRegistry() : undefined
+  const transactionOwnerForBody = existingOwner ?? ownedRegistry
+
   // ── Bracket the transaction with beforeTransaction/afterTransaction (#590) ──
   // beforeTransaction runs before the transaction opens; afterTransaction runs
-  // after it settles (commit or rollback), per the symmetric-bracket rule.
+  // after it settles (commit or rollback) — deferred to the owner for a joined
+  // write (ADR-0028), per the symmetric-bracket rule.
   return runWithTransactionBoundary({
     involvedLists,
     context,
+    joinedOwner: existingOwner,
+    ownedRegistry,
     runTransaction: () =>
       // ADR-0010: every write runs inside ONE interactive transaction. The
       // parent and ALL nested writes share this transaction's client `tx` as
@@ -282,7 +301,10 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
           // survive a rollback. Rebind the context's `db` (and `prisma`) to the
           // transaction client `tx` so before/afterOperation `context.db` writes
           // participate in — and roll back with — this write's transaction.
-          context: bindContextToTransaction(args, tx),
+          // Also carries the transaction owner (ADR-0028) so any such write
+          // defers its own transaction-boundary bracket instead of firing it
+          // before this transaction has actually settled.
+          context: bindContextToTransaction(args, tx, transactionOwnerForBody),
         }),
       ),
   })
@@ -301,10 +323,15 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
  * write issued from inside a `resolveOutput` hook keeps that hook's chain).
  * Plugin runtimes are NOT re-executed; the existing `plugins` object is
  * reused as-is.
+ *
+ * `transactionOwner` (ADR-0028) is carried onto the rebuilt context so a hook
+ * that issues its own `context.db` write from inside this transaction defers
+ * its transaction-boundary bracket to that owner instead of firing eagerly.
  */
 function bindContextToTransaction<TPrisma extends PrismaClientLike>(
   args: WritePipelineArgs<TPrisma>,
   tx: TPrisma,
+  transactionOwner: TransactionRegistry | undefined,
 ): AccessContext<TPrisma> {
   const { context, config } = args
   const txContext: AccessContext<TPrisma> = {
@@ -315,6 +342,7 @@ function bindContextToTransaction<TPrisma extends PrismaClientLike>(
     plugins: context.plugins,
     _isSudo: context._isSudo,
     _resolveOutputChain: context._resolveOutputChain,
+    _transactionOwner: transactionOwner,
   }
   // Rebuild the db delegate against `tx`, pointing back at `txContext` so hooks
   // reached through it also see the transactional context.

--- a/packages/core/tests/transaction-boundary-outermost.test.ts
+++ b/packages/core/tests/transaction-boundary-outermost.test.ts
@@ -1,0 +1,530 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import { config, list } from '../src/config/index.js'
+import { text, relationship } from '../src/fields/index.js'
+
+/**
+ * ADR-0028 / #899: a transaction-boundary hook reports the OUTERMOST
+ * transaction a write participates in, not the return of its own write.
+ *
+ * A write that joins a transaction it did not open (a JOINED write — either
+ * inside `context.transaction()`, or a hook's own `context.db` write inside a
+ * plain top-level write) defers its `afterTransaction` bracket until the
+ * transaction OWNER observes the real settle, instead of firing immediately.
+ *
+ * Per the ADR's verification note, these tests use a FAITHFUL transaction
+ * mock — the `tx` client handed to `$transaction`'s callback omits
+ * `$transaction` itself, mirroring real Prisma — because the bug is invisible
+ * under a mock whose transaction client still exposes `$transaction` (a
+ * nested write would open its own transaction rather than joining).
+ */
+
+function createFaithfulTxPrisma(extraTables: string[] = []) {
+  const tables: Record<string, Map<string, Record<string, unknown>>> = {
+    post: new Map(),
+    user: new Map(),
+    comment: new Map(),
+  }
+  for (const table of extraTables) tables[table] = new Map()
+  let idCounter = 0
+  const nextId = () => `id-${++idCounter}`
+
+  function applyNested(
+    table: string,
+    record: Record<string, unknown>,
+    data: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const result = { ...record }
+    for (const [key, value] of Object.entries(data)) {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const nested = value as Record<string, unknown>
+        if (nested.create || nested.update || nested.delete || nested.connect) {
+          const relTable = key === 'author' ? 'user' : key === 'comments' ? 'comment' : key
+          if (nested.create) {
+            const created = doCreate(relTable, nested.create as Record<string, unknown>)
+            result[key] = created
+          }
+          if (nested.update) {
+            const upd = nested.update as { where: { id: string }; data: Record<string, unknown> }
+            result[key] = doUpdate(relTable, upd.where, upd.data)
+          }
+          if (nested.delete) {
+            doDelete(relTable, nested.delete as { id: string })
+            result[key] = null
+          }
+          continue
+        }
+      }
+      result[key] = value
+    }
+    return result
+  }
+
+  function doCreate(table: string, data: Record<string, unknown>): Record<string, unknown> {
+    const id = (data.id as string) ?? nextId()
+    let record: Record<string, unknown> = { id }
+    record = applyNested(table, record, data)
+    tables[table].set(id, record)
+    return record
+  }
+
+  function doUpdate(
+    table: string,
+    where: { id: string },
+    data: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const existing = tables[table].get(where.id) ?? { id: where.id }
+    const updated = applyNested(table, existing, data)
+    tables[table].set(where.id, updated)
+    return updated
+  }
+
+  function doDelete(table: string, where: { id: string }): Record<string, unknown> {
+    const existing = tables[table].get(where.id) ?? { id: where.id }
+    tables[table].delete(where.id)
+    return existing
+  }
+
+  function makeModel(table: string) {
+    return {
+      findUnique: vi.fn(
+        async ({ where }: { where: { id: string } }) => tables[table].get(where.id) ?? null,
+      ),
+      findFirst: vi.fn(async ({ where }: { where?: { id?: string } } = {}) => {
+        if (where?.id) return tables[table].get(where.id) ?? null
+        return tables[table].values().next().value ?? null
+      }),
+      findMany: vi.fn(async () => Array.from(tables[table].values())),
+      count: vi.fn(async () => tables[table].size),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => doCreate(table, data)),
+      update: vi.fn(
+        async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) =>
+          doUpdate(table, where, data),
+      ),
+      delete: vi.fn(async ({ where }: { where: { id: string } }) => doDelete(table, where)),
+    }
+  }
+
+  const client: Record<string, unknown> = {
+    post: makeModel('post'),
+    user: makeModel('user'),
+    comment: makeModel('comment'),
+  }
+  for (const table of extraTables) client[table] = makeModel(table)
+
+  client.$transaction = async (fn: (tx: unknown) => Promise<unknown>) => {
+    const snapshot: Record<string, Map<string, Record<string, unknown>>> = {}
+    for (const [name, map] of Object.entries(tables)) {
+      snapshot[name] = new Map(map)
+    }
+    // Faithful to real Prisma: the tx client has the model delegates but NOT
+    // `$transaction` — this is how a nested write detects it must join rather
+    // than open a second transaction.
+    const { $transaction: _omit, ...models } = client
+    void _omit
+    try {
+      return await fn(models)
+    } catch (err) {
+      for (const [name, map] of Object.entries(snapshot)) {
+        tables[name] = map
+      }
+      throw err
+    }
+  }
+
+  return { client, tables }
+}
+
+const baseConfig = (hooks: {
+  user?: Record<string, unknown>
+  post?: Record<string, unknown>
+  comment?: Record<string, unknown>
+}) =>
+  config({
+    db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+    lists: {
+      User: list({
+        fields: { name: text() },
+        access: { operation: { query: () => true, create: () => true, update: () => true } },
+        hooks: hooks.user,
+      }),
+      Post: list({
+        fields: { title: text(), author: relationship({ ref: 'User.posts' }) },
+        access: { operation: { query: () => true, create: () => true, update: () => true } },
+        hooks: hooks.post,
+      }),
+      Comment: list({
+        fields: { body: text() },
+        access: { operation: { query: () => true, create: () => true, update: () => true } },
+        hooks: hooks.comment,
+      }),
+    },
+  })
+
+describe('ADR-0028 / #899: context.transaction() joined writes defer to the owner settle', () => {
+  let mock: ReturnType<typeof createFaithfulTxPrisma>
+
+  beforeEach(() => {
+    mock = createFaithfulTxPrisma()
+    vi.clearAllMocks()
+  })
+
+  it('commit: afterTransaction fires once, AFTER the callback returns, with status committed', async () => {
+    const events: string[] = []
+    const after = vi.fn(() => events.push('after'))
+
+    const testConfig = await baseConfig({ user: { afterTransaction: after } })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    const result = await context.transaction(async (tx) => {
+      const user = await tx.db.user.create({ data: { name: 'jane' } })
+      events.push('callback-write-done')
+      // afterTransaction must NOT have fired yet — the outer transaction has
+      // not settled while the callback is still running.
+      expect(after).not.toHaveBeenCalled()
+      return user
+    })
+
+    expect(events).toEqual(['callback-write-done', 'after'])
+    expect(after).toHaveBeenCalledTimes(1)
+    const arg = after.mock.calls[0][0]
+    expect(arg.status).toBe('committed')
+    expect(arg.item).toEqual(expect.objectContaining({ name: 'jane' }))
+    expect(result).toEqual(expect.objectContaining({ name: 'jane' }))
+  })
+
+  it('rollback: afterTransaction fires exactly once with status rolled-back and the callback error', async () => {
+    const after = vi.fn()
+    const testConfig = await baseConfig({ user: { afterTransaction: after } })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await expect(
+      context.transaction(async (tx) => {
+        await tx.db.user.create({ data: { name: 'jane' } })
+        throw new Error('callback boom')
+      }),
+    ).rejects.toThrow('callback boom')
+
+    expect(after).toHaveBeenCalledTimes(1)
+    const arg = after.mock.calls[0][0]
+    expect(arg.status).toBe('rolled-back')
+    expect(arg.error).toBeInstanceOf(Error)
+    expect((arg.error as Error).message).toBe('callback boom')
+    expect(arg.item).toBeUndefined()
+    expect(mock.tables.user.size).toBe(0)
+  })
+
+  it('beforeTransaction stays eager: runs during the callback, before the write settles', async () => {
+    const order: string[] = []
+    const testConfig = await baseConfig({
+      user: {
+        beforeTransaction: () => order.push('before'),
+        afterTransaction: () => order.push('after'),
+      },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await context.transaction(async (tx) => {
+      order.push('callback-start')
+      await tx.db.user.create({ data: { name: 'jane' } })
+      order.push('callback-end')
+    })
+
+    expect(order).toEqual(['callback-start', 'before', 'callback-end', 'after'])
+  })
+
+  it('three writes to the same list in one transaction flush in write order', async () => {
+    const order: string[] = []
+    const testConfig = await baseConfig({
+      user: {
+        beforeTransaction: ({ inputData }) => order.push(`before:${inputData?.name}`),
+        afterTransaction: ({ inputData }) => order.push(`after:${inputData?.name}`),
+      },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await context.transaction(async (tx) => {
+      await tx.db.user.create({ data: { name: 'a' } })
+      await tx.db.user.create({ data: { name: 'b' } })
+      await tx.db.user.create({ data: { name: 'c' } })
+    })
+
+    expect(order).toEqual(['before:a', 'before:b', 'before:c', 'after:a', 'after:b', 'after:c'])
+  })
+
+  it("a write's own error takes precedence over the transaction's outcome even when the transaction commits", async () => {
+    const userAfter = vi.fn()
+    const postAfter = vi.fn()
+    // A dedicated config: User.name is required, so a create with no `name`
+    // throws ValidationError — the write's OWN failure — independent of
+    // whatever the surrounding transaction ultimately does.
+    const testConfig = await config({
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        User: list({
+          fields: { name: text({ validation: { isRequired: true } }) },
+          access: { operation: { query: () => true, create: () => true } },
+          hooks: { afterTransaction: userAfter },
+        }),
+        Post: list({
+          fields: { title: text() },
+          access: { operation: { query: () => true, create: () => true } },
+          hooks: { afterTransaction: postAfter },
+        }),
+      },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    const result = await context.transaction(async (tx) => {
+      let userError: unknown
+      try {
+        // Missing the required `name` — throws ValidationError, the write's
+        // OWN failure, independent of the enclosing transaction's fate.
+        await tx.db.user.create({ data: {} })
+      } catch (err) {
+        userError = err
+      }
+      await tx.db.post.create({ data: { title: 'ok' } })
+      return { userError: userError instanceof Error ? userError.message : undefined }
+    })
+
+    // The transaction committed overall (Post persisted)...
+    expect(mock.tables.post.size).toBe(1)
+    expect(postAfter).toHaveBeenCalledWith(expect.objectContaining({ status: 'committed' }))
+    // ...but the User write's OWN failure is what its afterTransaction reports,
+    // not the transaction's (otherwise committed) outcome.
+    expect(userAfter).toHaveBeenCalledTimes(1)
+    const userArg = userAfter.mock.calls[0][0]
+    expect(userArg.status).toBe('rolled-back')
+    expect(result.userError).toBeDefined()
+  })
+
+  it('a transaction that commits with a throwing deferred hook rejects with AfterTransactionError; other compensators still ran', async () => {
+    const fired: string[] = []
+    const testConfig = await baseConfig({
+      user: {
+        afterTransaction: () => {
+          fired.push('user')
+          throw new Error('user compensator boom')
+        },
+      },
+      post: {
+        afterTransaction: () => {
+          fired.push('post')
+        },
+      },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await expect(
+      context.transaction(async (tx) => {
+        await tx.db.user.create({ data: { name: 'jane' } })
+        await tx.db.post.create({ data: { title: 'ok' } })
+      }),
+    ).rejects.toThrow(/afterTransaction hook\(s\) failed/)
+
+    expect(fired).toEqual(expect.arrayContaining(['user', 'post']))
+    // DB state is final — the underlying transaction already committed.
+    expect(mock.tables.user.size).toBe(1)
+    expect(mock.tables.post.size).toBe(1)
+  })
+
+  it('a nested context.transaction() joins the outer owner instead of creating a second registry', async () => {
+    const order: string[] = []
+    const testConfig = await baseConfig({
+      user: { afterTransaction: () => order.push('user-after') },
+      post: { afterTransaction: () => order.push('post-after') },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await context.transaction(async (tx) => {
+      await tx.db.user.create({ data: { name: 'jane' } })
+      // Nested call: same underlying tx client (no $transaction), so it runs
+      // directly — and per ADR-0028 must join the OUTER owner's queue.
+      await tx.transaction(async (inner) => {
+        await inner.db.post.create({ data: { title: 'nested' } })
+        order.push('inner-callback-done')
+      })
+      order.push('outer-callback-done')
+    })
+
+    // Both brackets flush only once the OUTER transaction settles.
+    expect(order).toEqual([
+      'inner-callback-done',
+      'outer-callback-done',
+      'user-after',
+      'post-after',
+    ])
+  })
+
+  it('a deferred afterTransaction hook receives a base-client context — a compensator write survives the enclosing rollback', async () => {
+    const testConfig = await baseConfig({
+      user: {
+        afterTransaction: async ({ status, context: hookContext }) => {
+          if (status === 'rolled-back') {
+            // Compensating write: NOT part of the (already rolled-back)
+            // transaction — it must succeed and persist independently.
+            await hookContext.db.comment.create({ data: { body: 'compensated' } })
+          }
+        },
+      },
+    })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await expect(
+      context.transaction(async (tx) => {
+        await tx.db.user.create({ data: { name: 'jane' } })
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+
+    // The original transaction rolled back (no user persisted)...
+    expect(mock.tables.user.size).toBe(0)
+    // ...but the compensator's own write, issued from the deferred hook,
+    // persisted — proving it ran against the base client, not the closed tx.
+    expect(mock.tables.comment.size).toBe(1)
+    expect(Array.from(mock.tables.comment.values())[0].body).toBe('compensated')
+  })
+})
+
+describe('ADR-0028 / #899: a hook-issued context.db write inside a plain top-level write', () => {
+  // A dedicated config per test in this block: Post's nested `author` (User)
+  // is processed BEFORE its nested `comments` (Comment) — object-literal key
+  // order — and each nested list's own `afterOperation` fires as a DEFERRED
+  // "after task" once the top-level write's own before/after-hooks are done,
+  // in that same order (see `runAfterTasks`). So User's afterOperation (which
+  // issues the hook's own separate `context.db.audit.create()` write — the
+  // JOINED write under test) always runs, and completes, BEFORE Comment's own
+  // afterOperation gets a chance to fail the whole transaction — letting each
+  // test control whether the ENCLOSING write settles by commit or rollback
+  // strictly AFTER the joined Audit write already happened.
+  function makeConfig(opts: { commentThrows: boolean; auditAfter: (arg: unknown) => void }) {
+    return config({
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        User: list({
+          fields: { name: text() },
+          access: { operation: { query: () => true, create: () => true, update: () => true } },
+          hooks: {
+            afterOperation: async ({ operation, context: hookContext }) => {
+              if (operation === 'create') {
+                await hookContext.db.audit.create({ data: { note: 'audit' } })
+              }
+            },
+          },
+        }),
+        Comment: list({
+          fields: { body: text() },
+          access: { operation: { query: () => true, create: () => true } },
+          hooks: opts.commentThrows
+            ? {
+                afterOperation: () => {
+                  throw new Error('comment afterOperation boom')
+                },
+              }
+            : undefined,
+        }),
+        Audit: list({
+          fields: { note: text() },
+          access: { operation: { query: () => true, create: () => true } },
+          hooks: { afterTransaction: opts.auditAfter },
+        }),
+        Post: list({
+          fields: {
+            title: text(),
+            author: relationship({ ref: 'User.posts' }),
+            comments: relationship({ ref: 'Comment', many: true }),
+          },
+          access: { operation: { query: () => true, create: () => true, update: () => true } },
+        }),
+      },
+    })
+  }
+
+  let mock: ReturnType<typeof createFaithfulTxPrisma>
+
+  beforeEach(() => {
+    mock = createFaithfulTxPrisma(['audit'])
+    vi.clearAllMocks()
+  })
+
+  it('defers and reports rolled-back when the enclosing (non-interactive) write later rolls back', async () => {
+    const auditAfter = vi.fn()
+    const testConfig = await makeConfig({ commentThrows: true, auditAfter })
+    mock.tables.post.set('p1', { id: 'p1', title: 'P' })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await expect(
+      context.db.post.update({
+        where: { id: 'p1' },
+        data: {
+          title: 'x',
+          author: { create: { name: 'jane' } },
+          comments: { create: [{ body: 'trigger' }] },
+        },
+      }),
+    ).rejects.toThrow('comment afterOperation boom')
+
+    // Nothing persisted — the whole write, including the hook's own Audit
+    // write, rolled back together (ADR-0010 atomicity).
+    expect(mock.tables.user.size).toBe(0)
+    expect(mock.tables.audit.size).toBe(0)
+
+    // The Audit write itself succeeded (no error of its own) — its
+    // afterTransaction must still report the OWNER's real (rolled-back)
+    // outcome, not fire optimistically with 'committed' at write time.
+    expect(auditAfter).toHaveBeenCalledTimes(1)
+    const arg = auditAfter.mock.calls[0][0]
+    expect(arg.status).toBe('rolled-back')
+    expect(arg.error).toBeInstanceOf(Error)
+    expect((arg.error as Error).message).toBe('comment afterOperation boom')
+  })
+
+  it('defers and reports committed with the persisted item when the enclosing write commits', async () => {
+    const auditAfter = vi.fn()
+    const testConfig = await makeConfig({ commentThrows: false, auditAfter })
+    mock.tables.post.set('p1', { id: 'p1', title: 'P' })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    await context.db.post.update({
+      where: { id: 'p1' },
+      data: {
+        title: 'x',
+        author: { create: { name: 'jane' } },
+        comments: { create: [{ body: 'fine' }] },
+      },
+    })
+
+    expect(mock.tables.audit.size).toBe(1)
+    expect(auditAfter).toHaveBeenCalledTimes(1)
+    const arg = auditAfter.mock.calls[0][0]
+    expect(arg.status).toBe('committed')
+    expect(arg.item).toEqual(expect.objectContaining({ note: 'audit' }))
+  })
+})
+
+describe('ADR-0028 / #899: a serialization failure still propagates unwrapped, with compensators run', () => {
+  it('P2034 rejects the caller unwrapped; the deferred afterTransaction still fired (rolled-back)', async () => {
+    const mock = createFaithfulTxPrisma()
+    const after = vi.fn()
+    const testConfig = await baseConfig({ user: { afterTransaction: after } })
+    const context = getContext(testConfig, mock.client, { userId: '1' })
+
+    const serializationError = Object.assign(new Error('could not serialize access'), {
+      code: 'P2034',
+    })
+
+    await expect(
+      context.transaction(async (tx) => {
+        await tx.db.user.create({ data: { name: 'jane' } })
+        throw serializationError
+      }),
+    ).rejects.toMatchObject({ code: 'P2034' })
+
+    // The error propagated UNWRAPPED (not an AfterTransactionError) — transaction
+    // errors keep precedence over hook errors, so a P2034 retry loop still works.
+    expect(after).toHaveBeenCalledTimes(1)
+    expect(after.mock.calls[0][0].status).toBe('rolled-back')
+    expect(mock.tables.user.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

A list write executed through `context.transaction()`, or via a hook's own `context.db` write, has its `afterTransaction` bracket settled by its own write returning, not by the outermost transaction settling. The outer transaction can still throw/rollback afterward, letting an external side effect dispatched on `status: 'committed'` escape a rollback. Design is settled in `docs/adr/0028-a-transaction-boundary-hook-reports-the-outermost-transaction.md`.

- A **JOINED write** (nested in a transaction it did not open) now DEFERS its `afterTransaction` bracket to the **transaction owner** (`context.transaction()`, or the Write Pipeline when it opened the transaction) instead of firing immediately. The owner flushes deferred brackets, in write order, once it observes the real commit/rollback.
- **Status is a conjunction**: `committed` iff the write itself succeeded **and** the enclosing transaction committed — the write's own error always wins over the transaction's outcome.
- `beforeTransaction` stays eager in every case (only `afterTransaction` is deferred).
- Deferred hooks always receive a context bound to the **base client**, never the (possibly already-closed/rolled-back) transaction client.
- A `context.transaction()` call can now **reject with `AfterTransactionError`** even after its underlying transaction already committed, if a deferred hook throws. A transaction/serialization error (e.g. `P2034`) still takes precedence and propagates unwrapped.
- A write with **no transaction owner** at all (app-managed `prisma.$transaction`, or a client — e.g. bare test mock — that can't open one) is unchanged: it still fires `afterTransaction` optimistically at write time.
- New internal plumbing: `TransactionRegistry` (`packages/core/src/access/transaction-registry.ts`), threaded through the context-rebind path via `AccessContext['_transactionOwner']` (`@internal`, no public surface change).
- Docs updated: `packages/core/CLAUDE.md` and `docs/content/concepts/hooks.md` now state the outermost-transaction rule, the stale-`item` caveat, the "rejection no longer implies rollback" caveat, and the `beforeTransaction`-runs-with-the-transaction-open hazard.

## Test plan

- [x] New test file `packages/core/tests/transaction-boundary-outermost.test.ts` (11 tests) using a FAITHFUL transaction mock (the `tx` client omits `$transaction`, per the ADR's verification note — a non-faithful mock hides this bug), covering:
  - `context.transaction()` commit/rollback deferral and ordering
  - `beforeTransaction` staying eager
  - three writes to the same list flushing in write order (FIFO)
  - a write's own error taking precedence over a committed transaction
  - `AfterTransactionError` surfacing from a committed transaction with a throwing deferred hook
  - a nested `context.transaction()` joining the outer owner's queue
  - a deferred hook's compensator write surviving a rollback (base-client context)
  - a hook-issued `context.db` write inside a plain top-level write (no interactive transaction) deferring to that write's own transaction owner, both commit and rollback
  - a `P2034` serialization failure still propagating unwrapped with compensators run
- [x] Full existing suite: `pnpm --filter @opensaas/stack-core test` — 1054/1054 passing (1043 pre-existing + 11 new); no existing test needed behavioral updates (none of the existing coverage exercised a genuinely joined write with a non-faithful mock and hook-timing assertions)
- [x] `pnpm --filter @opensaas/stack-auth test` — 261/261 passing (2 pre-existing skips)
- [x] `pnpm build` (full monorepo, including docs)
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format` — clean
- [x] Changeset added (`@opensaas/stack-core`: minor)

Closes #899


---
_Generated by [Claude Code](https://claude.ai/code/session_013DtLZaTb6rBH925mpqZT9s)_