### PR TITLE
chore(core): clean up comments in context/, add comments.md worked examples

### DIFF
--- a/.changeset/tidy-otters-relax.md
+++ b/.changeset/tidy-otters-relax.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Clean up comments in `src/context/` per the CLAUDE.md Comments rule. No behavior changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1077,6 +1077,8 @@ A file header should orient a reader in a line or two. If it needs a page, the e
 
 **Public API docblocks are the deliberate exception.** Exported config options, field builders, and plugin surfaces carry TSDoc because it is what the consumer's editor shows — that is a contract, not a narration of the implementation beneath it.
 
+See `docs/agents/comments.md` for worked before/after examples of applying this rule, including where the judgment calls above land in practice.
+
 ## Development Workflow
 
 ### Making Changes to Core

--- a/docs/agents/comments.md
+++ b/docs/agents/comments.md
@@ -1,0 +1,267 @@
+# Comments: worked examples
+
+`CLAUDE.md`'s "## Comments" section states the rule. This doc shows what applying it looks like, with real before/after pairs pulled from cleaning up `packages/core/src/context/` (issue #936) — the densest concentration of comments in the repo, and the first pass against the rule. Read this before doing a comment cleanup pass elsewhere in the codebase; it settles the judgment calls that recur every time.
+
+The rule, in two tests: **staleness** (does editing the line below make the comment false, with no test to catch it?) and **restatement** (does the comment just say what the code already says?). Fail either test and the comment goes. What survives is narrow: an outside constraint, a warning where the obvious edit is wrong, or a "Known limits" block — everything else is rationale, and rationale belongs in an ADR, the issue, the changeset, or the PR body, not beside the code.
+
+## 1. Restatement — delete the comment, not the line
+
+`packages/core/src/context/index.ts`, `parsePrismaError`:
+
+```ts
+// before
+/**
+ * Parse Prisma error and convert to user-friendly DatabaseError
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
+  // Check if it's a Prisma error
+  if (
+    error &&
+    typeof error === 'object' &&
+    ...
+```
+
+```ts
+// after
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
+  if (
+    error &&
+    typeof error === 'object' &&
+    ...
+```
+
+The function name already says "parse Prisma error"; the `if` condition already says "check if it's a Prisma error." Both comments were a second copy of a truth the code carries on its own. The `eslint-disable ... --` directive on the line between them is untouched — that's not commentary, it's a lint-tool contract with its own required reason, and it stays verbatim in every file in this cleanup.
+
+## 2. A rationale block repeated across siblings — state it once, point to it elsewhere
+
+`packages/core/src/context/index.ts`, the `ServerActionProps` union. Three sibling variants (`removeRelated`, `updateRelated`, `createRelated`) shared the same ADR-0018 boundary rationale, restated in full on each:
+
+```ts
+// before (updateRelated)
+// Relationship-table inline cell edit (issue #737). `listKey`/`id` target the
+// RELATED row and `field`/`value` a single scalar field on it, so the update
+// runs through the related list's OWN operation- and field-level access +
+// hooks/validation (never the parent's) — the same ADR-0018 boundary as
+// `removeRelated`. It returns a distinct `{ updated }` shape (never a
+// single-op `success`) so a UI wrapper that redirects on `success` — the
+// item-form pattern — cannot hijack an in-place cell edit.
+```
+
+```ts
+// after (updateRelated)
+// Relationship-table inline cell edit (issue #737); same ADR-0018 boundary
+// as `removeRelated` — `listKey`/`id` target the RELATED row. Returns a
+// distinct `{ updated }` shape, never `success`, so a UI wrapper that
+// redirects on `success` does not hijack an in-place cell edit.
+```
+
+The "runs through the related list's own access control, never the parent's" boundary is ADR-0018's whole point — it's stated once in full on `removeRelated` (the first variant) and referenced by name on its siblings, rather than re-derived three times. What did **not** get cut: each variant's own distinct footgun — the specific result shape (`{ updated }` vs `{ created }` vs `{ removed }`) and why it can't be `success`, which the ADR doesn't cover and which a reader would genuinely get wrong by "simplifying" to a shared shape.
+
+## 3. A warning where the obvious edit is wrong — keep it
+
+`packages/core/src/context/index.ts`, inside `serverAction`'s `bulkAction` error handling — kept verbatim, before and after:
+
+```ts
+// Anything else is an unexpected handler bug whose raw `.message` could
+// leak internal detail to the client — log it server-side and return a
+// generic client-facing message instead.
+console.error(`Bulk action "${props.key}" on list "${props.listKey}" failed:`, error)
+return { bulkAction: false, error: 'Action failed' }
+```
+
+This is the case CLAUDE.md's `isRequired`/`isNullable` example is pointing at: a reader skimming the catch block might reflexively return `error.message` to the client, the way the two branches above it do for known error types. That edit compiles, looks consistent with the surrounding code, and leaks internal detail. The comment is the only thing standing between the reader and that mistake — it survives because there's no name or type signature that carries the warning instead.
+
+## 4. A file header that needs a page — trim to an orientation line and a link
+
+`packages/core/src/context/apply-defaults.ts`, top of file:
+
+```ts
+// before (33 lines)
+/**
+ * Apply field `defaultValue`s to omitted inputs on CREATE — the runtime half of
+ * the resolve-then-validate ordering (Keystone 6 parity, issue #615).
+ *
+ * A field's `defaultValue` is otherwise only realised as a Prisma `@default(...)`
+ * applied by the database at write time, which is AFTER the write pipeline's
+ * validation phase has already run. That ordering means a required-with-default
+ * field (e.g. `select({ validation: { isRequired: true }, defaultValue: 'X' })`)
+ * fails `isRequired` validation on an omitted input even though a default exists.
+ *
+ * This helper closes that gap: in the resolve phase (after `resolveInput` hooks,
+ * before validation) it fills `resolvedData[field]` with the field's
+ * `defaultValue` ONLY when the field was OMITTED (value is `undefined`). It is a
+ * SINGLE shared mechanism used by both the top-level create path (Hook Pipeline)
+ * and the nested-relation create path.
+ *
+ * Guard rails (each acceptance-criteria-driven):
+ *   - CREATE only. Update never injects defaults for omitted fields ...
+ *   - Explicitly-provided values are preserved. A key present in `resolvedData`
+ *     — INCLUDING an explicit `null` — is left untouched; only `undefined`
+ *     (omitted) keys are filled.
+ *   - Virtual, system (`id`/`createdAt`/`updatedAt`) and relationship fields are
+ *     skipped ...
+ *   - The timestamp `{ kind: 'now' }` sentinel is NOT injected ...
+ *
+ * The function mutates and returns `resolvedData` ...
+ */
+```
+
+```ts
+// after (7 lines)
+/**
+ * Fills a field's `defaultValue` into `resolvedData` for CREATE when the field
+ * was omitted, run after resolveInput hooks and before validation. Shared by
+ * the top-level create path (Hook Pipeline) and the nested-relation create path.
+ *
+ * Prisma only realises `defaultValue` as `@default(...)` at the database write,
+ * which is after this pipeline's validation phase — so without this, a
+ * required field with a default (e.g. `select({ validation: { isRequired: true },
+ * defaultValue: 'X' })`) fails `isRequired` on an omitted input. See issue #615.
+ */
+```
+
+The "Guard rails" bullets were each a restatement of an `if` a few lines further down — the code already enforces CREATE-only, already skips virtual/system/relationship fields, already special-cases the `{ kind: 'now' }` sentinel. What's left is the one paragraph nothing else says: the Prisma default-timing gap this function exists to close, with the full history pointed at `#615` instead of reproduced.
+
+## 5. A docblock that's pure restatement — delete it, even on an internal helper
+
+`packages/core/src/context/write-pipeline.ts`, `isSingletonList`:
+
+```ts
+// before
+/**
+ * Check if a list is configured as a singleton.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function isSingletonList(listConfig: ListConfig<any>): boolean {
+  return !!listConfig.isSingleton
+}
+```
+
+```ts
+// after
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+function isSingletonList(listConfig: ListConfig<any>): boolean {
+  return !!listConfig.isSingleton
+}
+```
+
+Same shape as #1, at function-doc granularity rather than a file header: nothing in this repo needed its top-of-file header deleted to zero (every file header carried at least one line no doc/ADR states elsewhere), but plenty of function-level docblocks did — this is what that looks like. A one-line docblock whose only content is the function's name reworded is never worth the second copy.
+
+## 6. Public-API TSDoc: the boundary between contract and narration
+
+CLAUDE.md keeps TSDoc only on "exported config options, field builders, and plugin surfaces" — because that's what the consumer's editor shows. It's a narrow exception, not a blanket pass for anything exported. Two examples from the same file show the line:
+
+**Kept in full** — `StackContext.transaction`, the method every `context.transaction(fn, options)` caller sees in autocomplete:
+
+```ts
+/**
+ * Run `fn` inside ONE interactive transaction. The `txContext` handed to `fn`
+ * is a full {@link StackContext} whose `db.*` operations are access-checked and
+ * hook-firing (identical to this context) but persist against the transaction
+ * client, so every write in the callback is atomic — a throw anywhere rolls the
+ * whole transaction back.
+ *
+ * `options` (notably `isolationLevel`) is forwarded to the underlying Prisma
+ * transaction. Serialization failures (e.g. Prisma `P2034`) propagate to the
+ * caller rather than being swallowed, so the caller can own a retry loop. If
+ * the client cannot open an interactive transaction (e.g. a plain mock, or we
+ * are already inside a transaction), `fn` runs directly against the current
+ * client with identical hook/access semantics.
+ *
+ * Caveat: plugin runtime services (`txContext.plugins`) stay bound to the
+ * top-level (non-transaction) client — they are shared services initialised
+ * once per request. Reads through a plugin service therefore won't see this
+ * transaction's uncommitted writes, and a plugin service that WRITES would
+ * escape the transaction and survive a rollback. Use `txContext.db` (not a
+ * plugin service) for writes that must be atomic with the transaction.
+ */
+transaction: <T>(
+  fn: (txContext: StackContext<TPrisma>) => Promise<T>,
+  options?: TransactionOptions,
+) => Promise<T>
+```
+
+Every paragraph earns its place under the general rule too — the plugin-services caveat in particular is exactly the "obvious edit is wrong" case (reaching for `txContext.plugins` inside a transaction looks correct and silently isn't atomic). It would survive even without the public-API exception; being on `StackContext` is why it's this thorough.
+
+**Trimmed** — `getContext`, the exported context factory, is _not_ a config option, field builder, or plugin surface (it's the wiring function generated code calls), so its doc follows the ordinary rule rather than the exception:
+
+```ts
+// before
+/**
+ * Create an access-controlled context
+ *
+ * @param config - OpenSaas configuration
+ * @param prisma - Your Prisma client instance (pass as generic for type safety)
+ * @param session - Current session object (or null if not authenticated)
+ * @param storage - Optional storage utilities (uploadFile, uploadImage, deleteFile, deleteImage)
+ */
+export function getContext<...
+```
+
+```ts
+// after
+export function getContext<...
+```
+
+Every `@param` line restated the parameter name and type sitting three lines below it. Being exported and widely used doesn't protect a docblock — only falling into one of the three named categories does, and `getContext` doesn't.
+
+## 7. The same rationale threaded through several call sites — anchor it once
+
+`packages/core/src/context/nested-operations.ts`, `NestedOpHandlerArgs` — several fields exist purely to carry the `#588` owning-field access gate through to `verifyConnectReachable`, and each one had re-explained the gate from scratch:
+
+```ts
+// before
+/**
+ * Field-level `access` of the OWNING relationship field on the list being
+ * written (e.g. `Post.author`). Used by the connect/connectOrCreate handlers
+ * to gate connects by the owning field's create/update access (#588).
+ */
+owningFieldAccess: FieldAccess | undefined
+/**
+ * The enclosing write's operation (`create`/`update`), used as the field-access
+ * operation for the owning-field connect gate (#588).
+ */
+enclosingOperation: 'create' | 'update'
+/**
+ * The enclosing write's existing row (the parent `originalItem`): present for an
+ * enclosing UPDATE, `undefined` for an enclosing CREATE. Threaded into the
+ * connect-site owning-field gate so it evaluates `item` exactly like the
+ * canonical Phase-5 `filterWritableFields` call and the two cannot diverge
+ * (#588 finding).
+ */
+enclosingItem: Record<string, unknown> | undefined
+/**
+ * The enclosing write's input data. Threaded into the connect-site owning-field
+ * gate so it evaluates `inputData` exactly like the canonical Phase-5
+ * `filterWritableFields` call (#588 finding).
+ */
+enclosingInputData: Record<string, unknown> | undefined
+```
+
+```ts
+// after
+/**
+ * Field-level `access` of the OWNING relationship field (e.g. `Post.author`).
+ * Gates connect/connectOrCreate by the owning field's create/update access —
+ * see the #588 gate in {@link verifyConnectReachable}.
+ */
+owningFieldAccess: FieldAccess | undefined
+/** The enclosing write's operation, used as the owning-field gate's field-access operation. */
+enclosingOperation: 'create' | 'update'
+/**
+ * The enclosing write's `originalItem` (`undefined` for an enclosing create).
+ * Passed to the owning-field gate so it matches the canonical Phase-5
+ * `filterWritableFields` call and the two can't diverge (#588).
+ */
+enclosingItem: Record<string, unknown> | undefined
+/** The enclosing write's input data, passed to the owning-field gate for the same reason as `enclosingItem`. */
+enclosingInputData: Record<string, unknown> | undefined
+```
+
+`enclosingOperation` and `enclosingInputData` no longer re-derive why the gate needs them — they point at `enclosingItem`'s fuller explanation and at `{@link verifyConnectReachable}`, the one place the `#588` finding is worth spelling out completely. Four independent tellings of the same fact become one, with three pointers — not one telling with three silences, which would leave a reader at any of the trimmed sites with no path to the "why" at all.
+
+## What this doesn't cover
+
+Every example above is from non-test TypeScript in `packages/core/src/context/`. It doesn't settle comment conventions in JSX/UI code, generator output, or config-file examples in READMEs — later cleanup passes in this issue set may need their own calibration for those.

--- a/packages/core/src/context/apply-defaults.ts
+++ b/packages/core/src/context/apply-defaults.ts
@@ -1,63 +1,34 @@
 import type { FieldConfig } from '../config/types.js'
 
 /**
- * Apply field `defaultValue`s to omitted inputs on CREATE — the runtime half of
- * the resolve-then-validate ordering (Keystone 6 parity, issue #615).
+ * Fills a field's `defaultValue` into `resolvedData` for CREATE when the field
+ * was omitted, run after resolveInput hooks and before validation. Shared by
+ * the top-level create path (Hook Pipeline) and the nested-relation create path.
  *
- * A field's `defaultValue` is otherwise only realised as a Prisma `@default(...)`
- * applied by the database at write time, which is AFTER the write pipeline's
- * validation phase has already run. That ordering means a required-with-default
- * field (e.g. `select({ validation: { isRequired: true }, defaultValue: 'X' })`)
- * fails `isRequired` validation on an omitted input even though a default exists.
- *
- * This helper closes that gap: in the resolve phase (after `resolveInput` hooks,
- * before validation) it fills `resolvedData[field]` with the field's
- * `defaultValue` ONLY when the field was OMITTED (value is `undefined`). It is a
- * SINGLE shared mechanism used by both the top-level create path (Hook Pipeline)
- * and the nested-relation create path.
- *
- * Guard rails (each acceptance-criteria-driven):
- *   - CREATE only. Update never injects defaults for omitted fields (the caller
- *     only invokes this for `operation === 'create'`).
- *   - Explicitly-provided values are preserved. A key present in `resolvedData`
- *     — INCLUDING an explicit `null` — is left untouched; only `undefined`
- *     (omitted) keys are filled.
- *   - Virtual, system (`id`/`createdAt`/`updatedAt`) and relationship fields are
- *     skipped — they have no scalar `defaultValue` to inject and relationships
- *     carry connect/create payloads rather than literal defaults.
- *   - The timestamp `{ kind: 'now' }` sentinel is NOT injected: it is not a
- *     literal value but a request for the DB-level `@default(now())`, which still
- *     applies at write time. Injecting the sentinel object would corrupt the
- *     payload. (A concrete `Date` default is a real literal and IS injected.)
- *
- * The function mutates and returns `resolvedData` (consistent with the other
- * resolve-phase helpers that thread `resolvedData` through the pipeline).
+ * Prisma only realises `defaultValue` as `@default(...)` at the database write,
+ * which is after this pipeline's validation phase — so without this, a
+ * required field with a default (e.g. `select({ validation: { isRequired: true },
+ * defaultValue: 'X' })`) fails `isRequired` on an omitted input. See issue #615.
  */
 export function applyCreateDefaults(
   resolvedData: Record<string, unknown>,
   fieldConfigs: Record<string, FieldConfig>,
 ): Record<string, unknown> {
   for (const [fieldKey, fieldConfig] of Object.entries(fieldConfigs)) {
-    // Skip virtual fields — not stored in the database.
     if (fieldConfig.virtual) continue
-
-    // Skip system fields — always managed by the framework/DB.
     if (fieldKey === 'id' || fieldKey === 'createdAt' || fieldKey === 'updatedAt') continue
-
-    // Skip relationships — they carry connect/create payloads, not literal defaults.
+    // Relationships carry connect/create payloads, not literal defaults.
     if (fieldConfig.type === 'relationship') continue
-
-    // No declared default → nothing to inject.
     if (!('defaultValue' in fieldConfig) || fieldConfig.defaultValue === undefined) continue
 
-    // Only fill OMITTED keys. An explicitly-provided value (including explicit
-    // `null`) is preserved and must not be overwritten by the default.
+    // Only fill OMITTED (`undefined`) keys — an explicitly-provided value,
+    // including explicit `null`, must survive untouched.
     if (resolvedData[fieldKey] !== undefined) continue
 
     const defaultValue = fieldConfig.defaultValue
 
-    // The timestamp `{ kind: 'now' }` sentinel is a DB-level `@default(now())`
-    // request, not a literal — leave it for Prisma to apply at write time.
+    // `{ kind: 'now' }` requests the DB-level `@default(now())`, not a literal
+    // value — injecting the sentinel object itself would corrupt the payload.
     if (isNowSentinel(defaultValue)) continue
 
     resolvedData[fieldKey] = defaultValue
@@ -66,9 +37,6 @@ export function applyCreateDefaults(
   return resolvedData
 }
 
-/**
- * Detect the timestamp `{ kind: 'now' }` default sentinel.
- */
 function isNowSentinel(value: unknown): boolean {
   return (
     typeof value === 'object' &&

--- a/packages/core/src/context/hook-pipeline.ts
+++ b/packages/core/src/context/hook-pipeline.ts
@@ -12,78 +12,33 @@ import {
 import { applyCreateDefaults } from './apply-defaults.js'
 
 /**
- * Hook Pipeline — the single module that runs the transform+validate span of a
- * write: list `resolveInput` → field `resolveInput` → list `validate` → field
- * `validate` → built-in field rules (`validateFieldRules`). It owns the order of
- * these phases and the threading of `resolvedData` through them, in one place.
- *
- * It is THE place where input is shaped and validated; it throws
- * {@link ValidationError} on failure exactly as before (validate hooks via
- * `addValidationError`, then `validateFieldRules`) — validation is never silent.
- *
- * Side-effect hooks (`beforeOperation`/`afterOperation`), operation-level access,
- * writable-field filtering, nested operations, persistence and Field Visibility
- * are deliberately OUT of this span — they stay in the Write Pipeline. See the
- * "Hook Pipeline" and "Write Pipeline" glossary terms in CONTEXT.md.
+ * The transform+validate span of a write. See the "Hook Pipeline" and "Write
+ * Pipeline" glossary terms in CONTEXT.md for the full phase order and the
+ * boundary with the Write Pipeline (which owns side-effect hooks, access,
+ * writable-field filtering, nested operations, persistence, Field Visibility).
  */
 
-/**
- * Arguments for one transform+validate span. Only the create/update operations
- * run this span (delete skips the input-shaping phases entirely).
- */
 export interface HookPipelineArgs {
   operation: 'create' | 'update'
   listName: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   listConfig: ListConfig<any>
-  /** The original input data for the write. */
   inputData: Record<string, unknown>
-  /** The existing row for update; `undefined` for create. */
   item: Record<string, unknown> | undefined
   context: AccessContext
 }
 
-/**
- * Result of a transform+validate span: the fully-resolved write data after the
- * resolveInput hooks have run and all validation has passed.
- */
 export interface HookPipelineResult {
   resolvedData: Record<string, unknown>
 }
 
-/**
- * The transform+validate span, owning order + `resolvedData` threading.
- */
 export interface HookPipeline {
   run(args: HookPipelineArgs): Promise<HookPipelineResult>
 }
 
-/**
- * Run the transform+validate span once.
- *
- * Phase order (owned here, in one place):
- *   list `resolveInput`
- *     → field `resolveInput`
- *     → list `validate`
- *     → field `validate`
- *     → built-in field rules (`validateFieldRules`)
- *     → split multi-column fields (`splitMultiColumnFields`)
- *
- * Contract preserved exactly:
- *   - `resolvedData` starts as `inputData` and is threaded through each phase;
- *   - validate hooks report failures via `addValidationError` → THROW
- *     `ValidationError` (never silent);
- *   - built-in field rule failures THROW `ValidationError`;
- *   - a multi-column field (e.g. storage image()/file() in Keystone-parity
- *     mode) is validated under its LOGICAL key BEFORE it is split into
- *     physical columns (#789) — an unrecognised value throws instead of being
- *     silently split into null/undefined columns;
- *   - on success returns the transformed `resolvedData`.
- */
 async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResult> {
   const { operation, listName, listConfig, inputData, item, context } = args
 
-  // ── Phase 1: list-level resolveInput ──────────────────────────────────────
   let resolvedData = await executeResolveInput(
     listConfig.hooks,
     operation === 'create'
@@ -105,7 +60,6 @@ async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResu
         },
   )
 
-  // ── Phase 1.5: field-level resolveInput (e.g. hash passwords) ──────────────
   resolvedData = await executeFieldResolveInputHooks(
     inputData,
     resolvedData,
@@ -116,17 +70,13 @@ async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResu
     item,
   )
 
-  // ── Phase 1.75: apply field defaults to omitted inputs (CREATE only) ───────
-  // Resolve-then-validate (Keystone parity, #615): a field declaring a
-  // `defaultValue` is filled into `resolvedData` here — AFTER resolveInput hooks
-  // and BEFORE validation — but only when the field was OMITTED, so a
-  // required-with-default field passes `isRequired` instead of failing it.
-  // Update is untouched (no default injection on update).
+  // Must run after resolveInput hooks and before validation, so a
+  // required-with-default field passes `isRequired` on an omitted input
+  // instead of failing it (see applyCreateDefaults, issue #615).
   if (operation === 'create') {
     resolvedData = applyCreateDefaults(resolvedData, listConfig.fields)
   }
 
-  // ── Phase 2: list-level validate ──────────────────────────────────────────
   await executeValidate(
     listConfig.hooks,
     operation === 'create'
@@ -148,7 +98,6 @@ async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResu
         },
   )
 
-  // ── Phase 2.5: field-level validate ───────────────────────────────────────
   await executeFieldValidateHooks(
     inputData,
     resolvedData,
@@ -159,17 +108,16 @@ async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResu
     item,
   )
 
-  // ── Phase 3: built-in field rules (isRequired, length, etc.) ──────────────
-  // Validation failures THROW (validation is not silent).
+  // Unlike an access-denied `context.db` operation, a validation failure
+  // throws rather than returning null/[] — validation is never silent.
   const validation = validateFieldRules(resolvedData, listConfig.fields, operation)
   if (validation.errors.length > 0) {
     throw new ValidationError(validation.errors, validation.fieldErrors)
   }
 
-  // ── Phase 4: split multi-column fields into physical columns ──────────────
-  // Only reached once the logical value has passed validation (#789). Replaces
-  // each multi-column field's logical key with its per-part columns, gated by
-  // the field's own write access (see `splitMultiColumnFields`).
+  // Runs only once the logical value has passed validation above (#789) — a
+  // multi-column field validated after splitting could see an unrecognised
+  // value silently become null/undefined columns instead of throwing.
   resolvedData = await splitMultiColumnFields(
     inputData,
     resolvedData,
@@ -182,9 +130,6 @@ async function runHookPipeline(args: HookPipelineArgs): Promise<HookPipelineResu
   return { resolvedData }
 }
 
-/**
- * The default Hook Pipeline instance used by the Write Pipeline.
- */
 export const hookPipeline: HookPipeline = {
   run: runHookPipeline,
 }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -202,12 +202,8 @@ function getDefaultData(listConfig: ListConfig<any>): Record<string, unknown> {
   return data
 }
 
-/**
- * Parse Prisma error and convert to user-friendly DatabaseError
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
-  // Check if it's a Prisma error
   if (
     error &&
     typeof error === 'object' &&
@@ -217,15 +213,13 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
   ) {
     const prismaError = error as { code: string; meta?: { target?: string[] }; message?: string }
 
-    // Handle unique constraint violation
+    // P2002 is Prisma's unique constraint violation code.
     if (prismaError.code === 'P2002') {
       const target = prismaError.meta?.target
       const fieldErrors: Record<string, string> = {}
 
       if (target && Array.isArray(target)) {
-        // Get field names from the constraint target
         for (const fieldName of target) {
-          // Get the field config to get a better label
           const fieldConfig = listConfig.fields[fieldName]
           const label = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
 
@@ -236,7 +230,6 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
           }
         }
 
-        // Create a user-friendly general message
         const fieldLabels = target.map((f) => f.charAt(0).toUpperCase() + f.slice(1)).join(', ')
         return new DatabaseError(
           `${fieldLabels} must be unique. The value you entered is already in use.`,
@@ -248,7 +241,6 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
       return new DatabaseError('A record with this value already exists', {}, prismaError.code)
     }
 
-    // Handle other Prisma errors - return generic message
     return new DatabaseError(
       prismaError.message || 'A database error occurred',
       {},
@@ -256,22 +248,16 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
     )
   }
 
-  // Not a Prisma error, return as-is if it's already an Error
   if (error instanceof Error) {
     return error
   }
 
-  // Unknown error type
   return new Error('An unknown error occurred')
 }
 
 /**
- * Database transaction isolation levels.
- *
- * Mirrors Prisma's `TransactionIsolationLevel`. The level passed to
- * {@link StackContext.transaction} is forwarded to the underlying interactive
- * transaction; provider support varies (e.g. `Serializable` is supported by
- * PostgreSQL — required for the concurrency-sensitive capacity-gate pattern).
+ * Mirrors Prisma's `TransactionIsolationLevel`. Provider support varies —
+ * e.g. `Serializable` requires PostgreSQL.
  */
 export type TransactionIsolationLevel =
   'ReadUncommitted' | 'ReadCommitted' | 'RepeatableRead' | 'Serializable' | 'Snapshot'
@@ -348,12 +334,11 @@ export interface StackContext<TPrisma extends PrismaClientLike = PrismaClientLik
 
 /**
  * Drain a `context.transaction()` owner's deferral registry once its callback
- * (and any real underlying transaction) has settled (ADR-0028), then apply the
- * existing error-precedence rule: a transaction/callback error always wins
- * (compensators still all ran, but their errors are discarded in favor of
- * re-surfacing the original — matching the Write Pipeline's `txError`
- * precedence); otherwise, any deferred `afterTransaction` errors reject the
- * call with {@link AfterTransactionError} even though the callback itself
+ * (and any real underlying transaction) has settled (ADR-0028). A transaction/
+ * callback error always wins — compensators still all run, but their errors
+ * are discarded in favor of re-surfacing the original, matching the Write
+ * Pipeline's `txError` precedence — otherwise any deferred `afterTransaction`
+ * errors reject with {@link AfterTransactionError} even though the callback
  * succeeded and the transaction committed.
  */
 async function settleTransactionOwner<T>(
@@ -376,14 +361,6 @@ async function settleTransactionOwner<T>(
   return result
 }
 
-/**
- * Create an access-controlled context
- *
- * @param config - OpenSaas configuration
- * @param prisma - Your Prisma client instance (pass as generic for type safety)
- * @param session - Current session object (or null if not authenticated)
- * @param storage - Optional storage utilities (uploadFile, uploadImage, deleteFile, deleteImage)
- */
 export function getContext<
   TConfig extends OpenSaasConfig,
   TPrisma extends PrismaClientLike = PrismaClientLike,
@@ -401,12 +378,9 @@ export function getContext<
   // through this context join it instead of firing afterTransaction eagerly.
   _transactionOwner?: TransactionRegistry,
 ): StackContext<TPrisma> {
-  // Initialize db object - will be populated with access-controlled operations
-  // Type is intentionally broad to allow dynamic model access
+  // Broad type to allow dynamic model access; populated by populateDbDelegate below.
   const db: Record<string, unknown> = {}
 
-  // Create context with db reference (will be populated below)
-  // Storage utilities can be provided via parameter or use default stubs
   const context: AccessContext<TPrisma> = {
     session,
     prisma: prisma as TPrisma,
@@ -441,13 +415,10 @@ export function getContext<
     _transactionOwner,
   }
 
-  // Create access-controlled operations for each list, populating `db` in place.
   populateDbDelegate(db, config, prisma, context)
 
-  // Execute plugin runtime functions and populate context.plugins.
   // Skipped when reusing shared plugins (transaction rebind) so runtimes — and
   // any side effects they carry — run exactly once per top-level context.
-  // Use _plugins (sorted by dependencies) if available, otherwise fall back to plugins array
   if (!_sharedPlugins) {
     const pluginsToExecute = config._plugins || config.plugins || []
     for (const plugin of pluginsToExecute) {
@@ -461,7 +432,6 @@ export function getContext<
           )
         } catch (error) {
           console.error(`Error executing runtime for plugin "${plugin.name}":`, error)
-          // Continue with other plugins even if one fails
         }
       }
     }
@@ -509,7 +479,9 @@ export function getContext<
         try {
           const result = await model.delete({ where: { id } })
           if (result !== null && result !== undefined) deleted++
-        } catch {}
+        } catch {
+          // Skip this row (e.g. a DB constraint error); it is not counted.
+        }
       }
       return { deleted, total: props.ids.length }
     }
@@ -564,8 +536,7 @@ export function getContext<
       }
     }
 
-    // Relationship-table row removal (ADR-0018, #739). Runs on the RELATED row
-    // through the secured context, so the related list's access + hooks apply.
+    // Runs on the RELATED row (ADR-0018 boundary — see ServerActionProps above).
     // Honours Silent failure: an access-denied operation returns `null`, which
     // becomes `{ removed: false }` with a generic reason — never leaking whether
     // the row was denied or absent.
@@ -606,14 +577,13 @@ export function getContext<
       }
     }
 
-    // Relationship-table pre-linked create (ADR-0018, #738). Creates a row on
-    // the RELATED list through the secured context, so the related list's create
-    // access + hooks (and field-level access) apply — never the parent's. The
-    // back-reference to the parent is set here from `field`/`parentId` (a to-one
-    // back-ref connects a single parent; a to-many back-ref, e.g. many-to-many,
-    // connects the parent by id), so the client can never re-target the link.
-    // Honours Silent failure: an access-denied create returns `null`, surfaced
-    // as `{ created: false }` with a generic reason (no denied-vs-absent leak).
+    // Runs on the RELATED list (ADR-0018 boundary — see ServerActionProps above).
+    // The back-reference to the parent is set here from `field`/`parentId` (a
+    // to-one back-ref connects a single parent; a to-many back-ref, e.g.
+    // many-to-many, connects the parent by id), so the client can never
+    // re-target the link. Honours Silent failure: an access-denied create
+    // returns `null`, surfaced as `{ created: false }` with a generic reason
+    // (no denied-vs-absent leak).
     if (props.action === 'createRelated') {
       try {
         // Defensive guard (hardening; unreachable from the drawer, which always
@@ -671,11 +641,9 @@ export function getContext<
       }
     }
 
-    // Relationship-table inline cell edit (ADR-0018, #737). Updates ONE scalar
-    // field on the RELATED row through the secured context, so the related list's
-    // operation- and field-level update access plus its hooks/validation apply —
-    // never the parent's. Honours Silent failure: an access-denied update returns
-    // `null`, surfaced as `{ updated: false }` with a generic reason (no
+    // Updates ONE scalar field on the RELATED row (ADR-0018 boundary — see
+    // ServerActionProps above). Honours Silent failure: an access-denied update
+    // returns `null`, surfaced as `{ updated: false }` with a generic reason (no
     // denied-vs-absent leak); a validation/db error surfaces its message and
     // fieldErrors so the cell can revert with a reason and show an inline error.
     if (props.action === 'updateRelated') {
@@ -750,7 +718,6 @@ export function getContext<
         data: result,
       }
     } catch (error) {
-      // Handle ValidationError (has fieldErrors)
       if (error instanceof ValidationError) {
         return {
           success: false,
@@ -759,7 +726,6 @@ export function getContext<
         }
       }
 
-      // Handle DatabaseError (has fieldErrors)
       if (error instanceof DatabaseError) {
         return {
           success: false,
@@ -768,7 +734,6 @@ export function getContext<
         }
       }
 
-      // Parse and convert Prisma errors to user-friendly DatabaseError
       const dbError = parsePrismaError(error, listConfig)
       if (dbError instanceof DatabaseError) {
         return {
@@ -778,7 +743,6 @@ export function getContext<
         }
       }
 
-      // Generic error fallback
       return {
         success: false,
         error: dbError.message,
@@ -786,8 +750,7 @@ export function getContext<
     }
   }
 
-  // Sudo function - creates a new context that bypasses access control
-  // but still executes all hooks and validation
+  // Bypasses access control; hooks and validation still run.
   function sudo(): StackContext<TPrisma> {
     return getContext(
       config,
@@ -802,13 +765,8 @@ export function getContext<
     )
   }
 
-  // Interactive, hook-firing transaction (#614, ADR-0028 / #899). Rebinds the
-  // access-controlled context to the transaction client so every
-  // `txContext.db.*` write runs its access checks + hooks but persists inside
-  // ONE transaction (atomic). The transaction `options` (e.g. `isolationLevel`)
-  // pass through to Prisma, and a serialization failure thrown inside the
-  // callback propagates to the caller for retry (it is never converted to a
-  // silent `null`).
+  // Interactive, hook-firing transaction (#614). See the `transaction` doc on
+  // `StackContext` above for the atomicity/isolation/retry contract.
   //
   // This call OWNS a deferral registry for its callback's writes (ADR-0028):
   // it always observes when its own callback settles — resolve/reject — even
@@ -831,10 +789,10 @@ export function getContext<
 
     const settled =
       typeof client.$transaction !== 'function'
-        ? // No interactive transaction available — either a plain client/mock or
-          // we are already inside a transaction (a Prisma tx client exposes no
-          // `$transaction`). Run directly: hook/access semantics are identical
-          // and atomicity is provided by any enclosing transaction.
+        ? // No interactive transaction available (plain client/mock, or already
+          // inside one — see `TransactionCapable` above). Run directly: hook/
+          // access semantics are identical, atomicity comes from the enclosing
+          // transaction.
           fn(
             getContext(
               config,
@@ -899,7 +857,6 @@ export function populateDbDelegate<TPrisma extends PrismaClientLike>(
   for (const [listName, listConfig] of Object.entries(config.lists)) {
     const dbKey = getDbKey(listName)
 
-    // Create base operations
     const createOp = createCreate(listName, listConfig, prisma, context, config)
     const findManyOp = createFindMany(listName, listConfig, prisma, context, config)
     const updateOp = createUpdate(listName, listConfig, prisma, context, config)
@@ -923,7 +880,6 @@ export function populateDbDelegate<TPrisma extends PrismaClientLike>(
       ),
     }
 
-    // Add get() method for singleton lists
     if (isSingletonList(listConfig)) {
       operations.get = createGet(listName, listConfig, prisma, context, config, createOp)
     }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -972,9 +972,6 @@ async function resolveReadInclude(
   return { include, declaredOnly: folded.declaredOnly, selection: undefined }
 }
 
-/**
- * Create findUnique operation with access control
- */
 function createFindUnique<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -994,19 +991,15 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
     // `select` is not honoured — accepted only so the no-op can be made visible.
     select?: Record<string, unknown>
   }) => {
-    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
     warnIfSelectIgnored(args, listName, 'findUnique')
 
-    // Enforce unique-`where` (Keystone `findOne` parity). This is a caller-shape
-    // check independent of access, so it runs first and THROWS on misuse — it is
-    // not an access denial and must not be masked as a silent `null`. The
-    // type-level constraint already lives on the generated delegate: the custom
-    // `<List>FindUniqueArgs` only Omits `select`/`include` from
-    // `Prisma.<List>FindUniqueArgs`, so its `where` stays Prisma's
-    // `<List>WhereUniqueInput` — this runtime guard backstops untyped callers.
+    // Runs first, before the access check below — a non-unique `where` is a
+    // caller-shape error (see `assertUniqueWhere`), not an access denial. The
+    // generated `<List>FindUniqueArgs` only Omits `select`/`include` from
+    // Prisma's own type, so `where` stays `<List>WhereUniqueInput` — this
+    // runtime guard backstops untyped callers.
     assertUniqueWhere(args.where, getUniqueWhereKeys(listConfig), listName)
 
-    // Check query access (skip if sudo mode)
     let where: Record<string, unknown> = args.where
     if (!context._isSudo) {
       const queryAccess = listConfig.access?.operation?.query
@@ -1019,7 +1012,6 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
         return null
       }
 
-      // Merge access filter with where clause
       const mergedWhere = mergeFilters(args.where, accessResult)
       if (mergedWhere === null) {
         return null
@@ -1027,9 +1019,8 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       where = mergedWhere
     }
 
-    // When a query fragment is provided, build the include from the fragment
-    // instead of the access-controlled include. Access control still runs via
-    // filterReadableFields; the fragment then narrows to only the requested fields.
+    // Access control still runs via filterReadableFields even though a
+    // fragment drives `include`; the fragment only narrows which fields come back.
     const fragment = isFragment(args.query) ? args.query : null
 
     // Resolve `include`, folding any declared dependencies (`needs`,

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -33,23 +33,22 @@ export type ServerActionProps =
   | { listKey: string; action: 'update'; id: string; data: Record<string, unknown> }
   | { listKey: string; action: 'delete'; id: string }
   | { listKey: string; action: 'bulkDelete'; ids: string[] }
-  // Custom list-specific Bulk action (issue #736). `key` names an action
-  // declared in the list's `ui.listView.bulkActions`; the client only ever
-  // sends this serialisable `{ key, ids }` — the server-side `handler`
-  // (never serialised) is looked up by `key` and run with the rebuilt secured
-  // context over `ids`. Returns a distinct `{ bulkAction, message? }` shape so
-  // a redirect-on-`success` wrapper never hijacks it (same rationale as
-  // `bulkDelete`).
+  // Custom list-specific bulk action (issue #736). `key` names an action
+  // declared in the list's `ui.listView.bulkActions`; the client sends only
+  // this serialisable `{ key, ids }` and the server-side `handler` (never
+  // serialised) is looked up by `key`. Returns a distinct `{ bulkAction,
+  // message? }` shape, never `success`, so a redirect-on-`success` wrapper
+  // does not hijack it.
   | { listKey: string; action: 'bulkAction'; key: string; ids: string[] }
   // Relationship-table row removal (ADR-0018, #739). `listKey`/`id` target the
-  // RELATED row, so the related list's own access control + hooks apply (never
-  // the parent's). `mode: 'disconnect'` unlinks the row non-destructively by
-  // disconnecting its back-reference (`field`; `parentId` is the record being
-  // edited, needed only when that back-reference is to-many, e.g. a
-  // many-to-many join); `mode: 'delete'` truly deletes the row. Like
-  // `bulkDelete`, it returns a distinct `{ removed }` shape (never a
-  // single-op `success`) so a UI wrapper that redirects on `success` — the
-  // item-form pattern — does not hijack an in-place row removal.
+  // RELATED row, so the related list's own access control and hooks apply —
+  // never the parent's. The other relationship-table actions below share this
+  // boundary. `mode: 'disconnect'` unlinks the row by disconnecting its
+  // back-reference (`field`; `parentId` is needed only when that back-reference
+  // is to-many, e.g. a many-to-many join) without deleting it; `mode: 'delete'`
+  // truly deletes the row. Returns a distinct `{ removed }` shape, never
+  // `success`, so a UI wrapper that redirects on `success` does not hijack an
+  // in-place row removal.
   | {
       listKey: string
       action: 'removeRelated'
@@ -58,13 +57,10 @@ export type ServerActionProps =
       field?: string
       parentId?: string
     }
-  // Relationship-table inline cell edit (issue #737). `listKey`/`id` target the
-  // RELATED row and `field`/`value` a single scalar field on it, so the update
-  // runs through the related list's OWN operation- and field-level access +
-  // hooks/validation (never the parent's) — the same ADR-0018 boundary as
-  // `removeRelated`. It returns a distinct `{ updated }` shape (never a
-  // single-op `success`) so a UI wrapper that redirects on `success` — the
-  // item-form pattern — cannot hijack an in-place cell edit.
+  // Relationship-table inline cell edit (issue #737); same ADR-0018 boundary
+  // as `removeRelated` — `listKey`/`id` target the RELATED row. Returns a
+  // distinct `{ updated }` shape, never `success`, so a UI wrapper that
+  // redirects on `success` does not hijack an in-place cell edit.
   | {
       listKey: string
       action: 'updateRelated'
@@ -72,14 +68,12 @@ export type ServerActionProps =
       field: string
       value: unknown
     }
-  // Relationship-table pre-linked create (issue #738). `listKey` targets the
-  // RELATED list, so the related list's own create access control + hooks apply
-  // (never the parent's) — the same ADR-0018 boundary as `removeRelated`. The
-  // back-reference to the parent is set on the SERVER from `field`/`parentId`
-  // (never trusted from `data`), so the new row is linked to exactly the parent
-  // being edited. It returns a distinct `{ created }` shape (never a single-op
-  // `success`) so a UI wrapper that redirects on `success` — the item-form
-  // pattern — does not hijack an in-place create.
+  // Relationship-table pre-linked create (issue #738); same ADR-0018 boundary
+  // as `removeRelated` — `listKey` targets the RELATED list. The back-reference
+  // to the parent is set on the SERVER from `field`/`parentId`, never trusted
+  // from `data`, so a hostile client cannot re-target the link. Returns a
+  // distinct `{ created }` shape, never `success`, so a UI wrapper that
+  // redirects on `success` does not hijack an in-place create.
   | {
       listKey: string
       action: 'createRelated'
@@ -96,21 +90,11 @@ export type ServerActionProps =
       selectedIds?: string[]
     }
 
-/**
- * Tracks which (listName, operation) pairs have already warned about an ignored
- * `select` argument, so a misused read op warns once rather than on every call.
- */
 const selectWarnings = new Set<string>()
 
 /**
- * Warn (once per list+operation) when a caller passes a `select` argument to a
- * read op that does not honour it.
- *
- * `context.db` reads never apply Prisma `select` semantics — narrowing is done
- * via `include` or a fragment `query`. The op still runs and returns the full,
- * access-filtered result, so this is a visible no-op rather than an error.
- *
- * Centralised here so every affected read op shares one implementation.
+ * Warn once per (list, operation) when a caller passes `select` to a read op
+ * that ignores it. See "Narrowing Reads" in packages/core/CLAUDE.md.
  */
 function warnIfSelectIgnored(
   args: { select?: unknown } | undefined,
@@ -131,9 +115,6 @@ function warnIfSelectIgnored(
   )
 }
 
-/**
- * Check if a list is configured as a singleton
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function isSingletonList(listConfig: ListConfig<any>): boolean {
   return !!listConfig.isSingleton
@@ -141,25 +122,17 @@ function isSingletonList(listConfig: ListConfig<any>): boolean {
 
 /**
  * Compute the set of single-field unique selectors a `findUnique` `where` may be
- * keyed by, derived from what the list config exposes at runtime.
+ * keyed by, derived from what the list config exposes at runtime: `id`, plus any
+ * field declared `isIndexed: 'unique'` — for a `relationship` field, this is the
+ * foreign-key column name (`<field>Id`), since that's the column Prisma marks
+ * `@unique`, not the relation field itself.
  *
- * The set is:
- * - `id` — always a unique identifier on every list.
- * - Any field declared `isIndexed: 'unique'` in the config (e.g. `text({ isIndexed: 'unique' })`).
- * - For a `relationship` field declared `isIndexed: 'unique'`, the foreign-key
- *   column name (`<field>Id`) — that is the column Prisma marks `@unique`, so the
- *   unique `where` is keyed by `<field>Id`, not the relation field itself.
- *
- * Chosen rule (documented intentionally): the config does NOT expose compound
- * (`@@unique`) keys at runtime — there is no list-level unique declaration in the
- * config API — so we cannot validate compound `<Model>_<a>_<b>` selectors. We
- * therefore enforce the tractable subset: `where` must contain EXACTLY ONE
- * recognised single-field unique key and NO other keys. This rejects non-unique
- * filters (the bug in #567) and rejects extra non-unique keys alongside a unique
- * one, while never falsely rejecting a valid single-field unique lookup. If a
- * project legitimately needs a compound-unique lookup, that path is not covered
- * here and would need explicit config support; the safe escape hatch for any
- * non-unique single-row lookup is `findFirst` (see #565).
+ * The config exposes no list-level compound (`@@unique`) declaration, so this
+ * cannot validate a compound `<Model>_<a>_<b>` selector — `where` must contain
+ * exactly one recognised single-field unique key and no others. This rejects
+ * non-unique filters (#567) without ever rejecting a valid single-field unique
+ * lookup; a compound-unique or otherwise non-unique lookup should use
+ * `findFirst` instead (see #565).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function getUniqueWhereKeys(listConfig: ListConfig<any>): Set<string> {
@@ -205,10 +178,6 @@ function assertUniqueWhere(
   }
 }
 
-/**
- * Check if auto-create is enabled for a singleton list
- * Defaults to true if not explicitly set to false
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function shouldAutoCreate(listConfig: ListConfig<any>): boolean {
   if (!listConfig.isSingleton) return false
@@ -216,22 +185,15 @@ function shouldAutoCreate(listConfig: ListConfig<any>): boolean {
   return listConfig.isSingleton.autoCreate !== false
 }
 
-/**
- * Extract default values from field configs
- * Used to auto-create singleton records with sensible defaults
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function getDefaultData(listConfig: ListConfig<any>): Record<string, unknown> {
   const data: Record<string, unknown> = {}
 
   for (const [fieldKey, fieldConfig] of Object.entries(listConfig.fields)) {
-    // Skip virtual fields - they're not stored in database
     if (fieldConfig.virtual) continue
 
-    // Skip system fields (id, createdAt, updatedAt)
     if (fieldKey === 'id' || fieldKey === 'createdAt' || fieldKey === 'updatedAt') continue
 
-    // Add default value if present
     if ('defaultValue' in fieldConfig && fieldConfig.defaultValue !== undefined) {
       data[fieldKey] = fieldConfig.defaultValue
     }
@@ -505,34 +467,19 @@ export function getContext<
     }
   }
 
-  // Generic server action handler with discriminated union for type safety
-  // Returns a result object instead of throwing to work properly in Next.js production
+  // Returns a result object instead of throwing — required for server actions
+  // to work in Next.js production builds.
   async function serverAction(props: ServerActionProps): Promise<
     | { success: true; data: unknown }
     | { success: false; error: string; fieldErrors?: Record<string, string> }
-    // Bulk actions report a count rather than a single-op `success` flag: the
-    // shape is deliberately distinct so a UI wrapper that redirects on a
-    // single-item `success` (the item-form pattern) does not hijack a
-    // list-level bulk operation.
+    // The distinct shapes below (never `success`) mirror the ServerActionProps
+    // variants above — see their comments for the redirect-on-`success`
+    // footgun each one avoids.
     | { deleted: number; total: number }
-    // Relationship-table row removal reports `removed` (with an optional reason)
-    // rather than `success` — same distinct-shape rationale as `bulkDelete`, so
-    // an in-place removal never triggers a redirect-on-success wrapper.
     | { removed: boolean; error?: string }
-    // Relationship-table pre-linked create reports `created` (with the new row's
-    // id, or an error + fieldErrors for the drawer) rather than `success` — same
-    // distinct-shape rationale, so an in-place create never triggers a
-    // redirect-on-success wrapper.
     | { created: boolean; id?: string; error?: string; fieldErrors?: Record<string, string> }
-    // Custom Bulk action (issue #736) reports `bulkAction` with the handler's
-    // optional `message` (success) or an `error` (not found / denied / threw) —
-    // again a distinct shape from single-op `success`.
     | { bulkAction: true; message?: string }
     | { bulkAction: false; error: string }
-    // Relationship-table inline cell edit reports `updated` (with an optional
-    // reason + fieldErrors for the edited cell) rather than `success` — same
-    // distinct-shape rationale, so an in-place cell edit never triggers a
-    // redirect-on-success wrapper.
     | { updated: boolean; error?: string; fieldErrors?: Record<string, string> }
   > {
     const dbKey = getDbKey(props.listKey)
@@ -562,9 +509,7 @@ export function getContext<
         try {
           const result = await model.delete({ where: { id } })
           if (result !== null && result !== undefined) deleted++
-        } catch {
-          // Skip this row (e.g. a DB constraint error); it is not counted.
-        }
+        } catch {}
       }
       return { deleted, total: props.ids.length }
     }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1044,7 +1044,6 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
     // `undefined`), only the ones a fragment named otherwise.
     include = stripVirtualFieldsFromInclude(include, listConfig.fields, config)
 
-    // Execute query with optimized includes
     // Access Prisma model dynamically - required because model names are generated at runtime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const model = (prisma as any)[getDbKey(listName)]
@@ -1057,7 +1056,6 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       return null
     }
 
-    // Filter readable fields and apply resolveOutput hooks (including nested relationships)
     // Pass sudo flag through context to skip field-level access checks
     const filtered = await filterReadableFields(
       item,
@@ -1073,7 +1071,6 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       selection,
     )
 
-    // When a fragment is provided, pick only the requested fields from the result
     if (fragment) {
       return pickFields(filtered, fragment._fields)
     }
@@ -1082,9 +1079,6 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create findMany operation with access control
- */
 function createFindMany<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1104,10 +1098,10 @@ function createFindMany<TPrisma extends PrismaClientLike>(
     // `select` is not honoured — accepted only so the no-op can be made visible.
     select?: Record<string, unknown>
   }) => {
-    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
     warnIfSelectIgnored(args, listName, 'findMany')
 
-    // Check singleton constraint (throw error instead of silently returning empty)
+    // Singleton misuse throws rather than silently returning `[]` — unlike an
+    // access denial, this is a caller-shape error.
     if (isSingletonList(listConfig)) {
       throw new ValidationError(
         [`Cannot use findMany: ${listName} is a singleton list. Use get() instead.`],
@@ -1172,7 +1166,6 @@ function createFindMany<TPrisma extends PrismaClientLike>(
           })) as Record<string, unknown>)
         : args?.where
 
-      // Merge access filter with where clause
       const mergedWhere = mergeFilters(scopedWhere, accessResult)
       if (mergedWhere === null) {
         return []
@@ -1180,7 +1173,6 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       where = mergedWhere
     }
 
-    // When a query fragment is provided, build include from fragment fields
     const fragment = isFragment(args?.query) ? args.query : null
 
     // Resolve `include`, folding any declared dependencies (`needs`,
@@ -1195,16 +1187,10 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       config,
     )
 
-    // Virtual fields have no database column. Whichever path produced
-    // `include` (fragment, access-controlled merge, or sudo passthrough), a
-    // virtual key must never reach Prisma — it would throw "Unknown field"
-    // (#628). Below, `filterReadableFields` computes a virtual field's value
-    // exactly when `selection` says the read is going to return it (ADR-0027)
-    // — every one of them for a bare/`include`-based read (`selection` is
-    // `undefined`), only the ones a fragment named otherwise.
+    // Strips virtual keys from `include` before the Prisma call — see the
+    // `createFindUnique` comment above for why (#628, ADR-0027).
     include = stripVirtualFieldsFromInclude(include, listConfig.fields, config)
 
-    // Execute query with optimized includes
     // Access Prisma model dynamically - required because model names are generated at runtime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const model = (prisma as any)[getDbKey(listName)]
@@ -1216,7 +1202,6 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       include,
     })
 
-    // Filter readable fields for each item and apply resolveOutput hooks (including nested relationships)
     // Pass sudo flag through context to skip field-level access checks
     const filtered = await Promise.all(
       items.map((item: Record<string, unknown>) =>
@@ -1236,7 +1221,6 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       ),
     )
 
-    // When a fragment is provided, pick only the requested fields from each result
     if (fragment) {
       return filtered.map((item: Record<string, unknown>) => pickFields(item, fragment._fields))
     }
@@ -1270,9 +1254,6 @@ function createFindFirst(findManyOp: ReturnType<typeof createFindMany>) {
   }
 }
 
-/**
- * Create create operation with access control and hooks
- */
 function createCreate<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1296,10 +1277,8 @@ function createCreate<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create createMany operation with access control and hooks
- * Runs create in a loop to ensure all hooks and access control are executed for each item
- */
+// Runs create in a loop (not Prisma's native createMany) so every item still
+// gets its own hooks and access control.
 function createCreateMany<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1322,9 +1301,6 @@ function createCreateMany<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create update operation with access control and hooks
- */
 function createUpdate<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1348,10 +1324,8 @@ function createUpdate<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create updateMany operation with access control and hooks
- * Runs findMany to get records, then update in a loop to ensure all hooks and access control are executed
- */
+// Finds matching records, then updates each individually (not Prisma's native
+// updateMany) so every item still gets its own hooks and access control.
 function createUpdateMany<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1365,10 +1339,8 @@ function createUpdateMany<TPrisma extends PrismaClientLike>(
   updateFn: any,
 ) {
   return async (args: { where?: Record<string, unknown>; data: Record<string, unknown> }) => {
-    // First, find all matching records (respects access control)
     const items = await findManyFn({ where: args.where })
 
-    // Then update each one individually (runs hooks and access control for each)
     const results = []
     for (const item of items) {
       const result = await updateFn({ where: { id: item.id }, data: args.data })
@@ -1379,9 +1351,6 @@ function createUpdateMany<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create delete operation with access control and hooks
- */
 function createDelete<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1405,9 +1374,6 @@ function createDelete<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create count operation with access control
- */
 function createCount<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1468,7 +1434,6 @@ function createCount<TPrisma extends PrismaClientLike>(
           })) as Record<string, unknown>)
         : args?.where
 
-      // Merge access filter with where clause
       const mergedWhere = mergeFilters(scopedWhere, accessResult)
       if (mergedWhere === null) {
         return 0
@@ -1476,7 +1441,6 @@ function createCount<TPrisma extends PrismaClientLike>(
       where = mergedWhere
     }
 
-    // Execute count
     // Access Prisma model dynamically - required because model names are generated at runtime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const model = (prisma as any)[getDbKey(listName)]
@@ -1488,10 +1452,6 @@ function createCount<TPrisma extends PrismaClientLike>(
   }
 }
 
-/**
- * Create get operation for singleton lists
- * Returns the single record, or auto-creates it if enabled
- */
 function createGet<TPrisma extends PrismaClientLike>(
   listName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -1509,15 +1469,12 @@ function createGet<TPrisma extends PrismaClientLike>(
     // `select` is not honoured — accepted only so the no-op can be made visible.
     select?: Record<string, unknown>
   }) => {
-    // `select` is a visible no-op: warn, then proceed with include/query narrowing.
     warnIfSelectIgnored(args, listName, 'get')
 
-    // First try to find the existing record
     // Access Prisma model dynamically - required because model names are generated at runtime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const model = (prisma as any)[getDbKey(listName)]
 
-    // Check query access (skip if sudo mode)
     let where: Record<string, unknown> = {}
     if (!context._isSudo) {
       const queryAccess = listConfig.access?.operation?.query
@@ -1530,15 +1487,15 @@ function createGet<TPrisma extends PrismaClientLike>(
         return null
       }
 
-      // Merge access filter (for singleton, we don't have a specific where clause)
+      // A singleton has no per-record `where`, so the access filter (if any) is
+      // the whole `where`.
       if (accessResult && typeof accessResult === 'object') {
         where = accessResult
       }
     }
 
-    // When a query fragment is provided, build the include from the fragment
-    // instead of the access-controlled include. Access control still runs via
-    // filterReadableFields; the fragment then narrows to only the requested fields.
+    // Access control still runs via filterReadableFields even though a
+    // fragment drives `include`; the fragment only narrows which fields come back.
     const fragment = isFragment(args?.query) ? args.query : null
 
     // Resolve `include`, folding any declared dependencies (`needs`,
@@ -1556,15 +1513,12 @@ function createGet<TPrisma extends PrismaClientLike>(
     // Virtual fields have no database column and must never reach Prisma (#628).
     include = stripVirtualFieldsFromInclude(include, listConfig.fields, config)
 
-    // Try to find the record
     const item = await model.findFirst({
       where,
       include,
     })
 
-    // If record exists, return it
     if (item) {
-      // Filter readable fields and apply resolveOutput hooks
       const filtered = await filterReadableFields(
         item,
         listConfig.fields,
@@ -1578,20 +1532,17 @@ function createGet<TPrisma extends PrismaClientLike>(
         declaredOnly,
         selection,
       )
-      // When a fragment is provided, pick only the requested fields from the result
       if (fragment) {
         return pickFields(filtered, fragment._fields)
       }
       return filtered
     }
 
-    // If no record and auto-create is enabled, create it
     if (shouldAutoCreate(listConfig)) {
       const defaultData = getDefaultData(listConfig)
       return await createFn({ data: defaultData })
     }
 
-    // No record and auto-create is disabled
     return null
   }
 }

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -19,34 +19,15 @@ import { getDbKey } from '../lib/case-utils.js'
 import { applyCreateDefaults } from './apply-defaults.js'
 
 /**
- * Nested writes (#569 / ADR-0010).
- *
- * Nested `create`/`update`/`delete` must fire the SAME list- and field-level
- * `beforeOperation`/`afterOperation` as the equivalent top-level write, so a
- * record's side effects are identical whether it was written nested or
- * top-level. Persistence itself is still performed by Prisma's single nested
- * write (so Prisma keeps owning FK ordering and intra-statement atomicity); we
- * run the nested records' `beforeOperation` BEFORE that persist and their
- * `afterOperation` AFTER it, all inside the one interactive transaction the
- * Write Pipeline opens.
- *
- * Mechanism (per ADR-0010, "hooks around a single nested persist"):
- *   - `processNestedOperations` runs nested resolveInput/validate/field-rules
- *     (as before) AND nested `beforeOperation`, and returns the transformed
- *     payload together with a list of deferred {@link AfterTask}s.
- *   - The Write Pipeline persists the parent (with the nested relations
- *     `include`d so the persisted nested rows come back), then calls
- *     {@link runAfterTasks} so each nested record's `afterOperation` fires with
- *     a real persisted `item` and (for update/delete) its `originalItem`.
- *   - Everything runs inside the transaction, so a throwing `beforeOperation`/
- *     `afterOperation` rolls back the whole write.
+ * Nested writes (#569 / ADR-0010): give nested `create`/`update`/`delete` the
+ * same before/afterOperation hooks as an equivalent top-level write, inside
+ * the one transaction the Write Pipeline opens. `processNestedOperations`
+ * transforms the payload and runs `beforeOperation`, returning deferred
+ * {@link AfterTask}s that {@link runAfterTasks} runs once the parent has
+ * persisted. See ADR-0010 for the full mechanism.
  */
 
-/**
- * A deferred nested `afterOperation` task, run after the parent has persisted.
- * It receives the persisted parent row (with nested relations included) so it
- * can recover the persisted nested `item`.
- */
+/** A deferred nested `afterOperation` task, run once the parent has persisted. */
 export interface AfterTask {
   /** Field name on the parent linking to the related list (for include lookup). */
   fieldName: string
@@ -67,16 +48,11 @@ export interface NestedOpsResult {
   includeFields: Set<string>
 }
 
-/**
- * Check if a field config is a relationship field
- */
 function isRelationshipField(fieldConfig: FieldConfig | undefined): boolean {
   return fieldConfig?.type === 'relationship'
 }
 
-/**
- * Resolve the related list name for a related list config (config object identity).
- */
+/** Resolve a list name by matching config object identity, not by name. */
 function findListName(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   relatedListConfig: ListConfig<any>,
@@ -94,8 +70,7 @@ function findListName(
  * Read the rows of a parent's included relation as an array.
  *
  * A to-one relation comes back as a single row (or `null`); a to-many relation
- * comes back as an array. This normalises both to an array so callers can apply
- * a uniform id-diff.
+ * comes back as an array. Normalises both so callers can apply a uniform id-diff.
  */
 function includedRows(
   parentResult: Record<string, unknown>,
@@ -123,13 +98,10 @@ function recoverUpdatedRow(
 }
 
 /**
- * Recover the CREATED nested rows from the parent result by id-diff.
- *
- * Created rows have no known id before the write, so they are identified as the
- * included rows whose ids are NOT in `preExistingIds` (the set of related-row
- * ids captured before the persist). Returned in include order, which the create
- * handler pairs to its create-payload entries by position (see
- * {@link CreatedRowRecovery}).
+ * Recover the CREATED nested rows from the parent result by id-diff: the
+ * included rows whose ids are NOT in `preExistingIds`. Returned in include
+ * order, which {@link CreatedRowRecovery} pairs to create-payload entries by
+ * position — reordering this would break that pairing.
  */
 function recoverCreatedRows(
   parentResult: Record<string, unknown>,
@@ -143,19 +115,13 @@ function recoverCreatedRows(
 
 /**
  * Shared, memoised recovery of the rows created for ONE nested `create` payload
- * on ONE relation field.
+ * on ONE relation field, by id-diff against the parent's pre-persist related
+ * ids, paired to create-payload entries by position. See ADR-0010. The id-diff
+ * is cached per parent result so every entry's task shares it.
  *
- * A to-many `create: [{A},{B}]` produces several rows that must each fire their
- * own `afterOperation` against their OWN row. We cannot tell which included row
- * corresponds to which payload entry by content alone, so we identify the set of
- * NEW rows by id-diff against the ids that existed before the persist, then pair
- * them to the create-payload entries by POSITION (Prisma preserves create-array
- * order in the included result). The id-diff is computed once per parent result
- * and cached so every entry's task shares it.
- *
- * `inputData`↔row pairing is therefore positional and best-effort; `item`
- * correctness (each task gets a genuinely-created, distinct row) is guaranteed:
- * a pre-existing row can never be returned because it is excluded by the diff.
+ * `inputData`↔row pairing is positional and best-effort; `item` correctness
+ * (each task gets a genuinely-created, distinct row) is guaranteed — a
+ * pre-existing row can never be returned because the diff excludes it.
  */
 interface CreatedRowRecovery {
   /** Recover the created row for the create-payload entry at `index`. */
@@ -182,14 +148,8 @@ function createCreatedRowRecovery(
 
 /**
  * Capture the ids of the rows currently linked to the parent via `fieldName`,
- * BEFORE the parent persists. Used to identify which included rows are NEW
- * (created by this write) afterwards.
- *
- * - For a parent CREATE there are no pre-existing related rows (the parent does
- *   not exist yet), so the set is empty.
- * - For a parent UPDATE we read the parent row's current relation and collect
- *   its ids. The same `tx` client is used so the read participates in the
- *   transaction and sees a consistent snapshot.
+ * BEFORE the parent persists, so created rows can later be identified by id-diff.
+ * Empty for a parent CREATE (no parent row exists yet to have related rows).
  */
 async function capturePreExistingIds(
   parentListName: string,
@@ -220,11 +180,9 @@ async function capturePreExistingIds(
 }
 
 /**
- * Process nested create operations.
- *
- * Runs the target list's full input pipeline (resolveInput → validate →
- * field-rules → filter-writable → recurse) AND its `beforeOperation`, then
- * registers an `afterOperation` task keyed to the parent's included relation.
+ * Process nested create operations: run the target list's full input pipeline
+ * and `beforeOperation`, then register an `afterOperation` task keyed to the
+ * parent's included relation.
  */
 async function processNestedCreate(
   items: Record<string, unknown> | Array<Record<string, unknown>>,
@@ -242,7 +200,6 @@ async function processNestedCreate(
 
   const processedItems = await Promise.all(
     itemsArray.map(async (item, index) => {
-      // 1. Check create access (skip if sudo mode)
       if (!context._isSudo) {
         const createAccess = relatedListConfig.access?.operation?.create
         const accessResult = await checkAccess(createAccess, {
@@ -255,7 +212,6 @@ async function processNestedCreate(
         }
       }
 
-      // 2. Execute list-level resolveInput hook
       let resolvedData = await executeResolveInput(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'create',
@@ -265,7 +221,6 @@ async function processNestedCreate(
         context,
       })
 
-      // 3. Execute field-level resolveInput hooks
       resolvedData = await executeFieldResolveInputHooks(
         item,
         resolvedData,
@@ -275,13 +230,11 @@ async function processNestedCreate(
         relatedListName,
       )
 
-      // 3.5 Apply field defaults to omitted inputs (resolve-then-validate, #615).
-      // Mirrors the top-level Hook Pipeline so a nested required-with-default
-      // field resolves to its default before validation instead of failing
-      // `isRequired`. Create-only; explicit values (incl. null) are preserved.
+      // Apply field defaults to omitted inputs (resolve-then-validate, #615) so
+      // a nested required-with-default field resolves before `isRequired` runs,
+      // mirroring the top-level pipeline. Create-only.
       resolvedData = applyCreateDefaults(resolvedData, relatedListConfig.fields)
 
-      // 4. Execute validate hook
       await executeValidate(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'create',
@@ -291,7 +244,6 @@ async function processNestedCreate(
         context,
       })
 
-      // 4.5 Field-level validate hooks
       await executeFieldValidateHooks(
         item,
         resolvedData,
@@ -301,14 +253,13 @@ async function processNestedCreate(
         relatedListName,
       )
 
-      // 5. Field validation (built-in rules)
       const validation = validateFieldRules(resolvedData, relatedListConfig.fields, 'create')
       if (validation.errors.length > 0) {
         throw new ValidationError(validation.errors, validation.fieldErrors)
       }
 
-      // 5.5 Split multi-column fields into physical columns (#789). Only
-      // reached once the logical value has passed validation above.
+      // Split multi-column fields into physical columns (#789) — must run after
+      // validation, which operates on the logical (pre-split) value.
       resolvedData = await splitMultiColumnFields(
         item,
         resolvedData,
@@ -317,7 +268,6 @@ async function processNestedCreate(
         context,
       )
 
-      // 6. Filter writable fields
       const filtered = await filterWritableFields(
         resolvedData,
         relatedListConfig.fields,
@@ -329,9 +279,8 @@ async function processNestedCreate(
         },
       )
 
-      // 7. Recursively process nested operations in this item. This nested row
-      // is itself being CREATED, so its own relations have no pre-existing rows
-      // (parent originalItem is undefined → empty pre-existing set).
+      // This nested row is itself being created, so it has no pre-existing
+      // related rows of its own (parent originalItem is undefined below).
       const { data: nestedData, afterTasks: childAfterTasks } = await processNestedOperations(
         filtered,
         relatedListConfig.fields,
@@ -340,12 +289,11 @@ async function processNestedCreate(
         'create',
         relatedListName,
         undefined,
-        // This nested row is being CREATED, so its enclosing inputData is its own
-        // create payload (passed to the connect-site owning-field gate, #588).
+        // Its own create payload is the enclosing inputData for the connect-site
+        // owning-field gate (#588).
         item,
       )
 
-      // 8. Field-level beforeOperation (side effects) for this nested create
       await executeFieldBeforeOperationHooks(
         item,
         resolvedData,
@@ -355,7 +303,6 @@ async function processNestedCreate(
         relatedListName,
       )
 
-      // 9. List-level beforeOperation for this nested create
       await executeBeforeOperation(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'create',
@@ -364,26 +311,19 @@ async function processNestedCreate(
         context,
       })
 
-      // 10. Register afterOperation: fires once the parent (and thus this nested
-      // row) has persisted. The created row is recovered by id-diff and paired
-      // to THIS create-payload entry by position (see CreatedRowRecovery), so a
-      // to-many `create: [{A},{B}]` fires once per row, each against its OWN
-      // distinct row, and never against a pre-existing sibling.
+      // Fires once the parent has persisted. The row is recovered by id-diff and
+      // paired to THIS entry by position (see CreatedRowRecovery), so a to-many
+      // `create: [{A},{B}]` fires once per row against its own distinct row.
       afterTasks.push({
         fieldName,
         run: async (parentResult) => {
           const createdItem = recovery.rowAt(parentResult, index)
           if (!createdItem) {
-            // The created row could not be identified by id-diff — the parent
-            // write did not return this nested relation (e.g. the underlying
-            // client does not echo `include`d relations). We must NOT hand an
-            // id-less `{}` to a hook as if it were the persisted row (finding 4:
-            // that would fire `afterOperation` against a fabricated item). The
-            // before-persist hooks have already run; we deliberately SKIP this
-            // record's create `afterOperation` rather than fire it with a bogus
-            // item. Real Prisma always echoes the `include`d relation, so this
-            // skip is reached only by clients/mocks that omit it. `item`
-            // correctness is the must-have; a missing row is never fabricated.
+            // Could not identify the created row by id-diff — the parent write
+            // didn't echo this nested relation (e.g. a client/mock that doesn't
+            // honour `include`; real Prisma always does). Deliberately SKIP this
+            // record's `afterOperation` rather than fabricate an id-less item —
+            // `item` correctness is the must-have, so a missing row is never faked.
             return
           }
 
@@ -406,7 +346,6 @@ async function processNestedCreate(
             relatedListName,
           )
 
-          // Run any deeper nested afterOperation tasks, scoped to the persisted row.
           await runAfterTasks(childAfterTasks, createdItem)
         },
       })
@@ -421,23 +360,18 @@ async function processNestedCreate(
 /**
  * Verify that a single connection target is reachable for the caller.
  *
- * Connecting an existing row references it; it does not modify the row's own
- * data. Mirroring Keystone, this requires **read/query** access on the target
- * list (not `update`). When query access returns a filter object, the filter is
- * evaluated in the DATABASE (not in memory) via
- * `findFirst({ where: { AND: [connection, accessFilter] } })`. The connect is
- * allowed iff that query returns a row, which correctly handles arbitrary
- * nested-relation predicates and boolean combinators (`AND`/`OR`/`some`/
- * `none`/`not`). The existence check is folded into the reachability query so a
- * non-existent id is still denied.
+ * Connecting references an existing row rather than modifying it, so — mirroring
+ * Keystone — it requires **read/query** access on the target (#578), not update.
+ * A filter-result query access is evaluated in the DATABASE via
+ * `findFirst({ where: { AND: [connection, accessFilter] } })` rather than in
+ * memory, so it correctly handles arbitrary nested-relation predicates and
+ * boolean combinators; a non-existent id is folded into the same check.
  *
- * In ADDITION to the target read/reachability check (#578), the OWNING
- * relationship field's field-level access (its `create`/`update` access on the
- * list being written, e.g. `Post.author`) must permit the connect (#588). This
- * is the other half Keystone required: a connect needs read access on the
- * target AND write access on the owning relationship field. If the owning
- * field's field-level access denies, the connect is denied even when the target
- * row is readable/reachable.
+ * In ADDITION, the OWNING relationship field's field-level access (e.g.
+ * `Post.author`'s `create`/`update` access) must permit the connect (#588) —
+ * the other half Keystone requires: read access on the target AND write access
+ * on the owning field. A deny here denies the connect even when the target row
+ * is readable/reachable.
  *
  * Sudo bypasses the entire check (handled by the caller).
  */

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -391,18 +391,10 @@ async function verifyConnectReachable(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const model = (prisma as any)[getDbKey(relatedListName)]
 
-  // #588 — gate the connect by the OWNING relationship field's field-level
-  // access (evaluated for the enclosing write's operation). This runs in
-  // addition to the target read/reachability check below; a deny here denies
-  // the connect even if the target row is readable. `checkFieldAccess` returns
-  // `true` under sudo, but the caller already skips this whole function for
-  // sudo, so the gate never fires for trusted writes.
-  //
-  // `item`/`inputData` are the ENCLOSING write's `originalItem`/`inputData` —
-  // the SAME values the canonical Phase-5 `filterWritableFields` call passes for
-  // this field — so a field-access rule that depends on `item` or `inputData`
-  // (e.g. `({ item }) => item.status === 'draft'`) evaluates identically here and
-  // at Phase 5, and the two gates cannot diverge into a spurious connect denial.
+  // #588 owning-field gate (see docblock above). `item`/`inputData` are the
+  // ENCLOSING write's `originalItem`/`inputData` — the same values the canonical
+  // Phase-5 `filterWritableFields` call passes for this field — so an
+  // item-/inputData-dependent field-access rule can't diverge between the two gates.
   const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
     session: context.session,
     item: enclosingItem,
@@ -413,20 +405,17 @@ async function verifyConnectReachable(
     throw new Error('Access denied: Cannot connect to this item')
   }
 
-  // Connecting references an existing row; it requires READ (query) access on
-  // the target, not update access.
   const queryAccess = relatedListConfig.access?.operation?.query
   const accessResult = await checkAccess(queryAccess, {
     session: context.session,
     context,
   })
 
-  // Explicit denial.
   if (accessResult === false) {
     throw new Error('Access denied: Cannot connect to this item')
   }
 
-  // Full access: still verify the row exists (keep "Item not found" behaviour).
+  // Full access still verifies the row exists, to keep "Item not found" behaviour.
   if (accessResult === true) {
     const item = await model.findUnique({ where: connection })
     if (!item) {
@@ -435,11 +424,8 @@ async function verifyConnectReachable(
     return
   }
 
-  // Filter result: confirm the row is reachable under the access filter by
-  // AND-combining the connection identifier with the filter and querying the DB.
-  // A non-existent id and an unreachable row both yield no row → denied. This
-  // correctly evaluates arbitrary nested-relation predicates and boolean
-  // combinators because the database does the matching, not an in-memory walk.
+  // Filter result: reachable iff AND-combining the connection with the filter
+  // returns a row (see docblock above).
   const reachable = await model.findFirst({
     where: { AND: [connection, accessResult] },
   })
@@ -468,7 +454,6 @@ async function processNestedConnect(
 ): Promise<Record<string, unknown> | Array<Record<string, unknown>>> {
   const connectionsArray = Array.isArray(connections) ? connections : [connections]
 
-  // Check read access for each item being connected (skip if sudo mode)
   if (!context._isSudo) {
     for (const connection of connectionsArray) {
       await verifyConnectReachable(
@@ -516,18 +501,15 @@ async function processNestedUpdate(
 
       const where = (update as Record<string, unknown>).where as Record<string, unknown>
 
-      // Fetch the existing item — reused as `originalItem` for afterOperation.
+      // Fetched here and reused as `originalItem` for afterOperation.
       const originalItem = await model.findUnique({ where })
 
       if (!originalItem) {
         throw new Error('Cannot update: Item not found')
       }
 
-      // The updated row's id is known up front, so the included-result read-back
-      // finds this row directly by id.
       const knownId = typeof originalItem.id === 'string' ? (originalItem.id as string) : undefined
 
-      // Check update access (skip if sudo mode)
       if (!context._isSudo) {
         const updateAccess = relatedListConfig.access?.operation?.update
         const accessResult = await checkAccess(updateAccess, {
@@ -541,7 +523,6 @@ async function processNestedUpdate(
         }
       }
 
-      // Execute list-level resolveInput hook
       const updateData = (update as Record<string, unknown>).data as Record<string, unknown>
       let resolvedData = await executeResolveInput(relatedListConfig.hooks, {
         listKey: relatedListName,
@@ -552,7 +533,6 @@ async function processNestedUpdate(
         context,
       })
 
-      // Execute field-level resolveInput hooks
       resolvedData = await executeFieldResolveInputHooks(
         updateData,
         resolvedData,
@@ -563,7 +543,6 @@ async function processNestedUpdate(
         originalItem,
       )
 
-      // Execute validate hook
       await executeValidate(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'update',
@@ -573,7 +552,6 @@ async function processNestedUpdate(
         context,
       })
 
-      // Field-level validate hooks
       await executeFieldValidateHooks(
         updateData,
         resolvedData,
@@ -584,14 +562,13 @@ async function processNestedUpdate(
         originalItem,
       )
 
-      // Field validation (built-in rules)
       const validation = validateFieldRules(resolvedData, relatedListConfig.fields, 'update')
       if (validation.errors.length > 0) {
         throw new ValidationError(validation.errors, validation.fieldErrors)
       }
 
-      // Split multi-column fields into physical columns (#789). Only reached
-      // once the logical value has passed validation above.
+      // Split multi-column fields into physical columns (#789) — must run after
+      // validation, which operates on the logical (pre-split) value.
       resolvedData = await splitMultiColumnFields(
         updateData,
         resolvedData,
@@ -601,7 +578,6 @@ async function processNestedUpdate(
         originalItem,
       )
 
-      // Filter writable fields
       const filtered = await filterWritableFields(
         resolvedData,
         relatedListConfig.fields,
@@ -614,8 +590,8 @@ async function processNestedUpdate(
         },
       )
 
-      // Recursively process nested operations. This nested row is being UPDATED,
-      // so its own relations' pre-existing rows are captured from `originalItem`.
+      // This nested row is being updated, so its own relations' pre-existing
+      // rows are captured from `originalItem` below.
       const { data: nestedData, afterTasks: childAfterTasks } = await processNestedOperations(
         filtered,
         relatedListConfig.fields,
@@ -624,12 +600,11 @@ async function processNestedUpdate(
         'update',
         relatedListName,
         originalItem,
-        // This nested row is being UPDATED, so its enclosing inputData is its own
-        // update payload (passed to the connect-site owning-field gate, #588).
+        // Its own update payload is the enclosing inputData for the connect-site
+        // owning-field gate (#588).
         updateData,
       )
 
-      // Field-level beforeOperation (side effects)
       await executeFieldBeforeOperationHooks(
         updateData,
         resolvedData,
@@ -640,7 +615,6 @@ async function processNestedUpdate(
         originalItem,
       )
 
-      // List-level beforeOperation
       await executeBeforeOperation(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'update',
@@ -650,8 +624,7 @@ async function processNestedUpdate(
         context,
       })
 
-      // Register afterOperation: fires after the parent persist. The updated row
-      // is recovered from the parent's included relation by its known id.
+      // Fires after the parent persist; the row is recovered by its known id.
       afterTasks.push({
         fieldName,
         run: async (parentResult) => {
@@ -732,7 +705,6 @@ async function processNestedDelete(
         throw new Error('Cannot delete: Item not found')
       }
 
-      // Check delete access (skip if sudo mode)
       if (!context._isSudo) {
         const deleteAccess = relatedListConfig.access?.operation?.delete
         const accessResult = await checkAccess(deleteAccess, {
@@ -746,7 +718,6 @@ async function processNestedDelete(
         }
       }
 
-      // List-level validate (delete)
       await executeValidate(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'delete',
@@ -754,7 +725,6 @@ async function processNestedDelete(
         context,
       })
 
-      // Field-level validate (delete)
       await executeFieldValidateHooks(
         undefined,
         undefined,
@@ -765,7 +735,6 @@ async function processNestedDelete(
         originalItem,
       )
 
-      // Field-level beforeOperation (delete)
       await executeFieldBeforeOperationHooks(
         {},
         {},
@@ -776,7 +745,6 @@ async function processNestedDelete(
         originalItem,
       )
 
-      // List-level beforeOperation (delete)
       await executeBeforeOperation(relatedListConfig.hooks, {
         listKey: relatedListName,
         operation: 'delete',
@@ -784,8 +752,8 @@ async function processNestedDelete(
         context,
       })
 
-      // Register afterOperation: the row is gone after persist, so the
-      // originalItem is the authoritative record passed to after-hooks.
+      // The row is gone after persist, so originalItem is the authoritative
+      // record passed to the after-hooks below.
       afterTasks.push({
         fieldName: '',
         run: async () => {
@@ -814,9 +782,6 @@ async function processNestedDelete(
   return deletes
 }
 
-/**
- * Process nested connectOrCreate operations
- */
 async function processNestedConnectOrCreate(
   operations: Record<string, unknown> | Array<Record<string, unknown>>,
   fieldName: string,
@@ -839,15 +804,11 @@ async function processNestedConnectOrCreate(
     operationsArray.map(async (op) => {
       const opRecord = op as Record<string, unknown>
 
-      // Check access for the connect portion (skip if sudo mode).
-      //
-      // connectOrCreate connects an existing row when present, otherwise
-      // creates. So when the row exists we apply the same connect semantics as
-      // processNestedConnect — READ (query) access on the target, evaluated via
-      // DB reachability for filter results, PLUS the owning relationship field's
-      // field-level access (#588). When the row does not exist we fall through to
-      // create. We must NOT swallow an access-denied error: only the genuine
-      // "row absent" case may fall back to create.
+      // When the target row exists, connectOrCreate applies the same connect
+      // semantics as processNestedConnect (read access + #588 owning-field gate,
+      // both evaluated via DB reachability); otherwise it falls through to
+      // create. An access-denied error must NOT be swallowed into that fallback
+      // — only a genuine "row absent" may fall back to create.
       let rowExists = false
       if (!context._isSudo) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -856,18 +817,9 @@ async function processNestedConnectOrCreate(
 
         const existingItem = await model.findUnique({ where })
 
-        // Only enforce connect access when the row actually exists; otherwise
-        // the create branch is used.
         if (existingItem) {
           rowExists = true
 
-          // #588 — gate the connect branch by the OWNING relationship field's
-          // field-level access, identical to processNestedConnect. A deny here
-          // denies the connect even if the target row is readable/reachable.
-          // `item`/`inputData` are the ENCLOSING write's `originalItem`/
-          // `inputData` (the same values Phase-5 `filterWritableFields` passes),
-          // so item-/inputData-dependent field rules cannot diverge between the
-          // two gates.
           const owningFieldAllowed = await checkFieldAccess(owningFieldAccess, enclosingOperation, {
             session: context.session,
             item: enclosingItem,
@@ -889,8 +841,6 @@ async function processNestedConnectOrCreate(
             throw new Error('Access denied: Cannot connect to existing item')
           }
 
-          // Filter result: confirm the existing row is reachable under the
-          // access filter via DB reachability (handles nested/boolean filters).
           if (accessResult !== true) {
             const reachable = await model.findFirst({
               where: { AND: [where, accessResult] },
@@ -903,11 +853,10 @@ async function processNestedConnectOrCreate(
         }
       }
 
-      // Process the create portion through the full create pipeline (incl.
-      // before/afterOperation). Only register an afterOperation task when the
-      // create branch will actually run (row absent), so a pure connect does not
-      // fire create hooks. Under sudo we cannot statically know, so we let the
-      // create pipeline run its hooks (sudo bypasses access only, not hooks).
+      // Only register an afterOperation task when the create branch will
+      // actually run (row absent), so a pure connect doesn't fire create hooks.
+      // Under sudo we can't tell statically, so the create pipeline always runs
+      // its hooks there (sudo bypasses access only, not hooks).
       const runCreateHooks = context._isSudo || !rowExists
       const createAfterTasks: AfterTask[] = runCreateHooks ? afterTasks : []
       const processedCreate = await processNestedCreate(
@@ -945,29 +894,20 @@ interface NestedOpHandlerArgs {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   relatedListConfig: ListConfig<any>
   /**
-   * Field-level `access` of the OWNING relationship field on the list being
-   * written (e.g. `Post.author`). Used by the connect/connectOrCreate handlers
-   * to gate connects by the owning field's create/update access (#588).
+   * Field-level `access` of the OWNING relationship field (e.g. `Post.author`).
+   * Gates connect/connectOrCreate by the owning field's create/update access —
+   * see the #588 gate in {@link verifyConnectReachable}.
    */
   owningFieldAccess: FieldAccess | undefined
-  /**
-   * The enclosing write's operation (`create`/`update`), used as the field-access
-   * operation for the owning-field connect gate (#588).
-   */
+  /** The enclosing write's operation, used as the owning-field gate's field-access operation. */
   enclosingOperation: 'create' | 'update'
   /**
-   * The enclosing write's existing row (the parent `originalItem`): present for an
-   * enclosing UPDATE, `undefined` for an enclosing CREATE. Threaded into the
-   * connect-site owning-field gate so it evaluates `item` exactly like the
-   * canonical Phase-5 `filterWritableFields` call and the two cannot diverge
-   * (#588 finding).
+   * The enclosing write's `originalItem` (`undefined` for an enclosing create).
+   * Passed to the owning-field gate so it matches the canonical Phase-5
+   * `filterWritableFields` call and the two can't diverge (#588).
    */
   enclosingItem: Record<string, unknown> | undefined
-  /**
-   * The enclosing write's input data. Threaded into the connect-site owning-field
-   * gate so it evaluates `inputData` exactly like the canonical Phase-5
-   * `filterWritableFields` call (#588 finding).
-   */
+  /** The enclosing write's input data, passed to the owning-field gate for the same reason as `enclosingItem`. */
   enclosingInputData: Record<string, unknown> | undefined
   context: AccessContext
   config: OpenSaasConfig
@@ -1241,10 +1181,8 @@ export async function processNestedOperations(
   operation: 'create' | 'update',
   parentListName: string,
   parentOriginalItem: Record<string, unknown> | undefined,
-  // The enclosing write's input data (the SAME value Phase-5 `filterWritableFields`
-  // passes as `inputData`). Threaded into the connect-site owning-field gate (#588
-  // finding) so item-/inputData-dependent field-access rules cannot diverge between
-  // Phase 5 and the connect site. `undefined` is tolerated (defaults to `{}`).
+  // The enclosing write's inputData, for the #588 owning-field gate (see
+  // verifyConnectReachable). `undefined` is tolerated (defaults to `{}`).
   parentInputData: Record<string, unknown> | undefined = undefined,
 ): Promise<NestedOpsResult> {
   const afterTasks: AfterTask[] = []
@@ -1255,13 +1193,11 @@ export async function processNestedOperations(
   for (const [fieldName, value] of Object.entries(data)) {
     const fieldConfig = fieldConfigs[fieldName]
 
-    // If not a relationship field or no value, pass through
     if (!isRelationshipField(fieldConfig) || value === null || value === undefined) {
       processed[fieldName] = value
       continue
     }
 
-    // Get related list config
     const relationshipField = fieldConfig as { type: 'relationship'; ref: string }
     const relatedConfig = getRelatedListConfig(relationshipField.ref, config)
     if (!relatedConfig) {
@@ -1270,13 +1206,10 @@ export async function processNestedOperations(
     }
 
     const { listName: relatedListName, listConfig: relatedListConfig } = relatedConfig
-    // Sanity: ensure the resolved list name matches the config identity.
     const resolvedListName = relatedListName || findListName(relatedListConfig, config)
 
-    // #588 — the owning relationship field's field-level access (e.g. the
-    // `access` on `Post.author`). Threaded into the nested-op handlers so the
-    // connect/connectOrCreate handlers can gate connects by this field's
-    // create/update access, in addition to the target's read access.
+    // The owning relationship field's field-level access, for the #588 gate
+    // in verifyConnectReachable.
     const owningFieldAccess = fieldConfig.access
 
     processed[fieldName] = await processFieldNestedOps(
@@ -1287,10 +1220,8 @@ export async function processNestedOperations(
         relatedListConfig,
         owningFieldAccess,
         enclosingOperation: operation,
-        // The enclosing write's `originalItem`/`inputData` — the SAME values the
-        // canonical Phase-5 `filterWritableFields` call passes for this field — so
-        // the connect-site owning-field gate evaluates item-/inputData-dependent
-        // rules identically and cannot diverge into a spurious connect denial (#588).
+        // Same values Phase-5 `filterWritableFields` passes for this field, so
+        // the #588 owning-field gate can't diverge from it.
         enclosingItem: parentOriginalItem,
         enclosingInputData: parentInputData ?? {},
         context,

--- a/packages/core/src/context/transaction-boundary.ts
+++ b/packages/core/src/context/transaction-boundary.ts
@@ -54,17 +54,12 @@ function isRelationshipField(fieldConfig: FieldConfig | undefined): boolean {
 }
 
 /**
- * The number of distinct (listKey, operation) involvement pairs the walk
- * could ever record starting from `startListName` — computed from the
- * CONFIG's relationship graph (not the payload), so it bounds the walk by
- * what the schema can reach rather than by an arbitrary depth.
- *
- * Used as the saturation bound: once `walkNested` has recorded this many
- * pairs, no further pair can be new, so it stops descending. This replaces
- * the old depth cap as the cost bound (#835) — a payload nesting the config's
- * lists more deeply than any previous cap no longer loses their
- * transaction-boundary hooks, while a payload that repeats the same few
- * lists still terminates promptly instead of walking every entry.
+ * Distinct (listKey, operation) pairs reachable from `startListName` via the
+ * CONFIG's relationship graph (not the payload) — the saturation bound
+ * `walkNested` stops at once it has recorded this many. Bounding by reachable
+ * pairs rather than a depth cap (#835) avoids losing hooks for payloads
+ * nested deeper than any fixed cap, while still terminating promptly on
+ * payloads that repeat the same few lists.
  */
 function countReachableInvolvementPairs(
   startListName: string,
@@ -96,15 +91,7 @@ function asRecordArray(value: unknown): Array<Record<string, unknown>> {
   return []
 }
 
-/**
- * Extract the create/update payload from a nested-op entry so nested
- * `beforeTransaction` receives meaningful `inputData`.
- *
- *  - `create`: the entry itself is the create data.
- *  - `update`: the entry's `data`.
- *  - `connectOrCreate`: the entry's `create`.
- *  - `delete`: no input payload.
- */
+/** Extract a nested-op entry's create/update payload so its `beforeTransaction` receives meaningful `inputData`. */
 function nestedInputData(
   kind: string,
   entry: Record<string, unknown>,
@@ -124,10 +111,10 @@ function nestedInputData(
 
 /**
  * Recursively walk a write payload's relationship fields, appending one
- * {@link InvolvedList} per nested create/update/delete involvement. De-dups by
- * (listKey, operation) so a list with many nested records of the same operation
- * fires its transaction-boundary bracket once (these hooks are a per-LIST
- * compensation bracket, not per-record).
+ * {@link InvolvedList} per nested create/update/delete involvement. De-dups
+ * by (listKey, operation): these hooks are a per-LIST compensation bracket,
+ * not per-record, so a list with many nested records of the same operation
+ * fires its bracket once.
  */
 function walkNested(
   data: Record<string, unknown> | undefined,
@@ -137,8 +124,7 @@ function walkNested(
   seen: Set<string>,
   maxPairs: number,
 ): void {
-  // Every reachable pair is already recorded — no further recursion can add
-  // anything new, so stop instead of re-walking the rest of the payload.
+  // Saturated: no further pair can be new (see countReachableInvolvementPairs).
   if (!data || seen.size >= maxPairs) return
 
   for (const [fieldName, value] of Object.entries(data)) {
@@ -156,7 +142,6 @@ function walkNested(
       if (opValue === undefined) continue
 
       const entries = asRecordArray(opValue)
-      // Record the involvement once per (list, operation).
       const dedupeKey = `${relatedListName}:${operation}`
       if (!seen.has(dedupeKey)) {
         seen.add(dedupeKey)
@@ -172,7 +157,6 @@ function walkNested(
 
       if (seen.size >= maxPairs) return
 
-      // Recurse into each nested entry's own relationship payload.
       for (const entry of entries) {
         const childData = nestedInputData(kind, entry)
         walkNested(childData, relatedListConfig.fields, config, out, seen, maxPairs)
@@ -183,8 +167,8 @@ function walkNested(
 
 /**
  * Enumerate the lists involved in a write — the top-level list plus every
- * nested create/update/delete target reachable from the input tree — WITHOUT
- * any DB reads. The top-level list is always first.
+ * nested create/update/delete target — without DB reads. The top-level list
+ * is always first.
  */
 export function enumerateInvolvedLists(args: {
   listName: string
@@ -211,16 +195,12 @@ export function enumerateInvolvedLists(args: {
   const seen = new Set<string>([`${listName}:${operation}`])
   const maxPairs = countReachableInvolvementPairs(listName, listConfig, config)
 
-  // Delete has no nested payload to walk (inputData is undefined).
   walkNested(inputData, listConfig.fields, config, out, seen, maxPairs)
 
   return out
 }
 
-/**
- * Run the list- and field-level `beforeTransaction` hooks for one involved list.
- * A throw propagates to the caller (which aborts the write).
- */
+/** Runs one involved list's `beforeTransaction` hooks. A throw propagates to the caller (which aborts the write). */
 async function runBeforeTransactionForList<TPrisma extends PrismaClientLike>(
   involved: InvolvedList,
   context: AccessContext<TPrisma>,
@@ -262,13 +242,11 @@ async function runBeforeTransactionForList<TPrisma extends PrismaClientLike>(
 }
 
 /**
- * Run the list- and field-level `afterTransaction` hooks for one involved list
- * with the settled {@link TransactionOutcome}. Collects (does not throw) any
- * errors so the caller can keep running the remaining lists' compensators.
- *
- * Exported for {@link TransactionRegistry}-drained (deferred, joined-write)
- * flushes, which run this same per-list logic once the transaction owner
- * observes the real settle (ADR-0028).
+ * Runs one involved list's `afterTransaction` hooks against the settled
+ * {@link TransactionOutcome}, collecting rather than throwing errors so the
+ * caller can keep running the remaining lists' compensators. Exported for
+ * {@link TransactionRegistry} to reuse when draining a deferred, joined
+ * write's bracket (ADR-0028).
  */
 export async function runAfterTransactionForList<TPrisma extends PrismaClientLike>(
   involved: InvolvedList,
@@ -278,15 +256,13 @@ export async function runAfterTransactionForList<TPrisma extends PrismaClientLik
 ): Promise<void> {
   const { listKey, listConfig, operation, isTopLevel, inputData, originalItem } = involved
 
-  // On commit, the persisted row (`outcome.item`) is the TOP-LEVEL row. We only
-  // surface `item`/`originalItem` for the top-level list — handing the top-level
-  // row to a nested list's hook (whose type is the nested list's own item) would
-  // be unsound, since the hook would silently read the wrong record. For nested
-  // lists we pass `undefined`; per-record nested compensation must use the
-  // in-transaction `afterOperation`, which already receives the correct nested row.
+  // The persisted row (`outcome.item`) is the TOP-LEVEL row only. Handing it to
+  // a nested list's hook would silently mis-type as that list's own item — for
+  // nested lists `item`/`originalItem` stay `undefined`; per-record nested
+  // compensation belongs in the in-transaction `afterOperation`, which gets the
+  // correct row.
   try {
     if (outcome.status === 'committed') {
-      // The persisted row is surfaced only for the top-level list (see above).
       const committedItem = isTopLevel ? outcome.item : undefined
       if (operation === 'create') {
         await executeAfterTransaction(listConfig.hooks, {
@@ -317,7 +293,6 @@ export async function runAfterTransactionForList<TPrisma extends PrismaClientLik
         })
       }
     } else {
-      // rolled-back: no persisted item.
       if (operation === 'create') {
         await executeAfterTransaction(listConfig.hooks, {
           listKey,
@@ -387,10 +362,9 @@ export class AfterTransactionError extends Error {
 }
 
 /**
- * Compute a joined write's FINAL outcome once its owner's settle is known
- * (ADR-0028): the write's own error always wins (it never fires early — see
- * the ADR's provider-dependent-early-settle rejection); otherwise the write
- * committed if and only if the owner's transaction also committed.
+ * Resolves a joined write's final outcome once the owner's settle is known
+ * (ADR-0028): the write's own error always wins; otherwise committed iff the
+ * owner's transaction also committed.
  */
 function resolveDeferredOutcome(
   writeOutcome: TransactionOutcome,
@@ -402,37 +376,17 @@ function resolveDeferredOutcome(
 }
 
 /**
- * Bracket a write's transaction with the transaction-boundary hooks (#590,
- * ADR-0028 / #899).
+ * Brackets a write's transaction with the transaction-boundary hooks (#590,
+ * ADR-0028 / #899): runs every involved list's `beforeTransaction` eagerly —
+ * a throw here aborts before `runTransaction` (#569) ever opens the write's
+ * transaction — then routes `afterTransaction` by ownership: deferred onto
+ * `args.joinedOwner`'s {@link TransactionRegistry} for a joined write, run
+ * eagerly (draining `args.ownedRegistry`) for the write that opened the
+ * transaction, or run eagerly with neither set. See ADR-0028 for why. A
+ * joined write's `afterTransaction` errors therefore surface as an
+ * {@link AfterTransactionError} from the OWNER's promise, not this write's.
  *
- * Sequence:
- *  1. Run every involved list's `beforeTransaction` in order, tracking which
- *     ran (always eager — ADR-0028 keeps the symmetric bracket's "before" half
- *     synchronous even for a joined write). A throw aborts: the transaction is
- *     NEVER opened, and the throw is re-surfaced.
- *  2. Otherwise run `runTransaction` (the existing #569 machinery — opens a
- *     real transaction, joins one already open, or runs directly against a
- *     client with no transaction support at all).
- *  3. What happens to `afterTransaction` next depends on ownership:
- *     - **Joined** (`args.joinedOwner` set — this write's context is nested in
- *       a transaction it did not open): its bracket is DEFERRED — enqueued on
- *       the owner's {@link TransactionRegistry} instead of firing now. The
- *       owner drains it once it observes the real settle, at which point
- *       {@link resolveDeferredOutcome} decides the final status.
- *     - **Owner** (`args.ownedRegistry` set — this write just opened the
- *       transaction every joined write below it shares): runs its own bracket
- *       eagerly exactly as before, THEN drains `ownedRegistry` with the same
- *       settle outcome so every write that joined this transaction gets its
- *       deferred bracket flushed too.
- *     - **Unowned** (neither set — no `context.transaction()` and no real
- *       transaction to open, e.g. a bare test double): unchanged, fires
- *       eagerly at write time (the "unowned join" case — there is no owner to
- *       defer to and no settle signal to wait for).
- *  4. If any `afterTransaction` throws, the rest still run; the collected
- *     errors are surfaced afterward as an {@link AfterTransactionError} — for
- *     a joined write this surfaces from the OWNER's promise, not this write's.
- *
- * Sudo does not affect these hooks — they always run; sudo only bypasses access.
+ * Sudo bypasses access control only — never these hooks.
  */
 export async function runWithTransactionBoundary<TPrisma extends PrismaClientLike>(args: {
   involvedLists: InvolvedList[]
@@ -445,10 +399,10 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
 }): Promise<Record<string, unknown> | null> {
   const { involvedLists, context, joinedOwner, ownedRegistry, runTransaction } = args
 
-  // Lists whose beforeTransaction ran (in order), for the symmetric bracket. A
-  // list is marked as "ran" the moment its beforeTransaction BEGINS, so even a
-  // list whose beforeTransaction throws gets its afterTransaction (it may have
-  // taken a partial external action that needs compensating).
+  // A list counts as "ran" the moment its beforeTransaction BEGINS (pushed
+  // before the try below), not on success — so a list whose beforeTransaction
+  // itself throws still gets its afterTransaction, in case it took a partial
+  // external action that needs compensating.
   const ran: InvolvedList[] = []
 
   let beforeError: unknown
@@ -462,13 +416,13 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
     }
   }
 
-  // beforeTransaction threw → abort: never open the transaction, compensate the
-  // lists whose beforeTransaction ran, then surface the original error.
+  // Abort path: never open the transaction; compensate the lists that ran,
+  // then rethrow the original error.
   if (beforeError !== undefined) {
     const outcome: TransactionOutcome = { status: 'rolled-back', error: beforeError }
     if (joinedOwner) {
-      // Deferred: matches the eager branch below, which also discards any
-      // afterTransaction errors on this path (only beforeError propagates).
+      // Discards any afterTransaction errors on this path — only beforeError
+      // propagates, matching the eager branch below.
       joinedOwner.enqueue(async (_settle, _errors) => {
         const discarded: unknown[] = []
         for (const involved of ran) {
@@ -484,7 +438,7 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
     throw beforeError
   }
 
-  // Open (or join) the transaction and capture THIS WRITE's own settle outcome.
+  // Open (or join) the transaction and capture this write's own settle outcome.
   let outcome: TransactionOutcome
   let result: Record<string, unknown> | null = null
   let txError: unknown
@@ -497,9 +451,8 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
   }
 
   if (joinedOwner) {
-    // Deferred (ADR-0028): this write cannot observe the enclosing
-    // transaction's real settle, so its bracket is queued rather than fired.
-    // The write's own result/throw is unaffected — only afterTransaction waits.
+    // Deferred (ADR-0028) — only afterTransaction waits; this write's own
+    // result/throw is returned/thrown normally below.
     joinedOwner.enqueue(async (settle, errors) => {
       const finalOutcome = resolveDeferredOutcome(outcome, settle)
       for (const involved of ran) {
@@ -510,24 +463,21 @@ export async function runWithTransactionBoundary<TPrisma extends PrismaClientLik
     return result
   }
 
-  // afterTransaction always runs for every list whose beforeTransaction ran
-  // (here: all involved lists). All compensators run even if one throws.
+  // All compensators run even if one throws.
   const afterErrors: unknown[] = []
   for (const involved of ran) {
     await runAfterTransactionForList(involved, outcome, context, afterErrors)
   }
 
-  // This write OWNS the transaction every joined write below it shares — drain
-  // their deferred brackets now, with the same settle outcome this write just
-  // observed (ADR-0028).
+  // Owner: drain joined writes' deferred brackets with this write's own settle
+  // outcome (ADR-0028).
   if (ownedRegistry) {
     const settle: TransactionSettleOutcome =
       txError !== undefined ? { status: 'rolled-back', error: txError } : { status: 'committed' }
     await ownedRegistry.drain(settle, afterErrors)
   }
 
-  // Surface errors: the transaction's own error takes precedence (the write
-  // failed); otherwise any afterTransaction errors (own + drained).
+  // Transaction error takes precedence over afterTransaction errors (ADR-0028).
   if (txError !== undefined) throw txError
   if (afterErrors.length > 0) throw new AfterTransactionError(afterErrors)
 

--- a/packages/core/src/context/transaction-boundary.ts
+++ b/packages/core/src/context/transaction-boundary.ts
@@ -15,51 +15,30 @@ import type {
 } from '../access/transaction-registry.js'
 
 /**
- * Transaction-boundary hooks (#590 / ADR-0010).
- *
- * `beforeTransaction`/`afterTransaction` run OUTSIDE the write's `$transaction`
- * — `beforeTransaction` before it opens, `afterTransaction` after it settles —
- * for non-transactional side effects (e.g. external API calls) that must not
- * hold a DB transaction open and cannot be rolled back. The pair forms a
- * compensation bracket around the atomic write described by ADR-0010.
- *
- * This module:
- *  1. Enumerates the lists involved in a write up front, BY WALKING THE INPUT
- *     TREE only (no DB reads), so the bracket can run per involved list before
- *     the transaction opens (mirroring how in-transaction before/afterOperation
- *     fire per record, but at list granularity).
- *  2. Runs all `beforeTransaction` hooks, tracking exactly which involved lists'
- *     `beforeTransaction` ran, then — after the caller settles the transaction —
- *     runs `afterTransaction` ONLY for those lists (the symmetric-bracket
- *     "always-run" rule), surfacing any hook errors afterward.
+ * Transaction-boundary hooks (#590 / ADR-0010): `beforeTransaction`/`afterTransaction`
+ * bracket a write's `$transaction` from the outside, for non-transactional side
+ * effects. See ADR-0010 for the bracket's design and ADR-0028 for how a joined
+ * write's `afterTransaction` defers to the transaction owner.
  */
 
 /**
- * One list involved in a write, with the data the transaction-boundary hooks
- * receive. Enumerated purely from the input tree (no DB reads).
- *
- * The persisted/pre-write rows (`item`/`originalItem`) are surfaced to
- * `afterTransaction` ONLY for the TOP-LEVEL record (`isTopLevel`). For nested
- * lists the per-record persisted row is not reliably recoverable outside the
- * transaction, so they are passed as `undefined` rather than mis-handing the
- * top-level row as if it were the nested row. `originalItem` here is therefore
- * populated only for the top-level update/delete target (the pipeline resolves
- * it before the transaction opens).
+ * One list involved in a write, enumerated purely from the input tree (no DB
+ * reads). `item`/`originalItem` are populated only for the top-level record
+ * (`isTopLevel`) — a nested list's persisted row isn't reliably recoverable
+ * outside the transaction, so handing it the top-level row instead would be
+ * silently wrong.
  */
 export interface InvolvedList {
   listKey: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
   listConfig: ListConfig<any>
   operation: WriteOperation
-  /** Whether this is the top-level write target (the only list with a reliable persisted row). */
   isTopLevel: boolean
-  /** The input payload for this involvement (create/update); `undefined` for delete. */
+  /** `undefined` for delete, which has no input payload. */
   inputData: Record<string, unknown> | undefined
-  /** The existing row for the TOP-LEVEL update/delete target; `undefined` otherwise. */
   originalItem: Record<string, unknown> | undefined
 }
 
-/** Nested-op kinds whose payloads imply an involved list + operation. */
 const NESTED_OP_OPERATIONS: ReadonlyArray<{ kind: string; operation: WriteOperation }> = [
   { kind: 'create', operation: 'create' },
   { kind: 'update', operation: 'update' },
@@ -68,7 +47,6 @@ const NESTED_OP_OPERATIONS: ReadonlyArray<{ kind: string; operation: WriteOperat
   { kind: 'connectOrCreate', operation: 'create' },
 ]
 
-/** Distinct dedupe-key operations `NESTED_OP_OPERATIONS` can produce (create/update/delete). */
 const DISTINCT_OPERATION_COUNT = new Set(NESTED_OP_OPERATIONS.map((o) => o.operation)).size
 
 function isRelationshipField(fieldConfig: FieldConfig | undefined): boolean {

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -28,30 +28,18 @@ import { getDbKey } from '../lib/case-utils.js'
 import { buildDbDelegate } from './index.js'
 
 /**
- * Write Pipeline — the single module that runs the canonical, secured write
- * sequence for one create/update/delete. It owns the phase order in one place;
- * the per-operation differences (target resolution + access, which input phases
- * run, the DB verb and returned row) are supplied by a {@link WriteStrategy}.
- *
- * The phase order is the framework's single most important invariant. See the
- * "Write Pipeline" glossary term in CONTEXT.md and the hooks ordering in
- * CLAUDE.md. Reads (findUnique/findMany) and the two-phase read model
- * (ADR-0001) are intentionally out of scope here.
+ * Write Pipeline — runs the canonical, secured write sequence for one
+ * create/update/delete; see the "Write Pipeline" glossary entry in CONTEXT.md
+ * for the phase order and the hooks ordering in CLAUDE.md. Reads are out of
+ * scope (ADR-0001).
  */
 
-/**
- * The write operations the pipeline can run.
- */
 export type WriteOperation = 'create' | 'update' | 'delete'
 
 /**
- * Result of resolving a write target (axis 1).
- *
- * - `{ status: 'ok', originalItem }` — proceed. `originalItem` is the existing
- *   row for update/delete, or `undefined` for create.
- * - `{ status: 'denied' }` — access denied, missing target, or filter
- *   non-match. The pipeline short-circuits to `null` (silent failure) BEFORE
- *   any input phases, before-hooks, or the DB call.
+ * Result of resolving a write target (axis 1). `denied` covers access denial,
+ * a missing target, or a filter non-match alike, and short-circuits to `null`
+ * before any hooks or the DB call.
  */
 export type TargetResolution =
   { status: 'ok'; originalItem: Record<string, unknown> | undefined } | { status: 'denied' }
@@ -78,21 +66,14 @@ export interface PrismaModel {
 
 /**
  * Per-operation strategy. Supplies the three axes on which create/update/delete
- * genuinely differ; the pipeline owns the shared phase order around them.
- *
- *   1. `resolveTarget` — fetch the target row (if any) + operation-level access.
- *   2. `runInputPhases` — whether the resolveInput → validate-hooks → field
- *      rules → filter-writable → nested-ops span runs (create & update: yes;
- *      delete: no).
- *   3. `persist` — the DB verb; returns the row passed through Field Visibility.
+ * differ; the pipeline owns the shared phase order around them.
  */
 export interface WriteStrategy {
   operation: WriteOperation
 
   /**
-   * Axis 1: resolve the target row and check operation-level access. Receives
-   * the dynamically-resolved Prisma model so it can fetch rows and perform
-   * filter re-checks. Implementations must honour `context._isSudo`.
+   * Axis 1: resolve the target row and check operation-level access.
+   * Implementations must honour `context._isSudo`.
    */
   resolveTarget(model: PrismaModel): Promise<TargetResolution>
 
@@ -118,8 +99,8 @@ export interface WriteStrategy {
 
 /**
  * Resolve the dynamic Prisma model for a list. Model names are generated at
- * runtime from list keys, which is the one place a cast is unavoidable — it is
- * kept localized here (mirroring the existing pattern in `context/index.ts`).
+ * runtime, so the cast is unavoidable — kept localized here (mirrors
+ * `context/index.ts`).
  */
 function getModel<TPrisma extends PrismaClientLike>(
   prisma: TPrisma,
@@ -130,11 +111,8 @@ function getModel<TPrisma extends PrismaClientLike>(
 }
 
 /**
- * Minimal shape of a Prisma interactive-transaction-capable client.
- *
- * The transaction client `tx` is dynamically typed exactly like the model
- * surface above (model names are generated at runtime), so the cast is kept
- * localized and commented per the house rules.
+ * Minimal shape of a Prisma interactive-transaction-capable client. `tx` is
+ * dynamically typed like the model surface above (names generated at runtime).
  */
 interface TransactionCapable {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- $transaction callback receives a dynamically-typed tx client
@@ -142,15 +120,12 @@ interface TransactionCapable {
 }
 
 /**
- * Run `fn` inside ONE interactive transaction (ADR-0010: every write is
- * transactional, so the hook contract does not depend on whether a write
- * happened to be nested). The transaction client `tx` is passed to `fn` and
- * used as the persistence target for the parent + all nested writes, so they
- * are atomic and a throwing hook rolls the whole write back.
+ * Run `fn` inside ONE interactive transaction, used as the persistence target
+ * for the parent and all nested writes (ADR-0010).
  *
- * If the client does not expose `$transaction` (e.g. a test mock), `fn` runs
- * directly against the client — the hook ordering and arguments are identical;
- * only the rollback guarantee is provided by the real transaction.
+ * Without `$transaction` (e.g. a test mock), `fn` runs directly against the
+ * client — hook ordering and arguments are identical, but only a real
+ * transaction provides the rollback guarantee.
  */
 async function runInTransaction<TPrisma extends PrismaClientLike>(
   prisma: TPrisma,
@@ -166,17 +141,11 @@ async function runInTransaction<TPrisma extends PrismaClientLike>(
   return fn(prisma)
 }
 
-/**
- * Check if a list is configured as a singleton.
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function isSingletonList(listConfig: ListConfig<any>): boolean {
   return !!listConfig.isSingleton
 }
 
-/**
- * Arguments shared by every write pipeline run.
- */
 export interface WritePipelineArgs<TPrisma extends PrismaClientLike> {
   listName: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
@@ -186,45 +155,28 @@ export interface WritePipelineArgs<TPrisma extends PrismaClientLike> {
   config: OpenSaasConfig
   /** The original input data for the write (create/update). `undefined` for delete. */
   inputData: Record<string, unknown> | undefined
-  /** The per-operation strategy supplying the three variation axes. */
+  /** The per-operation strategy (see {@link WriteStrategy}). */
   strategy: WriteStrategy
   /**
-   * The target resolution computed ONCE before the transaction opened (#590).
-   *
-   * The transaction-boundary bracket resolves the top-level target + access
-   * before opening the transaction (both to gate silent-failures without firing
-   * boundary hooks, and to supply `originalItem` to `beforeTransaction`). To
-   * avoid a second resolution inside the transaction, the in-transaction body
-   * reuses this result instead of calling `strategy.resolveTarget` again.
+   * The target resolution computed once before the transaction opens, and
+   * reused inside it rather than resolved a second time — see the
+   * pre-transaction gate in {@link runWritePipeline}.
    */
   preResolvedTarget?: TargetResolution
 }
 
 /**
- * Run the canonical secured write sequence once.
- *
- * Phase order (owned here, in one place):
- *   resolve target + operation-level access
- *     → list/field `resolveInput`
- *     → list/field `validate`
- *     → built-in field rules (`validateFieldRules`)
- *     → filter writable fields
- *     → nested operations
- *     → list/field `beforeOperation`
- *     → DB
- *     → list/field `afterOperation`
- *     → `filterReadableFields` (Field Visibility)
+ * Run the canonical secured write sequence once. Phase order matches the
+ * "Write Pipeline" glossary entry in CONTEXT.md.
  *
  * Contract preserved exactly:
  *   - missing target / access denied / filter non-match → `null` (silent),
  *     BEFORE the DB call and BEFORE `beforeOperation`.
  *   - validation failure → THROW `ValidationError` (never silent).
- *   - sudo mode skips access checks and writable-field filtering (the strategy
- *     and `filterWritableFields` both honour `context._isSudo`).
+ *   - sudo mode skips access checks and writable-field filtering.
  *   - `afterOperation` receives `originalItem` for update/delete (undefined for
  *     create).
- *   - delete returns the deleted row as-is (no Field Visibility pass), matching
- *     current behaviour.
+ *   - delete returns the deleted row as-is (no Field Visibility pass).
  */
 export async function runWritePipeline<TPrisma extends PrismaClientLike>(
   args: WritePipelineArgs<TPrisma>,
@@ -232,16 +184,12 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
   const { prisma, listName, listConfig, context, config, inputData, strategy } = args
 
   // ── Pre-transaction access gate (#590) ──────────────────────────────────────
-  // Resolve the TOP-LEVEL target + operation-level access OUTSIDE the
-  // transaction first, using the NON-transactional client. A
-  // denied/missing/filter-non-match target short-circuits to `null` (silent
-  // failure) WITHOUT firing any transaction-boundary hooks — a denied write
-  // opens no transaction and takes no external action, so it must not run
-  // beforeTransaction/afterTransaction. This resolution also yields the
-  // top-level `originalItem` the boundary hooks receive for update/delete.
-  // The result is passed into the transaction as `preResolvedTarget` and REUSED
-  // there (the in-transaction resolveTarget does NOT re-run), so the target is
-  // read exactly once — #569's resolveTarget call-count semantics are preserved.
+  // Resolves the top-level target + access OUTSIDE the transaction so a denied
+  // write short-circuits to `null` WITHOUT firing beforeTransaction/
+  // afterTransaction — a denied write takes no external action, so the
+  // boundary hooks must not run. The result feeds `preResolvedTarget` and is
+  // REUSED inside the transaction rather than re-resolved, keeping the target
+  // read exactly once (#569).
   const gate = await strategy.resolveTarget(getModel(prisma, listName))
   if (gate.status === 'denied') {
     return null
@@ -258,14 +206,10 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
   })
 
   // ── Transaction ownership for the transaction-boundary hooks (ADR-0028) ────
-  // A write already reached through a context carrying `_transactionOwner` is
-  // itself JOINING an enclosing transaction it did not open (a nested
-  // `context.transaction()`, or a hook's own `context.db` write) — regardless
-  // of whether `prisma` here happens to still expose `$transaction`, it must
-  // defer to that owner rather than opening a second transaction. Otherwise,
-  // if `prisma` can open a real interactive transaction, THIS write becomes
-  // the owner: it creates the registry every joined write below it (including
-  // hook-issued writes reached via `bindContextToTransaction`) enqueues into.
+  // A context carrying `_transactionOwner` is JOINING an enclosing transaction
+  // it did not open — defer to that owner even if `prisma` here still exposes
+  // `$transaction`. Otherwise this write becomes the owner: the registry every
+  // joined write below it enqueues into.
   const existingOwner = context._transactionOwner
   const opensOwnTransaction =
     !existingOwner && typeof (prisma as TransactionCapable).$transaction === 'function'
@@ -273,37 +217,23 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
   const transactionOwnerForBody = existingOwner ?? ownedRegistry
 
   // ── Bracket the transaction with beforeTransaction/afterTransaction (#590) ──
-  // beforeTransaction runs before the transaction opens; afterTransaction runs
-  // after it settles (commit or rollback) — deferred to the owner for a joined
-  // write (ADR-0028), per the symmetric-bracket rule.
+  // afterTransaction fires when the transaction settles, deferred to the owner
+  // for a joined write (ADR-0028, symmetric-bracket rule).
   return runWithTransactionBoundary({
     involvedLists,
     context,
     joinedOwner: existingOwner,
     ownedRegistry,
     runTransaction: () =>
-      // ADR-0010: every write runs inside ONE interactive transaction. The
-      // parent and ALL nested writes share this transaction's client `tx` as
-      // their persistence target, so they are atomic and a throwing
-      // `beforeOperation`/`afterOperation` (or validation) rolls the whole write
-      // back. `runWriteInTransaction` resolves the target row, runs the full
-      // hook pipeline, persists, and runs nested + own `afterOperation` — all
-      // against `tx`.
+      // ADR-0010: parent + nested writes share `tx` as their persistence target.
       runInTransaction(prisma, (tx) =>
         runWriteInTransaction({
           ...args,
           prisma: tx,
-          // Reuse the pre-transaction target resolution (computed above) so the
-          // target is read exactly once (#569 call-count semantics preserved).
+          // Reuse the pre-transaction target resolution (#569 call-count semantics).
           preResolvedTarget: gate,
-          // ADR-0010 atomicity: hooks that write via `context.db` must hit the
-          // SAME transaction, or those writes would commit independently and
-          // survive a rollback. Rebind the context's `db` (and `prisma`) to the
-          // transaction client `tx` so before/afterOperation `context.db` writes
-          // participate in — and roll back with — this write's transaction.
-          // Also carries the transaction owner (ADR-0028) so any such write
-          // defers its own transaction-boundary bracket instead of firing it
-          // before this transaction has actually settled.
+          // Rebind context.db/prisma to `tx` (ADR-0010 atomicity) and carry the
+          // transaction owner (ADR-0028) — see bindContextToTransaction below.
           context: bindContextToTransaction(args, tx, transactionOwnerForBody),
         }),
       ),
@@ -312,21 +242,19 @@ export async function runWritePipeline<TPrisma extends PrismaClientLike>(
 
 /**
  * Build an {@link AccessContext} whose `db`/`prisma` target the transaction
- * client `tx`, so any `context.db` write a hook performs runs inside this
- * write's transaction and rolls back with it (ADR-0010).
+ * client `tx`, so a `context.db` write a hook performs runs inside — and rolls
+ * back with — this write's transaction (ADR-0010).
  *
  * The access-controlled `db` delegates capture their Prisma client at
- * construction, so the request-time `context.db` is bound to the ORIGINAL
- * client. We rebuild the delegates against `tx` via {@link buildDbDelegate},
- * reusing the request context's `session`, `storage`, `plugins`, `_isSudo`, and
- * the current `_resolveOutputChain` value (carried through unchanged, so a
- * write issued from inside a `resolveOutput` hook keeps that hook's chain).
- * Plugin runtimes are NOT re-executed; the existing `plugins` object is
- * reused as-is.
+ * construction, so swapping `context.prisma` alone would not rebind `db` — we
+ * rebuild the delegates against `tx` via {@link buildDbDelegate}, reusing the
+ * request context's `session`, `storage`, `plugins`, `_isSudo`, and
+ * `_resolveOutputChain` as-is (so a write from inside a `resolveOutput` hook
+ * keeps that hook's chain). Plugin runtimes are NOT re-executed.
  *
- * `transactionOwner` (ADR-0028) is carried onto the rebuilt context so a hook
- * that issues its own `context.db` write from inside this transaction defers
- * its transaction-boundary bracket to that owner instead of firing eagerly.
+ * `transactionOwner` (ADR-0028) is carried onto the rebuilt context so a hook's
+ * own `context.db` write defers its transaction-boundary bracket to that owner
+ * instead of firing eagerly.
  */
 function bindContextToTransaction<TPrisma extends PrismaClientLike>(
   args: WritePipelineArgs<TPrisma>,
@@ -344,8 +272,8 @@ function bindContextToTransaction<TPrisma extends PrismaClientLike>(
     _resolveOutputChain: context._resolveOutputChain,
     _transactionOwner: transactionOwner,
   }
-  // Rebuild the db delegate against `tx`, pointing back at `txContext` so hooks
-  // reached through it also see the transactional context.
+  // Rebuild `db` against `tx`, referencing `txContext` itself so hooks reached
+  // through it see the transactional context.
   txContext.db = buildDbDelegate(config, tx, txContext)
   return txContext
 }
@@ -364,12 +292,9 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
   const model = getModel(tx, listName)
 
   // ── Phase 1: resolve target + operation-level access ──────────────────────
-  // Short-circuits to `null` (silent failure) for missing target, denied
-  // access, or filter non-match — before any hook side effects or the DB call.
-  // The transaction-boundary bracket (#590) already resolved this once before
-  // opening the transaction; reuse that result rather than reading the target
-  // twice. (When invoked without the bracket — e.g. a direct unit test — fall
-  // back to resolving here against the tx model.)
+  // Reuses `preResolvedTarget` from the pre-transaction gate rather than
+  // reading the target twice; falls back to resolving here when invoked
+  // directly (e.g. a unit test) without that bracket.
   const resolution = args.preResolvedTarget ?? (await strategy.resolveTarget(model))
   if (resolution.status === 'denied') {
     return null
@@ -377,22 +302,18 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
   const originalItem = resolution.originalItem
 
   // ── Delete path: skip input phases, run only validate/field-validate ────────
-  // (matches current delete behaviour exactly).
   if (!strategy.runInputPhases) {
     return runDeletePath({ listName, listConfig, context, originalItem, model, strategy })
   }
 
-  // Only create/update reach here (delete short-circuited above). Narrow the
-  // operation so the field-hook helpers receive a 'create' | 'update' value.
+  // Only create/update reach here (delete short-circuited above); narrow so
+  // field-hook helpers receive a 'create' | 'update' value.
   const writeOp: 'create' | 'update' = operation === 'create' ? 'create' : 'update'
 
-  // `inputData` is always present for create/update (the operations that run
-  // input phases). Default to {} only as a defensive measure.
+  // `inputData` is always present here; `?? {}` is only a defensive fallback.
   const input = inputData ?? {}
 
-  // ── Phases 2–4: transform + validate span (Hook Pipeline) ──────────────────
-  // The Hook Pipeline owns the list/field `resolveInput` → list/field `validate`
-  // → built-in field rules span and the `resolvedData` threading through it. It
+  // ── Phases 2–4: transform + validate span (Hook Pipeline glossary, CONTEXT.md) ──
   // THROWS `ValidationError` on any validation failure (never silent).
   const { resolvedData } = await hookPipeline.run({
     operation: writeOp,
@@ -412,11 +333,10 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
   })
 
   // ── Phase 5.5: process nested relationship operations ───────────────────────
-  // This runs each nested record's resolveInput/validate/field-rules AND its
-  // `beforeOperation` (inside this transaction), returning the transformed
-  // payload plus deferred `afterOperation` tasks and the relation fields to
-  // `include` so those tasks can recover their persisted `item`. All nested DB
-  // reads/persistence go through `tx`.
+  // Runs each nested record's resolveInput/validate/field-rules AND its
+  // `beforeOperation` inside this transaction, returning deferred
+  // `afterOperation` tasks plus the relation fields to `include` so those tasks
+  // can recover their persisted `item`.
   const { data, afterTasks, includeFields } = await processNestedOperations(
     filteredData,
     listConfig.fields,
@@ -425,10 +345,9 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
     writeOp,
     listName,
     originalItem,
-    // Pass the enclosing write's `inputData` (the SAME value the Phase-5
-    // `filterWritableFields` call above uses) so the connect-site owning-field
-    // gate evaluates item-/inputData-dependent field rules identically to Phase 5
-    // and the two cannot diverge into a spurious connect denial (#588 finding).
+    // Same `inputData` Phase 5's filterWritableFields used, so the connect-site
+    // owning-field gate evaluates identically and can't diverge into a
+    // spurious connect denial (#588).
     input,
   )
 
@@ -465,8 +384,8 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
   )
 
   // ── Phase 8: DB write ───────────────────────────────────────────────────────
-  // Ask the DB to return the nested relations that have deferred
-  // `afterOperation` tasks so they can recover their persisted `item`.
+  // `include` returns the nested relations with deferred `afterOperation`
+  // tasks so they can recover their persisted `item`.
   const include = buildIncludeFromFields(includeFields)
   const item = await strategy.persist(model, data, include)
 
@@ -486,7 +405,7 @@ async function runWriteInTransaction<TPrisma extends PrismaClientLike>(
           listKey: listName,
           operation: 'update',
           inputData: input,
-          // originalItem is the row before the update
+          // Non-null for update (fetched in Phase 1); cast narrows the type.
           originalItem: originalItem as Record<string, unknown>,
           item,
           resolvedData,
@@ -542,11 +461,9 @@ function buildIncludeFromFields(includeFields: Set<string>): Record<string, unkn
 
 /**
  * Run the deferred nested `afterOperation` tasks against the persisted parent
- * row. The persisted parent is always a record here; the `?? {}` is only a
- * type-narrowing guard. Each task recovers its OWN nested row from `item` by
- * id-diff (create) or known id (update); if a created row cannot be recovered
- * the task THROWS rather than firing `afterOperation` with a fabricated item
- * (see `recoverCreatedRows`/the create task in `nested-operations.ts`).
+ * row (`?? {}` is only a type-narrowing guard — parent is always a record
+ * here). Each task recovers its own nested row by id-diff/known id and THROWS
+ * if it can't, rather than firing with a fabricated item (ADR-0010).
  */
 async function runNestedAfterTasks(
   afterTasks: AfterTask[],
@@ -557,10 +474,9 @@ async function runNestedAfterTasks(
 }
 
 /**
- * The delete tail of the pipeline: skips the input-shaping phases and runs only
- * validate/field-validate before the DB delete, then the after-hooks. Returns
- * the deleted row as-is (no Field Visibility pass) — matching current delete
- * behaviour exactly.
+ * The delete tail of the pipeline: skips the input-shaping phases and runs
+ * only validate/field-validate before the DB delete, then the after-hooks.
+ * Returns the deleted row as-is (no Field Visibility pass).
  */
 async function runDeletePath(args: {
   listName: string
@@ -641,11 +557,11 @@ async function runDeletePath(args: {
 // ── Per-operation strategies ──────────────────────────────────────────────────
 
 /**
- * Create strategy.
+ * Create strategy for {@link WriteStrategy}.
  *
- * Axis 1: checks `create` access with NO existing row. Enforces the
- * singleton-create constraint even under sudo. On create, an access result of
- * `true` OR a filter object both proceed — there is no filter re-check.
+ * Axis 1: checks `create` access with no existing row; a filter result
+ * proceeds with no re-check (unlike update/delete). Enforces the
+ * singleton-create constraint even under sudo.
  * Axis 2: runs all input phases.
  * Axis 3: `model.create({ data })`, prepending `id: 1` for singleton lists.
  */
@@ -737,7 +653,7 @@ function resolveExistingTarget(
 }
 
 /**
- * Update strategy.
+ * Update strategy for {@link WriteStrategy}.
  *
  * Axis 1: fetch row, check `update` access, re-check filter results.
  * Axis 2: runs all input phases.
@@ -760,11 +676,11 @@ export function updateWriteStrategy(
 }
 
 /**
- * Delete strategy.
+ * Delete strategy for {@link WriteStrategy}.
  *
  * Axis 1: enforce singleton constraint (even under sudo), fetch row, check
  * `delete` access, re-check filter results.
- * Axis 2: SKIPS input phases (runs only validate/field-validate).
+ * Axis 2: skips input phases (runs only validate/field-validate).
  * Axis 3: `model.delete({ where })`; afterOperation gets `originalItem`.
  */
 export function deleteWriteStrategy(


### PR DESCRIPTION
## Summary

- Apply the `CLAUDE.md` Comments rule to `packages/core/src/context/` (6 files: `index.ts`, `nested-operations.ts`, `write-pipeline.ts`, `transaction-boundary.ts`, `hook-pipeline.ts`, `apply-defaults.ts`) — the densest concentration of comments in the repo, and the calibration pass for a broader cleanup effort.
- Delete pure-restatement comments, condense rationale blocks that duplicate an ADR or issue into short pointers (keeping only the parts genuinely not derivable from the ADR — usually a footgun warning specific to that call site), trim/delete docblocks that aren't public-API TSDoc, and keep every `eslint-disable ... --` directive and genuine footgun warning untouched.
- Comment-only change, verified by diffing each file with all comment/blank lines stripped against `origin/main` — no code, imports, or behavior changed.
- Add `docs/agents/comments.md` with 7 real before/after pairs drawn from this diff, covering the judgment calls the rule leaves open: rationale-block-to-pointer condensation, file-header trimming, full docblock deletion, the public-API-TSDoc-vs-internal-doc boundary, and collapsing the same rationale repeated across several call sites into one canonical explanation plus pointers. Linked from `CLAUDE.md`'s Comments section.
- Add a patch changeset for `@opensaas/stack-core`.

## Test plan

- [x] `git diff` against `origin/main` verified comment-only per file (comment/blank lines stripped, code diff is empty)
- [x] `pnpm lint` — clean (2 pre-existing warnings elsewhere, unrelated to this change)
- [x] `pnpm format` — clean
- [x] `pnpm build` (core) — `tsc` clean
- [x] `cd packages/core && pnpm test` — 1054 tests passed, 0 changed
- [x] `pnpm manypkg fix` — clean
- [x] Changeset added (`@opensaas/stack-core`, patch)

Closes #936

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS2L5jj1uEkNgcCUuWB4wy)_