### PR TITLE
chore(core): comment cleanup across access, config, fields, filter, hooks, mcp, query, lib, utils, validation

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Clean up comments across `access/`, `config/`, `fields/`, `filter/`, `hooks/`, `lib/`, `mcp/`, `query/`, `utils/` and `validation/` per the CLAUDE.md Comments rule. No behavior changes.

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -69,8 +69,7 @@ function asEntryObject(value: unknown): IncludeEntryObject | null {
  *
  * The access filter is authoritative: the caller's filter may only NARROW the
  * result further, never widen past what access permits. We therefore wrap both
- * in a Prisma `AND` so neither can override the other. If only one side is
- * present, it is returned as-is; if neither is present, the result is undefined.
+ * in a Prisma `AND` so neither can override the other.
  */
 function andWhere(
   accessWhere: PrismaFilter | undefined,

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -349,7 +349,6 @@ export function stripVirtualFieldsFromInclude(
   for (const [key, value] of Object.entries(include)) {
     const fieldConfig = fieldConfigs[key]
 
-    // Virtual fields have no database column — drop them from the include.
     if (fieldConfig?.virtual) continue
 
     const isDeclaredRelationship =

--- a/packages/core/src/access/declared-dependencies.ts
+++ b/packages/core/src/access/declared-dependencies.ts
@@ -180,12 +180,8 @@ export function foldDeclaredDependencies(
     const relatedConfig = getRelatedListConfig(fieldConfig.ref, config)
     if (!relatedConfig) continue
     // Defensive cycle guard (see module doc comment) — a DECLARATION-ADDED
-    // edge into a list already on this path stops here rather than recursing
-    // without bound. The value at `key` is left exactly as-is. The guard is
-    // deliberately not applied to an edge the request itself named: that
-    // recursion is bounded by the request's own finite literal and cannot
-    // loop, so stopping it would silently drop the folds beneath a request
-    // that merely revisits a list (e.g. `Post → author → posts`).
+    // edge into a list already on this path stops here; the value at `key`
+    // is left exactly as-is.
     if (declaredOnly.keys.has(key) && visitedLists.includes(relatedConfig.listName)) continue
 
     // A branch added purely by the fold has no fragment scope of its own —
@@ -213,9 +209,8 @@ export function foldDeclaredDependencies(
       }
     }
 
-    // A whole branch added purely by the fold above is stripped wholesale by
-    // field-visibility regardless of what's nested inside it, so it needs no
-    // individual nested-key tracking of its own.
+    // Declaration-added branches need no nested tracking of their own (see
+    // module doc comment) — only caller/fragment-named branches do.
     if (!declaredOnly.keys.has(key) && !isDeclaredOnlyTreeEmpty(nested.declaredOnly)) {
       declaredOnly.nested[key] = nested.declaredOnly
     }

--- a/packages/core/src/access/engine.ts
+++ b/packages/core/src/access/engine.ts
@@ -16,28 +16,14 @@ import type { OpenSaasConfig, ListConfig } from '../config/types.js'
  * and the access-control glossary in `CONTEXT.md`.
  */
 
-/**
- * Check if access control result is a boolean
- */
 export function isBoolean(value: unknown): value is boolean {
   return typeof value === 'boolean'
 }
 
-/**
- * Check if access control result is a Prisma filter
- */
 export function isPrismaFilter(value: unknown): value is PrismaFilter {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-/**
- * Parse a relationship ref and get the related list configuration
- * Relationship refs are in the format "ListName.fieldName"
- *
- * @param relationshipRef - The ref string (e.g., "Post.author")
- * @param config - The OpenSaas configuration
- * @returns The related list name and config, or null if not found
- */
 export function getRelatedListConfig(
   relationshipRef: string,
   config: OpenSaasConfig,
@@ -59,9 +45,6 @@ export function getRelatedListConfig(
   return { listName, listConfig }
 }
 
-/**
- * Execute an access control function
- */
 export async function checkAccess<T = Record<string, unknown>>(
   accessControl: AccessControl<T> | undefined,
   args: {
@@ -75,35 +58,27 @@ export async function checkAccess<T = Record<string, unknown>>(
     return false
   }
 
-  // Execute the access control function
   const result = await accessControl(args)
 
   return result
 }
 
-/**
- * Merge user filter with access control filter
- */
 export function mergeFilters(
   userFilter: PrismaFilter | undefined,
   accessFilter: boolean | PrismaFilter,
 ): PrismaFilter | null {
-  // If access is denied, return null
   if (accessFilter === false) {
     return null
   }
 
-  // If access is fully granted, use user filter
   if (accessFilter === true) {
     return userFilter || {}
   }
 
-  // Merge access filter with user filter
   if (!userFilter) {
     return accessFilter
   }
 
-  // Combine filters with AND
   return {
     AND: [accessFilter, userFilter],
   }

--- a/packages/core/src/access/field-access.ts
+++ b/packages/core/src/access/field-access.ts
@@ -78,13 +78,12 @@ export async function checkFieldAccess(
     inputData?: Record<string, unknown>
   },
 ): Promise<boolean> {
-  // Skip access check in sudo mode
   if (args.context._isSudo) {
     return true
   }
 
   if (!fieldAccess) {
-    return true // No field access means allow
+    return true
   }
 
   // `FieldAccess['read']` is narrower than `FieldAccess['create'/'update']` (it
@@ -97,7 +96,7 @@ export async function checkFieldAccess(
   // whichever operation is actually requested.
   const accessControl = fieldAccess[operation] as FieldAccessControl | undefined
   if (!accessControl) {
-    return true // No specific access control means allow
+    return true
   }
 
   const result = await accessControl({
@@ -108,12 +107,10 @@ export async function checkFieldAccess(
     operation,
   } as Parameters<typeof accessControl>[0])
 
-  // If result is false, deny access
   if (result === false) {
     return false
   }
 
-  // If result is true, allow access
   if (result === true) {
     return true
   }
@@ -141,10 +138,9 @@ export async function checkFieldAccess(
  * the pre-query counterpart, called from `query-validation.ts`'s `where`/
  * `orderBy` walk for every key that resolves to a declared field.
  *
- * It delegates to the SAME evaluator Field Visibility uses
- * (`checkFieldAccess`) — there is no second, parallel field-access evaluator
- * for predicates, matching this module's own rule for every other caller.
- * The one difference is the `item` it hands the rule: there is no fetched row
+ * It delegates to the same evaluator Field Visibility uses (`checkFieldAccess`),
+ * per this module's canonical-evaluator rule above. The one difference is the
+ * `item` it hands the rule: there is no fetched row
  * yet, so a rule that depends on one (the shape `FieldAccess['read']`
  * documents as the norm, e.g. `item?.ownerId === session?.userId`) cannot be
  * answered here. Rather than skip the check for such a rule — which would
@@ -184,9 +180,6 @@ export async function isFieldReadableForPredicate(
   }
 }
 
-/**
- * Filter fields from input data based on write access (create/update)
- */
 export async function filterWritableFields<T extends Record<string, unknown>>(
   data: T,
   fieldConfigs: Record<
@@ -207,8 +200,7 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
 ): Promise<Partial<T>> {
   const filtered: Record<string, unknown> = {}
 
-  // Build a set of foreign key field names to exclude
-  // Foreign keys should not be in the data when using Prisma's relation syntax
+  // Foreign keys must not appear in `data` when using Prisma's relation syntax.
   const foreignKeyFields = new Set<string>()
   // Map each raw per-part column name contributed by a multi-column field
   // (e.g. storage image()/file() in Keystone-parity mode) back to its OWNING
@@ -247,19 +239,18 @@ export async function filterWritableFields<T extends Record<string, unknown>>(
   for (const [fieldName, value] of Object.entries(data)) {
     const fieldConfig = fieldConfigs[fieldName]
 
-    // Skip system fields
     if (['id', 'createdAt', 'updatedAt'].includes(fieldName)) {
       continue
     }
 
-    // Skip virtual fields - they don't store in database
-    // Virtual fields with resolveInput hooks handle side effects separately
+    // Virtual fields don't store in the database — skipped here, but their
+    // resolveInput hooks still run as a separate side-effect step.
     if (fieldConfig && 'virtual' in fieldConfig && fieldConfig.virtual) {
       continue
     }
 
-    // Skip foreign key fields (e.g., authorId) when their corresponding relationship field exists
-    // This prevents conflicts when using Prisma's relation syntax (e.g., author: { connect: { id } })
+    // Prevents conflicts with Prisma's relation syntax (e.g.,
+    // `author: { connect: { id } }`).
     if (foreignKeyFields.has(fieldName)) {
       continue
     }

--- a/packages/core/src/access/field-transforms.ts
+++ b/packages/core/src/access/field-transforms.ts
@@ -1,29 +1,20 @@
 import type { OpenSaasConfig, FieldConfig } from '../config/types.js'
 import type { HashedPassword } from '../utils/password.js'
 
-/**
- * Extract the return type of a field's afterOperation hook
- * If the field has an afterOperation hook, infer its return type
- * Otherwise, use the original type
- */
 export type InferFieldReadType<TField extends FieldConfig, TOriginal> = TField extends {
-  // Generic `any` is required here for TypeScript's conditional type inference to work correctly
-  // This allows us to infer the exact return type `R` from hooks of any signature
+  // Uses `any` here so TypeScript's conditional type inference can pick up the
+  // exact return type `R` from a hook of any signature.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hooks?: { afterOperation?: (...args: any[]) => infer R }
 }
   ? R extends never
-    ? TOriginal // No hook defined
-    : R // Hook return type
-  : TOriginal // No hooks at all
+    ? TOriginal
+    : R
+  : TOriginal
 
-/**
- * Transform a Prisma model's field types based on OpenSaas field configs
- * This applies afterOperation hook transformations to field types
- */
 export type TransformModelFields<
-  // Generic constraint requires `any` to allow indexing by string keys from Prisma models
-  // This is necessary for mapped types to work with Prisma's generated model types
+  // Uses `any` so this constraint accepts Prisma's generated model types, which are
+  // indexed by string keys.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TModel extends Record<string, any>,
   TFields extends Record<string, FieldConfig>,
@@ -33,34 +24,22 @@ export type TransformModelFields<
     : TModel[K]
 }
 
-/**
- * Get the field configs for a specific list from the OpenSaas config
- */
 export type GetListFields<
   TConfig extends OpenSaasConfig,
   TListKey extends keyof TConfig['lists'],
 > = TConfig['lists'][TListKey]['fields']
 
-/**
- * Transform a Prisma model result based on OpenSaas config
- * Applies field hooks transformations
- */
 export type TransformResult<
   TConfig extends OpenSaasConfig,
   TListKey extends keyof TConfig['lists'],
   TResult,
 > =
-  // Generic constraint requires `any` to check if TResult is an object type that can be transformed
-  // This pattern is standard in TypeScript for conditional types on object shapes
+  // Uses `any` to check whether TResult is an object type that can be transformed.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TResult extends Record<string, any>
     ? TransformModelFields<TResult, GetListFields<TConfig, TListKey>>
     : TResult
 
-/**
- * Transform a Prisma operation's return type
- * Handles single results, arrays, and null cases
- */
 export type TransformOperationResult<
   TConfig extends OpenSaasConfig,
   TListKey extends keyof TConfig['lists'],
@@ -76,20 +55,10 @@ export type TransformOperationResult<
       >
     : never
 
-/**
- * Known field type mappings for afterOperation hooks
- * These provide concrete type hints for common field transformations
- */
 export interface FieldTypeTransforms {
   password: HashedPassword
-  // Future field types can be added here
-  // richText: TiptapContent
-  // json: JSONValue
 }
 
-/**
- * Helper to infer field type based on field config type
- */
 export type InferFieldTypeTransform<TField extends FieldConfig> = TField extends {
   type: infer TType
 }

--- a/packages/core/src/access/field-visibility.ts
+++ b/packages/core/src/access/field-visibility.ts
@@ -30,18 +30,14 @@ import { buildDbDelegate } from '../context/index.js'
  * level this way; a bare or `include`-based read, and any relation reached
  * purely to satisfy a `needs` declaration, still compute every field, as
  * before. A field the read is not going to return does no work at all —
- * neither its read-access evaluation nor its hook.
+ * neither its read-access evaluation nor its hook. The projection-aware skip
+ * below shows this rule at each of the two places it applies.
  *
  * Phase 1 (pre-query row/relation scoping) lives in `access-filter.ts`. See
  * `docs/adr/0001-access-control-is-a-two-phase-read.md` and the access-control
  * glossary in `CONTEXT.md`.
  */
 
-/**
- * Runtime type for resolveOutput hooks
- * Used when we need to call hooks generically without knowing the specific field type
- * Supports both sync and async implementations
- */
 type ResolveOutputHookRuntime = (args: {
   operation: 'query'
   value: unknown
@@ -123,7 +119,6 @@ async function resolveReadableFieldValue(params: {
 }): Promise<{ readable: false } | { readable: true; value: unknown }> {
   const { fieldConfig, fieldName, value, accessItem, hookItem, listKey, args, config } = params
 
-  // Check field access (checkFieldAccess already handles sudo mode)
   const canRead = await checkFieldAccess(fieldConfig?.access, 'read', {
     ...args,
     item: accessItem,
@@ -133,10 +128,9 @@ async function resolveReadableFieldValue(params: {
     return { readable: false }
   }
 
-  // Apply resolveOutput hook if present
   if (fieldConfig?.hooks?.resolveOutput && listKey) {
-    // Cast to runtime type for generic execution
-    // At runtime, the hook will receive the correct value type for the field
+    // The hook is erased to this runtime shape here; at the actual call it
+    // receives the value typed for its own field.
     const hook = fieldConfig.hooks.resolveOutput as unknown as ResolveOutputHookRuntime
     const link = { listKey, fieldKey: fieldName }
     const chain = args.context._resolveOutputChain
@@ -164,7 +158,6 @@ async function resolveReadableFieldValue(params: {
       return { readable: false }
     }
 
-    // Use Promise.resolve() to handle both sync and async hooks
     const resolved = await Promise.resolve(
       hook({
         value,
@@ -181,10 +174,6 @@ async function resolveReadableFieldValue(params: {
   return { readable: true, value }
 }
 
-/**
- * Filter fields from an object based on read access
- * Recursively applies access control to nested relationships
- */
 export async function filterReadableFields<T extends Record<string, unknown>>(
   item: T,
   fieldConfigs: Record<string, FieldConfig>,
@@ -201,12 +190,8 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
   // returned — after resolveOutput has had a chance to read them — so a
   // declared dependency never widens what the caller receives.
   declaredOnly: DeclaredOnlyTree = emptyDeclaredOnlyTree(),
-  // The fragment scope this level was reached under (ADR-0027), and the same
-  // tree one level down for each nested relation. `undefined` — the default,
-  // and what a bare/`include`-based read passes at every level — means
-  // unrestricted: every field on the list is computed, unchanged from
-  // before ADR-0027. Only a `query` fragment's own field selection ever
-  // restricts a level.
+  // The fragment scope this level was reached under (ADR-0027, see module doc
+  // above), and the same tree one level down for each nested relation.
   selection?: FieldSelectionScope,
 ): Promise<Partial<T>> {
   const filtered: Record<string, unknown> = {}
@@ -246,26 +231,22 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
   for (const [fieldName, value] of Object.entries(workingItem)) {
     const fieldConfig = fieldConfigs[fieldName]
 
-    // Always include id, createdAt, updatedAt
     if (['id', 'createdAt', 'updatedAt'].includes(fieldName)) {
       filtered[fieldName] = value
       continue
     }
 
-    // Projection-aware skip (ADR-0027): a fragment read that does not select
-    // this field does no work for it at all — no field-level read-access
-    // check, no resolveOutput, no recursion into a relation — because the
-    // read is never going to return it. `selection` is only ever restricted
-    // by a fragment's own field selection; a bare/`include`-based read, and a
-    // relation reached only to satisfy another field's `needs`, pass no
-    // selection at all and compute every field here, unchanged.
+    // Projection-aware skip (ADR-0027, see module doc above): a field this
+    // level's fragment did not select gets no read-access check, no
+    // resolveOutput, and no recursion into a relation — none of that work
+    // happens for a value the read isn't going to return.
     if (selection?.fields && !selection.fields.has(fieldName)) {
       continue
     }
 
-    // Handle relationship fields - recursively filter fields within related items
-    // Note: Access control filtering is now done at database level via buildAccessScopedInclude
-    // This only handles field-level access (hiding sensitive fields)
+    // Row/relation-level access is already scoped at the DB level via
+    // buildAccessScopedInclude; this only handles field-level access (hiding
+    // sensitive fields).
     //
     // Deliberately uncapped: the row/relation scoping in access-filter.ts bounds
     // what gets FETCHED (a caller include past its depth cap is now a denial,
@@ -283,7 +264,6 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       value !== null &&
       value !== undefined
     ) {
-      // Gate the relationship on read access before recursing.
       const canRead = await checkFieldAccess(fieldConfig?.access, 'read', {
         ...args,
         item: workingItem,
@@ -308,8 +288,6 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       const nestedSelection = selection?.nested[fieldName]
 
       if (relatedConfig) {
-        // For many relationships (arrays) - recursively filter fields in each item
-        // The recursive call already handles applying resolveOutput hooks
         if (Array.isArray(value)) {
           filtered[fieldName] = await Promise.all(
             value.map((relatedItem) =>
@@ -325,10 +303,7 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
               ),
             ),
           )
-        }
-        // For single relationships (objects) - recursively filter fields
-        // The recursive call already handles applying resolveOutput hooks
-        else if (typeof value === 'object') {
+        } else if (typeof value === 'object') {
           filtered[fieldName] = await filterReadableFields(
             value as Record<string, unknown>,
             relatedConfig.listConfig.fields,
@@ -341,14 +316,13 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
           )
         }
       } else {
-        // Related config not found, include the value as-is
         filtered[fieldName] = value
       }
       continue
     }
 
-    // Non-relationship field (or relationship without an includable value):
-    // check read access and apply resolveOutput via the shared helper.
+    // Non-relationship field, or a relationship field whose value is not
+    // includable (null/undefined) — falls through to the shared helper.
     const result = await resolveReadableFieldValue({
       fieldConfig,
       fieldName,
@@ -394,15 +368,11 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
     delete computedFieldItem[key]
   }
 
-  // Process virtual fields - compute values from other fields
-  // Virtual fields don't exist in the database result, so we need to compute them separately
   for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
-    // Skip if already processed (from database result)
     if (fieldName in filtered) {
       continue
     }
 
-    // Only process virtual fields
     if (!fieldConfig.virtual) {
       continue
     }
@@ -423,7 +393,6 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       continue
     }
 
-    // Check read access and compute the value via the shared helper.
     const result = await resolveReadableFieldValue({
       fieldConfig,
       fieldName,

--- a/packages/core/src/access/query-validation.ts
+++ b/packages/core/src/access/query-validation.ts
@@ -282,11 +282,9 @@ async function checkKeyReadableOrThrow(
 /**
  * Check field-level `read` access for every key at ONE level of a `where`
  * clause, recursing only into logical operators (`AND`/`OR`/`NOT`) — never
- * into a relationship field's own nested value. Exported so `access-filter.ts`
- * can call it once per hop, against the RELATED list's own config, as its
- * relation-filter walk (#916) descends — the same field-read check this
- * module runs for the CURRENT list via `validateQueryFieldReadAccess`, reused
- * rather than duplicated.
+ * into a relationship field's own nested value. Exported for `access-filter.ts`'s
+ * #916 reuse (see module doc comment above) — called once per hop against the
+ * RELATED list's own config.
  */
 export async function walkWhereReadAccess(
   where: unknown,

--- a/packages/core/src/access/relationship-count.ts
+++ b/packages/core/src/access/relationship-count.ts
@@ -99,7 +99,6 @@ export async function buildRelationshipCountSelect(
   return Object.keys(select).length > 0 ? select : undefined
 }
 
-/** Read a to-many relationship's count off a fetched row's `_count` payload. */
 function readRelationshipCount(row: Record<string, unknown>, fieldName: string): number {
   const counts = row._count
   if (counts && typeof counts === 'object') {
@@ -109,7 +108,6 @@ function readRelationshipCount(row: Record<string, unknown>, fieldName: string):
   return 0
 }
 
-/** Whether a count satisfies a Filter operator/value comparison. */
 function matchesCount(count: number, operator: FilterOperator, value: number): boolean {
   switch (operator) {
     case 'eq':
@@ -140,7 +138,6 @@ function asCountDelegate(value: unknown): CountFindManyDelegate | null {
   return null
 }
 
-/** Extract the `RelationshipCountFilterMarker` from a condition value, if present. */
 function readCountMarker(value: unknown): RelationshipCountFilterMarker | null {
   if (!value || typeof value !== 'object') return null
   const marker = (value as Record<string, unknown>)[RELATIONSHIP_COUNT_FILTER_KEY]
@@ -291,13 +288,8 @@ export async function resolveRelationshipCountFilters(
       args,
       config,
     )
-    // Preserve any sibling conditions co-present on this member rather than
-    // replacing it wholesale with the resolved `{ id: { in } }`. The filter engine
-    // currently guarantees each AND-member (and the no-AND single object) carries
-    // exactly one field condition, so `siblings` is empty today and this equals the
-    // previous wholesale replacement — but if a future engine change ever merged
-    // multiple conditions into one member, spreading keeps the marker's siblings
-    // from being silently dropped.
+    // Preserve any sibling conditions rather than replacing the member
+    // wholesale — see `mergeResolvedMember` above for why.
     const siblings: Record<string, unknown> = { ...member }
     delete siblings[found.field]
     resolvedMembers.push(mergeResolvedMember(siblings, resolved))

--- a/packages/core/src/access/relationship-label-filter.ts
+++ b/packages/core/src/access/relationship-label-filter.ts
@@ -49,10 +49,8 @@ export function isToOneRelationshipField(field: FieldConfig | undefined): boolea
 }
 
 /**
- * No longer folds access into to-one relationship label filters — the engine
- * (`buildAccessScopedWhere`, #916) now scopes every relation filter in
- * `where` directly, including the `{ is: {...} }` shape a label filter
- * produces. Returns `where` unchanged. See the module doc comment above.
+ * No longer folds access into label filters — see the module doc above.
+ * Returns `where` unchanged.
  */
 export async function resolveRelationshipLabelFilters(
   where: Record<string, unknown> | undefined,

--- a/packages/core/src/access/transaction-registry.ts
+++ b/packages/core/src/access/transaction-registry.ts
@@ -50,7 +50,6 @@ export class TransactionRegistry {
     this.queue.push(flush)
   }
 
-  /** Run every queued flush, in enqueue order, against the settled outcome. */
   async drain(settle: TransactionSettleOutcome, errors: unknown[]): Promise<void> {
     for (const flush of this.queue) {
       await flush(settle, errors)

--- a/packages/core/src/access/types.ts
+++ b/packages/core/src/access/types.ts
@@ -38,9 +38,6 @@ export interface Session {
   [key: string]: unknown
 }
 
-/**
- * Generic Prisma model delegate type
- */
 export type PrismaModelDelegate = {
   findUnique: (args: unknown) => Promise<unknown>
   findFirst: (args: unknown) => Promise<unknown>
@@ -51,12 +48,8 @@ export type PrismaModelDelegate = {
   count: (args?: unknown) => Promise<number>
 }
 
-/**
- * Generic Prisma client type
- * This is intentionally permissive to allow actual PrismaClient types
- * Uses `any` because Prisma generates highly complex client types that are difficult to constrain
- * This type is used as a generic constraint and the actual type safety comes from TPrisma parameter
- */
+// Uses `any` because Prisma generates highly complex client types that are difficult
+// to constrain here; actual type safety comes from the TPrisma generic parameter.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PrismaClientLike = any
 
@@ -103,11 +96,9 @@ export type FindManyQueryArgs = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface AugmentedFindMany<TOriginal extends (...args: any[]) => any> {
-  // Overload 1: with query fragment — return type narrows to ResultOf<fragment>[]
   <TItem, TFields extends FieldSelection<TItem>>(
     args: FindManyQueryArgs & { query: Fragment<TItem, TFields> },
   ): Promise<ResultOf<Fragment<TItem, TFields>>[]>
-  // Overload 2: original Prisma behaviour
   (...args: Parameters<TOriginal>): ReturnType<TOriginal>
 }
 
@@ -145,11 +136,9 @@ export type FindFirstQueryArgs = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface AugmentedFindFirst<TOriginal extends (...args: any[]) => any> {
-  // Overload 1: with query fragment — return type narrows to ResultOf<fragment> | null
   <TItem, TFields extends FieldSelection<TItem>>(
     args: FindFirstQueryArgs & { query: Fragment<TItem, TFields> },
   ): Promise<ResultOf<Fragment<TItem, TFields>> | null>
-  // Overload 2: original Prisma behaviour
   (...args: Parameters<TOriginal>): ReturnType<TOriginal>
 }
 
@@ -172,23 +161,17 @@ export interface AugmentedFindFirst<TOriginal extends (...args: any[]) => any> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface AugmentedFindUnique<TOriginal extends (...args: any[]) => any> {
-  // Overload 1: with query fragment — return type narrows to ResultOf<fragment> | null
   <TItem, TFields extends FieldSelection<TItem>>(args: {
     where: Record<string, unknown>
     query: Fragment<TItem, TFields>
   }): Promise<ResultOf<Fragment<TItem, TFields>> | null>
-  // Overload 2: original Prisma behaviour
   (...args: Parameters<TOriginal>): ReturnType<TOriginal>
 }
 
-/**
- * Map Prisma client to access-controlled database context
- * Preserves Prisma's type information for each model
- */
 export type AccessControlledDB<TPrisma extends PrismaClientLike> = {
   [K in keyof TPrisma]: TPrisma[K] extends {
-    // Uses `any` in conditional type checks to verify Prisma model shape
-    // This is a standard TypeScript pattern for checking if a property exists with any signature
+    // Uses `any` here to check the property exists with any signature, a standard
+    // TypeScript pattern for verifying Prisma model shape in a conditional type.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     findUnique: any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -233,17 +216,7 @@ export type AccessControlledDB<TPrisma extends PrismaClientLike> = {
   [key: string]: any
 }
 
-/**
- * Storage utilities for file/image uploads
- */
 export type StorageUtils = {
-  /**
-   * Upload a file to storage
-   * @param providerName - Name of storage provider from config
-   * @param file - File object
-   * @param buffer - File contents as Buffer
-   * @param options - Upload options (validation, metadata)
-   */
   uploadFile: (
     providerName: string,
     file: File,
@@ -251,13 +224,6 @@ export type StorageUtils = {
     options?: unknown,
   ) => Promise<unknown>
 
-  /**
-   * Upload an image with transformations
-   * @param providerName - Name of storage provider from config
-   * @param file - File object
-   * @param buffer - File contents as Buffer
-   * @param options - Upload options (validation, transformations, metadata)
-   */
   uploadImage: (
     providerName: string,
     file: File,
@@ -265,24 +231,12 @@ export type StorageUtils = {
     options?: unknown,
   ) => Promise<unknown>
 
-  /**
-   * Delete a file from storage
-   * @param providerName - Name of storage provider from config
-   * @param filename - Name of file to delete
-   */
   deleteFile: (providerName: string, filename: string) => Promise<void>
 
-  /**
-   * Delete an image and all its transformations
-   * @param metadata - Image metadata containing storage provider and filename
-   */
   deleteImage: (metadata: unknown) => Promise<void>
 }
 
-/**
- * Context type (simplified for access control)
- * Using interface instead of type to allow module augmentation
- */
+// Uses `interface` rather than `type` so consumers can extend it via module augmentation.
 export interface AccessContext<TPrisma extends PrismaClientLike = PrismaClientLike> {
   session: Session | null
   prisma: TPrisma
@@ -317,14 +271,9 @@ export interface AccessContext<TPrisma extends PrismaClientLike = PrismaClientLi
   _transactionOwner?: TransactionRegistry
 }
 
-/**
- * Prisma filter type - represents a where clause
- * Uses Partial to allow filtering by any subset of fields
- */
 export type PrismaFilter<T = Record<string, unknown>> = Partial<Record<keyof T, unknown>>
 
 /**
- * Access control function type
  * Can return:
  * - boolean: true = allow, false = deny
  * - PrismaFilter: Prisma where clause to filter results
@@ -373,7 +322,6 @@ type FieldAccessControlArgs<TItem, TCreateInput, TUpdateInput> =
     }
 
 /**
- * Field-level access control function.
  * For create/update operations, receives inputData to validate incoming values.
  *
  * Unlike operation-level `AccessControl`, this returns `boolean` only. Field
@@ -401,8 +349,6 @@ export type FieldAccessControl<
 > = (args: FieldAccessControlArgs<TItem, TCreateInput, TUpdateInput>) => boolean | Promise<boolean>
 
 /**
- * Field-level access control
- *
  * `read` is typed from the single `operation: 'read'` member of
  * `FieldAccessControlArgs`, not the full `FieldAccessControl` union — so a
  * rule written directly for this slot sees `item` as always present (never

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -8,16 +8,11 @@ import type {
 import { executePlugins } from './plugin-engine.js'
 import type { AccessControl } from '../access/types.js'
 
-/**
- * Normalize access control shorthand to object form
- * Converts function shorthand to { operation: { query, create, update, delete } } form
- */
 function normalizeListAccess<T>(
   access: ListAccessControl<T> | undefined,
 ): { operation?: OperationAccess<T> } | undefined {
   if (!access) return undefined
 
-  // If it's a function, convert to object form applying to all operations
   if (typeof access === 'function') {
     const fn = access as AccessControl<T>
     return {
@@ -30,32 +25,31 @@ function normalizeListAccess<T>(
     }
   }
 
-  // Already in object form
   return access
 }
 
 /**
- * Helper function to define configuration with type safety
- * Executes plugins if present in config.plugins array
+ * Define an OpenSaas config, executing `plugins` if present.
  *
- * Note: This function is now async when plugins are present
- * For synchronous config definition without plugins, config can still be returned directly
+ * Returns synchronously when there are no plugins (backward compatible);
+ * returns a `Promise` when plugins are present, since plugin execution is
+ * async.
  */
 export function config(userConfig: OpenSaasConfig): OpenSaasConfig | Promise<OpenSaasConfig> {
-  // If no plugins, return config as-is (synchronous, backward compatible)
   if (!userConfig.plugins || userConfig.plugins.length === 0) {
     return userConfig
   }
 
-  // Execute plugins and return promise
   return executePlugins(userConfig)
 }
 
 /**
- * Helper function to define a list with type safety
+ * Define a list with type safety.
  *
- * Accepts raw field configs and transforms them to inject the item type
- * This enables proper typing in field hooks where item is typed correctly
+ * `ListConfigInput<TTypeInfo>` accepts raw field configs; the return type
+ * `ListConfig<TTypeInfo>` injects `TTypeInfo` so hook/field callbacks (e.g.
+ * `resolveInput`'s `item`) are properly typed once `TTypeInfo` is supplied
+ * from generated types.
  *
  * @example
  * ```typescript
@@ -108,18 +102,15 @@ export function config(userConfig: OpenSaasConfig): OpenSaasConfig | Promise<Ope
 export function list<TTypeInfo extends import('./types.js').TypeInfo>(
   config: ListConfigInput<TTypeInfo>,
 ): ListConfig<TTypeInfo> {
-  // Normalize access control shorthand to object form
   const normalizedConfig = {
     ...config,
     access: normalizeListAccess(config.access),
   }
 
-  // At runtime, field configs are unchanged
-  // At type level, they're transformed to inject TypeInfo types
+  // Runtime shape is unchanged; the cast only narrows the TS type to inject TTypeInfo.
   return normalizedConfig as ListConfig<TTypeInfo>
 }
 
-// Re-export all types
 export type {
   OpenSaasConfig,
   OutputConfig,
@@ -171,16 +162,13 @@ export type {
   FileMetadata,
   ImageMetadata,
   ImageTransformationResult,
-  // Plugin system types
   Plugin,
   PluginContext,
   GeneratedFiles,
-  // List-level hook argument types
   ResolveInputHookArgs,
   ValidateHookArgs,
   BeforeOperationHookArgs,
   AfterOperationHookArgs,
-  // Field-level hook argument types
   FieldResolveInputHookArgs,
   FieldValidateHookArgs,
   FieldBeforeOperationHookArgs,

--- a/packages/core/src/config/label.ts
+++ b/packages/core/src/config/label.ts
@@ -1,8 +1,11 @@
 import type { ListConfig } from './types.js'
 
 /**
- * Resolve the field name used as a list's Label field — see the "Label
- * field" glossary entry in `CONTEXT.md`.
+ * Resolve the field name used as a list's Label field: `ui.labelField` if
+ * set, else `name`, else `title`, else `id`.
+ *
+ * @throws if `ui.labelField` names a field not declared on the list, or a
+ * relationship field (the Label field must be a scalar).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function getLabelFieldName(listConfig: ListConfig<any>): string {
@@ -29,8 +32,8 @@ export function getLabelFieldName(listConfig: ListConfig<any>): string {
 }
 
 /**
- * Render a row's Label field as text — see the "Item label" glossary entry
- * in `CONTEXT.md`.
+ * Render a row's Label field ({@link getLabelFieldName}) as text, falling
+ * back to `item.id` when the value is `null`/`undefined`.
  */
 export function getItemLabel(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo

--- a/packages/core/src/config/label.ts
+++ b/packages/core/src/config/label.ts
@@ -1,16 +1,8 @@
 import type { ListConfig } from './types.js'
 
 /**
- * Resolve the field name that represents a list's rows as a single label —
- * the projection half of the label seam. `getItemLabel` reads exactly the
- * field this returns, so the field chosen for projection can never drift
- * from the field used for rendering.
- *
- * Fallback order: configured `ui.labelField` → `name` → `title` → `id`
- * (first field that exists on the list).
- *
- * @throws if `ui.labelField` is set but does not reference a declared,
- * non-relationship field on the list.
+ * Resolve the field name used as a list's Label field — see the "Label
+ * field" glossary entry in `CONTEXT.md`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 export function getLabelFieldName(listConfig: ListConfig<any>): string {
@@ -37,10 +29,8 @@ export function getLabelFieldName(listConfig: ListConfig<any>): string {
 }
 
 /**
- * Resolve the display label for a single row — the render half of the label
- * seam. Reads the field `getLabelFieldName` resolves, falling back to `id`
- * when that field is missing from the row (e.g. stripped by field-level
- * access).
+ * Render a row's Label field as text — see the "Item label" glossary entry
+ * in `CONTEXT.md`.
  */
 export function getItemLabel(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo

--- a/packages/core/src/config/nav-count.ts
+++ b/packages/core/src/config/nav-count.ts
@@ -13,13 +13,12 @@ type CountDelegate = {
 
 /**
  * Whether a list's query access is **statically denied** — provably no session
- * can read any row without evaluating a session-dependent function.
+ * can read any row, without evaluating a session-dependent function.
  *
- * Mirrors the list view's `canDeleteList` static check (issue #733): query
- * access is statically denied when it is absent (deny-by-default, matching the
- * access engine) or the literal boolean `false`. A function — or `true` —
- * cannot be decided up front, so the count is fetched through the secured
- * context, which re-applies the real rule per row.
+ * Mirrors the list view's `canDeleteList` static check (issue #733): absent
+ * access is deny-by-default (matching the access engine), so only an explicit
+ * `false` counts as statically denied here — a function or `true` falls
+ * through to a real per-row check via the secured context.
  *
  * A statically-denied list must render no nav count at all: a `0` there would
  * imply "this list is empty" when the truth is "you may see none of it".
@@ -35,20 +34,13 @@ export function isListQueryStaticallyDenied(
 }
 
 /**
- * Resolve the access-scoped nav counts for the lists that opt in via
- * `ui.navCount` (issue #735).
+ * Resolve the access-scoped nav counts for lists that opt in via
+ * `ui.navCount` (issue #735). A list gets an entry only if it opts in, isn't
+ * a singleton (no meaningful count), and isn't {@link isListQueryStaticallyDenied}
+ * — everything else is omitted from the map, never zeroed.
  *
- * The returned map is keyed by list key and contains an entry **only** for a
- * list that:
- *
- * 1. opts in (`ui.navCount === true`) — no count query runs for any other list,
- * 2. is not a singleton (a single-record list has no meaningful count), and
- * 3. does not have statically-denied query access (see
- *    {@link isListQueryStaticallyDenied}).
- *
- * Each count is read through the secured `context.db`, whose `count` applies the
- * access filter, so the number reflects exactly what the current session may
- * see (a denied row is not counted). Counts are fetched concurrently.
+ * Each count is read through the secured `context.db`, so it reflects
+ * exactly what the current session may see.
  */
 export async function resolveNavCounts(
   context: AccessContext,

--- a/packages/core/src/config/plugin-engine.ts
+++ b/packages/core/src/config/plugin-engine.ts
@@ -8,17 +8,12 @@ import type {
   BaseFieldConfig,
 } from './types.js'
 
-/**
- * Topological sort for plugin dependency resolution
- * Ensures plugins execute in correct order based on dependencies
- */
 function sortPluginsByDependencies(plugins: Plugin[]): Plugin[] {
   const pluginMap = new Map<string, Plugin>()
   const visited = new Set<string>()
   const visiting = new Set<string>()
   const sorted: Plugin[] = []
 
-  // Build plugin map
   for (const plugin of plugins) {
     if (pluginMap.has(plugin.name)) {
       throw new Error(`Duplicate plugin name: ${plugin.name}`)
@@ -42,7 +37,6 @@ function sortPluginsByDependencies(plugins: Plugin[]): Plugin[] {
 
     visiting.add(pluginName)
 
-    // Visit dependencies first
     if (plugin.dependencies) {
       for (const dep of plugin.dependencies) {
         visit(dep, [...path, pluginName])
@@ -54,7 +48,6 @@ function sortPluginsByDependencies(plugins: Plugin[]): Plugin[] {
     sorted.push(plugin)
   }
 
-  // Visit all plugins
   for (const plugin of plugins) {
     visit(plugin.name)
   }
@@ -62,17 +55,12 @@ function sortPluginsByDependencies(plugins: Plugin[]): Plugin[] {
   return sorted
 }
 
-/**
- * Merge hooks from extension into existing hooks
- * Combines hook arrays so multiple plugins can add hooks
- */
 function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): Hooks | undefined {
   if (!extension) return existing
   if (!existing) return extension
 
   const merged: Partial<Hooks> = {}
 
-  // Merge resolveInput hooks (chain them, passing resolvedData through)
   if (existing.resolveInput || extension.resolveInput) {
     if (existing.resolveInput && extension.resolveInput) {
       merged.resolveInput = async (args) => {
@@ -85,7 +73,6 @@ function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): 
     }
   }
 
-  // Merge validateInput hooks (run both)
   if (existing.validateInput || extension.validateInput) {
     if (existing.validateInput && extension.validateInput) {
       merged.validateInput = async (args) => {
@@ -97,7 +84,6 @@ function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): 
     }
   }
 
-  // Merge beforeOperation hooks (run both in sequence)
   if (existing.beforeOperation || extension.beforeOperation) {
     if (existing.beforeOperation && extension.beforeOperation) {
       merged.beforeOperation = async (args) => {
@@ -109,7 +95,6 @@ function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): 
     }
   }
 
-  // Merge afterOperation hooks (run both in sequence)
   if (existing.afterOperation || extension.afterOperation) {
     if (existing.afterOperation && extension.afterOperation) {
       merged.afterOperation = async (args) => {
@@ -124,33 +109,24 @@ function mergeHooks(existing: Hooks | undefined, extension: Hooks | undefined): 
   return Object.keys(merged).length > 0 ? (merged as Hooks) : undefined
 }
 
-/**
- * Execute plugins and transform config
- * Returns modified config with plugin data attached
- */
 export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasConfig> {
   if (!config.plugins || config.plugins.length === 0) {
     return config
   }
 
-  // Sort plugins by dependencies
   const sortedPlugins = sortPluginsByDependencies(config.plugins)
 
-  // Initialize mutable config state - preserve all config properties
   let currentConfig: OpenSaasConfig = {
     ...config,
     lists: { ...config.lists }, // Clone lists object to avoid mutating original
     _pluginData: {},
   }
 
-  // Field type registry (for third-party fields)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Registry must accept any field config builder
   const fieldTypeRegistry = new Map<string, (options?: unknown) => BaseFieldConfig<any>>()
 
-  // MCP tools registry
   const mcpToolsRegistry: McpCustomTool[] = []
 
-  // Execute each plugin
   for (const plugin of sortedPlugins) {
     const context: PluginContext = {
       config: currentConfig,
@@ -186,16 +162,13 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
           )
         }
 
-        // Deep merge fields
         const mergedFields = {
           ...existing.fields,
           ...extension.fields,
         }
 
-        // Merge hooks
         const mergedHooks = mergeHooks(existing.hooks, extension.hooks)
 
-        // Merge MCP config
         const mergedMcp = extension.mcp
           ? {
               ...existing.mcp,
@@ -233,11 +206,9 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
       },
     }
 
-    // Execute plugin init
     await plugin.init(context)
   }
 
-  // Store registered MCP tools in config (if any)
   if (mcpToolsRegistry.length > 0) {
     if (!currentConfig._pluginData) {
       currentConfig._pluginData = {}
@@ -245,8 +216,7 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
     currentConfig._pluginData.__mcpTools = mcpToolsRegistry
   }
 
-  // Store plugin instances in config for runtime access
-  // This allows context creation to call plugin.runtime() functions
+  // Stored so context creation can call each plugin's runtime() function.
   if (!currentConfig._plugins) {
     currentConfig._plugins = []
   }
@@ -255,9 +225,6 @@ export async function executePlugins(config: OpenSaasConfig): Promise<OpenSaasCo
   return currentConfig
 }
 
-/**
- * Execute beforeGenerate hooks from plugins
- */
 export async function executeBeforeGenerateHooks(config: OpenSaasConfig): Promise<OpenSaasConfig> {
   if (!config.plugins || config.plugins.length === 0) {
     return config
@@ -274,9 +241,6 @@ export async function executeBeforeGenerateHooks(config: OpenSaasConfig): Promis
   return currentConfig
 }
 
-/**
- * Execute afterGenerate hooks from plugins
- */
 export async function executeAfterGenerateHooks(
   config: OpenSaasConfig,
   files: { prismaSchema: string; types: string; context: string; [key: string]: string },

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2903,15 +2903,17 @@ export type PluginContext = {
 
   /**
    * Add a new list to the config
-   * Throws error if list already exists (unless merge strategy used)
+   * Throws error if list already exists
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API must accept any list config
   addList: (name: string, listConfig: ListConfig<any>) => void
 
   /**
-   * Extend an existing list with additional fields, hooks, or access control
-   * Deep merges fields, hooks, and access control
-   * Throws error if list doesn't exist
+   * Extend an existing list with additional fields, hooks, or MCP config.
+   * Merges fields, hooks, and MCP config. Throws if the list doesn't exist,
+   * or if the extension sets operation-level `access` — access control
+   * belongs to whoever created the list, never a plugin extending it
+   * (ADR-0013).
    */
   extendList: (
     name: string,
@@ -3031,10 +3033,6 @@ export type Plugin = {
 }
 
 /**
- * Main configuration type
- * Using interface instead of type to allow module augmentation
- */
-/**
  * Configurable generator output locations.
  *
  * Lets a project relocate the generated Prisma schema and the `.opensaas`
@@ -3095,6 +3093,10 @@ export interface OutputConfig {
   buildTarget?: 'node'
 }
 
+/**
+ * Main configuration type.
+ * Uses an interface, not a type alias, so it can be extended via module augmentation.
+ */
 export interface OpenSaasConfig {
   db: DatabaseConfig
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Config must accept any list configuration

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2329,9 +2329,6 @@ export type ListConfigInput<TTypeInfo extends TypeInfo> = Omit<ListConfig<TTypeI
   access?: ListAccessControl<TTypeInfo['item']>
 }
 
-/**
- * Database configuration
- */
 export type DatabaseConfig = {
   provider: 'postgresql' | 'mysql' | 'sqlite'
   /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2,9 +2,6 @@ import type { AccessControl, FieldAccess } from '../access/types.js'
 import type { FilterSpec } from '../filter/types.js'
 import type { z } from 'zod'
 
-/**
- * Field configuration types
- */
 export type FieldType =
   'text' | 'integer' | 'checkbox' | 'timestamp' | 'password' | 'select' | 'relationship' | string // Allow custom field types from third-party packages
 
@@ -12,10 +9,7 @@ export type FieldType =
  * Field-level hook argument types (exported for user annotations)
  */
 
-/**
- * Arguments for field-level resolveInput hook
- * Used to transform field values before database write
- */
+/** Arguments for {@link FieldHooks.resolveInput}. */
 export type FieldResolveInputHookArgs<
   TTypeInfo extends TypeInfo,
   TFieldKey extends FieldKeys<TTypeInfo['fields']> = FieldKeys<TTypeInfo['fields']>,
@@ -39,10 +33,7 @@ export type FieldResolveInputHookArgs<
       context: import('../access/types.js').AccessContext
     }
 
-/**
- * Arguments for field-level validate hook
- * Used for custom validation logic
- */
+/** Arguments for {@link FieldHooks.validate} (and its deprecated `validateInput` alias). */
 export type FieldValidateHookArgs<
   TTypeInfo extends TypeInfo,
   TFieldKey extends FieldKeys<TTypeInfo['fields']> = FieldKeys<TTypeInfo['fields']>,
@@ -76,10 +67,7 @@ export type FieldValidateHookArgs<
       addValidationError: (msg: string) => void
     }
 
-/**
- * Arguments for field-level beforeOperation hook
- * Used for side effects before database write
- */
+/** Arguments for {@link FieldHooks.beforeOperation}. */
 export type FieldBeforeOperationHookArgs<
   TTypeInfo extends TypeInfo,
   TFieldKey extends FieldKeys<TTypeInfo['fields']> = FieldKeys<TTypeInfo['fields']>,
@@ -109,10 +97,7 @@ export type FieldBeforeOperationHookArgs<
       context: import('../access/types.js').AccessContext
     }
 
-/**
- * Arguments for field-level afterOperation hook
- * Used for side effects after database operation
- */
+/** Arguments for {@link FieldHooks.afterOperation}. */
 export type FieldAfterOperationHookArgs<
   TTypeInfo extends TypeInfo,
   TFieldKey extends FieldKeys<TTypeInfo['fields']> = FieldKeys<TTypeInfo['fields']>,
@@ -263,10 +248,7 @@ export type FieldAfterTransactionHookArgs<
       context: import('../access/types.js').AccessContext
     }
 
-/**
- * Arguments for field-level resolveOutput hook
- * Used to transform field values after database read
- */
+/** Arguments for {@link FieldHooks.resolveOutput}. */
 export type FieldResolveOutputHookArgs<
   TTypeInfo extends TypeInfo,
   TFieldKey extends FieldKeys<TTypeInfo['fields']> = FieldKeys<TTypeInfo['fields']>,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2547,9 +2547,6 @@ export type DatabaseConfig = {
   }
 }
 
-/**
- * Session configuration
- */
 export type SessionConfig = {
   // Uses `any` return type because session structure is user-defined and varies per application
   // The stack doesn't enforce a specific session shape - users can use NextAuth, Clerk, etc.
@@ -2557,9 +2554,6 @@ export type SessionConfig = {
   getSession: () => Promise<any>
 }
 
-/**
- * Theme preset options
- */
 export type ThemePreset = 'modern' | 'classic' | 'neon'
 
 /**
@@ -2655,14 +2649,8 @@ export type ThemeConfig = {
   shadows?: ThemeShadows
 }
 
-/**
- * UI configuration
- */
 export type UIConfig = {
   basePath?: string
-  /**
-   * Theme configuration for the admin UI
-   */
   theme?: ThemeConfig
 }
 
@@ -2705,18 +2693,12 @@ export type McpCustomTool = {
    * Unique name for the tool
    */
   name: string
-  /**
-   * Description of what the tool does
-   */
   description: string
   /**
    * Input schema (Zod schema)
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputSchema: any
-  /**
-   * Handler function that executes the tool
-   */
   handler: (args: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any
@@ -2724,9 +2706,6 @@ export type McpCustomTool = {
   }) => Promise<unknown>
 }
 
-/**
- * List-level MCP configuration
- */
 export type ListMcpConfig = {
   /**
    * Enable MCP tools for this list
@@ -2797,9 +2776,6 @@ export type McpAuthConfig =
        * Authentication type - custom auth provider
        */
       type: string
-      /**
-       * Additional auth-specific configuration
-       */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Allows custom auth provider configuration
       [key: string]: any
     }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -489,10 +489,10 @@ export type BaseFieldConfig<TTypeInfo extends TypeInfo> = {
   defaultValue?: unknown
   hooks?: FieldHooks<TTypeInfo>
   /**
-   * Marks this field as virtual - not stored in database
-   * Virtual fields use resolveInput/resolveOutput hooks for computation
-   * They are excluded from Prisma schema and input types
-   * Only computed when explicitly selected/included in queries
+   * Marks this field as virtual — not stored in database, computed via
+   * `resolveInput`/`resolveOutput` hooks, and excluded from the Prisma
+   * schema and input types. Computed whenever the read is going to return
+   * it (ADR-0027) — not gated behind an explicit `include`/selection.
    */
   virtual?: boolean
   /**
@@ -1359,20 +1359,8 @@ export type VirtualField<TTypeInfo extends TypeInfo> = BaseFieldConfig<TTypeInfo
  */
 export type FieldConfig = BaseFieldConfig<TypeInfo>
 
-/**
- * List configuration types
- */
-
-/**
- * Utility type to inject TypeInfo into a single field config
- * Extracts TInput and TOutput from BaseFieldConfig and reconstructs with new TypeInfo
- */
 type WithTypeInfo<TTypeInfo extends TypeInfo> = BaseFieldConfig<TTypeInfo>
 
-/**
- * Utility type to transform all fields in a record to inject TypeInfo
- * Maps over each field and applies WithTypeInfo transformation
- */
 export type FieldsWithTypeInfo<TTypeInfo extends TypeInfo> = {
   [key: string]: WithTypeInfo<TTypeInfo>
 }
@@ -1548,8 +1536,7 @@ export type ListAccessControl<T = any> =
     }
 
 /**
- * Hook arguments for resolveInput hook
- * Uses discriminated union to provide proper types based on operation
+ * Hook arguments for the list-level `resolveInput` hook.
  * - create: resolvedData is CreateInput, item is undefined
  * - update: resolvedData is UpdateInput, item is the existing record
  */
@@ -1576,8 +1563,7 @@ export type ResolveInputHookArgs<
     }
 
 /**
- * Hook arguments for validate hook (renamed from validateInput for Keystone compatibility)
- * Uses discriminated union to provide proper types based on operation
+ * Hook arguments for the list-level `validate` hook (renamed from `validateInput` for Keystone compatibility).
  * - create: resolvedData is CreateInput, item is undefined
  * - update: resolvedData is UpdateInput, item is the existing record
  * - delete: item is the item being deleted
@@ -1614,8 +1600,7 @@ export type ValidateHookArgs<
     }
 
 /**
- * Hook arguments for beforeOperation hook
- * Uses discriminated union to provide proper types based on operation
+ * Hook arguments for the list-level `beforeOperation` hook.
  * - create: has inputData and resolvedData, no item
  * - update: has inputData, resolvedData, and item
  * - delete: has item only
@@ -1648,8 +1633,7 @@ export type BeforeOperationHookArgs<
     }
 
 /**
- * Hook arguments for afterOperation hook
- * Uses discriminated union to provide proper types based on operation
+ * Hook arguments for the list-level `afterOperation` hook.
  * - create: has item, inputData, and resolvedData, no originalItem
  * - update: has item, originalItem, inputData, and resolvedData
  * - delete: has originalItem only
@@ -2039,9 +2023,6 @@ export type ListConfig<TTypeInfo extends TypeInfo> = {
      */
     indexes?: ListIndex[]
   }
-  /**
-   * MCP server configuration for this list
-   */
   mcp?: ListMcpConfig
   /**
    * Restricts this list to a single record (singleton pattern)

--- a/packages/core/src/fields/format-prisma-default.ts
+++ b/packages/core/src/fields/format-prisma-default.ts
@@ -42,19 +42,16 @@ export function formatPrismaDefault(
 
   switch (fieldType) {
     case 'integer':
-      // Bare numeric literal — Prisma expects no quotes for Int defaults.
       return String(value)
 
     case 'text':
-      // Double-quoted string literal. The value is escaped via JSON.stringify so
-      // embedded quotes/backslashes are handled correctly.
+      // JSON.stringify (not a template literal) so embedded quotes/backslashes
+      // in the value are escaped correctly.
       return JSON.stringify(String(value))
 
     case 'json': {
-      // Keystone's JSON-literal form: canonical, space-free JSON.stringify of the
-      // value, then wrap the whole serialised string in escaped double quotes so
-      // Prisma stores the JSON text as the column default. The outer
-      // JSON.stringify produces the escaped, double-quoted wrapper.
+      // Double JSON.stringify: once to canonicalize the value as JSON text,
+      // again to wrap that text in an escaped, double-quoted Prisma literal.
       const serialised = JSON.stringify(value)
       // JSON.stringify can return undefined for unserialisable values (e.g. a
       // function). Treat that as "no default" rather than emitting `@default()`.

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -22,13 +22,9 @@ import { getLabelFieldName } from '../config/label.js'
 import type { FilterOperator, FilterSpec } from '../filter/types.js'
 import { RELATIONSHIP_COUNT_FILTER_KEY } from '../filter/types.js'
 
-/**
- * Operators shared by numeric/date fields: plain equality plus the four
- * comparisons. `eq` maps to Prisma's `equals`; the comparisons pass through.
- */
+/** Operators shared by numeric/date fields' `getFilterSpec`. */
 const COMPARISON_OPERATORS: FilterOperator[] = ['eq', 'gt', 'gte', 'lt', 'lte']
 
-/** Map a Filter operator to its Prisma condition key (`eq` → `equals`). */
 function prismaComparisonKey(operator: FilterOperator): string {
   return operator === 'eq' ? 'equals' : operator
 }
@@ -55,9 +51,6 @@ export type {
   MultiColumnPrismaResult,
 } from '../config/types.js'
 
-/**
- * Format field name for display in error messages
- */
 function formatFieldName(fieldName: string): string {
   return fieldName
     .replace(/([A-Z])/g, ' $1')
@@ -119,12 +112,10 @@ export function text<
       const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Native type modifier (e.g., @db.Text)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
@@ -153,7 +144,6 @@ export function text<
         modifiers += ' @unique'
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -173,9 +163,6 @@ export function text<
         optional: !isRequired,
       }
     },
-    // Text fields drive free-text search: a bare word (or a `field:value`) maps
-    // to a case-preserving `contains`. This is what replaces the old hard-coded
-    // `type === 'text'` search in the admin list view.
     getFilterSpec: (fieldName: string): FilterSpec => ({
       operators: ['eq'],
       freeText: true,
@@ -225,24 +212,19 @@ export function integer<
       const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Native type modifier (e.g., @db.SmallInt, @db.BigInt)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Default value if provided (bare numeric literal). Independent of the
-      // nullable `?` modifier above — the default never overwrites nullability.
       const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'integer')
       if (defaultLiteral !== undefined) {
         modifiers += ` @default(${defaultLiteral})`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -260,8 +242,7 @@ export function integer<
         optional: !isRequired,
       }
     },
-    // Integers support equality and comparisons (`orders:>5`). A non-integer
-    // value can't be interpreted, so its token degrades to free text.
+    // A non-integer token can't be interpreted, so it degrades to free text.
     getFilterSpec: (fieldName: string): FilterSpec => ({
       operators: COMPARISON_OPERATORS,
       toCondition: (operator, value) => {
@@ -329,8 +310,6 @@ export function decimal<
     scale,
     ...options,
     getZodSchema: (fieldName: string, operation: 'create' | 'update') => {
-      // Decimal values can be provided as strings or numbers
-      // Prisma will convert them to Decimal instances
       const baseSchema = z.union(
         [
           z.string({
@@ -347,7 +326,6 @@ export function decimal<
 
       let schema = baseSchema
 
-      // Add min validation if specified
       if (options?.validation?.min !== undefined) {
         const minValue = parseFloat(options.validation.min)
         schema = schema.refine(
@@ -361,7 +339,6 @@ export function decimal<
         )
       }
 
-      // Add max validation if specified
       if (options?.validation?.max !== undefined) {
         const maxValue = parseFloat(options.validation.max)
         schema = schema.refine(
@@ -387,27 +364,22 @@ export function decimal<
 
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Precision and scale
       modifiers += ` @db.Decimal(${precision}, ${scale})`
 
-      // Default value if provided
       if (options?.defaultValue !== undefined) {
         modifiers += ` @default(${options.defaultValue})`
       }
 
-      // Database mapping
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
 
-      // Unique modifier. A non-unique index has no field-level form in Prisma,
-      // so it is requested out-of-line via `index` below and emitted by the
-      // generator as `@@index([...])` on the model.
+      // Unique modifier — non-unique index routes through `index` below,
+      // same as `text()`'s getPrismaType.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
       }
@@ -530,30 +502,24 @@ export function bigInt<
       const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Native type modifier (e.g., @db.UnsignedBigInt on MySQL)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Default value if provided (bare integer literal). Independent of the
-      // nullable `?` modifier above — the default never overwrites nullability.
       if (options?.defaultValue !== undefined) {
         modifiers += ` @default(${options.defaultValue})`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
 
-      // Unique modifier. A non-unique index has no field-level form in Prisma,
-      // so it is requested out-of-line via `index` below and emitted by the
-      // generator as `@@index([...])` on the model.
+      // Unique modifier — non-unique index routes through `index` below,
+      // same as `text()`'s getPrismaType.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
       }
@@ -572,7 +538,7 @@ export function bigInt<
         optional: !isRequired,
       }
     },
-    // BigInts compare like integers; a non-integer token degrades to free text.
+    // A non-integer token degrades to free text.
     getFilterSpec: (fieldName: string): FilterSpec => ({
       operators: COMPARISON_OPERATORS,
       toCondition: (operator, value) => {
@@ -602,8 +568,9 @@ export function checkbox<
       const hasDefault = options?.defaultValue !== undefined
       let modifiers = ''
 
-      // Nullable modifier - checkbox fields are non-nullable by default (must be true or false)
-      // Use db.isNullable: true to allow NULL values in the database
+      // Checkboxes are non-nullable by default (must be true or false), unlike
+      // the other scalar fields' nullable-unless-required default — set
+      // db.isNullable: true to allow NULL.
       if (db?.isNullable === true) {
         modifiers += '?'
       }
@@ -612,7 +579,6 @@ export function checkbox<
         modifiers += ` @default(${options.defaultValue})`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -628,8 +594,7 @@ export function checkbox<
         optional: options?.defaultValue === undefined,
       }
     },
-    // Checkboxes filter by equality against the two enumerated values. Anything
-    // other than true/false can't be interpreted and degrades to free text.
+    // Anything other than true/false degrades to free text.
     getFilterSpec: (fieldName: string): FilterSpec => ({
       operators: ['eq'],
       toCondition: (operator, value) => {
@@ -672,27 +637,22 @@ export function timestamp<
         'kind' in options.defaultValue &&
         options.defaultValue.kind === 'now'
 
-      // Nullability: explicit db.isNullable overrides the default (nullable unless @default(now()))
       const isNullable = db?.isNullable ?? !hasDefaultNow
 
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Default value
       if (hasDefaultNow) {
         modifiers += ' @default(now())'
       }
 
-      // Native type modifier (e.g., @db.Timestamptz for PostgreSQL)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -714,8 +674,7 @@ export function timestamp<
         optional: !hasDefault,
       }
     },
-    // Timestamps support equality and comparisons (`joined:>2024-01-01`). An
-    // unparseable date degrades to free text.
+    // An unparseable date degrades to free text.
     getFilterSpec: (fieldName: string): FilterSpec => ({
       operators: COMPARISON_OPERATORS,
       toCondition: (operator, value) => {
@@ -794,23 +753,11 @@ export function calendarDay<
   return {
     type: 'calendarDay',
     ...options,
-    // Writes: the write pipeline runs field resolveInput BEFORE zod
-    // validation (Hook Pipeline: field resolveInput → built-in field rules),
-    // so this is the only point a YYYY-MM-DD string can be turned into
-    // something Prisma's `@db.Date` write validator accepts — Prisma 7
-    // rejects a bare date string there (#621). Convert a valid string to a
-    // UTC-midnight Date; leave anything else (a Date already, null/undefined,
-    // or a malformed string) untouched so the zod schema below still rejects
-    // malformed input with a clear message. Reads resolvedData[fieldKey]
-    // (not raw inputData) so a list-level resolveInput that injects a default
-    // for an omitted key is still coerced instead of being overwritten.
-    //
-    // Reads: the underlying @db.Date column hands Prisma a Date (or a TEXT
-    // string under the SQLite fallback). Normalise to a YYYY-MM-DD string so the
-    // runtime value matches the declared `string` type. UTC components are used
-    // so the formatting never drifts a day in non-UTC timezones.
-    // Cast hooks to any since field builders are generic and can't know the
-    // specific TFieldKey (same pattern as password()).
+    // Hook Pipeline runs field resolveInput before zod validation — the only
+    // point a YYYY-MM-DD string can be turned into what Prisma's `@db.Date`
+    // write validator accepts (#621). Reads resolvedData[fieldKey], not raw
+    // inputData, so a list-level resolveInput's injected default for an
+    // omitted key is still coerced rather than overwritten.
     hooks: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
       resolveInput: ({ resolvedData, fieldKey }: { resolvedData: any; fieldKey: string }) => {
@@ -823,7 +770,6 @@ export function calendarDay<
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
       resolveOutput: ({ value }: { value: any }) => formatCalendarDay(value),
-      // Merge with user-provided hooks if any
       ...options?.hooks,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hook object needs type assertion for field builder
     } as any,
@@ -831,10 +777,9 @@ export function calendarDay<
       const validation = options?.validation
       const isRequired = validation?.isRequired
 
-      // Accept ISO8601 date strings (YYYY-MM-DD) in the shape a caller passes,
-      // or a `Date` — the shape resolveInput above turns a valid string into
-      // before this schema runs. Malformed strings fall through resolveInput
-      // untouched and still fail the regex here with a clear message.
+      // Accepts a `Date` because resolveInput above already converted a valid
+      // string to one before this schema runs; a malformed string falls
+      // through resolveInput untouched and fails the regex here instead.
       const stringSchema = z
         .string({
           message: `${formatFieldName(fieldName)} must be a valid date in ISO8601 format (YYYY-MM-DD)`,
@@ -848,7 +793,6 @@ export function calendarDay<
       if (isRequired && operation === 'create') {
         return dateSchema
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: omitted keys pass; present values must be valid
         return dateSchema.optional()
       } else {
         return dateSchema.optional().nullable()
@@ -862,31 +806,26 @@ export function calendarDay<
 
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Add @db.Date attribute for date-only storage
-      // Only for PostgreSQL/MySQL - SQLite doesn't support native DATE type
-      // SQLite will use TEXT for DateTime fields
+      // SQLite has no native DATE type and falls back to TEXT for DateTime
+      // columns, so @db.Date only applies on PostgreSQL/MySQL.
       if (provider && provider.toLowerCase() !== 'sqlite') {
         modifiers += ' @db.Date'
       }
 
-      // Default value if provided
       if (options?.defaultValue !== undefined) {
         modifiers += ` @default("${options.defaultValue}")`
       }
 
-      // Database mapping
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
 
-      // Unique modifier. A non-unique index has no field-level form in Prisma,
-      // so it is requested out-of-line via `index` below and emitted by the
-      // generator as `@@index([...])` on the model.
+      // Unique modifier — non-unique index routes through `index` below,
+      // same as `text()`'s getPrismaType.
       if (options?.isIndexed === 'unique') {
         modifiers += ' @unique'
       }
@@ -903,12 +842,6 @@ export function calendarDay<
       const isRequired = validation?.isRequired
       const isNullable = db?.isNullable ?? !isRequired
 
-      // calendarDay is a YYYY-MM-DD string end-to-end (Keystone's CalendarDay
-      // scalar). Returning 'string' here makes the entity/read type and the
-      // standalone generated CreateInput/UpdateInput types `string`. At the
-      // context.db write path a Date is still rejected at runtime by validation
-      // (the generated db method `data` type derives from Prisma's `Date | string`
-      // input — making it a compile-time error is tracked in #599).
       return {
         type: 'string',
         optional: isNullable,
@@ -1019,46 +952,37 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
     ...options,
     resultExtension: {
       outputType: "import('@opensaas/stack-core/internal').HashedPassword",
-      // No compute - delegates to resolveOutput hook
     },
     ui: {
       ...options?.ui,
       valueForClientSerialization: ({ value }) => ({ isSet: !!value }),
     },
-    // Cast hooks to any since field builders are generic and can't know the specific TFieldKey
     hooks: {
-      // Hash password before writing to database
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
       resolveInput: async ({ inputData, fieldKey }: { inputData: any; fieldKey: string }) => {
-        // Skip if undefined or null (allows partial updates)
         const inputValue = inputData[fieldKey]
         if (inputValue === undefined || inputValue === null) {
           return inputValue
         }
 
-        // Skip if not a string
         if (typeof inputValue !== 'string' || inputValue.length === 0) {
           return inputValue
         }
 
-        // Skip if already hashed (idempotent)
+        // Idempotent: skip re-hashing a value that's already a hash.
         if (isHashedPassword(inputValue)) {
           return inputValue
         }
 
-        // Hash the password
         return (await hashPassword(inputValue)).toString()
       },
-      // Wrap password with HashedPassword class after reading from database
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks must be generic
       resolveOutput: ({ value }: { value: any }) => {
-        // Only wrap string values (hashed passwords)
         if (typeof value === 'string' && value.length > 0) {
           return new HashedPassword(value)
         }
         return undefined
       },
-      // Merge with user-provided hooks if any
       ...options?.hooks,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hook object needs type assertion for field builder
     } as any,
@@ -1067,7 +991,6 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
       const isRequired = validation?.isRequired
 
       if (isRequired && operation === 'create') {
-        // Required in create mode: reject undefined and empty strings
         return z
           .string({
             message: `${formatFieldName(fieldName)} must be text`,
@@ -1076,7 +999,6 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
             message: `${formatFieldName(fieldName)} is required`,
           })
       } else if (isRequired && operation === 'update') {
-        // Required in update mode: omitted keys pass; if provided, reject empty strings
         return z
           .string()
           .min(1, {
@@ -1084,7 +1006,6 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
           })
           .optional()
       } else {
-        // Not required: can be undefined or any string
         return z
           .string({
             message: `${formatFieldName(fieldName)} must be text`,
@@ -1100,17 +1021,14 @@ export function password<TTypeInfo extends import('../config/types.js').TypeInfo
       const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Native type modifier (e.g., @db.Text)
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -1190,7 +1108,6 @@ export function select<
       const isNullable = options.db?.isNullable ?? (!isRequired && !hasDefault)
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
@@ -1203,12 +1120,11 @@ export function select<
         const derivedEnumName = listName ? `${listName}${capitalizedField}` : capitalizedField
         const enumName = options.db?.enumName ?? derivedEnumName
 
-        // Add default value if provided (no quotes for enum values)
+        // No quotes for enum default values (unlike the string branch below).
         if (hasDefault) {
           modifiers += ` @default(${options.defaultValue})`
         }
 
-        // Map modifier
         if (options.db?.map) {
           modifiers += ` @map("${options.db.map}")`
         }
@@ -1222,12 +1138,10 @@ export function select<
 
       // String type (default)
 
-      // Add default value if provided
       if (hasDefault) {
         modifiers += ` @default("${options.defaultValue}")`
       }
 
-      // Map modifier
       if (options.db?.map) {
         modifiers += ` @map("${options.db.map}")`
       }
@@ -1294,9 +1208,6 @@ function parseRelationshipRef(ref: string): { list: string; field?: string } {
   }
 }
 
-/**
- * Check if a relationship is one-to-one (bidirectional with both sides having many: false).
- */
 function isOneToOneRelationship(
   fieldName: string,
   field: RelationshipField,
@@ -1329,10 +1240,6 @@ function isOneToOneRelationship(
   return !(targetFieldConfig as RelationshipField).many
 }
 
-/**
- * Determine if this side of a relationship should store the foreign key.
- * For one-to-one relationships, only one side stores the foreign key.
- */
 function shouldHaveForeignKey(
   listKey: string,
   fieldName: string,
@@ -1383,9 +1290,6 @@ function shouldHaveForeignKey(
   return fieldName.localeCompare(targetField) < 0
 }
 
-/**
- * Check whether a many relationship is a true many-to-many (both sides many).
- */
 function isManyToMany(
   fieldName: string,
   field: RelationshipField,
@@ -1459,13 +1363,9 @@ function computeManyToManyRelationName(
     return `${listKey}_${fieldName}`
   }
 
-  // Default Prisma naming - no explicit relation name needed
   return undefined
 }
 
-/**
- * Build the Prisma schema contribution for a relationship field.
- */
 function getPrismaRelation(
   field: RelationshipField,
   fieldName: string,
@@ -1579,7 +1479,6 @@ export function relationship<
     throw new Error('Relationship field must have a ref')
   }
 
-  // Validate ref format: 'ListName.fieldName' or 'ListName'
   const refParts = options.ref.split('.')
   if (refParts.length !== 1 && refParts.length !== 2) {
     throw new Error(
@@ -1587,9 +1486,7 @@ export function relationship<
     )
   }
 
-  // Validate db.foreignKey usage
   if (options.db?.foreignKey !== undefined) {
-    // Can only be used on single relationships (not many)
     if (options.many) {
       throw new Error(
         'db.foreignKey can only be used on single relationships (many: false or undefined). ' +
@@ -1597,7 +1494,6 @@ export function relationship<
       )
     }
 
-    // Can only be used on bidirectional relationships (with target field)
     if (refParts.length === 1) {
       throw new Error(
         'db.foreignKey can only be used on bidirectional relationships (ref: "ListName.fieldName"). ' +
@@ -1606,9 +1502,6 @@ export function relationship<
     }
   }
 
-  // Validate db.isNullable usage: only the FK-owning (single) side of a
-  // relationship has a column to make non-nullable — the many side always
-  // generates an array field with no nullability of its own.
   if (options.db?.isNullable !== undefined && options.many) {
     throw new Error(
       'db.isNullable can only be used on single relationships (many: false or undefined). ' +
@@ -1736,7 +1629,6 @@ export function json<
       const validation = options?.validation
       const isRequired = validation?.isRequired
 
-      // Accept any valid JSON value
       const baseSchema = z.unknown()
 
       if (isRequired && operation === 'create') {
@@ -1762,7 +1654,6 @@ export function json<
           })
           .optional()
       } else {
-        // Not required: can be undefined or null
         return baseSchema.optional().nullable()
       }
     },
@@ -1773,25 +1664,19 @@ export function json<
       const isNullable = db?.isNullable ?? !isRequired
       let modifiers = ''
 
-      // Optional modifier
       if (isNullable) {
         modifiers += '?'
       }
 
-      // Native type modifier
       if (db?.nativeType) {
         modifiers += ` @db.${db.nativeType}`
       }
 
-      // Default value if provided. Uses Keystone's JSON-literal form: canonical
-      // (space-free) JSON wrapped in escaped double quotes. Independent of the
-      // nullable `?` modifier above — the default never overwrites nullability.
       const defaultLiteral = formatPrismaDefault(options?.defaultValue, 'json')
       if (defaultLiteral !== undefined) {
         modifiers += ` @default(${defaultLiteral})`
       }
 
-      // Map modifier
       if (db?.map) {
         modifiers += ` @map("${db.map}")`
       }
@@ -1824,21 +1709,14 @@ function typeDescriptorToString(descriptor: import('../config/types.js').TypeDes
     return descriptor
   }
 
-  // Extract type name from constructor or use provided name
   const typeName = descriptor.name || descriptor.value.name
 
-  // Generate import string
   return `import('${descriptor.from}').${typeName}`
 }
 
-/**
- * Extract TypeScript imports from a TypeDescriptor
- * Returns array of import statements needed for type generation
- */
 function typeDescriptorToImports(
   descriptor: import('../config/types.js').TypeDescriptor,
 ): Array<{ names: string[]; from: string; typeOnly?: boolean }> {
-  // If it's a string, check if it's an import string
   if (typeof descriptor === 'string') {
     const importMatch = descriptor.match(/import\('([^']+)'\)\.(\w+)/)
     if (importMatch) {
@@ -1939,7 +1817,6 @@ export function virtual<TTypeInfo extends import('../config/types.js').TypeInfo>
     type: import('../config/types.js').TypeDescriptor
   },
 ): VirtualField<TTypeInfo> {
-  // Validate that resolveOutput is provided
   if (!options.hooks?.resolveOutput) {
     throw new Error(
       'Virtual fields must provide a resolveOutput hook to compute their value. ' +
@@ -1947,7 +1824,6 @@ export function virtual<TTypeInfo extends import('../config/types.js').TypeInfo>
     )
   }
 
-  // Convert type descriptor to string
   const outputType = typeDescriptorToString(options.type)
   const imports = typeDescriptorToImports(options.type)
 
@@ -1958,19 +1834,16 @@ export function virtual<TTypeInfo extends import('../config/types.js').TypeInfo>
     virtual: true,
     outputType,
     ...rest,
-    // Virtual fields don't create database columns
-    // Return undefined to signal generator to skip this field
+    // undefined signals the generator to skip creating a database column.
     getPrismaType: undefined,
-    // Virtual fields appear in output types with their specified type
     getTypeScriptType: () => {
       return {
         type: outputType,
-        optional: false, // Virtual fields always compute a value
+        optional: false, // A virtual field always computes a value.
       }
     },
-    // Add import statements if needed
     getTypeScriptImports: imports.length > 0 ? () => imports : undefined,
-    // Virtual fields never validate input (they don't accept database input)
+    // Virtual fields don't accept database input, so validation always fails.
     getZodSchema: () => {
       return z.never()
     },

--- a/packages/core/src/filter/map.ts
+++ b/packages/core/src/filter/map.ts
@@ -25,7 +25,6 @@ export function buildFilterWhere(
   const freeTextFields = Object.keys(specs).filter((field) => specs[field].freeText)
 
   for (const token of tokens) {
-    // Bare free-text word.
     if (token.field === null) {
       if (token.value) freeTextWords.push(token.value)
       continue
@@ -33,8 +32,6 @@ export function buildFilterWhere(
 
     const spec = specs[token.field]
 
-    // Unknown field / no spec / unsupported operator / empty value →
-    // degrade to free text (search the value across free-text fields).
     if (!spec || !spec.operators.includes(token.operator) || token.value === '') {
       if (token.value) freeTextWords.push(token.value)
       continue
@@ -42,7 +39,6 @@ export function buildFilterWhere(
 
     const condition = spec.toCondition(token.operator, token.value)
     if (condition === null) {
-      // Value couldn't be interpreted for this field → free text.
       freeTextWords.push(token.value)
       continue
     }
@@ -50,7 +46,6 @@ export function buildFilterWhere(
     andConditions.push(condition)
   }
 
-  // Each free-text word: OR across every free-text field's `eq` mapping.
   if (freeTextFields.length > 0) {
     for (const word of freeTextWords) {
       const orConditions = freeTextFields

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -48,15 +48,11 @@ export function parseFilterQuery(query: string): FilterToken[] {
   let i = 0
 
   while (i < n) {
-    // Skip leading whitespace between tokens.
     while (i < n && isWhitespace(query[i])) i++
     if (i >= n) break
 
     const start = i
 
-    // Optional `field:` prefix. A URL scheme (`http://…`) is not a field
-    // prefix: when the colon is immediately followed by `//`, keep the whole
-    // token as free text so pasted URLs are searched verbatim.
     let field: string | null = null
     const prefixMatch = FIELD_PREFIX_RE.exec(query.slice(i))
     if (prefixMatch && !query.startsWith('//', i + prefixMatch[0].length)) {
@@ -64,8 +60,6 @@ export function parseFilterQuery(query: string): FilterToken[] {
       i += prefixMatch[0].length
     }
 
-    // Comparison operator prefix — only meaningful once a field is present.
-    // A leading `>`/`<` on a bare word is left as part of the free-text value.
     let operator: FilterOperator = 'eq'
     if (field) {
       if (query.startsWith('>=', i)) {
@@ -83,15 +77,14 @@ export function parseFilterQuery(query: string): FilterToken[] {
       }
     }
 
-    // Value: quoted (spaces kept) or a run up to the next whitespace.
     let value = ''
     if (query[i] === '"') {
-      i++ // opening quote
+      i++
       while (i < n && query[i] !== '"') {
         value += query[i]
         i++
       }
-      if (i < n) i++ // closing quote
+      if (i < n) i++
     } else {
       while (i < n && !isWhitespace(query[i])) {
         value += query[i]

--- a/packages/core/src/filter/serialize.ts
+++ b/packages/core/src/filter/serialize.ts
@@ -56,13 +56,11 @@ export function serializeFilterQuery(tokens: FilterToken[]): string {
   const parts: string[] = []
 
   for (const token of tokens) {
-    // An empty value is not a filter — skip it rather than emit `field:` / `""`.
     if (token.value === '') continue
 
     if (token.field === null) {
-      // Bare free-text word. A leading `>`/`<` stays literal for bare words
-      // (the parser only treats them as operators after a `field:`), so no
-      // operator guard is needed here.
+      // A leading `>`/`<` stays literal for a bare word (the parser only
+      // treats them as operators after a `field:`), so no operator guard here.
       parts.push(quoteIfNeeded(token.value, false))
       continue
     }

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -4,9 +4,6 @@ import type { FieldConfig } from '../config/types.js'
 import { validateWithZod } from '../validation/schema.js'
 import { checkFieldAccess } from '../access/field-access.js'
 
-/**
- * Validation error collection
- */
 export class ValidationError extends Error {
   public errors: string[]
   public fieldErrors: Record<string, string>
@@ -19,10 +16,7 @@ export class ValidationError extends Error {
   }
 }
 
-/**
- * Database error with field-specific error information
- * Used for Prisma errors like unique constraint violations
- */
+/** Used for Prisma errors like unique constraint violations. */
 export class DatabaseError extends Error {
   public fieldErrors: Record<string, string>
   public code?: string
@@ -35,10 +29,6 @@ export class DatabaseError extends Error {
   }
 }
 
-/**
- * Execute resolveInput hook
- * Allows modification of input data before validation
- */
 export async function executeResolveInput<
   TOutput = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
@@ -71,10 +61,7 @@ export async function executeResolveInput<
   return result
 }
 
-/**
- * Execute validate hook (supports both 'validate' and deprecated 'validateInput')
- * Allows custom validation logic
- */
+/** Supports both `validate` and the deprecated `validateInput` alias for backwards compatibility. */
 export async function executeValidate<
   TOutput = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
@@ -105,7 +92,6 @@ export async function executeValidate<
         context: AccessContext
       },
 ): Promise<void> {
-  // Support both 'validate' (new) and 'validateInput' (deprecated) for backwards compatibility
   const validateHook = hooks?.validate || hooks?.validateInput
   if (!validateHook) {
     return
@@ -132,10 +118,7 @@ export async function executeValidate<
  */
 export const executeValidateInput = executeValidate
 
-/**
- * Execute beforeOperation hook
- * Runs before database operation (cannot modify data)
- */
+/** Side effects only — cannot modify data before the database write. */
 export async function executeBeforeOperation<
   TOutput = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
@@ -172,10 +155,6 @@ export async function executeBeforeOperation<
   await hooks.beforeOperation(args as Parameters<typeof hooks.beforeOperation>[0])
 }
 
-/**
- * Execute afterOperation hook
- * Runs after database operation
- */
 export async function executeAfterOperation<
   TOutput = Record<string, unknown>,
   TCreateInput = Record<string, unknown>,
@@ -410,7 +389,6 @@ export async function executeFieldAfterTransactionHooks(
   isTopLevel: boolean,
   originalItem?: Record<string, unknown>,
 ): Promise<void> {
-  // The persisted/pre-write rows are surfaced only for the top-level list.
   const committedItem = outcome.status === 'committed' && isTopLevel ? outcome.item : undefined
   const committedOriginalItem = isTopLevel ? originalItem : undefined
 
@@ -449,7 +427,6 @@ export async function executeFieldAfterTransactionHooks(
       continue
     }
 
-    // committed
     if (operation === 'delete') {
       await fieldConfig.hooks.afterTransaction({
         ...base,
@@ -479,9 +456,6 @@ export async function executeFieldAfterTransactionHooks(
 }
 
 /**
- * Execute field-level resolveInput hooks
- * Allows fields to transform their input values before database write
- *
  * NOTE (#789): multi-column fields (e.g. storage image()/file() in
  * Keystone-parity mode) are NOT split here. This phase only resolves each
  * field's value under its LOGICAL key, so that phases 2-3 (list/field
@@ -506,11 +480,9 @@ export async function executeFieldResolveInputHooks(
   let result = { ...resolvedData }
 
   for (const [fieldKey, fieldConfig] of Object.entries(fields)) {
-    // Skip if field not in data, or if there's nothing to resolve
     if (!(fieldKey in result)) continue
     if (!fieldConfig.hooks?.resolveInput) continue
 
-    // Execute field hook
     // Type assertion is safe here because hooks are typed correctly in field definitions
     // and we're working with runtime values that match those types
     const resolvedValue = await fieldConfig.hooks.resolveInput({
@@ -595,10 +567,7 @@ export async function splitMultiColumnFields(
   return result
 }
 
-/**
- * Execute field-level validate hooks
- * Allows fields to perform custom validation after resolveInput but before database write
- */
+/** Runs after resolveInput and before the database write. */
 export async function executeFieldValidateHooks(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputData: Record<string, any> | undefined,
@@ -620,11 +589,10 @@ export async function executeFieldValidateHooks(
   }
 
   for (const [fieldKey, fieldConfig] of Object.entries(fields)) {
-    // Support both 'validate' (new) and 'validateInput' (deprecated) for backwards compatibility
+    // validate / deprecated validateInput fallback — see executeValidate
     const validateHook = fieldConfig.hooks?.validate ?? fieldConfig.hooks?.validateInput
     if (!validateHook) continue
 
-    // Execute field hook
     // Type assertion is safe here because hooks are typed correctly in field definitions
     if (operation === 'delete') {
       await validateHook({
@@ -647,7 +615,6 @@ export async function executeFieldValidateHooks(
         addValidationError: addValidationError(fieldKey),
       } as Parameters<typeof validateHook>[0])
     } else {
-      // operation === 'update'
       await validateHook({
         listKey,
         fieldKey,
@@ -666,10 +633,6 @@ export async function executeFieldValidateHooks(
   }
 }
 
-/**
- * Execute field-level beforeOperation hooks (side effects only)
- * Allows fields to perform side effects before database write
- */
 export async function executeFieldBeforeOperationHooks(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputData: Record<string, any>,
@@ -683,13 +646,9 @@ export async function executeFieldBeforeOperationHooks(
   item?: any,
 ): Promise<void> {
   for (const [fieldKey, fieldConfig] of Object.entries(fields)) {
-    // Skip if no hooks defined
     if (!fieldConfig.hooks?.beforeOperation) continue
-    // Skip if field not in data (for create/update)
     if (operation !== 'delete' && !(fieldKey in resolvedData)) continue
 
-    // Execute field hook (side effects only, no return value used)
-    // Type assertion is safe here because hooks are typed correctly in field definitions
     if (operation === 'delete') {
       await fieldConfig.hooks.beforeOperation({
         listKey,
@@ -708,7 +667,6 @@ export async function executeFieldBeforeOperationHooks(
         context,
       } as Parameters<typeof fieldConfig.hooks.beforeOperation>[0])
     } else {
-      // operation === 'update'
       await fieldConfig.hooks.beforeOperation({
         listKey,
         fieldKey,
@@ -722,10 +680,6 @@ export async function executeFieldBeforeOperationHooks(
   }
 }
 
-/**
- * Execute field-level afterOperation hooks (side effects only)
- * Allows fields to perform side effects after database operations
- */
 export async function executeFieldAfterOperationHooks(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   item: any,
@@ -739,10 +693,8 @@ export async function executeFieldAfterOperationHooks(
   originalItem?: any,
 ): Promise<void> {
   for (const [fieldKey, fieldConfig] of Object.entries(fields)) {
-    // Skip if no hooks defined
     if (!fieldConfig.hooks?.afterOperation) continue
 
-    // Execute field hook (side effects only, no return value used)
     if (operation === 'delete') {
       await fieldConfig.hooks.afterOperation({
         listKey,
@@ -762,7 +714,6 @@ export async function executeFieldAfterOperationHooks(
         context,
       } as Parameters<typeof fieldConfig.hooks.afterOperation>[0])
     } else {
-      // operation === 'update'
       await fieldConfig.hooks.afterOperation({
         listKey,
         fieldKey,
@@ -777,10 +728,6 @@ export async function executeFieldAfterOperationHooks(
   }
 }
 
-/**
- * Validate field-level validation rules using Zod
- * Checks isRequired, length constraints, etc.
- */
 export function validateFieldRules(
   data: Record<string, unknown>,
   fieldConfigs: Record<string, FieldConfig>,
@@ -792,7 +739,6 @@ export function validateFieldRules(
     return { errors: [], fieldErrors: {} }
   }
 
-  // Convert field errors to array of error messages
   const errors = Object.entries(result.errors).map(([_field, message]) => message)
 
   return { errors, fieldErrors: result.errors }

--- a/packages/core/src/lib/case-utils.ts
+++ b/packages/core/src/lib/case-utils.ts
@@ -8,31 +8,16 @@
  * - URLs: kebab-case (e.g., "auth-user", "blog-post")
  */
 
-/**
- * Convert PascalCase to camelCase
- * AuthUser -> authUser
- * BlogPost -> blogPost
- */
 export function pascalToCamel(str: string): string {
   return str.charAt(0).toLowerCase() + str.slice(1)
 }
 
-/**
- * Convert PascalCase to kebab-case
- * AuthUser -> auth-user
- * BlogPost -> blog-post
- */
 export function pascalToKebab(str: string): string {
   return str.replace(/([A-Z])/g, (match, p1, offset) => {
     return offset > 0 ? `-${p1.toLowerCase()}` : p1.toLowerCase()
   })
 }
 
-/**
- * Convert kebab-case to PascalCase
- * auth-user -> AuthUser
- * blog-post -> BlogPost
- */
 export function kebabToPascal(str: string): string {
   return str
     .split('-')
@@ -40,35 +25,18 @@ export function kebabToPascal(str: string): string {
     .join('')
 }
 
-/**
- * Convert kebab-case to camelCase
- * auth-user -> authUser
- * blog-post -> blogPost
- */
 export function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (match, p1) => p1.toUpperCase())
 }
 
-/**
- * Get the database key for a list (camelCase)
- * Used for accessing context.db and prisma client
- */
 export function getDbKey(listKey: string): string {
   return pascalToCamel(listKey)
 }
 
-/**
- * Get the URL segment for a list (kebab-case)
- * Used for constructing admin URLs
- */
 export function getUrlKey(listKey: string): string {
   return pascalToKebab(listKey)
 }
 
-/**
- * Get the list key from a URL segment (PascalCase)
- * Used for parsing admin URLs
- */
 export function getListKeyFromUrl(urlSegment: string): string {
   return kebabToPascal(urlSegment)
 }

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -30,11 +30,7 @@ function isZodSchema(schema: any): schema is z.ZodType {
   return !!schema && typeof schema.safeParse === 'function'
 }
 
-/**
- * Normalize a custom tool's inputSchema for the tools/list response.
- * Zod schemas are converted to JSON Schema (the MCP wire format); plain
- * objects are passed through as-is.
- */
+/** Zod schemas are converted to JSON Schema (the MCP wire format); plain objects pass through as-is. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- inputSchema is user-supplied
 function toolInputSchemaToJson(inputSchema: any): McpTool['inputSchema'] {
   if (isZodSchema(inputSchema)) {
@@ -82,7 +78,6 @@ export function createMcpHandlers(options: {
 } {
   const { config, getSession, getContext } = options
 
-  // Validate MCP is enabled
   if (!config.mcp?.enabled) {
     const notEnabledHandler = async () =>
       new Response(JSON.stringify({ error: 'MCP not enabled' }), {
@@ -94,11 +89,7 @@ export function createMcpHandlers(options: {
 
   const basePath = config.mcp.basePath || '/api/mcp'
 
-  /**
-   * Main MCP request handler
-   */
   const handler = async (req: Request): Promise<Response> => {
-    // Authenticate using provided session provider
     const session = await getSession(req.headers)
     if (!session) {
       return new Response(null, {
@@ -118,23 +109,19 @@ export function createMcpHandlers(options: {
         params?: any
       }
 
-      // Handle initialize
       if (body.method === 'initialize') {
         return handleInitialize(body.params, body.id)
       }
 
-      // Handle notifications/initialized (sent by client after initialize response)
       if (body.method === 'notifications/initialized') {
         // Notifications don't require a response in JSON-RPC 2.0
         return new Response(null, { status: 204 })
       }
 
-      // Handle tools/list
       if (body.method === 'tools/list') {
         return handleToolsList(config, body.id)
       }
 
-      // Handle tools/call
       if (body.method === 'tools/call') {
         return await handleToolsCall(body.params, session, config, getContext, body.id)
       }

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -1,8 +1,3 @@
-/**
- * Runtime MCP route handler
- * Creates MCP API handlers from OpenSaaS config at runtime
- */
-
 import * as z from 'zod'
 import type { OpenSaasConfig, FieldConfig, McpCustomTool } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
@@ -16,12 +11,7 @@ import type { McpSession, McpSessionProvider } from './types.js'
  */
 type ContextSession = { userId: string; [key: string]: unknown }
 
-/**
- * Convert an MCP session into a context session.
- * Transport-level fields (accessToken, expiresAt, scopes) are stripped;
- * everything else — userId plus any custom fields the session provider
- * attached (email, role, ...) — flows through to access control.
- */
+/** Strips transport-level fields; userId and any custom session fields flow through to access control. */
 function toContextSession(session: McpSession): ContextSession {
   const { accessToken: _accessToken, expiresAt: _expiresAt, scopes: _scopes, ...rest } = session
   return rest as ContextSession
@@ -35,10 +25,6 @@ function getPluginMcpTools(config: OpenSaasConfig): McpCustomTool[] {
   return (config._pluginData?.__mcpTools as McpCustomTool[] | undefined) ?? []
 }
 
-/**
- * Whether a custom tool's inputSchema is a Zod schema (as opposed to a plain
- * JSON Schema object). Duck-typed so it works across zod module instances.
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- duck-typing across zod instances
 function isZodSchema(schema: any): schema is z.ZodType {
   return !!schema && typeof schema.safeParse === 'function'

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -171,9 +171,6 @@ type McpTool = {
   }
 }
 
-/**
- * Handle initialize request - respond with server capabilities
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Initialize params are from the client
 function handleInitialize(_params?: any, id?: number | string): Response {
   return new Response(
@@ -197,9 +194,6 @@ function handleInitialize(_params?: any, id?: number | string): Response {
   )
 }
 
-/**
- * Convert field config to JSON schema property
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field configs have varying structures
 function fieldToJsonSchema(fieldName: string, fieldConfig: any): Record<string, unknown> {
   const baseSchema: Record<string, unknown> = {}
@@ -234,7 +228,6 @@ function fieldToJsonSchema(fieldName: string, fieldConfig: any): Record<string, 
       }
       break
     case 'relationship':
-      // For relationships, expect an ID or connect object
       baseSchema.type = 'object'
       baseSchema.properties = {
         connect: {
@@ -246,16 +239,11 @@ function fieldToJsonSchema(fieldName: string, fieldConfig: any): Record<string, 
       }
       break
     default:
-      // For custom field types, default to string
       baseSchema.type = 'string'
   }
 
   return baseSchema
 }
-
-/**
- * Generate field schemas for create/update operations
- */
 
 function generateFieldSchemas(
   fields: Record<string, FieldConfig>,
@@ -268,12 +256,10 @@ function generateFieldSchemas(
   const required: string[] = []
 
   for (const [fieldName, fieldConfig] of Object.entries(fields)) {
-    // Skip system fields
     if (['id', 'createdAt', 'updatedAt'].includes(fieldName)) continue
 
     properties[fieldName] = fieldToJsonSchema(fieldName, fieldConfig)
 
-    // Add to required array if field is required for this operation
     if (
       operation === 'create' &&
       'validation' in fieldConfig &&
@@ -287,15 +273,10 @@ function generateFieldSchemas(
   return { properties, required }
 }
 
-/**
- * Handle tools/list request - list all available tools
- */
 function handleToolsList(config: OpenSaasConfig, id?: number | string): Response {
   const tools: McpTool[] = []
 
-  // Generate CRUD tools for each list
   for (const [listKey, listConfig] of Object.entries(config.lists)) {
-    // Check if MCP is enabled for this list
     if (listConfig.mcp?.enabled === false) continue
 
     const dbKey = getDbKey(listKey)
@@ -313,7 +294,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
       delete: listConfig.mcp?.tools?.delete ?? defaultTools.delete ?? true,
     }
 
-    // Read tool
     if (enabledTools.read) {
       tools.push({
         name: `list_${dbKey}_query`,
@@ -330,7 +310,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
       })
     }
 
-    // Create tool
     if (enabledTools.create) {
       const fieldSchemas = generateFieldSchemas(listConfig.fields, 'create')
       tools.push({
@@ -351,7 +330,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
       })
     }
 
-    // Update tool
     if (enabledTools.update) {
       const fieldSchemas = generateFieldSchemas(listConfig.fields, 'update')
       tools.push({
@@ -379,7 +357,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
       })
     }
 
-    // Delete tool
     if (enabledTools.delete) {
       tools.push({
         name: `list_${dbKey}_delete`,
@@ -401,7 +378,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
       })
     }
 
-    // Custom tools
     if (listConfig.mcp?.customTools) {
       for (const customTool of listConfig.mcp.customTools) {
         tools.push({
@@ -434,9 +410,6 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
   )
 }
 
-/**
- * Handle tools/call request - execute a tool
- */
 async function handleToolsCall(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- MCP tool params vary by tool
   params: any,
@@ -462,7 +435,6 @@ async function handleToolsCall(
     )
   }
 
-  // Parse tool name: list_{dbKey}_{operation}
   const match = toolName.match(/^list_([a-z][a-zA-Z0-9]*)_(query|create|update|delete)$/)
 
   if (match) {
@@ -474,9 +446,6 @@ async function handleToolsCall(
   return await handleCustomTool(toolName, toolArgs, session, config, getContext, id)
 }
 
-/**
- * Handle CRUD tool execution
- */
 async function handleCrudTool(
   dbKey: string,
   operation: string,
@@ -487,7 +456,6 @@ async function handleCrudTool(
   getContext: (session?: ContextSession) => Promise<AccessContext>,
   id?: number | string,
 ): Promise<Response> {
-  // Create context with the user session (custom session fields pass through)
   const context = await getContext(toContextSession(session))
 
   try {
@@ -558,9 +526,6 @@ async function handleCrudTool(
   }
 }
 
-/**
- * Handle custom tool execution
- */
 async function handleCustomTool(
   toolName: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Custom tool arguments are user-defined
@@ -582,7 +547,6 @@ async function handleCustomTool(
     return createErrorResponse(`Unknown tool: ${toolName}`, id)
   }
 
-  // Validate input when the tool declares a Zod schema
   let input = args
   if (isZodSchema(customTool.inputSchema)) {
     const parsed = customTool.inputSchema.safeParse(args)
@@ -634,9 +598,6 @@ function mcpJsonReplacer(_key: string, value: unknown): unknown {
   return typeof value === 'bigint' ? value.toString() : value
 }
 
-/**
- * Helper to create success response
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Response data structure is flexible per MCP protocol
 function createSuccessResponse(data: any, id?: number | string): Response {
   return new Response(
@@ -653,9 +614,6 @@ function createSuccessResponse(data: any, id?: number | string): Response {
   )
 }
 
-/**
- * Helper to create error response
- */
 function createErrorResponse(message: string, id?: number | string): Response {
   return new Response(
     JSON.stringify({

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -442,7 +442,6 @@ async function handleToolsCall(
     return await handleCrudTool(dbKey, operation, toolArgs, session, config, getContext, id)
   }
 
-  // Handle custom tools
   return await handleCustomTool(toolName, toolArgs, session, config, getContext, id)
 }
 

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -4,15 +4,6 @@ import { getDbKey } from '../lib/case-utils.js'
 // Internal helpers
 // ─────────────────────────────────────────────────────────────
 
-/**
- * Unwrap the item type from a field type, stripping null, undefined, and
- * Array wrappers so we can constrain nested fragment shapes.
- *
- * Examples:
- *   User | null     → User
- *   User[]          → User
- *   (User | null)[] → User
- */
 type UnwrapItem<T> = NonNullable<T> extends Array<infer U> ? NonNullable<U> : NonNullable<T>
 
 // ─────────────────────────────────────────────────────────────
@@ -20,44 +11,9 @@ type UnwrapItem<T> = NonNullable<T> extends Array<infer U> ? NonNullable<U> : No
 // ─────────────────────────────────────────────────────────────
 
 /**
- * A selector for a relationship field.
- *
- * Two forms are accepted:
- * 1. A `Fragment` directly (shorthand — no extra Prisma args on the nested query).
- * 2. An object `{ query, where?, orderBy?, take?, skip? }` to combine a fragment
- *    with Prisma filter/ordering/pagination applied to the nested relationship.
- *
- * @example Shorthand (most common)
- * ```ts
- * const postFrag = defineFragment<Post>()({
- *   id: true,
- *   author: authorFragment,   // shorthand
- * } as const)
- * ```
- *
- * @example With nested filtering
- * ```ts
- * const postFrag = defineFragment<Post>()({
- *   id: true,
- *   comments: {
- *     query:   commentFragment,
- *     where:   { approved: true },
- *     orderBy: { createdAt: 'desc' },
- *     take:    5,
- *   },
- * } as const)
- * ```
- *
- * @example Variables via factory function
- * ```ts
- * function makePostFragment(status: string) {
- *   return defineFragment<Post>()({
- *     id:      true,
- *     comments: { query: commentFragment, where: { status } },
- *   } as const)
- * }
- * type PostData = ResultOf<ReturnType<typeof makePostFragment>>
- * ```
+ * A selector for a relationship field: either a {@link Fragment} directly
+ * (shorthand), or `{ query, where?, orderBy?, take?, skip? }` to combine a
+ * fragment with Prisma filter/ordering/pagination on the nested relationship.
  */
 export type RelationSelector<TRelated extends Record<string, unknown>> =
   | Fragment<TRelated, FieldSelection<TRelated>>
@@ -70,26 +26,9 @@ export type RelationSelector<TRelated extends Record<string, unknown>> =
     }
 
 /**
- * A field selection for model type `TItem`.
- *
- * Each key maps to:
- * - `true`                — include the scalar/primitive field as-is
- * - A `Fragment`          — include a relationship and recurse (shorthand)
- * - A `RelationSelector`  — include a relationship with optional Prisma filter/ordering
- *
- * Only keys present in `TItem` are accepted. For relationship (object) fields
- * you may pass a Fragment, a RelationSelector, or `true` (returns the raw Prisma
- * value and loses type narrowing).
- *
- * @example
- * ```ts
- * const sel: FieldSelection<Post> = {
- *   id: true,
- *   title: true,
- *   author: authorFragment,
- *   comments: { query: commentFragment, where: { approved: true } },
- * }
- * ```
+ * A field selection for model type `TItem`. Passing `true` for a
+ * relationship field returns the raw Prisma value and loses type narrowing —
+ * use a {@link Fragment} or {@link RelationSelector} to keep it typed.
  */
 export type FieldSelection<T> = {
   readonly [K in keyof T]?: UnwrapItem<T[K]> extends Record<string, unknown>
@@ -99,19 +38,7 @@ export type FieldSelection<T> = {
 
 /**
  * A reusable, composable field-selection descriptor for model type `TItem`.
- *
- * Create with {@link defineFragment}. Compose by referencing another Fragment
- * (or a {@link RelationSelector}) as the value for a relationship key.
- *
- * @example
- * ```ts
- * const userFragment = defineFragment<User>()({ id: true, name: true } as const)
- * const postFragment = defineFragment<Post>()({
- *   id: true,
- *   title: true,
- *   author: userFragment,
- * } as const)
- * ```
+ * Create with {@link defineFragment}.
  */
 export type Fragment<TItem, TFields extends FieldSelection<TItem> = FieldSelection<TItem>> = {
   readonly _type: 'fragment'
@@ -122,11 +49,7 @@ export type Fragment<TItem, TFields extends FieldSelection<TItem> = FieldSelecti
 // Internal type helpers
 // ─────────────────────────────────────────────────────────────
 
-/**
- * @internal
- * Extract the Fragment from either a Fragment directly or a RelationSelector object.
- * Returns `never` for scalar `true` selections (so they fall to the scalar branch).
- */
+/** @internal Returns `never` for scalar `true` selections, so they fall to the scalar branch in {@link SelectedFields}. */
 type ExtractFragment<TSelector> =
   TSelector extends Fragment<infer TItem, infer TFields>
     ? Fragment<TItem, TFields>
@@ -134,16 +57,12 @@ type ExtractFragment<TSelector> =
       ? Fragment<TItem, TFields>
       : never
 
-/**
- * @internal
- * Map a FieldSelection over a model type, computing the picked output type.
- */
+/** @internal */
 type SelectedFields<TItem, TFields extends FieldSelection<TItem>> = {
   [K in keyof TFields & keyof TItem]: [ExtractFragment<TFields[K]>] extends [never]
-    ? // Scalar field (value is `true`) — tuple wrapping avoids the vacuous `never extends T` pitfall
+    ? // tuple wrapping avoids the vacuous `never extends T` pitfall
       TItem[K]
-    : // Relationship field — preserve array/null/undefined wrappers from the model
-      TItem[K] extends Array<unknown>
+    : TItem[K] extends Array<unknown>
       ? ResultOf<ExtractFragment<TFields[K]>>[]
       : null extends TItem[K]
         ? ResultOf<ExtractFragment<TFields[K]>> | null
@@ -157,24 +76,8 @@ type SelectedFields<TItem, TFields extends FieldSelection<TItem>> = {
 // ─────────────────────────────────────────────────────────────
 
 /**
- * Infer the TypeScript result type from a Fragment.
- *
- * Analogous to `gql.tada`'s `ResultOf` helper — given a fragment definition,
- * `ResultOf` tells you exactly what shape you will receive at runtime.
- *
- * - Scalar fields selected with `true` retain their original Prisma type.
- * - Relationship fields selected with a nested Fragment/RelationSelector are
- *   recursively narrowed.
- * - Nullability and array wrappers from the original model type are preserved.
- *
- * @example
- * ```ts
- * type UserData  = ResultOf<typeof userFragment>
- * // → { id: string; name: string }
- *
- * type PostData  = ResultOf<typeof postFragment>
- * // → { id: string; title: string; author: { id: string; name: string } | null }
- * ```
+ * Infer the TypeScript result type from a {@link Fragment} — the shape
+ * `runQuery`/`runQueryOne` return at runtime for that fragment.
  */
 export type ResultOf<F> =
   F extends Fragment<infer TItem, infer TFields> ? SelectedFields<TItem, TFields> : never
@@ -183,20 +86,14 @@ export type ResultOf<F> =
  * Arguments accepted by {@link runQuery}.
  */
 export type QueryArgs = {
-  /** Prisma where filter. The access control layer will additionally scope results. */
+  /** Prisma where filter — the access control layer additionally scopes results. */
   where?: Record<string, unknown>
-  /** Prisma orderBy clause. Pass a single object or an array for multi-column ordering. */
   orderBy?: Record<string, 'asc' | 'desc'> | Array<Record<string, 'asc' | 'desc'>>
-  /** Maximum number of records to return. */
   take?: number
-  /** Number of records to skip (for pagination). */
   skip?: number
 }
 
-/**
- * Minimal context shape required by the query runners.
- * Compatible with the full `AccessContext` produced by `getContext()`.
- */
+/** Compatible with the full `AccessContext` produced by `getContext()`. */
 export interface QueryRunnerContext {
   db: {
     [key: string]: {
@@ -211,64 +108,9 @@ export interface QueryRunnerContext {
 // ─────────────────────────────────────────────────────────────
 
 /**
- * Create a type-safe, reusable fragment for a given model type.
- *
- * The function is curried so that TypeScript can infer both the model type
- * (from the explicit type parameter) and the field selection (from the
- * argument), without requiring you to repeat yourself.
- *
- * @example Basic usage
- * ```ts
- * import type { User } from '.prisma/client'
- * import { defineFragment } from '@opensaas/stack-core'
- *
- * export const userFragment = defineFragment<User>()({
- *   id:    true,
- *   name:  true,
- *   email: true,
- * } as const)
- * ```
- *
- * @example Compose fragments
- * ```ts
- * import type { Post } from '.prisma/client'
- *
- * export const postFragment = defineFragment<Post>()({
- *   id:      true,
- *   title:   true,
- *   author:  userFragment,
- * } as const)
- * ```
- *
- * @example Nested filtering with RelationSelector
- * ```ts
- * export const postWithApprovedComments = defineFragment<Post>()({
- *   id:    true,
- *   title: true,
- *   comments: {
- *     query:   commentFragment,
- *     where:   { approved: true },
- *     orderBy: { createdAt: 'desc' },
- *     take:    5,
- *   },
- * } as const)
- * ```
- *
- * @example Variables via factory function
- * ```ts
- * function makePostFragment(status: string) {
- *   return defineFragment<Post>()({
- *     id:      true,
- *     comments: { query: commentFragment, where: { status } },
- *   } as const)
- * }
- * type PostData = ResultOf<ReturnType<typeof makePostFragment>>
- *
- * const posts = await context.db.post.findMany({
- *   query: makePostFragment('approved'),
- *   where: { published: true },
- * })
- * ```
+ * Create a type-safe, reusable fragment for a given model type. Curried so
+ * TypeScript can infer the model type from the explicit type parameter and
+ * the field selection from the argument.
  */
 export function defineFragment<TItem>() {
   return function <TFields extends FieldSelection<TItem>>(
@@ -279,7 +121,7 @@ export function defineFragment<TItem>() {
 }
 
 // ─────────────────────────────────────────────────────────────
-// Runtime helpers — exported for use in context/index.ts
+// Runtime helpers
 // ─────────────────────────────────────────────────────────────
 
 /** @internal */
@@ -293,14 +135,10 @@ export function isFragment(value: unknown): value is Fragment<unknown, FieldSele
 }
 
 /**
- * Walk a field selection and build the Prisma `include` map needed to eagerly
- * load all nested relationship fragments/selectors.
- *
- * Scalar fields (`true`) do not require an include entry — Prisma returns all
- * scalar columns by default. Only relationship fields backed by a Fragment or
- * RelationSelector generate include entries (recursively).
- *
- * Exported for use in `context/index.ts` when the `query` parameter is present.
+ * Build the Prisma `include` map for a field selection's nested fragments.
+ * Scalar fields (`true`) need no include entry — Prisma returns all scalar
+ * columns by default; only relationship fields backed by a Fragment or
+ * RelationSelector generate one (recursively).
  * @internal
  */
 export function buildInclude(fields: FieldSelection<unknown>): Record<string, unknown> | undefined {
@@ -312,7 +150,6 @@ export function buildInclude(fields: FieldSelection<unknown>): Record<string, un
 
     const val = value as Record<string, unknown>
 
-    // ── Shorthand: Fragment directly ──────────────────────────
     if (isFragment(val)) {
       hasIncludes = true
       const nestedInclude = buildInclude(val._fields as FieldSelection<unknown>)
@@ -320,7 +157,6 @@ export function buildInclude(fields: FieldSelection<unknown>): Record<string, un
       continue
     }
 
-    // ── RelationSelector: { query, where?, orderBy?, take?, skip? } ──
     if ('query' in val && isFragment(val.query)) {
       hasIncludes = true
       const selector = val as {
@@ -400,10 +236,7 @@ export function buildFieldSelectionScope(fields: FieldSelection<unknown>): Field
 
 /**
  * Recursively pick only the fields requested by a fragment from a raw Prisma
- * result object. This ensures the runtime shape exactly matches the type
- * produced by `ResultOf<F>`.
- *
- * Exported for use in `context/index.ts`.
+ * result object, so the runtime shape matches `ResultOf<F>`.
  * @internal
  */
 export function pickFields<TItem, TFields extends FieldSelection<TItem>>(
@@ -424,7 +257,6 @@ export function pickFields<TItem, TFields extends FieldSelection<TItem>>(
 
     const val = value as Record<string, unknown>
 
-    // ── Shorthand: Fragment directly ──────────────────────────
     if (isFragment(val)) {
       if (Array.isArray(fieldValue)) {
         result[key] = fieldValue.map((elem) =>
@@ -438,7 +270,6 @@ export function pickFields<TItem, TFields extends FieldSelection<TItem>>(
       continue
     }
 
-    // ── RelationSelector: { query, where?, ... } ──────────────
     if ('query' in val && isFragment(val.query)) {
       const nestedFrag = val.query as Fragment<unknown, FieldSelection<unknown>>
       if (Array.isArray(fieldValue)) {
@@ -466,29 +297,9 @@ export function pickFields<TItem, TFields extends FieldSelection<TItem>>(
 
 /**
  * Execute a fragment-based query against a list, returning all matching
- * records shaped to the fragment's field selection.
- *
- * Under the hood this calls `context.db[listKey].findMany()`, so all access
- * control rules defined in your config are still enforced.
- *
- * **Tip:** You can also call `context.db.post.findMany({ query: fragment, ... })`
- * directly — both forms produce the same result.
- *
- * @param context - An `AccessContext` (or any object with a compatible `db`).
- * @param listKey - The PascalCase list name (e.g. `'Post'`, `'BlogPost'`).
- * @param fragment - A fragment created with {@link defineFragment}.
- * @param args     - Optional query arguments (where, orderBy, take, skip).
- * @returns        An array typed to exactly the fragment's field selection.
- *
- * @example
- * ```ts
- * const posts = await runQuery(context, 'Post', postFragment, {
- *   where:   { published: true },
- *   orderBy: { createdAt: 'desc' },
- *   take:    10,
- * })
- * // posts: Array<ResultOf<typeof postFragment>>
- * ```
+ * records shaped to the fragment's field selection. Calls
+ * `context.db[listKey].findMany()` under the hood, so access control still
+ * applies.
  */
 export async function runQuery<TItem, TFields extends FieldSelection<TItem>>(
   context: QueryRunnerContext,
@@ -518,25 +329,8 @@ export async function runQuery<TItem, TFields extends FieldSelection<TItem>>(
 
 /**
  * Execute a fragment-based query that returns a single record (or `null`).
- *
- * Under the hood this calls `context.db[listKey].findFirst()`, so all access
- * control rules are still enforced.
- *
- * **Tip:** You can also call `context.db.post.findUnique({ where: { id }, query: fragment })`
- * directly.
- *
- * @param context - An `AccessContext` (or any object with a compatible `db`).
- * @param listKey - The PascalCase list name (e.g. `'Post'`).
- * @param fragment - A fragment created with {@link defineFragment}.
- * @param where    - A Prisma where clause to identify the record.
- * @returns        The matched record shaped to the fragment, or `null`.
- *
- * @example
- * ```ts
- * const post = await runQueryOne(context, 'Post', postFragment, { id: postId })
- * if (!post) return notFound()
- * // post: ResultOf<typeof postFragment>
- * ```
+ * Calls `context.db[listKey].findFirst()` under the hood, so access control
+ * still applies.
  */
 export async function runQueryOne<TItem, TFields extends FieldSelection<TItem>>(
   context: QueryRunnerContext,

--- a/packages/core/src/utils/password.ts
+++ b/packages/core/src/utils/password.ts
@@ -1,25 +1,8 @@
 import bcrypt from 'bcryptjs'
 
-/**
- * Default bcrypt cost factor (rounds)
- * Higher values = more secure but slower
- * 10 is a good balance for production use
- */
+// Bcrypt cost factor: higher is slower but more resistant to brute force.
 const DEFAULT_COST_FACTOR = 10
 
-/**
- * Hash a plain text password using bcrypt
- *
- * @param plainPassword - The plain text password to hash
- * @param costFactor - The bcrypt cost factor (default: 10)
- * @returns Promise resolving to the hashed password
- *
- * @example
- * ```typescript
- * const hashed = await hashPassword('mypassword')
- * // Returns: $2a$10$...
- * ```
- */
 export async function hashPassword(
   plainPassword: string,
   costFactor: number = DEFAULT_COST_FACTOR,
@@ -31,21 +14,6 @@ export async function hashPassword(
   return bcrypt.hash(plainPassword, costFactor)
 }
 
-/**
- * Compare a plain text password with a hashed password
- *
- * @param plainPassword - The plain text password to compare
- * @param hashedPassword - The hashed password to compare against
- * @returns Promise resolving to true if passwords match, false otherwise
- *
- * @example
- * ```typescript
- * const isValid = await comparePassword('mypassword', hashedPassword)
- * if (isValid) {
- *   // Password is correct
- * }
- * ```
- */
 export async function comparePassword(
   plainPassword: string,
   hashedPassword: string,
@@ -61,38 +29,21 @@ export async function comparePassword(
   try {
     return await bcrypt.compare(plainPassword, hashedPassword)
   } catch (error) {
-    // Invalid hash format or other bcrypt error
+    // Fail closed on a malformed hash or other bcrypt error, rather than
+    // letting it propagate as an authentication-bypassing exception.
     console.error('Password comparison failed:', error)
     return false
   }
 }
 
-/**
- * Check if a string appears to be a bcrypt hash
- * Bcrypt hashes follow the format: $2a$10$...
- *
- * @param value - The string to check
- * @returns True if the string looks like a bcrypt hash
- */
 export function isHashedPassword(value: string): boolean {
   if (typeof value !== 'string') return false
 
-  // Bcrypt hashes start with $2a$, $2b$, or $2y$ followed by cost factor
-  // and are typically 60 characters long
   return /^\$2[aby]\$\d{2}\$.{53}$/.test(value)
 }
 
-/**
- * HashedPassword class wraps a bcrypt hash and provides a compare method
- * This allows password field values to be used as strings while also
- * providing a convenient compare() method for authentication
- *
- * @example
- * ```typescript
- * const user = await context.db.user.findUnique({ where: { id: '1' } })
- * const isValid = await user.password.compare('plaintextPassword')
- * ```
- */
+// Wraps a bcrypt hash so a password field's value can still be used as a
+// plain string while also exposing compare() for authentication.
 export class HashedPassword {
   constructor(private readonly hash: string) {
     if (!hash || typeof hash !== 'string') {
@@ -100,28 +51,15 @@ export class HashedPassword {
     }
   }
 
-  /**
-   * Compare a plain text password with this hashed password
-   *
-   * @param plainPassword - The plain text password to compare
-   * @returns Promise resolving to true if passwords match
-   */
   async compare(plainPassword: string): Promise<boolean> {
     return comparePassword(plainPassword, this.hash)
   }
 
-  /**
-   * Get the underlying hash string
-   * This allows the HashedPassword to be used anywhere a string is expected
-   */
   toString(): string {
     return this.hash
   }
 
-  /**
-   * Get the underlying hash when used in string contexts
-   * This allows the HashedPassword to be coerced to a string automatically
-   */
+  // Implicit coercion (template literals, string concatenation) resolves here.
   [Symbol.toPrimitive](hint: string): string {
     if (hint === 'string' || hint === 'default') {
       return this.hash
@@ -129,18 +67,11 @@ export class HashedPassword {
     return this.hash
   }
 
-  /**
-   * Return the hash for JSON serialization
-   * This ensures the hash is properly serialized when converting to JSON
-   */
+  // JSON.stringify calls this when present, so the hash serializes as a plain string.
   toJSON(): string {
     return this.hash
   }
 
-  /**
-   * Get the underlying hash value
-   * This allows accessing the raw hash string
-   */
   valueOf(): string {
     return this.hash
   }

--- a/packages/core/src/validation/field-config.ts
+++ b/packages/core/src/validation/field-config.ts
@@ -44,9 +44,6 @@ function hasFieldMethod(field: FieldConfig, method: string): boolean {
   return typeof value === 'function'
 }
 
-/**
- * Build the canonical error message for a missing contract method.
- */
 function buildMessage(
   fieldType: string,
   method: FieldConfigValidationError['missingMethod'],
@@ -102,19 +99,16 @@ export function validateFieldConfig(
   }
 
   if (field.type === 'relationship') {
-    // Relationships render through the relationship path only.
     requireMethod('getPrismaRelation')
     return errors
   }
 
   if (field.virtual === true || field.type === 'virtual') {
-    // Virtual fields are not persisted, so getPrismaType is intentionally absent.
     requireMethod('getTypeScriptType')
     requireMethod('getZodSchema')
     return errors
   }
 
-  // Stored scalar fields must implement the full generation contract.
   requireMethod('getPrismaType')
   requireMethod('getTypeScriptType')
   requireMethod('getZodSchema')

--- a/packages/core/src/validation/schema.ts
+++ b/packages/core/src/validation/schema.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod'
 import type { FieldConfig } from '../config/types.js'
 
-/**
- * Generate Zod schema from field configurations
- */
 export function generateZodSchema(
   fieldConfigs: Record<string, FieldConfig>,
   operation: 'create' | 'update' = 'create',
@@ -11,7 +8,6 @@ export function generateZodSchema(
   const shape: Record<string, z.ZodTypeAny> = {}
 
   for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
-    // Skip system fields, relationships, and virtual fields
     // Virtual fields don't accept input - they only compute output
     if (
       ['id', 'createdAt', 'updatedAt'].includes(fieldName) ||
@@ -21,7 +17,6 @@ export function generateZodSchema(
       continue
     }
 
-    // Use the field's schema generator
     if (fieldConfig.getZodSchema) {
       shape[fieldName] = fieldConfig.getZodSchema(fieldName, operation)
     } else {
@@ -33,10 +28,6 @@ export function generateZodSchema(
   return z.object(shape)
 }
 
-/**
- * Validate data against field configurations using Zod
- * Returns structured errors by field
- */
 export function validateWithZod(
   data: Record<string, unknown>,
   fieldConfigs: Record<string, FieldConfig>,
@@ -50,7 +41,6 @@ export function validateWithZod(
     return { success: true }
   }
 
-  // Convert Zod errors to field-specific error messages
   const errors: Record<string, string> = {}
   for (const issue of result.error.issues) {
     const fieldPath = issue.path.join('.')


### PR DESCRIPTION
## Summary

Applies the `CLAUDE.md` Comments rule to all of `packages/core/src` except `context/` (cleaned up in #945/#946), following the judgement calls calibrated in `docs/agents/comments.md` (produced by #936):

- Deleted comments that fail the **staleness** or **restatement** tests: restated function/variable names, per-field boilerplate repeated across sibling field builders (`text`, `integer`, `decimal`, etc.), duplicate rationale blocks re-explained at every call site instead of stated once and pointed to.
- Kept every `eslint-disable ... --` justification verbatim.
- Kept public-API TSDoc on exported field builders (`fields/index.ts`), config builders (`config()`/`list()`), the `AccessControl`/`FieldAccessControl` contract types (`access/types.ts`), and plugin surfaces — trimmed only the narration inside their implementation bodies.
- Kept genuine outside-constraint notes and footgun warnings (e.g. the fail-closed default-deny comment in `access/engine.ts`, the bulk-action error-leak warning pattern, ADR/issue-citing correctness rationale in the access-control engine files).
- `config/types.ts` (~3,200 lines, almost entirely public config-authoring contract) was pruned conservatively per the issue's explicit guidance — only ~14 items removed/condensed against several hundred docblocks left untouched.
- Along the way, fixed three comments that had gone stale relative to the code they sit beside (corrected the text, not deleted): `BaseFieldConfig.virtual`'s doc contradicted ADR-0027 on when virtual fields compute; `PluginContext.addList`/`extendList` docs described a merge strategy that doesn't exist (the engine actually throws per ADR-0013); and an `OpenSaasConfig` docblock had been orphaned above the wrong interface by an earlier edit.

`access/` and `fields/index.ts` were the two densest areas named in the issue; `config/types.ts` was handled with the "delete very little" guidance the issue calls out explicitly.

## Test plan

- [x] `pnpm build` (core) — clean, no type errors
- [x] `pnpm test` (core) — 1054/1054 tests pass, unchanged
- [x] `pnpm lint` — clean (2 pre-existing warnings unrelated to this change)
- [x] `pnpm format` — no changes needed
- [x] `pnpm manypkg fix` — clean
- [x] No test files touched (`git diff --stat -- '*.test.ts' '*.test.tsx'` is empty)
- [x] Patch changeset added for `@opensaas/stack-core`

Closes #938

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfZLYh8qhK3cEYZAVRFHoH)_