### PR TITLE
fix(cli): don't let a bare "*" tsconfig path corrupt config resolution

### DIFF
--- a/.changeset/tame-suns-relax.md
+++ b/.changeset/tame-suns-relax.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Fix `resolveTsconfigAlias` corrupting resolution of `opensaas.config.ts` and its whole import closure when `tsconfig.json` has a bare `"*"` path pattern (e.g. `{ "*": ["./src/*"] }`, a common catch-all for unprefixed imports like `lib/utils`). The bare pattern now produces an empty alias key, which jiti's prefix-based resolution would otherwise match against every specifier; it is now skipped and reported as a warning like other unrepresentable path entries.

--- a/packages/cli/src/generator/tsconfig-alias.test.ts
+++ b/packages/cli/src/generator/tsconfig-alias.test.ts
@@ -106,6 +106,19 @@ describe('resolveTsconfigAlias', () => {
     expect(warnings).toHaveLength(1)
   })
 
+  it('warns and skips a bare "*" catch-all pattern instead of aliasing every specifier', () => {
+    writeTsconfig({
+      compilerOptions: { paths: { '*': ['./src/*'], '@utils/*': ['./src/utils/*'] } },
+    })
+
+    const { alias, warnings } = resolveTsconfigAlias(tempDir)
+
+    expect(alias).toEqual({ '@utils/': path.join(tempDir, 'src', 'utils') })
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('"*"')
+    expect(warnings[0]).toContain('catch-all')
+  })
+
   it('mixes representable and unrepresentable entries: resolves one, warns on the other', () => {
     writeTsconfig({
       compilerOptions: {
@@ -213,6 +226,23 @@ describe('resolveTsconfigAlias + jiti integration', () => {
       default: { lists: { hello: string } }
     }
     expect(mod.default.lists).toEqual({ hello: 'transitive' })
+  })
+
+  it('a bare "*" catch-all does not corrupt resolution of the config’s own absolute path (issue repro)', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { paths: { '*': ['./src/*'] } } }),
+    )
+    fs.writeFileSync(path.join(tempDir, 'opensaas.config.ts'), 'export default { lists: {} }\n')
+
+    const { alias } = resolveTsconfigAlias(tempDir)
+    expect(alias).toBeUndefined()
+
+    const jiti = createJiti(tempDir, { interopDefault: true, alias })
+    const mod = (await jiti.import(path.join(tempDir, 'opensaas.config.ts'))) as {
+      default: { lists: Record<string, never> }
+    }
+    expect(mod.default.lists).toEqual({})
   })
 
   it('fails to resolve the alias when no tsconfig.json is present (baseline without the fix)', async () => {

--- a/packages/cli/src/generator/tsconfig-alias.ts
+++ b/packages/cli/src/generator/tsconfig-alias.ts
@@ -35,6 +35,16 @@ export interface TsconfigAliasResult {
  * (`extends` chains, project references, conditional exports) is out of
  * scope.
  *
+ * A bare `"*"` pattern (`{ "*": ["./src/*"] }`, a common catch-all for
+ * unprefixed imports like `lib/utils`) is a single-trailing-star pattern too,
+ * but stripping its trailing `*` leaves an EMPTY alias key. `pathe`'s
+ * `resolveAlias` matches keys by prefix (`id.startsWith(key)`), and every
+ * string starts with `''` — so an empty key aliases every module specifier
+ * jiti resolves, including `opensaas.config.ts`'s own absolute path and every
+ * relative import in its closure, not just the bare imports it was meant for.
+ * This is therefore skipped and reported as a warning like any other
+ * unrepresentable entry, rather than corrupting unrelated resolution.
+ *
  * A project with no `tsconfig.json`, or one with no `paths`, returns
  * `{ alias: undefined, warnings: [] }` so callers behave exactly as they did
  * before this translation existed.
@@ -87,6 +97,13 @@ export function resolveTsconfigAlias(cwd: string): TsconfigAliasResult {
     }
 
     const aliasKey = pattern.slice(0, -1)
+    if (aliasKey === '') {
+      warnings.push(
+        `tsconfig.json path "${pattern}" -> "${target}" is a catch-all alias (empty prefix); jiti's prefix-based alias resolution would apply it to every module specifier, not just unprefixed imports, so this alias will not be resolved.`,
+      )
+      continue
+    }
+
     const aliasTarget = path.resolve(baseDir, target.slice(0, -1))
     alias[aliasKey] = aliasTarget
   }


### PR DESCRIPTION
## Summary

Fixes #949.

- `resolveTsconfigAlias()` (`packages/cli/src/generator/tsconfig-alias.ts`, added in #932 / 0.39.0) translates a `tsconfig.json` `paths` entry into a `jiti` alias by stripping the trailing `*` from both the pattern and its target. For a bare `"*"` pattern (e.g. `{ "*": ["./src/*"] }`, a common catch-all for unprefixed imports like `lib/utils`), stripping the trailing `*` leaves an **empty-string alias key**.
- `jiti` delegates alias resolution to `pathe`'s `resolveAlias`, which matches by prefix (`id.startsWith(key)`). Every string starts with `''`, so the empty key ends up aliasing **every module specifier** jiti resolves — not just the unprefixed imports the pattern was meant to cover. This corrupts resolution of `opensaas.config.ts`'s own absolute path and its whole import closure, breaking `opensaas generate` outright with a "Cannot find module" error for any project using this pattern.
- Fix: skip (and warn on) a `paths` entry whose alias key resolves to the empty string, the same way other unrepresentable entries are already skipped.

Found while upgrading a downstream app (`borisno2/emily-calder-performing-arts`) from 0.38.0 to 0.39.0.

## Test plan

- [x] Added a unit test asserting a bare `"*"` pattern is skipped with a warning, alongside a valid sibling alias that still resolves
- [x] Added a jiti-integration regression test reproducing the exact failure mode (a bare `"*"` catch-all no longer corrupts resolution of the config's own absolute path)
- [x] `pnpm vitest run` in `packages/cli` — 379 tests pass (was 377 before, +2 new)
- [x] Changeset added (`@opensaas/stack-cli`: patch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9ZQpYzrE4GUGq4XPVeMsK)_