### PR TITLE
Comment cleanup: packages/cli migration, mcp and commands

### DIFF
--- a/.changeset/tame-eagles-relax.md
+++ b/.changeset/tame-eagles-relax.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-cli': patch
+---
+
+Clean up stale/restating comments in migration, MCP, and commands source per CLAUDE.md's Comments rule. No behavior changes.

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -8,7 +8,6 @@ export async function devCommand() {
   const cwd = process.cwd()
   const configPath = path.join(cwd, 'opensaas.config.ts')
 
-  // Check if config exists
   if (!fs.existsSync(configPath)) {
     console.error(chalk.red('Error: opensaas.config.ts not found in current directory'))
     console.error(chalk.gray('   Please run this command from your project root'))
@@ -18,10 +17,8 @@ export async function devCommand() {
   console.log(chalk.bold.cyan('\nOpenSaas Dev Mode\n'))
   console.log(chalk.gray('Watching for changes to opensaas.config.ts...\n'))
 
-  // Run initial generation
   await generateCommand()
 
-  // Watch for changes
   const watcher = chokidar.watch(configPath, {
     persistent: true,
     ignoreInitial: true,
@@ -36,10 +33,8 @@ export async function devCommand() {
     console.error(chalk.red('\nWatcher error:'), error)
   })
 
-  // Keep the process running
   console.log(chalk.gray('Press Ctrl+C to stop watching\n'))
 
-  // Handle graceful shutdown
   process.on('SIGINT', () => {
     console.log(chalk.yellow('\n\nStopping dev mode...'))
     watcher.close()

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -24,12 +24,6 @@ import {
 } from '@opensaas/stack-core'
 import type { FieldConfigValidationError, NeedsClosureError } from '@opensaas/stack-core'
 
-/**
- * Format field self-containment errors into a friendly, multi-line message.
- * Each violation names the list, field, and the contract method it omits, so
- * a misimplemented (often third-party) field is actionable at a glance rather
- * than surfacing as a deep generator stack trace.
- */
 export function formatFieldValidationErrors(errors: FieldConfigValidationError[]): string {
   const lines = errors.map((error) => {
     const location = error.listKey ? `${error.listKey}.${error.fieldKey}` : error.fieldKey
@@ -63,7 +57,6 @@ export async function generateCommand() {
   const cwd = process.cwd()
   const configPath = path.join(cwd, 'opensaas.config.ts')
 
-  // Check if config exists
   if (!fs.existsSync(configPath)) {
     console.error(chalk.red('❌ Error: opensaas.config.ts not found in current directory'))
     console.error(chalk.gray('   Please run this command from your project root'))
@@ -80,22 +73,18 @@ export async function generateCommand() {
     // `alias: undefined`, which is identical to omitting the option.
     const { alias, warnings: aliasWarnings } = resolveTsconfigAlias(cwd)
 
-    // Load config using jiti (supports TypeScript)
     const jiti = createJiti(cwd, {
       interopDefault: true,
       alias,
     })
 
-    // Config may be async (if plugins are present)
-    // jiti.import() returns a module object with 'default' export
-    // We need to manually extract the default export since interopDefault doesn't work with async exports
+    // jiti's `interopDefault` doesn't unwrap an async `default` export, so it
+    // must be extracted manually here (config may be a Promise when plugins
+    // are present).
     const module = (await jiti.import(configPath)) as { default: Promise<OpenSaasConfig> }
     const configOrPromise = module.default
-
-    // Resolve the config if it's a Promise (from plugin execution)
     let config = await Promise.resolve(configOrPromise)
 
-    // Log plugin count if plugins are present
     if (config.plugins && config.plugins.length > 0) {
       spinner.text = `Loading configuration with ${config.plugins.length} plugin(s)...`
     }
@@ -105,12 +94,11 @@ export async function generateCommand() {
       console.log(chalk.yellow(`⚠️  ${warning}`))
     }
 
-    // Execute beforeGenerate hooks if plugins are present
     if (config.plugins && config.plugins.length > 0) {
       const pluginSpinner = ora('Running plugin beforeGenerate hooks...').start()
 
       try {
-        // Import plugin engine (avoid circular dependency)
+        // Dynamic import avoids a circular dependency with the plugin engine.
         const { executeBeforeGenerateHooks } =
           await import('@opensaas/stack-core/config/plugin-engine')
         config = await executeBeforeGenerateHooks(config)
@@ -121,9 +109,6 @@ export async function generateCommand() {
       }
     }
 
-    // Validate field self-containment up front, before any generation runs.
-    // A misimplemented field surfaces a clear, per-field message here rather
-    // than throwing deep inside schema/type generation.
     const validationSpinner = ora('Validating field configuration...').start()
     const fieldErrors = validateConfigFields(config)
     if (fieldErrors.length > 0) {
@@ -146,7 +131,6 @@ export async function generateCommand() {
     }
     needsSpinner.succeed(chalk.green('Declared dependencies valid'))
 
-    // Generate Prisma schema, types, and context
     // Captured here so the (optional) Node build step, which runs after
     // `prisma generate` outside this try block, knows where the bundle lives.
     let opensaasDir = ''
@@ -192,24 +176,20 @@ export async function generateCommand() {
       console.log(chalk.green('✅ Context factory generated'))
       console.log(chalk.green('✅ Plugin types generated'))
 
-      // Execute afterGenerate hooks if plugins are present
       if (config.plugins && config.plugins.length > 0) {
         const afterGenSpinner = ora('Running plugin afterGenerate hooks...').start()
 
         try {
-          // Read generated files
           const generatedFiles = {
             prismaSchema: fs.readFileSync(prismaSchemaPath, 'utf-8'),
             types: fs.readFileSync(typesPath, 'utf-8'),
             context: fs.readFileSync(contextPath, 'utf-8'),
           }
 
-          // Execute afterGenerate hooks
           const { executeAfterGenerateHooks } =
             await import('@opensaas/stack-core/config/plugin-engine')
           const modifiedFiles = await executeAfterGenerateHooks(config, generatedFiles)
 
-          // Write back modified files
           if (modifiedFiles.prismaSchema !== generatedFiles.prismaSchema) {
             fs.writeFileSync(prismaSchemaPath, modifiedFiles.prismaSchema)
           }
@@ -220,7 +200,6 @@ export async function generateCommand() {
             fs.writeFileSync(contextPath, modifiedFiles.context)
           }
 
-          // Write any additional files plugins generated
           for (const [filename, content] of Object.entries(modifiedFiles)) {
             if (!['prismaSchema', 'types', 'context'].includes(filename)) {
               const filePath = path.join(paths.opensaasDir, filename)
@@ -236,7 +215,6 @@ export async function generateCommand() {
         }
       }
 
-      // Format Prisma schema
       const formatSpinner = ora('Formatting Prisma schema...').start()
       try {
         execSync('npx prisma format', {
@@ -264,7 +242,6 @@ export async function generateCommand() {
       process.exit(1)
     }
 
-    // Run Prisma generate to create the Prisma client
     const prismaSpinner = ora('Generating Prisma client...').start()
     try {
       execSync('npx prisma generate', {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,17 +2,11 @@ import { spawn } from 'child_process'
 import chalk from 'chalk'
 
 /**
- * Initialize a new OpenSaas Stack project.
- *
- * This command delegates to create-opensaas-app for the actual scaffolding.
- * It's kept here for backwards compatibility with `opensaas init`.
- *
- * @param args - Command line arguments (project name and flags)
+ * Delegates to create-opensaas-app; kept for backwards compatibility with `opensaas init`.
  */
 export async function initCommand(args: string[]) {
   console.log(chalk.dim('Delegating to create-opensaas-app...\n'))
 
-  // Forward all arguments to create-opensaas-app
   const child = spawn('npx', ['create-opensaas-app@latest', ...args], {
     stdio: 'inherit',
     shell: true,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -11,8 +11,6 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 function getServerPath(): string {
-  // In development: cli/dist/mcp/server/index.js
-  // In production: same structure
   return join(__dirname, '..', 'mcp', 'server', 'index.js')
 }
 

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -136,7 +136,6 @@ async function setupClaudeCode(cwd: string, analysis: ProjectAnalysis): Promise<
     JSON.stringify(projectMetadata, null, 2),
   )
 
-  // Configure Claude Code marketplace and plugins in settings.json
   const settingsPath = path.join(claudeDir, 'settings.json')
   let settings: {
     extraKnownMarketplaces?: Record<
@@ -269,7 +268,6 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
 
   spinner.succeed(chalk.green(`Detected: ${projectTypes.join(', ')}`))
 
-  // Step 2: Analyze schema
   const analysisSpinner = ora('Analyzing schema...').start()
 
   const analysis: ProjectAnalysis = {
@@ -299,7 +297,6 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
     analysisSpinner.succeed(chalk.yellow('No models found (will create from scratch)'))
   }
 
-  // Step 3: Setup Claude Code (if --with-ai)
   if (options.withAi) {
     const claudeSpinner = ora('Setting up Claude Code...').start()
 
@@ -318,7 +315,6 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
     }
   }
 
-  // Step 4: Display next steps
   console.log(chalk.green('\n✅ Analysis complete!\n'))
 
   if (options.withAi) {
@@ -337,9 +333,6 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
   console.log()
 }
 
-/**
- * Create the migrate command for Commander
- */
 export function createMigrateCommand(): Command {
   const migrate = new Command('migrate')
   migrate.description('Migrate an existing project to OpenSaaS Stack')

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -15,35 +15,23 @@ interface MigrateOptions {
 }
 
 /**
- * Canonical published Keystone → OpenSaaS Stack migration guide URL.
- *
  * The CLI points migrators at this page rather than embedding the guide text,
  * so the binary stays small and the docs stay the single source of truth.
  */
 export const MIGRATION_GUIDE_URL = 'https://stack.opensaas.au/docs/how-to/migrate-from-keystone'
 
-/**
- * Claude Code marketplace + plugin identifiers used to install the
- * `opensaas-migration` plugin (its skills, commands, and agent).
- */
 export const MIGRATION_PLUGIN_ID = 'opensaas-migration@opensaas-stack-marketplace'
 export const MIGRATION_MARKETPLACE = 'OpenSaasAU/stack'
 
 /**
- * Manual install steps for the `opensaas-migration` Claude Code plugin.
- * These are slash commands run inside Claude Code; `opensaas migrate --with-ai`
- * wires them up automatically instead.
+ * Manual install steps for the `opensaas-migration` Claude Code plugin;
+ * `opensaas migrate --with-ai` wires them up automatically instead.
  */
 export const MIGRATION_PLUGIN_INSTALL_STEPS: readonly string[] = [
   `/plugin marketplace add ${MIGRATION_MARKETPLACE}`,
   `/plugin install ${MIGRATION_PLUGIN_ID}`,
 ]
 
-/**
- * Print the published migration guide URL and how to install the
- * `opensaas-migration` plugin. Kept lightweight on purpose — it points at the
- * canonical guide instead of duplicating its contents.
- */
 export function printMigrationResources(): void {
   console.log(chalk.bold('\n📚 Migration guide:\n'))
   console.log(chalk.cyan(`   ${MIGRATION_GUIDE_URL}`))
@@ -57,26 +45,20 @@ export function printMigrationResources(): void {
   }
 }
 
-/**
- * Detect what type of project this is
- */
 async function detectProjectType(cwd: string): Promise<ProjectType[]> {
   const types: ProjectType[] = []
 
-  // Check for Prisma
   const prismaSchemaPath = path.join(cwd, 'prisma', 'schema.prisma')
   if (fs.existsSync(prismaSchemaPath)) {
     types.push('prisma')
   }
 
-  // Check for KeystoneJS
   const keystoneConfigPath = path.join(cwd, 'keystone.config.ts')
   const keystoneAltPath = path.join(cwd, 'keystone.ts')
   if (fs.existsSync(keystoneConfigPath) || fs.existsSync(keystoneAltPath)) {
     types.push('keystone')
   }
 
-  // Check for Next.js
   const packageJsonPath = path.join(cwd, 'package.json')
   if (fs.existsSync(packageJsonPath)) {
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
@@ -88,9 +70,6 @@ async function detectProjectType(cwd: string): Promise<ProjectType[]> {
   return types
 }
 
-/**
- * Analyze a Prisma schema
- */
 async function analyzePrismaSchema(cwd: string): Promise<{
   models: Array<{ name: string; fieldCount: number }>
   provider: string
@@ -98,7 +77,6 @@ async function analyzePrismaSchema(cwd: string): Promise<{
   const schemaPath = path.join(cwd, 'prisma', 'schema.prisma')
   const schema = fs.readFileSync(schemaPath, 'utf-8')
 
-  // Extract models
   const modelRegex = /model\s+(\w+)\s*\{([^}]+)\}/g
   const models: Array<{ name: string; fieldCount: number }> = []
   let match
@@ -114,53 +92,38 @@ async function analyzePrismaSchema(cwd: string): Promise<{
     models.push({ name, fieldCount })
   }
 
-  // Extract provider
   const providerMatch = schema.match(/provider\s*=\s*"(\w+)"/)
   const provider = providerMatch ? providerMatch[1] : 'unknown'
 
   return { models, provider }
 }
 
-/**
- * Ensure directory exists
- */
 function ensureDir(dirPath: string): void {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true })
   }
 }
 
-/**
- * Get marketplace source for OpenSaaS Stack plugins
- */
 function getMarketplaceSource():
   | { source: 'github'; repo: string }
   | { source: 'git'; url: string }
   | { source: 'local'; path: string } {
-  // Try to detect if we're in development (local monorepo)
+  // Detect a local monorepo checkout (development) vs. an installed package (production).
   const cliPackageDir = path.dirname(path.dirname(new URL(import.meta.url).pathname))
   const potentialMonorepoRoot = path.join(cliPackageDir, '..', '..')
   const marketplacePath = path.join(potentialMonorepoRoot, 'claude-plugins', 'marketplace.json')
 
   if (fs.existsSync(marketplacePath)) {
-    // Development mode - use local marketplace
     return { source: 'local', path: path.join(potentialMonorepoRoot, 'claude-plugins') }
   }
 
-  // Production mode - use GitHub marketplace
   return { source: 'github', repo: 'OpenSaasAU/stack' }
 }
 
-/**
- * Setup Claude Code integration with plugin
- */
 async function setupClaudeCode(cwd: string, analysis: ProjectAnalysis): Promise<void> {
   const claudeDir = path.join(cwd, '.claude')
-
-  // Create .claude directory
   ensureDir(claudeDir)
 
-  // Write project metadata file for the plugin to read
   const projectMetadata = {
     projectTypes: analysis.projectTypes,
     provider: analysis.provider || 'sqlite',
@@ -188,20 +151,16 @@ async function setupClaudeCode(cwd: string, analysis: ProjectAnalysis): Promise<
     enabledPlugins?: Record<string, boolean>
   } = {}
 
-  // Read existing settings if they exist
   if (fs.existsSync(settingsPath)) {
     try {
       settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
     } catch {
-      // If settings file is invalid, start fresh
       settings = {}
     }
   }
 
-  // Get the marketplace source
   const marketplaceSource = getMarketplaceSource()
 
-  // Add marketplace configuration
   if (!settings.extraKnownMarketplaces) {
     settings.extraKnownMarketplaces = {}
   }
@@ -210,19 +169,15 @@ async function setupClaudeCode(cwd: string, analysis: ProjectAnalysis): Promise<
     source: marketplaceSource,
   }
 
-  // Add enabled plugins
   if (!settings.enabledPlugins) {
     settings.enabledPlugins = {}
   }
 
-  // Add migration plugin if not already enabled
   const migrationPluginId = 'opensaas-migration@opensaas-stack-marketplace'
   settings.enabledPlugins[migrationPluginId] = true
 
-  // Write settings back
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2))
 
-  // Create a simple README explaining the setup
   const readmeContent = `# OpenSaaS Stack Migration
 
 This project is set up for AI-assisted migration to OpenSaaS Stack.
@@ -288,15 +243,11 @@ When you open this project in Claude Code, the MCP server will be automatically 
   fs.writeFileSync(path.join(claudeDir, 'README.md'), readmeContent)
 }
 
-/**
- * Main migrate command
- */
 async function migrateCommand(options: MigrateOptions): Promise<void> {
   const cwd = process.cwd()
 
   console.log(chalk.bold.cyan('\n🚀 OpenSaaS Stack Migration\n'))
 
-  // Step 1: Detect project type
   const spinner = ora('Detecting project type...').start()
 
   let projectTypes: ProjectType[]
@@ -339,7 +290,6 @@ async function migrateCommand(options: MigrateOptions): Promise<void> {
   if (analysis.models && analysis.models.length > 0) {
     analysisSpinner.succeed(chalk.green(`Found ${analysis.models.length} models`))
 
-    // Display model tree
     const lastIndex = analysis.models.length - 1
     analysis.models.forEach((model, index) => {
       const prefix = index === lastIndex ? '└─' : '├─'

--- a/packages/cli/src/mcp/lib/documentation-provider.ts
+++ b/packages/cli/src/mcp/lib/documentation-provider.ts
@@ -228,6 +228,7 @@ For ${query}, you can also check:
           }
         }
       } catch {
+        // Skip files that can't be read
       }
     }
 

--- a/packages/cli/src/mcp/lib/documentation-provider.ts
+++ b/packages/cli/src/mcp/lib/documentation-provider.ts
@@ -1,7 +1,3 @@
-/**
- * Documentation provider - Fetches documentation from the hosted docs site
- */
-
 import fs from 'fs-extra'
 import path from 'path'
 import { glob } from 'glob'
@@ -38,9 +34,8 @@ interface ExampleConfig {
 export class OpenSaasDocumentationProvider {
   private readonly DOCS_API = 'https://stack.opensaas.au/api/search'
   private cache = new Map<string, { data: DocumentationLookup; timestamp: number }>()
-  private readonly CACHE_TTL = 1000 * 60 * 30 // 30 minutes
+  private readonly CACHE_TTL = 1000 * 60 * 30
 
-  // Topic mappings for user-friendly queries
   private topicMappings: Record<string, string> = {
     fields: 'field-types',
     'field types': 'field-types',
@@ -71,13 +66,9 @@ export class OpenSaasDocumentationProvider {
     deploy: 'deployment',
   }
 
-  /**
-   * Search documentation by query
-   */
   async searchDocs(query: string, limit = 5, minScore = 0.7): Promise<DocumentationLookup> {
     const cacheKey = `search:${query}:${limit}:${minScore}`
 
-    // Check cache
     const cached = this.cache.get(cacheKey)
     if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
       return cached.data
@@ -106,7 +97,6 @@ export class OpenSaasDocumentationProvider {
         relatedTopics: this.extractRelatedTopics(data.results),
       }
 
-      // Cache the result
       this.cache.set(cacheKey, { data: docLookup, timestamp: Date.now() })
 
       return docLookup
@@ -116,19 +106,12 @@ export class OpenSaasDocumentationProvider {
     }
   }
 
-  /**
-   * Get documentation for a specific topic
-   */
   async getTopicDocs(topic: string): Promise<DocumentationLookup> {
-    // Normalize topic using mappings
     const normalizedTopic = this.topicMappings[topic.toLowerCase()] || topic
 
     return this.searchDocs(normalizedTopic, 3, 0.8)
   }
 
-  /**
-   * Format search results into readable content
-   */
   private formatSearchResults(results: SearchResult[]): string {
     if (results.length === 0) {
       return 'No documentation found for this query.'
@@ -145,9 +128,6 @@ export class OpenSaasDocumentationProvider {
       .join('\n---\n\n')
   }
 
-  /**
-   * Extract code examples from search results
-   */
   private extractCodeExamples(results: SearchResult[]): string[] {
     const codeExamples: string[] = []
     const codeBlockRegex = /```[\s\S]*?```/g
@@ -162,9 +142,6 @@ export class OpenSaasDocumentationProvider {
     return codeExamples
   }
 
-  /**
-   * Extract related topics from search results
-   */
   private extractRelatedTopics(results: SearchResult[]): string[] {
     const topics = new Set<string>()
 
@@ -177,9 +154,6 @@ export class OpenSaasDocumentationProvider {
     return Array.from(topics)
   }
 
-  /**
-   * Fallback documentation when API is unavailable
-   */
   private getFallbackDocs(query: string): DocumentationLookup {
     return {
       topic: query,
@@ -197,13 +171,9 @@ For ${query}, you can also check:
     }
   }
 
-  /**
-   * Search local CLAUDE.md files in the monorepo
-   */
   async searchLocalDocs(query: string): Promise<LocalDocResult> {
     const cwd = process.cwd()
 
-    // Find CLAUDE.md files
     const claudeFiles = await glob('**/CLAUDE.md', {
       cwd,
       ignore: ['node_modules/**', '.next/**', 'dist/**', 'build/**'],
@@ -219,7 +189,6 @@ For ${query}, you can also check:
         const content = await fs.readFile(file, 'utf-8')
         const contentLower = content.toLowerCase()
 
-        // Simple relevance scoring
         let score = 0
         for (const term of queryTerms) {
           if (contentLower.includes(term)) {
@@ -228,7 +197,6 @@ For ${query}, you can also check:
         }
 
         if (score > 0) {
-          // Extract relevant section
           const lines = content.split('\n')
           const relevantLines: string[] = []
           let inRelevantSection = false
@@ -236,21 +204,17 @@ For ${query}, you can also check:
           for (const line of lines) {
             const lineLower = line.toLowerCase()
 
-            // Check if line starts a section
             if (line.startsWith('#')) {
-              // Check if this section title is relevant
               const titleRelevant = queryTerms.some((term) => lineLower.includes(term))
               if (titleRelevant) {
                 inRelevantSection = true
                 relevantLines.push(line)
               } else if (inRelevantSection) {
-                // We've left the relevant section
                 break
               }
             } else if (inRelevantSection) {
               relevantLines.push(line)
             } else if (queryTerms.some((term) => lineLower.includes(term))) {
-              // Found relevant content outside a section
               relevantLines.push(line)
             }
           }
@@ -264,11 +228,9 @@ For ${query}, you can also check:
           }
         }
       } catch {
-        // Skip files that can't be read
       }
     }
 
-    // Sort by score
     results.sort((a, b) => b.score - a.score)
 
     if (results.length === 0) {
@@ -286,9 +248,6 @@ For ${query}, you can also check:
     }
   }
 
-  /**
-   * Get example config code for a feature
-   */
   async getExampleConfig(feature: string): Promise<ExampleConfig | null> {
     const examples: Record<string, ExampleConfig> = {
       'blog-with-auth': {
@@ -521,9 +480,6 @@ fields: {
     return examples[normalizedFeature] || null
   }
 
-  /**
-   * Get migration-specific documentation for a project type
-   */
   async findMigrationGuide(projectType: string): Promise<string> {
     const guides: Record<string, string> = {
       prisma: `# Prisma to OpenSaaS Migration
@@ -686,9 +642,6 @@ npx prisma db push
     return guides[projectType.toLowerCase()] || guides.prisma
   }
 
-  /**
-   * Clear expired cache entries
-   */
   clearExpiredCache(): void {
     const now = Date.now()
     for (const [key, value] of this.cache.entries()) {
@@ -698,9 +651,6 @@ npx prisma db push
     }
   }
 
-  /**
-   * Clear all cache
-   */
   clearCache(): void {
     this.cache.clear()
   }

--- a/packages/cli/src/mcp/lib/features/catalog.ts
+++ b/packages/cli/src/mcp/lib/features/catalog.ts
@@ -1,7 +1,3 @@
-/**
- * Feature catalog - Defines all available features with their configuration wizards
- */
-
 import type { Feature } from '../types.js'
 
 export const AUTHENTICATION_FEATURE: Feature = {
@@ -268,9 +264,6 @@ export const SEMANTIC_SEARCH_FEATURE: Feature = {
   ],
 }
 
-/**
- * Feature catalog - maps feature IDs to feature definitions
- */
 export const FeatureCatalog = new Map<string, Feature>([
   ['authentication', AUTHENTICATION_FEATURE],
   ['blog', BLOG_FEATURE],
@@ -279,23 +272,14 @@ export const FeatureCatalog = new Map<string, Feature>([
   ['semantic-search', SEMANTIC_SEARCH_FEATURE],
 ])
 
-/**
- * Get feature by ID
- */
 export function getFeature(featureId: string): Feature | undefined {
   return FeatureCatalog.get(featureId)
 }
 
-/**
- * Get all available features
- */
 export function getAllFeatures(): Feature[] {
   return Array.from(FeatureCatalog.values())
 }
 
-/**
- * Get features by category
- */
 export function getFeaturesByCategory(category: Feature['category']): Feature[] {
   return getAllFeatures().filter((f) => f.category === category)
 }

--- a/packages/cli/src/mcp/lib/generators/feature-generator.ts
+++ b/packages/cli/src/mcp/lib/generators/feature-generator.ts
@@ -1,10 +1,7 @@
 /**
- * Feature generator - Generates code, config, and documentation for features
- *
- * Emitted code must match the current stack APIs. Canonical references:
- * - examples/starter-auth (authPlugin, access helpers, lib/auth wiring)
- * - examples/file-upload-demo (storage config, file/image fields)
- * - examples/rag-openai-chatbot and examples/rag-ollama-demo (ragPlugin, searchable)
+ * Generates code, config, and docs for features. Emitted code must match the
+ * current stack APIs — see examples/starter-auth, examples/file-upload-demo,
+ * and examples/rag-openai-chatbot / examples/rag-ollama-demo for references.
  */
 
 import type { Feature, FeatureImplementation, GeneratedFile } from '../types.js'
@@ -33,9 +30,6 @@ export class FeatureGenerator {
     private followUpAnswers: Record<string, string | boolean | string[]>,
   ) {}
 
-  /**
-   * Generate complete feature implementation
-   */
   generate(): FeatureImplementation {
     const featureType = this.feature.id
 
@@ -55,9 +49,6 @@ export class FeatureGenerator {
     }
   }
 
-  /**
-   * Generate authentication feature
-   */
   private generateAuthentication(): FeatureImplementation {
     const authMethods = this.answers['auth-methods'] as string[]
     const hasRoles = this.answers['user-roles'] as boolean
@@ -167,7 +158,6 @@ export default config({
 
     const files: GeneratedFile[] = []
 
-    // Better-auth server instance
     files.push({
       path: 'lib/auth.ts',
       language: 'typescript',
@@ -197,7 +187,6 @@ export const GET = auth.handler
 export const POST = auth.handler`,
     })
 
-    // Auth API route
     files.push({
       path: 'app/api/auth/[...all]/route.ts',
       language: 'typescript',
@@ -303,7 +292,6 @@ export async function signInAction(input: SignInInput): Promise<AuthActionResult
 `,
     })
 
-    // Sign-in page
     files.push({
       path: 'app/sign-in/page.tsx',
       language: 'tsx',
@@ -341,7 +329,6 @@ export default function SignInPage() {
 }`,
     })
 
-    // Sign-up page
     if (hasPassword) {
       files.push({
         path: 'app/sign-up/page.tsx',
@@ -366,7 +353,6 @@ export default function SignUpPage() {
 }`,
       })
 
-      // Forgot-password page
       files.push({
         path: 'app/forgot-password/page.tsx',
         language: 'tsx',
@@ -390,7 +376,7 @@ export default function ForgotPasswordPage() {
 }`,
       })
 
-      // Reset-password page (target of the reset email link)
+      // Target of the password-reset email link
       files.push({
         path: 'app/reset-password/page.tsx',
         language: 'tsx',
@@ -416,7 +402,6 @@ export default async function ResetPasswordPage({
       })
     }
 
-    // Access control helpers
     files.push({
       path: 'lib/access-control.ts',
       language: 'typescript',
@@ -444,7 +429,6 @@ export const ownRecordsOnly: AccessControl = ({ session }) =>
   session ? { userId: { equals: session.userId } } : false`,
     })
 
-    // Environment variables
     const envVars: Record<string, string> = {
       DATABASE_URL: 'file:./dev.db',
       BETTER_AUTH_SECRET: '<generate-with-openssl-rand-base64-32>',
@@ -462,7 +446,6 @@ export const ownRecordsOnly: AccessControl = ({ session }) =>
       envVars.GITHUB_CLIENT_SECRET = '<your-github-client-secret>'
     }
 
-    // Next steps
     const nextSteps = [
       'Install dependencies: `pnpm add @opensaas/stack-auth @prisma/adapter-better-sqlite3`',
       'Merge the config updates into your `opensaas.config.ts`',
@@ -475,7 +458,6 @@ export const ownRecordsOnly: AccessControl = ({ session }) =>
       `Visit http://localhost:3000/${hasPassword ? 'sign-up' : 'sign-in'} to test authentication`,
     ].filter(Boolean) as string[]
 
-    // Dev guide section
     const devGuideSection = `## Authentication Feature
 
 This project uses Better-auth (via \`@opensaas/stack-auth\`) with:
@@ -544,9 +526,6 @@ const currentUser = session
     }
   }
 
-  /**
-   * Generate blog feature
-   */
   private generateBlog(): FeatureImplementation {
     const contentEditor = this.answers['content-editor'] as string
     const hasStatus = this.answers['post-status'] as boolean
@@ -557,7 +536,6 @@ const currentUser = session
     const hasCategories = taxonomy.includes('Categories')
     const hasTags = taxonomy.includes('Tags')
 
-    // Build Post fields
     const fields = [
       'title: text({ validation: { isRequired: true } })',
       "slug: text({ validation: { isRequired: true }, isIndexed: 'unique' })",
@@ -701,7 +679,6 @@ ${useTiptap ? "import { richText } from '@opensaas/stack-tiptap/fields'" : ''}
 
     const files: GeneratedFile[] = []
 
-    // Blog list page
     files.push({
       path: 'app/blog/page.tsx',
       language: 'tsx',
@@ -739,7 +716,6 @@ export default async function BlogPage() {
 }`,
     })
 
-    // Blog post page
     files.push({
       path: 'app/blog/[slug]/page.tsx',
       language: 'tsx',
@@ -824,16 +800,12 @@ ${taxonomy.length > 0 ? `- ${taxonomy.join(' and ')} for organization` : ''}
     }
   }
 
-  /**
-   * Generate comments feature
-   */
   private generateComments(): FeatureImplementation {
     const targets = (this.answers['comment-targets'] as string[]) || ['Posts']
     const nestedReplies = this.answers['nested-replies'] as boolean
     const moderation = this.answers['moderation'] as string
     const requiresApproval = moderation === 'Require admin approval'
 
-    // Build one relationship per commentable list (Posts → Post, Products → Product)
     const targetLists = targets
       .filter((t) => t !== 'Other')
       .map((t) => (t.endsWith('s') ? t.slice(0, -1) : t))
@@ -952,9 +924,6 @@ Threaded comments on: ${targetLists.join(', ')}
     }
   }
 
-  /**
-   * Generate file upload feature
-   */
   private generateFileUpload(): FeatureImplementation {
     const provider = this.answers['storage-provider'] as string
     const associations = (this.answers['file-associations'] as string[]) || []
@@ -1084,9 +1053,6 @@ Storage provider: ${provider}
     }
   }
 
-  /**
-   * Generate semantic search feature
-   */
   private generateSemanticSearch(): FeatureImplementation {
     const searchableContent = (this.answers['searchable-content'] as string[]) || ['Posts']
     const embeddingProvider = this.answers['embedding-provider'] as string

--- a/packages/cli/src/mcp/lib/types.ts
+++ b/packages/cli/src/mcp/lib/types.ts
@@ -1,7 +1,3 @@
-/**
- * Feature catalog types for OpenSaaS Stack MCP server
- */
-
 export type QuestionType = 'text' | 'textarea' | 'select' | 'multiselect' | 'boolean'
 
 export interface FeatureQuestion {
@@ -28,7 +24,7 @@ export interface Feature {
   name: string
   description: string
   includes: string[]
-  dependsOn?: string[] // Other feature IDs required
+  dependsOn?: string[]
   questions: FeatureQuestion[]
   category: 'authentication' | 'content' | 'storage' | 'search' | 'custom'
 }

--- a/packages/cli/src/mcp/lib/wizards/migration-wizard.ts
+++ b/packages/cli/src/mcp/lib/wizards/migration-wizard.ts
@@ -1,7 +1,3 @@
-/**
- * Migration Wizard - Interactive guide for migrating to OpenSaaS Stack
- */
-
 import type {
   ProjectType,
   MigrationSession,
@@ -24,22 +20,12 @@ export class MigrationWizard {
     this.generator = new MigrationGenerator()
   }
 
-  /**
-   * Start a new migration wizard session.
-   *
-   * For KeystoneJS projects, uses a minimal fast-path: only asks about
-   * database provider and auth, since lists/fields/hooks/access copy over
-   * unchanged. Produces a targeted migration guide rather than a full rewrite.
-   *
-   * For Prisma/Next.js projects, uses the full interactive question flow.
-   */
   async startMigration(
     projectType: ProjectType,
     analysis?: IntrospectedSchema,
   ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
     const sessionId = this.generateSessionId()
 
-    // Generate questions based on project type and analysis
     const questions = this.generateQuestions(projectType, analysis)
 
     const session: MigrationSession & { questions?: MigrationQuestion[] } = {
@@ -68,7 +54,6 @@ export class MigrationWizard {
     const firstQuestion = questions[0]
     const progressBar = this.renderProgressBar(1, totalQuestions)
 
-    // For Keystone, add a note that this is a fast-path (only a few questions)
     const keystoneNote =
       projectType === 'keystone'
         ? `\n> **Note:** For KeystoneJS migrations, only a few questions are needed. Your lists, fields, hooks, and access control copy over unchanged — we just need to know about your database and auth setup.\n`
@@ -112,9 +97,6 @@ ${this.renderQuestion(firstQuestion, 1, totalQuestions)}
     }
   }
 
-  /**
-   * Answer a wizard question
-   */
   async answerQuestion(
     sessionId: string,
     answer: string | boolean | string[],
@@ -136,7 +118,6 @@ Please start a new migration with \`opensaas_start_migration\`.`,
     const questions = session.questions!
     const currentQuestion = questions[session.currentQuestionIndex]
 
-    // Validate answer
     const validation = this.validateAnswer(answer, currentQuestion)
     if (!validation.valid) {
       return {
@@ -151,7 +132,6 @@ ${this.renderQuestion(currentQuestion, session.currentQuestionIndex + 1, questio
       }
     }
 
-    // Normalize and store answer
     let normalizedAnswer = answer
     if (currentQuestion.type === 'boolean') {
       const boolValue = this.normalizeBoolean(answer)
@@ -162,11 +142,9 @@ ${this.renderQuestion(currentQuestion, session.currentQuestionIndex + 1, questio
     session.answers[currentQuestion.id] = normalizedAnswer
     session.updatedAt = new Date()
 
-    // Move to next question, skipping conditional questions
     session.currentQuestionIndex++
     while (session.currentQuestionIndex < questions.length) {
       const nextQ = questions[session.currentQuestionIndex]
-      // Skip if this question depends on a previous answer that doesn't match
       if (
         nextQ.dependsOn &&
         session.answers[nextQ.dependsOn.questionId] !== nextQ.dependsOn.value
@@ -177,13 +155,11 @@ ${this.renderQuestion(currentQuestion, session.currentQuestionIndex + 1, questio
       }
     }
 
-    // Check if complete
     if (session.currentQuestionIndex >= questions.length) {
       session.isComplete = true
       return this.generateMigrationConfig(session)
     }
 
-    // Render next question
     const nextQuestion = questions[session.currentQuestionIndex]
     const questionNum = session.currentQuestionIndex + 1
     const progressBar = this.renderProgressBar(questionNum, questions.length)
@@ -206,14 +182,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
     }
   }
 
-  /**
-   * Generate questions based on project type and analysis.
-   *
-   * KeystoneJS fast-path: only asks about db provider and auth.
-   * Lists, fields, hooks, and access control are 1:1 compatible and need no input.
-   *
-   * Prisma/Next.js full flow: asks about access control strategy, per-model config, etc.
-   */
   private generateQuestions(
     projectType: ProjectType,
     analysis?: IntrospectedSchema,
@@ -224,13 +192,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
     return this.generateFullQuestions(analysis)
   }
 
-  /**
-   * Minimal question set for KeystoneJS migrations.
-   *
-   * Keystone and OpenSaaS Stack share the same list/field/hook/access API so we
-   * only need to know the database provider (to generate the adapter config) and
-   * whether the user wants auth (so we know if they're migrating Keystone auth).
-   */
   private generateKeystoneQuestions(analysis?: IntrospectedSchema): MigrationQuestion[] {
     const questions: MigrationQuestion[] = []
 
@@ -271,14 +232,9 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
     return questions
   }
 
-  /**
-   * Full question set for Prisma/Next.js migrations where a new config is
-   * generated from scratch.
-   */
   private generateFullQuestions(analysis?: IntrospectedSchema): MigrationQuestion[] {
     const questions: MigrationQuestion[] = []
 
-    // 1. Database configuration
     questions.push({
       id: 'preserve_database',
       text: 'Do you want to keep your existing database?',
@@ -294,7 +250,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       defaultValue: analysis?.provider || 'sqlite',
     })
 
-    // 2. Authentication
     questions.push({
       id: 'enable_auth',
       text: 'Do you want to add authentication?',
@@ -314,7 +269,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       },
     })
 
-    // 3. Access control strategy
     questions.push({
       id: 'default_access',
       text: 'What should be the default access control strategy?',
@@ -323,7 +277,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       defaultValue: 'public-read-auth-write',
     })
 
-    // 4. Per-model configuration (if models detected)
     if (analysis?.models && analysis.models.length > 0) {
       const modelNames = analysis.models.map((m) => m.name)
 
@@ -351,7 +304,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       }
     }
 
-    // 5. Admin UI
     questions.push({
       id: 'admin_base_path',
       text: 'What base path should the admin UI use?',
@@ -359,7 +311,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       defaultValue: '/admin',
     })
 
-    // 6. Additional features
     questions.push({
       id: 'additional_features',
       text: 'Do you want to add any additional features?',
@@ -368,7 +319,6 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
       defaultValue: [],
     })
 
-    // 7. Final confirmation
     questions.push({
       id: 'confirm',
       text: 'Ready to generate your opensaas.config.ts?',
@@ -379,16 +329,12 @@ ${this.renderQuestion(nextQuestion, questionNum, questions.length)}
     return questions
   }
 
-  /**
-   * Generate the final migration config
-   */
   private async generateMigrationConfig(
     session: MigrationSession,
   ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
     try {
       const output = await this.generator.generate(session)
 
-      // Clean up session
       delete this.sessions[session.id]
 
       const isKeystoneMigration = session.projectType === 'keystone'
@@ -480,18 +426,12 @@ Please try again or create the config manually.
     }
   }
 
-  /**
-   * Check if analysis includes auth-related models
-   */
   private hasAuthModels(analysis?: IntrospectedSchema): boolean {
     if (!analysis?.models) return false
     const authModelNames = ['User', 'Account', 'Session']
     return analysis.models.some((m) => authModelNames.includes(m.name))
   }
 
-  /**
-   * Guess which models should have owner-based access
-   */
   private guessOwnerModels(models: IntrospectedModel[], modelNames: string[]): string[] {
     const ownerModels: string[] = []
 
@@ -499,7 +439,6 @@ Please try again or create the config manually.
       const model = models.find((m) => m.name === name)
       if (!model) continue
 
-      // Check if model has a relationship to User
       const hasUserRelation = model.fields.some(
         (f) =>
           f.relation &&
@@ -516,9 +455,6 @@ Please try again or create the config manually.
     return ownerModels
   }
 
-  /**
-   * Render a question for display
-   */
   private renderQuestion(
     question: MigrationQuestion,
     questionNum: number,
@@ -544,9 +480,6 @@ Please try again or create the config manually.
     return rendered
   }
 
-  /**
-   * Validate an answer
-   */
   private validateAnswer(
     answer: string | boolean | string[],
     question: MigrationQuestion,
@@ -590,9 +523,6 @@ Please try again or create the config manually.
     return { valid: true }
   }
 
-  /**
-   * Normalize boolean answer
-   */
   private normalizeBoolean(answer: string | boolean | string[]): boolean | null {
     if (typeof answer === 'boolean') return answer
     if (typeof answer !== 'string') return null
@@ -603,41 +533,27 @@ Please try again or create the config manually.
     return null
   }
 
-  /**
-   * Format an answer for display
-   */
   private formatAnswer(answer: string | boolean | string[]): string {
     if (typeof answer === 'boolean') return answer ? 'Yes' : 'No'
     if (Array.isArray(answer)) return answer.length > 0 ? answer.join(', ') : '(none)'
     return String(answer)
   }
 
-  /**
-   * Generate a unique session ID
-   */
   private generateSessionId(): string {
     return `migration_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
   }
 
-  /**
-   * Render a progress bar
-   */
   private renderProgressBar(current: number, total: number): string {
     const filled = Math.round((current / total) * 10)
     const empty = 10 - filled
     return '▓'.repeat(filled) + '░'.repeat(empty)
   }
 
-  /**
-   * Get a session by ID (for testing/debugging)
-   */
+  // Exposed for tests/debugging.
   getSession(sessionId: string): MigrationSession | undefined {
     return this.sessions[sessionId]
   }
 
-  /**
-   * Clear completed sessions
-   */
   clearCompletedSessions(): void {
     Object.keys(this.sessions).forEach((id) => {
       if (this.sessions[id].isComplete) {
@@ -646,9 +562,6 @@ Please try again or create the config manually.
     })
   }
 
-  /**
-   * Clear old sessions (older than 1 hour)
-   */
   clearOldSessions(): void {
     const oneHourAgo = Date.now() - 60 * 60 * 1000
     Object.keys(this.sessions).forEach((id) => {

--- a/packages/cli/src/mcp/lib/wizards/wizard-engine.ts
+++ b/packages/cli/src/mcp/lib/wizards/wizard-engine.ts
@@ -1,7 +1,3 @@
-/**
- * Wizard engine for multi-step feature implementation flows
- */
-
 import type { Feature, WizardSession, SessionStorage, FeatureQuestion } from '../types.js'
 import { getFeature } from '../features/catalog.js'
 import { FeatureGenerator } from '../generators/feature-generator.js'
@@ -9,9 +5,6 @@ import { FeatureGenerator } from '../generators/feature-generator.js'
 export class WizardEngine {
   private sessions: SessionStorage = {}
 
-  /**
-   * Start a new feature implementation wizard
-   */
   async startFeature(featureId: string): Promise<{
     content: Array<{ type: string; text: string }>
   }> {
@@ -74,9 +67,6 @@ ${firstQuestion}
     }
   }
 
-  /**
-   * Process an answer and move to next question or complete the wizard
-   */
   async answerQuestion(
     sessionId: string,
     answer: string | boolean | string[],
@@ -97,7 +87,6 @@ ${firstQuestion}
 
     const currentQ = session.feature.questions[session.currentQuestionIndex]
 
-    // Validate answer
     const validation = this.validateAnswer(answer, currentQ)
     if (!validation.valid) {
       return {
@@ -110,11 +99,9 @@ ${firstQuestion}
       }
     }
 
-    // Store answer
     session.answers[currentQ.id] = answer
     session.updatedAt = new Date()
 
-    // Check for follow-up questions
     if (currentQ.followUp) {
       const shouldAskFollowUp =
         currentQ.followUp.if === answer ||
@@ -133,16 +120,13 @@ ${firstQuestion}
       }
     }
 
-    // Move to next question
     session.currentQuestionIndex++
 
-    // Check if complete
     if (session.currentQuestionIndex >= session.feature.questions.length) {
       session.isComplete = true
       return this.generateFeatureImplementation(session)
     }
 
-    // Render next question
     const nextQ = session.feature.questions[session.currentQuestionIndex]
     const questionNum = session.currentQuestionIndex + 1
     const progressBar = this.renderProgressBar(questionNum, session.feature.questions.length)
@@ -157,9 +141,6 @@ ${firstQuestion}
     }
   }
 
-  /**
-   * Handle follow-up question answers
-   */
   async answerFollowUp(
     sessionId: string,
     answer: string,
@@ -181,20 +162,16 @@ ${firstQuestion}
     const currentQ = session.feature.questions[session.currentQuestionIndex]
     const followUpKey = `${currentQ.id}_followup`
 
-    // Store follow-up answer
     session.followUpAnswers[followUpKey] = answer
     session.updatedAt = new Date()
 
-    // Move to next question
     session.currentQuestionIndex++
 
-    // Check if complete
     if (session.currentQuestionIndex >= session.feature.questions.length) {
       session.isComplete = true
       return this.generateFeatureImplementation(session)
     }
 
-    // Render next question
     const nextQ = session.feature.questions[session.currentQuestionIndex]
     const questionNum = session.currentQuestionIndex + 1
     const progressBar = this.renderProgressBar(questionNum, session.feature.questions.length)
@@ -209,9 +186,6 @@ ${firstQuestion}
     }
   }
 
-  /**
-   * Generate the complete feature implementation
-   */
   private async generateFeatureImplementation(session: WizardSession): Promise<{
     content: Array<{ type: string; text: string }>
   }> {
@@ -290,9 +264,6 @@ For more help, see the docs at https://stack.opensaas.au/
     }
   }
 
-  /**
-   * Create a new wizard session
-   */
   private createSession(sessionId: string, feature: Feature): WizardSession {
     return {
       id: sessionId,
@@ -307,16 +278,10 @@ For more help, see the docs at https://stack.opensaas.au/
     }
   }
 
-  /**
-   * Generate a unique session ID
-   */
   private generateSessionId(): string {
     return `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
   }
 
-  /**
-   * Render a question for the user
-   */
   private renderQuestion(
     question: FeatureQuestion,
     session: WizardSession,
@@ -342,9 +307,6 @@ For more help, see the docs at https://stack.opensaas.au/
     return rendered
   }
 
-  /**
-   * Validate an answer against question requirements
-   */
   private validateAnswer(
     answer: string | boolean | string[],
     question: FeatureQuestion,
@@ -385,18 +347,12 @@ For more help, see the docs at https://stack.opensaas.au/
     return { valid: true }
   }
 
-  /**
-   * Render a progress bar
-   */
   private renderProgressBar(current: number, total: number): string {
     const filled = Math.round((current / total) * 10)
     const empty = 10 - filled
     return '▓'.repeat(filled) + '░'.repeat(empty)
   }
 
-  /**
-   * Format an answer for display
-   */
   private formatAnswer(answer: string | boolean | string[]): string {
     if (typeof answer === 'boolean') {
       return answer ? 'Yes' : 'No'
@@ -407,16 +363,10 @@ For more help, see the docs at https://stack.opensaas.au/
     return answer
   }
 
-  /**
-   * Get session by ID (for debugging/testing)
-   */
   getSession(sessionId: string): WizardSession | undefined {
     return this.sessions[sessionId]
   }
 
-  /**
-   * Clear completed sessions (cleanup)
-   */
   clearCompletedSessions(): void {
     Object.keys(this.sessions).forEach((id) => {
       if (this.sessions[id].isComplete) {

--- a/packages/cli/src/mcp/server/index.ts
+++ b/packages/cli/src/mcp/server/index.ts
@@ -11,7 +11,6 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { StackMCPServer } from './stack-mcp-server.js'
 
-// Tool definitions
 const TOOLS: Tool[] = [
   {
     name: 'opensaas_implement_feature',
@@ -232,9 +231,6 @@ const TOOLS: Tool[] = [
   },
 ]
 
-/**
- * Create and start the MCP server
- */
 export async function startMCPServer() {
   const server = new Server(
     {
@@ -250,12 +246,10 @@ export async function startMCPServer() {
 
   const stackServer = new StackMCPServer()
 
-  // Register tool list handler
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return { tools: TOOLS }
   })
 
-  // Register tool call handler
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params
 
@@ -337,15 +331,13 @@ export async function startMCPServer() {
     }
   })
 
-  // Periodic cleanup
   setInterval(
     () => {
       stackServer.cleanup()
     },
     1000 * 60 * 15,
-  ) // Every 15 minutes
+  )
 
-  // Start server
   const transport = new StdioServerTransport()
   await server.connect(transport)
 

--- a/packages/cli/src/mcp/server/stack-mcp-server.ts
+++ b/packages/cli/src/mcp/server/stack-mcp-server.ts
@@ -25,9 +25,6 @@ export class StackMCPServer {
     this.keystoneIntrospector = new KeystoneIntrospector()
   }
 
-  /**
-   * Implement a feature - starts the wizard flow
-   */
   async implementFeature({ feature, description }: { feature: string; description?: string }) {
     if (feature === 'custom' && !description) {
       return {
@@ -66,9 +63,6 @@ Would you like me to help you design the config for this feature?`,
     return this.wizardEngine.startFeature(feature)
   }
 
-  /**
-   * Answer a wizard question
-   */
   async answerFeatureQuestion({
     sessionId,
     answer,
@@ -79,16 +73,10 @@ Would you like me to help you design the config for this feature?`,
     return this.wizardEngine.answerQuestion(sessionId, answer)
   }
 
-  /**
-   * Answer a follow-up question
-   */
   async answerFollowUpQuestion({ sessionId, answer }: { sessionId: string; answer: string }) {
     return this.wizardEngine.answerFollowUp(sessionId, answer)
   }
 
-  /**
-   * Search documentation
-   */
   async searchFeatureDocs({ topic }: { topic: string }) {
     const docs = await this.docsProvider.getTopicDocs(topic)
 
@@ -112,9 +100,6 @@ ${docs.relatedTopics.length > 0 ? `\n## Related Topics\n\n${docs.relatedTopics.m
     }
   }
 
-  /**
-   * List all available features
-   */
   async listFeatures() {
     const features = getAllFeatures()
     const categories = {
@@ -180,9 +165,6 @@ opensaas_implement_feature({
     }
   }
 
-  /**
-   * Suggest complementary features based on described features
-   */
   async suggestFeatures({ currentFeatures }: { currentFeatures?: string[] }) {
     const allFeatures = getAllFeatures()
     const implemented = new Set(currentFeatures || [])
@@ -192,7 +174,6 @@ opensaas_implement_feature({
       .map((f) => {
         let reasoning = ''
 
-        // Add context-aware suggestions
         if (f.id === 'authentication' && !implemented.has('authentication')) {
           reasoning = 'Essential for user management and access control'
         } else if (f.id === 'blog' && implemented.has('authentication')) {
@@ -252,9 +233,6 @@ ${s.feature.includes.map((inc) => `- ${inc}`).join('\n')}
     }
   }
 
-  /**
-   * Validate a feature implementation
-   */
   async validateFeature({ feature }: { feature: string; configPath?: string }) {
     const featureDefinition = getFeature(feature)
 
@@ -269,8 +247,7 @@ ${s.feature.includes.map((inc) => `- ${inc}`).join('\n')}
       }
     }
 
-    // TODO: Implement actual validation by reading the config file
-    // For now, return validation checklist
+    // TODO: validate by reading the config file instead of returning a static checklist
 
     return {
       content: [
@@ -301,16 +278,10 @@ ${featureDefinition.dependsOn && featureDefinition.dependsOn.length > 0 ? `\n## 
     }
   }
 
-  /**
-   * Start a migration wizard session
-   */
   async startMigration({ projectType }: { projectType: ProjectType }) {
     return this.migrationWizard.startMigration(projectType)
   }
 
-  /**
-   * Answer a migration wizard question
-   */
   async answerMigration({
     sessionId,
     answer,
@@ -321,9 +292,6 @@ ${featureDefinition.dependsOn && featureDefinition.dependsOn.length > 0 ? `\n## 
     return this.migrationWizard.answerQuestion(sessionId, answer)
   }
 
-  /**
-   * Introspect a Prisma schema
-   */
   async introspectPrisma({ schemaPath }: { schemaPath?: string }) {
     const cwd = process.cwd()
     const path = schemaPath || 'prisma/schema.prisma'
@@ -386,9 +354,6 @@ ${enumList}
     }
   }
 
-  /**
-   * Introspect a KeystoneJS config
-   */
   async introspectKeystone({ configPath }: { configPath?: string }) {
     const cwd = process.cwd()
     const path = configPath || 'keystone.config.ts'
@@ -437,14 +402,8 @@ ${listInfo}
     }
   }
 
-  /**
-   * Search migration documentation
-   */
   async searchMigrationDocs({ query }: { query: string }) {
-    // First try local CLAUDE.md files
     const localDocs = await this.docsProvider.searchLocalDocs(query)
-
-    // Then try hosted docs
     const hostedDocs = await this.docsProvider.searchDocs(query)
 
     const sections: string[] = []
@@ -486,9 +445,6 @@ Or visit: https://stack.opensaas.au/`,
     }
   }
 
-  /**
-   * Get example code for a feature
-   */
   async getExample({ feature }: { feature: string }) {
     const example = await this.docsProvider.getExampleConfig(feature)
 
@@ -534,9 +490,6 @@ ${example.notes ? `\n## Notes\n\n${example.notes}` : ''}
     }
   }
 
-  /**
-   * Cleanup - clear wizard sessions and caches
-   */
   cleanup() {
     this.wizardEngine.clearCompletedSessions()
     this.docsProvider.clearExpiredCache()

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -177,9 +177,6 @@ ${virtualFieldsNote}${contextGraphqlNote}`
     }
   }
 
-  /**
-   * Generate the database adapter example for the migration guide
-   */
   private generateDatabaseAdapterExample(provider: string): string {
     switch (provider) {
       case 'postgresql':
@@ -229,9 +226,6 @@ db: {
     }
   }
 
-  /**
-   * Generate auth migration section for the guide
-   */
   private generateAuthMigrationExample(answers: Record<string, unknown>): string {
     const authMethods = (answers.auth_methods as string[]) || ['email-password']
     const options: string[] = []
@@ -288,9 +282,6 @@ control.
 `
   }
 
-  /**
-   * Generate Keystone-specific dependency list
-   */
   private generateKeystoneDependencies(dbProvider: string, useAuth: boolean): string[] {
     const remove = ['@keystone-6/core', '@keystone-6/auth', '@keystone-6/fields-document']
     const add: string[] = ['@opensaas/stack-core', '@opensaas/stack-ui']
@@ -316,9 +307,6 @@ control.
     return [`# Remove: ${remove.join(', ')}`, `# Add: ${add.join(', ')}`, ...add]
   }
 
-  /**
-   * Generate next steps for a Keystone migration
-   */
   private generateKeystoneSteps(useAuth: boolean, hasVirtualFields: boolean): string[] {
     const steps = [
       'Rename keystone.ts → opensaas.config.ts',
@@ -350,9 +338,6 @@ control.
     return steps
   }
 
-  /**
-   * Generate list definitions from schema
-   */
   private generateLists(
     schema: IntrospectedSchema | undefined,
     answers: Record<string, unknown>,
@@ -360,7 +345,6 @@ control.
     warnings: string[],
   ): string {
     if (!schema || schema.models.length === 0) {
-      // No schema, generate example lists
       usedFieldTypes.add('timestamp')
       return `    // Add your lists here
     // Example:
@@ -373,7 +357,6 @@ control.
     // }),`
     }
 
-    // Filter out auth models if using auth plugin
     const skipAuthModels = answers.skip_auth_models === true
     const authModelNames = ['User', 'Account', 'Session', 'Verification']
 
@@ -384,10 +367,8 @@ control.
       return true
     })
 
-    // Get models that should have owner access
     const ownerModels = new Set((answers.models_with_owner as string[]) || [])
 
-    // Generate each list
     const listDefinitions = modelsToGenerate.map((model) => {
       return this.generateList(
         model,
@@ -402,9 +383,6 @@ control.
     return listDefinitions.join('\n')
   }
 
-  /**
-   * Generate a single list definition
-   */
   private generateList(
     model: IntrospectedModel,
     schema: IntrospectedSchema,
@@ -415,12 +393,12 @@ control.
   ): string {
     const fields: string[] = []
 
-    // Skip system fields (id, createdAt, updatedAt) - OpenSaaS adds these automatically
+    // OpenSaaS adds id/createdAt/updatedAt automatically - skip them here
     const systemFields = ['id', 'createdAt', 'updatedAt']
 
     for (const field of model.fields) {
       if (systemFields.includes(field.name)) continue
-      if (field.isId) continue // Skip ID fields
+      if (field.isId) continue
 
       const fieldDef = this.generateField(field, schema, usedFieldTypes, warnings)
       if (fieldDef) {
@@ -428,7 +406,6 @@ control.
       }
     }
 
-    // Generate access control
     const access = this.generateListAccess(hasOwnerAccess, model, answers)
 
     const fieldsBlock = fields.length > 0 ? `\n${fields.join('\n')}\n      ` : ''
@@ -438,20 +415,15 @@ control.
     }),`
   }
 
-  /**
-   * Generate a field definition
-   */
   private generateField(
     field: IntrospectedField,
     schema: IntrospectedSchema,
     usedFieldTypes: Set<string>,
     warnings: string[],
   ): string | null {
-    // Handle relationships
     if (field.relation) {
       usedFieldTypes.add('relationship')
 
-      // Find the related model and back-reference field
       const relatedModel = schema.models.find((m) => m.name === field.relation!.model)
       const backRef = relatedModel?.fields.find(
         (f) => f.relation && f.relation.model === field.type,
@@ -463,7 +435,6 @@ control.
       return `relationship({ ref: '${ref}'${many} })`
     }
 
-    // Handle enums as select fields
     const enumDef = schema.enums.find((e) => e.name === field.type)
     if (enumDef) {
       usedFieldTypes.add('select')
@@ -477,11 +448,9 @@ control.
       return `select({ ${selectOptions} })`
     }
 
-    // Map Prisma/Keystone types to OpenSaaS
     const mapping = this.prismaIntrospector.mapPrismaTypeToOpenSaas(field.type)
     usedFieldTypes.add(mapping.import)
 
-    // Build options
     const options: string[] = []
 
     if (field.isRequired && !field.defaultValue) {
@@ -503,17 +472,16 @@ control.
       options.push(`scale: ${scale}`)
     }
 
-    // Handle default values
     if (field.defaultValue) {
       if (field.type === 'DateTime' && field.defaultValue === 'now()') {
         options.push("defaultValue: { kind: 'now' }")
       } else if (field.type === 'Boolean') {
         options.push(`defaultValue: ${field.defaultValue}`)
       }
-      // Other defaults are harder to map automatically
+      // Known limit: other default value expressions (e.g. sequences,
+      // dbgenerated(), string/numeric literals) are not mapped.
     }
 
-    // Generate unsupported type warning
     if (field.type === 'Bytes') {
       warnings.push(
         `Field "${field.name}" uses unsupported type "${field.type}" - mapped to text()`,

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -478,8 +478,7 @@ control.
       } else if (field.type === 'Boolean') {
         options.push(`defaultValue: ${field.defaultValue}`)
       }
-      // Known limit: other default value expressions (e.g. sequences,
-      // dbgenerated(), string/numeric literals) are not mapped.
+      // Other defaults are harder to map automatically
     }
 
     if (field.type === 'Bytes') {
@@ -499,9 +498,6 @@ control.
     return `${mapping.type}(${optionsStr})`
   }
 
-  /**
-   * Generate list access control
-   */
   private generateListAccess(
     hasOwnerAccess: boolean,
     model: IntrospectedModel,
@@ -510,7 +506,6 @@ control.
     const defaultAccess = (answers.default_access as string) || 'public-read-auth-write'
 
     if (hasOwnerAccess) {
-      // Find the user relationship field
       const userField = model.fields.find(
         (f) =>
           f.relation?.model === 'User' ||
@@ -537,7 +532,6 @@ control.
       },`
     }
 
-    // Generate based on default access pattern
     switch (defaultAccess) {
       case 'authenticated-only':
         return `
@@ -588,9 +582,6 @@ control.
     }
   }
 
-  /**
-   * Generate access control helper functions
-   */
   private generateAccessHelpers(answers: Record<string, unknown>): string {
     const helpers: string[] = []
     const ownerModels = (answers.models_with_owner as string[]) || []
@@ -613,9 +604,6 @@ const isOwner: AccessControl = ({ session, item }) => {
     return helpers.join('\n')
   }
 
-  /**
-   * Generate database configuration
-   */
   private generateDatabaseConfig(provider: string): {
     provider: string
     configCode: string
@@ -669,9 +657,6 @@ const isOwner: AccessControl = ({ session, item }) => {
     }
   }
 
-  /**
-   * Generate import statements
-   */
   private generateImports(
     usedFieldTypes: Set<string>,
     useAuth: boolean,
@@ -679,29 +664,22 @@ const isOwner: AccessControl = ({ session, item }) => {
   ): string {
     const imports: string[] = []
 
-    // Core imports
     imports.push("import { config, list } from '@opensaas/stack-core'")
 
-    // Field imports
     const fieldTypes = Array.from(usedFieldTypes).sort()
     imports.push(`import { ${fieldTypes.join(', ')} } from '@opensaas/stack-core/fields'`)
 
-    // Auth imports
     if (useAuth) {
       imports.push("import { authPlugin } from '@opensaas/stack-auth'")
       imports.push("import type { AccessControl } from '@opensaas/stack-core'")
     }
 
-    // Database adapter imports
     const dbConfig = this.generateDatabaseConfig(dbProvider)
     imports.push(...dbConfig.imports)
 
     return imports.join('\n')
   }
 
-  /**
-   * Assemble the complete config file
-   */
   private assembleConfig(options: {
     imports: string
     accessHelpers: string
@@ -713,7 +691,6 @@ const isOwner: AccessControl = ({ session, item }) => {
   }): string {
     const { imports, accessHelpers, dbConfig, lists, useAuth, authMethods, adminBasePath } = options
 
-    // Generate auth plugin config
     let authPluginStr = ''
     if (useAuth) {
       const authOptions: string[] = []
@@ -755,7 +732,6 @@ ${authOptions.join('\n')}
     }),`
     }
 
-    // Build config body
     const pluginsBlock = useAuth
       ? `  plugins: [
 ${authPluginStr}
@@ -780,9 +756,6 @@ ${accessHelpers}${configBody}
 `
   }
 
-  /**
-   * Generate list of dependencies to install
-   */
   private generateDependencies(dbProvider: string, useAuth: boolean): string[] {
     const deps: string[] = [
       '@opensaas/stack-core',

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -764,7 +764,6 @@ ${accessHelpers}${configBody}
       'prisma',
     ]
 
-    // Database adapter deps
     switch (dbProvider) {
       case 'postgresql':
         deps.push('@prisma/adapter-pg', 'pg', '@types/pg')
@@ -778,7 +777,6 @@ ${accessHelpers}${configBody}
         break
     }
 
-    // Auth deps
     if (useAuth) {
       deps.push('@opensaas/stack-auth', 'better-auth')
     }
@@ -786,9 +784,6 @@ ${accessHelpers}${configBody}
     return deps
   }
 
-  /**
-   * Generate additional files if needed
-   */
   private generateAdditionalFiles(
     answers: Record<string, unknown>,
     dbProvider: string,
@@ -805,10 +800,8 @@ ${accessHelpers}${configBody}
       description: string
     }> = []
 
-    // Generate .env.example
     const envVars: string[] = ['# Database']
 
-    // Database URL based on provider
     switch (dbProvider) {
       case 'postgresql':
         envVars.push('DATABASE_URL="postgresql://user:password@localhost:5432/mydb"')
@@ -855,9 +848,6 @@ ${accessHelpers}${configBody}
     return files
   }
 
-  /**
-   * Generate next steps
-   */
   private generateSteps(useAuth: boolean, dbProvider: string): string[] {
     const steps = [
       'Save the generated config to `opensaas.config.ts`',

--- a/packages/cli/src/migration/generators/migration-generator.ts
+++ b/packages/cli/src/migration/generators/migration-generator.ts
@@ -27,13 +27,9 @@ export class MigrationGenerator {
     this.keystoneIntrospector = new KeystoneIntrospector()
   }
 
-  /**
-   * Generate migration output from session
-   */
   async generate(session: MigrationSession): Promise<MigrationOutput> {
     const { projectType, analysis, answers } = session
 
-    // Get full schema if available
     let schema: IntrospectedSchema | undefined
     try {
       if (projectType === 'prisma') {
@@ -45,35 +41,22 @@ export class MigrationGenerator {
       // Continue without schema - will generate example config
     }
 
-    // For Keystone projects, produce a targeted migration guide rather than
-    // regenerating a full config. Lists, fields, hooks, and access control are
-    // identical between Keystone and OpenSaaS Stack.
     if (projectType === 'keystone') {
       return this.generateKeystoneMigrationGuide(schema, answers)
     }
 
-    // Collect used field types for imports
-    const usedFieldTypes = new Set<string>(['text']) // Always need text
+    const usedFieldTypes = new Set<string>(['text'])
     const warnings: string[] = []
 
-    // Generate lists
     const lists = this.generateLists(schema, answers, usedFieldTypes, warnings)
-
-    // Generate access control helpers
     const accessHelpers = this.generateAccessHelpers(answers)
-
-    // Generate database config
     const dbConfig = this.generateDatabaseConfig(
       (answers.db_provider as string) || analysis.provider || 'sqlite',
     )
 
-    // Determine if using auth
     const useAuth = answers.enable_auth === true
-
-    // Generate imports
     const imports = this.generateImports(usedFieldTypes, useAuth, dbConfig.provider)
 
-    // Generate the full config
     const configContent = this.assembleConfig({
       imports,
       accessHelpers,
@@ -84,16 +67,10 @@ export class MigrationGenerator {
       adminBasePath: (answers.admin_base_path as string) || '/admin',
     })
 
-    // Generate dependencies list
     const dependencies = this.generateDependencies(dbConfig.provider, useAuth)
-
-    // Generate additional files
     const files = this.generateAdditionalFiles(answers, dbConfig.provider)
-
-    // Generate next steps
     const steps = this.generateSteps(useAuth, dbConfig.provider)
 
-    // Add warnings from introspection
     if (schema) {
       const introspectorWarnings =
         projectType === 'prisma'
@@ -111,13 +88,6 @@ export class MigrationGenerator {
     }
   }
 
-  /**
-   * Generate a targeted migration guide for KeystoneJS projects.
-   *
-   * KeystoneJS and OpenSaaS Stack share the same list/field/hook/access API.
-   * The guide focuses only on what actually needs to change rather than
-   * regenerating the entire config.
-   */
   private generateKeystoneMigrationGuide(
     schema: IntrospectedSchema | undefined,
     answers: Record<string, unknown>,

--- a/packages/cli/src/migration/introspectors/index.ts
+++ b/packages/cli/src/migration/introspectors/index.ts
@@ -1,10 +1,3 @@
-/**
- * Schema introspectors for migration system
- *
- * These introspectors parse existing schemas and configs to extract
- * model and field information for automated migration.
- */
-
 export { PrismaIntrospector } from './prisma-introspector.js'
 export { KeystoneIntrospector } from './keystone-introspector.js'
 export type { KeystoneList, KeystoneField, KeystoneSchema } from './keystone-introspector.js'

--- a/packages/cli/src/migration/introspectors/keystone-introspector.ts
+++ b/packages/cli/src/migration/introspectors/keystone-introspector.ts
@@ -1,10 +1,3 @@
-/**
- * KeystoneJS Config Introspector
- *
- * Loads keystone.config.ts using jiti and extracts list definitions.
- * KeystoneJS → OpenSaaS migration is mostly 1:1.
- */
-
 import path from 'path'
 import fs from 'fs-extra'
 import { createJiti } from 'jiti'
@@ -33,16 +26,12 @@ export interface KeystoneSchema {
 }
 
 export class KeystoneIntrospector {
-  /**
-   * Introspect a KeystoneJS config file
-   */
   async introspect(
     cwd: string,
     configPath: string = 'keystone.config.ts',
   ): Promise<IntrospectedSchema> {
     const fullPath = path.isAbsolute(configPath) ? configPath : path.join(cwd, configPath)
 
-    // Try alternative paths
     const paths = [fullPath, path.join(cwd, 'keystone.ts'), path.join(cwd, 'keystone.config.js')]
 
     let foundPath: string | undefined
@@ -66,7 +55,6 @@ export class KeystoneIntrospector {
         console.warn(`⚠️  ${warning}`)
       }
 
-      // Use jiti to load TypeScript config
       const jiti = createJiti(import.meta.url, {
         interopDefault: true,
         moduleCache: false,
@@ -81,7 +69,6 @@ export class KeystoneIntrospector {
 
       const keystoneSchema = this.parseConfig(config)
 
-      // Convert KeystoneSchema to IntrospectedSchema
       return this.convertToIntrospectedSchema(keystoneSchema)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -89,9 +76,6 @@ export class KeystoneIntrospector {
     }
   }
 
-  /**
-   * Parse the loaded KeystoneJS config object
-   */
   private parseConfig(config: unknown): KeystoneSchema {
     const result: KeystoneSchema = {
       lists: [],
@@ -103,7 +87,6 @@ export class KeystoneIntrospector {
 
     const configObj = config as Record<string, unknown>
 
-    // Extract database config
     if (configObj.db && typeof configObj.db === 'object' && configObj.db !== null) {
       const db = configObj.db as Record<string, unknown>
       result.db = {
@@ -112,7 +95,6 @@ export class KeystoneIntrospector {
       }
     }
 
-    // Extract lists
     if (configObj.lists && typeof configObj.lists === 'object' && configObj.lists !== null) {
       for (const [name, listDef] of Object.entries(configObj.lists)) {
         const list = this.parseList(name, listDef)
@@ -123,9 +105,6 @@ export class KeystoneIntrospector {
     return result
   }
 
-  /**
-   * Parse a single list definition
-   */
   private parseList(name: string, listDef: unknown): KeystoneList {
     const list: KeystoneList = {
       name,
@@ -138,7 +117,6 @@ export class KeystoneIntrospector {
 
     const listDefObj = listDef as Record<string, unknown>
 
-    // Extract fields
     if (listDefObj.fields && typeof listDefObj.fields === 'object' && listDefObj.fields !== null) {
       for (const [fieldName, fieldDef] of Object.entries(listDefObj.fields)) {
         const field = this.parseField(fieldName, fieldDef)
@@ -157,9 +135,6 @@ export class KeystoneIntrospector {
     return list
   }
 
-  /**
-   * Parse a single field definition
-   */
   private parseField(name: string, fieldDef: unknown): KeystoneField {
     // KeystoneJS fields are objects with a type property or function results
     let type = 'unknown'
@@ -168,7 +143,6 @@ export class KeystoneIntrospector {
     if (typeof fieldDef === 'object' && fieldDef !== null) {
       const fieldDefObj = fieldDef as Record<string, unknown>
 
-      // Check for common field type patterns
       if (typeof fieldDefObj.type === 'string') {
         type = fieldDefObj.type
       } else if (typeof fieldDefObj._type === 'string') {
@@ -184,7 +158,6 @@ export class KeystoneIntrospector {
         }
       }
 
-      // Extract common options
       if (fieldDefObj.validation !== undefined) options.validation = fieldDefObj.validation
       if (fieldDefObj.defaultValue !== undefined) options.defaultValue = fieldDefObj.defaultValue
       if (fieldDefObj.isRequired !== undefined) options.isRequired = fieldDefObj.isRequired
@@ -195,9 +168,6 @@ export class KeystoneIntrospector {
     return { name, type, options }
   }
 
-  /**
-   * Convert KeystoneSchema to IntrospectedSchema format
-   */
   private convertToIntrospectedSchema(keystoneSchema: KeystoneSchema): IntrospectedSchema {
     const models: IntrospectedModel[] = keystoneSchema.lists.map((list) => {
       const fields: IntrospectedField[] = list.fields.map((field) => {
@@ -247,9 +217,6 @@ export class KeystoneIntrospector {
     }
   }
 
-  /**
-   * Map KeystoneJS field type to OpenSaaS equivalent
-   */
   mapKeystoneTypeToOpenSaas(keystoneType: string): { type: string; import: string } {
     // KeystoneJS → OpenSaaS is mostly 1:1
     const mappings: Record<string, { type: string; import: string }> = {
@@ -266,9 +233,7 @@ export class KeystoneIntrospector {
       // Storage field types (from @opensaas/stack-storage)
       image: { type: 'image', import: 'image' },
       file: { type: 'file', import: 'file' },
-      // Virtual/computed fields
       virtual: { type: 'virtual', import: 'virtual' },
-      // Other field types
       calendarDay: { type: 'timestamp', import: 'timestamp' },
     }
 
@@ -276,9 +241,6 @@ export class KeystoneIntrospector {
     return mappings[lower] || { type: 'text', import: 'text' }
   }
 
-  /**
-   * Get warnings for unsupported features
-   */
   getWarnings(schema: IntrospectedSchema): string[] {
     const warnings: string[] = []
     const hasFileOrImageFields = schema.models.some((model) =>
@@ -291,21 +253,18 @@ export class KeystoneIntrospector {
       model.fields.some((field) => field.type.toLowerCase() === 'float'),
     )
 
-    // Add storage configuration reminder if file/image fields are present
     if (hasFileOrImageFields) {
       warnings.push(
         "Your schema uses file/image fields - you'll need to configure storage providers in your OpenSaaS config",
       )
     }
 
-    // Add virtual field migration reminder
     if (hasVirtualFields) {
       warnings.push(
         "Your schema uses virtual() fields — you'll need to manually migrate these. OpenSaaS Stack has no GraphQL: replace graphql.field({ resolve }) with hooks: { resolveOutput } and declare the field type. See the migration guide or invoke the migrate-virtual-fields skill.",
       )
     }
 
-    // Add float field migration reminder
     if (hasFloatFields) {
       warnings.push(
         'Your schema uses float() fields - these will be mapped to decimal() (a decimal.js Decimal, not a JS number). Review precision/rounding.',

--- a/packages/cli/src/migration/introspectors/nextjs-introspector.ts
+++ b/packages/cli/src/migration/introspectors/nextjs-introspector.ts
@@ -1,10 +1,3 @@
-/**
- * Next.js Project Introspector
- *
- * Detects Next.js version, auth libraries, database libraries,
- * and other project characteristics.
- */
-
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -20,9 +13,6 @@ export interface NextjsAnalysis {
 }
 
 export class NextjsIntrospector {
-  /**
-   * Analyze a Next.js project
-   */
   async introspect(cwd: string): Promise<NextjsAnalysis> {
     const packageJsonPath = path.join(cwd, 'package.json')
 
@@ -45,29 +35,19 @@ export class NextjsIntrospector {
       existingDependencies: this.getAllDependencies(pkg),
     }
 
-    // Detect auth library
     analysis.authLibrary = this.detectAuthLibrary(pkg)
-
-    // Detect database library
     analysis.databaseLibrary = this.detectDatabaseLibrary(pkg)
 
     return analysis
   }
 
-  /**
-   * Get Next.js version from package.json
-   */
   private getNextVersion(pkg: Record<string, unknown>): string {
     const deps = pkg.dependencies as Record<string, string> | undefined
     const devDeps = pkg.devDependencies as Record<string, string> | undefined
     const version = deps?.next || devDeps?.next || 'unknown'
-    // Strip semver prefixes like ^ or ~
     return version.replace(/^[\^~]/, '')
   }
 
-  /**
-   * Detect if project uses app router, pages router, or both
-   */
   private async detectRouterType(cwd: string): Promise<'app' | 'pages' | 'both' | 'unknown'> {
     const hasApp =
       (await fs.pathExists(path.join(cwd, 'app'))) ||
@@ -82,34 +62,22 @@ export class NextjsIntrospector {
     return 'unknown'
   }
 
-  /**
-   * Check if project uses TypeScript
-   */
   private async hasTypeScript(cwd: string): Promise<boolean> {
     return await fs.pathExists(path.join(cwd, 'tsconfig.json'))
   }
 
-  /**
-   * Check if package.json has a dependency
-   */
   private hasDependency(pkg: Record<string, unknown>, name: string): boolean {
     const deps = pkg.dependencies as Record<string, string> | undefined
     const devDeps = pkg.devDependencies as Record<string, string> | undefined
     return !!(deps?.[name] || devDeps?.[name])
   }
 
-  /**
-   * Get all dependencies
-   */
   private getAllDependencies(pkg: Record<string, unknown>): string[] {
     const deps = pkg.dependencies as Record<string, string> | undefined
     const devDeps = pkg.devDependencies as Record<string, string> | undefined
     return [...Object.keys(deps || {}), ...Object.keys(devDeps || {})]
   }
 
-  /**
-   * Detect auth library being used
-   */
   private detectAuthLibrary(pkg: Record<string, unknown>): string | undefined {
     const authLibraries = [
       { name: 'next-auth', dep: 'next-auth' },
@@ -130,9 +98,6 @@ export class NextjsIntrospector {
     return undefined
   }
 
-  /**
-   * Detect database library being used
-   */
   private detectDatabaseLibrary(pkg: Record<string, unknown>): string | undefined {
     const dbLibraries = [
       { name: 'prisma', dep: '@prisma/client' },
@@ -153,9 +118,6 @@ export class NextjsIntrospector {
     return undefined
   }
 
-  /**
-   * Get migration recommendations based on analysis
-   */
   getRecommendations(analysis: NextjsAnalysis): string[] {
     const recommendations: string[] = []
 
@@ -186,9 +148,6 @@ export class NextjsIntrospector {
     return recommendations
   }
 
-  /**
-   * Get warnings for potential issues
-   */
   getWarnings(analysis: NextjsAnalysis): string[] {
     const warnings: string[] = []
 

--- a/packages/cli/src/migration/introspectors/prisma-introspector.ts
+++ b/packages/cli/src/migration/introspectors/prisma-introspector.ts
@@ -1,18 +1,8 @@
-/**
- * Prisma Schema Introspector
- *
- * Parses prisma/schema.prisma and extracts structured information
- * about models, fields, relationships, and enums.
- */
-
 import fs from 'fs-extra'
 import path from 'path'
 import type { IntrospectedSchema, IntrospectedModel, IntrospectedField } from '../types.js'
 
 export class PrismaIntrospector {
-  /**
-   * Introspect a Prisma schema file
-   */
   async introspect(
     cwd: string,
     schemaPath: string = 'prisma/schema.prisma',
@@ -32,21 +22,14 @@ export class PrismaIntrospector {
     }
   }
 
-  /**
-   * Extract database provider from datasource block
-   */
   private extractProvider(schema: string): string {
     const match = schema.match(/datasource\s+\w+\s*\{[^}]*provider\s*=\s*"(\w+)"/)
     return match ? match[1] : 'unknown'
   }
 
-  /**
-   * Extract all model definitions
-   */
   private extractModels(schema: string): IntrospectedModel[] {
     const models: IntrospectedModel[] = []
 
-    // Match model blocks
     const modelRegex = /model\s+(\w+)\s*\{([^}]+)\}/g
     let match
 
@@ -68,9 +51,6 @@ export class PrismaIntrospector {
     return models
   }
 
-  /**
-   * Extract fields from a model body
-   */
   private extractFields(body: string): IntrospectedField[] {
     const fields: IntrospectedField[] = []
     const lines = body.split('\n')
@@ -78,7 +58,6 @@ export class PrismaIntrospector {
     for (const line of lines) {
       const trimmed = line.trim()
 
-      // Skip empty lines, comments, and model-level attributes
       if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) {
         continue
       }
@@ -92,9 +71,6 @@ export class PrismaIntrospector {
     return fields
   }
 
-  /**
-   * Parse a single field line
-   */
   private parseFieldLine(line: string): IntrospectedField | null {
     // Basic field pattern: name Type modifiers attributes
     // Examples:
@@ -104,16 +80,13 @@ export class PrismaIntrospector {
     //   posts     Post[]
     //   author    User     @relation(fields: [authorId], references: [id])
 
-    // Remove comments
     const withoutComment = line.split('//')[0].trim()
 
-    // Match field name and type
     const fieldMatch = withoutComment.match(/^(\w+)\s+(\w+)(\?)?(\[\])?(.*)$/)
     if (!fieldMatch) return null
 
     const [, name, rawType, optional, isList, rest] = fieldMatch
 
-    // Skip if this looks like an index or other non-field line
     if (['@@', 'index', 'unique'].some((kw) => name.startsWith(kw))) {
       return null
     }
@@ -143,7 +116,6 @@ export class PrismaIntrospector {
       field.defaultValue = rest.substring(startIdx, endIdx)
     }
 
-    // Extract native type attribute (e.g. `@db.Decimal(10, 2)`)
     const nativeTypeMatch = rest.match(/@db\.(\w+)(?:\(([^)]*)\))?/)
     if (nativeTypeMatch) {
       const [, nativeName, nativeArgs] = nativeTypeMatch
@@ -158,12 +130,10 @@ export class PrismaIntrospector {
       }
     }
 
-    // Extract relation
     const relationMatch = rest.match(/@relation\(([^)]+)\)/)
     if (relationMatch) {
       const relationBody = relationMatch[1]
 
-      // Parse relation parts
       const fieldsMatch = relationBody.match(/fields:\s*\[([^\]]+)\]/)
       const referencesMatch = relationBody.match(/references:\s*\[([^\]]+)\]/)
       const nameMatch = relationBody.match(/name:\s*"([^"]+)"/) || relationBody.match(/"([^"]+)"/)
@@ -179,13 +149,9 @@ export class PrismaIntrospector {
     return field
   }
 
-  /**
-   * Extract enum definitions
-   */
   private extractEnums(schema: string): Array<{ name: string; values: string[] }> {
     const enums: Array<{ name: string; values: string[] }> = []
 
-    // Match enum blocks
     const enumRegex = /enum\s+(\w+)\s*\{([^}]+)\}/g
     let match
 
@@ -204,9 +170,6 @@ export class PrismaIntrospector {
     return enums
   }
 
-  /**
-   * Map Prisma type to OpenSaaS field type
-   */
   mapPrismaTypeToOpenSaas(prismaType: string): { type: string; import: string } {
     const mappings: Record<string, { type: string; import: string }> = {
       String: { type: 'text', import: 'text' },
@@ -223,13 +186,9 @@ export class PrismaIntrospector {
     return mappings[prismaType] || { type: 'text', import: 'text' }
   }
 
-  /**
-   * Get warnings for unsupported features
-   */
   getWarnings(schema: IntrospectedSchema): string[] {
     const warnings: string[] = []
 
-    // Check for unsupported types
     for (const model of schema.models) {
       for (const field of model.fields) {
         if (field.type === 'Bytes') {
@@ -245,8 +204,7 @@ export class PrismaIntrospector {
       }
     }
 
-    // Check for composite IDs
-    // This would require checking for @@id in the original schema
+    // Known limit: composite IDs (@@id) are not checked for or warned about.
 
     return warnings
   }

--- a/packages/cli/src/migration/types.ts
+++ b/packages/cli/src/migration/types.ts
@@ -1,7 +1,3 @@
-/**
- * Migration types - Shared types for the migration system
- */
-
 export type ProjectType = 'prisma' | 'nextjs' | 'keystone'
 
 export interface ModelInfo {
@@ -85,8 +81,7 @@ export interface IntrospectedField {
   }
   /**
    * A Prisma native type attribute (e.g. `@db.Decimal(10, 2)`), if the field
-   * declared one. Generalised beyond `Decimal` so other native types
-   * (`@db.VarChar`, `@db.SmallInt`, ...) can reuse the same channel later.
+   * declared one.
    */
   nativeType?: {
     name: string


### PR DESCRIPTION
## Summary

Applies the Comments rule from `CLAUDE.md`'s `## Comments` section to `packages/cli/src/migration/`, `packages/cli/src/mcp/`, and `packages/cli/src/commands/`, following the calibration worked out in `docs/agents/comments.md` (issue #936).

- Deleted comments that restated the line beneath them, docblocks on self-describing methods/constants, comments explaining the absence of something, and long file headers (trimmed to an orientation line where one was warranted).
- Kept `eslint-disable ... --` justifications verbatim, genuine external-constraint notes (Prisma/Better-auth/Next.js/MCP-protocol behavior, ADR references), footgun warnings where the obvious edit is wrong, and "Known limits" notes on the migration introspectors (what they can't map isn't derivable from the code).
- No public-API TSDoc was affected — this code is internal generator/wizard/CLI-command logic, not exported config options, field builders, or plugin surfaces.
- One incidental fix: removing the comment inside `documentation-provider.ts`'s `searchLocalDocs` left a truly empty `catch {}` block, which trips ESLint's `no-empty` rule (it only tolerates an empty catch when it contains a comment signaling the swallow is intentional). Restored that one comment.

## Scope

- Comments only. No behavior changes, no renames, no adjacent refactors.
- Test files were left untouched (none needed changes).

## Test plan

- [x] `pnpm build` for `@opensaas/stack-core` and `@opensaas/stack-cli` — no TypeScript errors
- [x] `pnpm lint` — passes (0 errors; the only 2 warnings are pre-existing and unrelated: an unused var in `examples/blog/test-singleton.ts` and an unused `dbProvider` arg in `migration-generator.ts`'s `generateSteps`, both present on `main` before this change)
- [x] `pnpm format` — no diffs
- [x] `pnpm manypkg fix` — no changes needed
- [x] `packages/cli` test suite (`pnpm test`) — 376/376 tests pass, unchanged
- [x] Confirmed via `git diff` that no test files (`*.test.ts`/`*.test.tsx`) were touched
- [x] Patch changeset added for `@opensaas/stack-cli`

Closes #940


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2VvCFvBLF6KKjAapZRkyN)_