### PR TITLE
Comment cleanup: packages/ui

### DIFF
--- a/.changeset/gentle-otters-clean.md
+++ b/.changeset/gentle-otters-clean.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-ui': patch
+---
+
+Remove comments that restated the line below them or duplicated rationale already stated elsewhere in `packages/ui/src`. No behavior changes.

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -45,10 +45,7 @@ export interface AdminUIProps {
 }
 
 /**
- * Main AdminUI component - complete admin interface with routing
- * Server Component
- *
- * Handles routing based on params array:
+ * Routes based on `params`:
  * - [] → Dashboard
  * - [list] → ListView (or SingletonView when the list is `isSingleton`)
  * - [list, 'create'] → ItemForm (create)
@@ -71,30 +68,20 @@ export async function AdminUI({
     )
   }
 
-  // Parse route from params
   const [urlSegment, action] = params
-
-  // Convert URL segment (kebab-case) to PascalCase listKey
   const listKey = urlSegment ? getListKeyFromUrl(urlSegment) : undefined
-
-  // Determine current path for navigation highlighting
   const currentPath = deriveCurrentPath(params)
 
-  // Route to appropriate component
   let content: React.ReactNode
 
   if (!listKey) {
-    // Dashboard
     content = <Dashboard context={context} config={config} basePath={basePath} />
   } else if (config.lists[listKey]?.isSingleton && action) {
     // A singleton has a single record edited at its bare [list] route, so the
     // create/id sub-routes (`[list, 'create']` / `[list, id]`) don't apply.
-    // Redirect them to the bare editor so old links keep working. This runs
-    // before the create/edit ItemForm branches; non-singleton routing below is
-    // unchanged.
+    // Redirect them to the bare editor so old links keep working.
     redirect(`${basePath}/${getUrlKey(listKey)}`)
   } else if (action === 'create') {
-    // Create form
     content = (
       <ItemForm
         context={context}
@@ -106,7 +93,7 @@ export async function AdminUI({
       />
     )
   } else if (action && action !== 'create') {
-    // Edit form (action is the item ID)
+    // `action` is the item ID here.
     content = (
       <ItemForm
         context={context}
@@ -119,8 +106,6 @@ export async function AdminUI({
       />
     )
   } else if (config.lists[listKey]?.isSingleton) {
-    // Singleton editor: a singleton has a single record, so its bare [list]
-    // route renders a single-record editor instead of a list table.
     content = (
       <SingletonView
         context={context}
@@ -131,7 +116,6 @@ export async function AdminUI({
       />
     )
   } else {
-    // List view
     const search = typeof searchParams.search === 'string' ? searchParams.search : undefined
     const page = typeof searchParams.page === 'string' ? parseInt(searchParams.page, 10) : 1
     // Optional `?pageSize=` override (Keystone-style). When absent, ListView's
@@ -191,14 +175,12 @@ export async function AdminUI({
     fallback = <ListViewSkeleton />
   }
 
-  // Generate theme styles if custom theme is configured
   const themeStyles = config.ui?.theme ? compileTheme(config.ui.theme) : null
 
-  // Access-scoped nav counts for opted-in lists (issue #735). Runs zero queries
-  // when no list sets `ui.navCount`, so existing apps pay nothing; each count is
-  // fetched through the secured `context.db`, reflecting only what this session
-  // may see. Skipped entirely when the chrome slot is supplied (ADR-0021) —
-  // host-owned chrome resolves its own counts, so this avoids paying twice.
+  // Access-scoped nav counts for opted-in lists (issue #735). Zero queries when
+  // no list sets `ui.navCount`; each count goes through the secured
+  // `context.db`. Skipped when `navigation` is supplied — see that prop's doc
+  // (ADR-0021).
   const navCounts = navigation ? undefined : await resolveNavCounts(context, config)
 
   const sidebar = navigation ?? (

--- a/packages/ui/src/components/ConfirmDialog.tsx
+++ b/packages/ui/src/components/ConfirmDialog.tsx
@@ -21,10 +21,6 @@ export interface ConfirmDialogProps {
   variant?: 'danger' | 'warning'
 }
 
-/**
- * Reusable confirmation dialog component
- * Used for destructive actions like delete
- */
 export function ConfirmDialog({
   isOpen,
   title,

--- a/packages/ui/src/components/Dashboard.tsx
+++ b/packages/ui/src/components/Dashboard.tsx
@@ -12,10 +12,6 @@ export interface DashboardProps {
   basePath?: string
 }
 
-/**
- * Dashboard landing page showing all available lists
- * Server Component
- */
 export async function Dashboard({ context, config, basePath = '/admin' }: DashboardProps) {
   const lists = Object.keys(config.lists || {})
 
@@ -25,8 +21,6 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
   const standardLists = lists.filter((listKey) => !config.lists[listKey]?.isSingleton)
   const singletonLists = lists.filter((listKey) => config.lists[listKey]?.isSingleton)
 
-  // Get counts for the standard lists only. Singletons don't show a count, so
-  // there's no need to call count() for them here.
   const listCounts = await Promise.all(
     standardLists.map(async (listKey) => {
       try {
@@ -95,8 +89,6 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
         </div>
       ) : null}
 
-      {/* Settings section — singletons present a "Configure" affordance instead
-          of a misleading "N items" count. */}
       {singletonLists.length > 0 && (
         <div className={standardLists.length > 0 ? 'mt-12' : ''}>
           <div className="mb-4 flex items-center gap-2">
@@ -151,8 +143,6 @@ export async function Dashboard({ context, config, basePath = '/admin' }: Dashbo
           </CardHeader>
           <CardContent>
             <div className="flex flex-wrap gap-3">
-              {/* Singletons have a single record (no create), so they're
-                  excluded here — only standard lists get a "Create" quick-action. */}
               {standardLists.map((listKey) => {
                 const urlKey = getUrlKey(listKey)
                 return (

--- a/packages/ui/src/components/FilterBuilder.tsx
+++ b/packages/ui/src/components/FilterBuilder.tsx
@@ -96,15 +96,12 @@ function initialValueForSource(_source: FilterValueSource): string {
 }
 
 /**
- * Filter builder input UI (issue #731, part of #728; layered on the #730 filter
- * engine / ADR-0017).
- *
  * Constructs the admin list's `?search=` filter query from a friendly UI —
  * structured field/operator/value rows plus a free-text box — and produces the
- * exact grammar the engine already consumes (`serializeFilterQuery`). It never
- * invents a parallel filter path: the applied query flows through the same URL
- * param the secured `context.db` reads server-side, so filtering can only ever
- * narrow, never widen, what a session may see.
+ * exact grammar the filter engine already consumes (`serializeFilterQuery`,
+ * ADR-0017). It never invents a parallel filter path: the applied query flows
+ * through the same URL param the secured `context.db` reads server-side, so
+ * filtering can only ever narrow, never widen, what a session may see.
  *
  * Available fields, operators and value suggestions are derived entirely from
  * the serializable {@link FilterFieldSuggestion}s (each field's self-contained

--- a/packages/ui/src/components/ItemForm.tsx
+++ b/packages/ui/src/components/ItemForm.tsx
@@ -25,7 +25,7 @@ export interface ItemFormProps {
   mode: 'create' | 'edit'
   itemId?: string
   basePath?: string
-  // Server action can return any shape depending on the list item type
+  // See AdminUIProps.serverAction for why this is Promise<unknown>.
   serverAction: (input: ServerActionInput) => Promise<unknown>
 }
 
@@ -129,8 +129,7 @@ export function buildDetailsItemData(
  * Edit-mode item view whose layout is DERIVED from the list shape (issue #734):
  * scalar/to-one fields (and picker-demoted relationships) in a details card
  * with the existing whole-form Save/Cancel, and each to-many relationship as a
- * read-only Relationship table. The arrangement follows from the number of
- * tables — one → two-column split, several → stacked.
+ * read-only Relationship table.
  */
 async function ItemViewLayoutView({
   context,
@@ -153,13 +152,10 @@ async function ItemViewLayoutView({
 }) {
   const urlKey = getUrlKey(listKey)
 
-  // One secured read: details relationships one level deep, each Relationship
-  // table nested-included (bounded by `take`, issue #752) so its cells resolve.
-  // Access control on the include means only access-visible rows/fields are
-  // returned. The full access-scoped total for each table's "showing N of M"
-  // footer comes from a filtered `_count` in the SAME read — folding each
-  // related list's own `query` access into the count so a denied related list
-  // never leaks a true total (mirrors the list view's #732 count columns).
+  // One secured read: {@link buildItemViewInclude} bounds each table's nested
+  // include, and the filtered `_count` below is fetched in the SAME call so
+  // {@link readAccessScopedTotal} never leaks a denied list's true total
+  // (mirrors the list view's #732 count columns).
   const include: Record<string, unknown> = { ...buildItemViewInclude(listConfig, config, layout) }
   const countSelect = await buildRelationshipCountSelect(
     listConfig,
@@ -247,9 +243,7 @@ async function ItemViewLayoutView({
         config={config}
         section={section}
         rows={rows}
-        // M for "showing N of M": the access-scoped total from `_count`, falling
-        // back to the bounded row count when the related list is denied (0) or
-        // uncounted — never a leak of a denied list's true total.
+        // M for "showing N of M" — see {@link readAccessScopedTotal}.
         total={readAccessScopedTotal(countPayload, section.fieldName, rows.length)}
         basePath={basePath}
         context={context}
@@ -288,10 +282,6 @@ async function ItemViewLayoutView({
   )
 }
 
-/**
- * Item form component - create or edit an item
- * Server Component that fetches data and sets up actions
- */
 export async function ItemForm({
   context,
   config,
@@ -337,11 +327,9 @@ export async function ItemForm({
     }
   }
 
-  // Fetch item data if in edit mode
   let itemData: Record<string, unknown> = {}
   if (mode === 'edit' && itemId) {
     try {
-      // Fetch item with relationships included
       const includeRelationships = buildRelationshipInclude(listConfig)
       const delegate = context.db[getDbKey(listKey)]
       if (delegate?.findUnique) {
@@ -375,8 +363,7 @@ export async function ItemForm({
     }
   }
 
-  // Fetch relationship options, serialize field configs, and transform the
-  // record into client-ready form data (shared with the singleton editor).
+  // Also used by SingletonView so both editors serialize identically.
   const { serializableFields, initialData, relationshipData } = await prepareItemForm(
     context,
     config,
@@ -392,7 +379,6 @@ export async function ItemForm({
         title={`${mode === 'create' ? 'Create' : 'Edit'} ${formatListName(listKey)}`}
       />
 
-      {/* Form */}
       <div className="bg-card border border-border rounded-lg p-6">
         <ItemFormClient
           listKey={listKey}

--- a/packages/ui/src/components/ItemFormClient.tsx
+++ b/packages/ui/src/components/ItemFormClient.tsx
@@ -49,8 +49,6 @@ function toSubmitResult(result: unknown, deniedMessage: string): ItemFormSubmitR
 }
 
 /**
- * Client component for the AdminUI item form.
- *
  * Shares the form state/transform/error/pending logic with the standalone
  * forms via `useItemForm`; this component only adapts submission to the
  * AdminUI server action + router navigation, and adds the delete flow.
@@ -122,14 +120,12 @@ export function ItemFormClient({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      {/* General Error */}
       {generalError && (
         <div className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-4">
           <p className="text-sm font-medium">{generalError}</p>
         </div>
       )}
 
-      {/* Form Fields */}
       <div className="space-y-6">
         {editableFields.map(([fieldName, fieldConfig]) => (
           <FieldRenderer
@@ -150,7 +146,6 @@ export function ItemFormClient({
         ))}
       </div>
 
-      {/* Form Actions */}
       <div className="flex items-center justify-between pt-6 border-t border-border">
         <div className="flex gap-3">
           <Button type="submit" disabled={busy} className="gap-2">
@@ -172,7 +167,6 @@ export function ItemFormClient({
           </Button>
         </div>
 
-        {/* Delete Button (Edit Mode Only; suppressed for singletons) */}
         {mode === 'edit' && itemId && canDelete && (
           <Button
             type="button"
@@ -185,7 +179,6 @@ export function ItemFormClient({
         )}
       </div>
 
-      {/* Delete Confirmation Dialog */}
       <ConfirmDialog
         isOpen={showDeleteConfirm}
         title="Delete Item"

--- a/packages/ui/src/components/ListView.tsx
+++ b/packages/ui/src/components/ListView.tsx
@@ -96,9 +96,6 @@ function toRelationshipLabel(
 
 /**
  * Whether a field can seed an `orderBy` for the list table (issue #732).
- * Virtual fields have no column to order by, and a to-one relationship has no
- * scalar to order by; a to-many relationship orders by its related `_count`, and
- * every scalar column orders by its own value.
  *
  * A field the session cannot READ is excluded too (#915) — evaluated the same
  * predicate-time way `context.db.*`'s `findMany`/`count` now enforce, so a
@@ -164,10 +161,6 @@ export interface ListViewProps {
   serverAction?: (input: ServerActionInput) => Promise<unknown>
 }
 
-/**
- * List view component - displays items in a table
- * Server Component that fetches data and renders client table
- */
 export async function ListView({
   context,
   config,
@@ -196,18 +189,14 @@ export async function ListView({
     )
   }
 
-  // URL sort takes precedence over config initialSort, but only if the field is
-  // actually sortable — an unknown field, a virtual field, a to-one
-  // relationship, or a field this session cannot read (#915) has no orderable
-  // column and would make either Prisma or the engine's own predicate-time
-  // check throw (issue #732).
+  // URL sort takes precedence over config initialSort, but only for a
+  // sortable field — see `isSortableField`.
   const sortFieldReadable =
     sort &&
     (await isSortableField(listConfig.fields[sort.field], { session: context.session, context }))
   const validatedSort = sortFieldReadable ? sort : undefined
   const activeSort = validatedSort ?? initialSort
 
-  // Fetch items using access-controlled context
   const skip = (page - 1) * pageSize
   let items: Array<Record<string, unknown>> = []
   let total = 0
@@ -245,13 +234,6 @@ export async function ListView({
       config,
     )
 
-    // A to-one relationship label-filter condition (`author:Ada` →
-    // `{ author: { is: { name: {...} } } }`) used to need its own access fold
-    // here (issue #749) so the nested `is` clause could only ever match rows
-    // the session may also see directly on the related list. The secured
-    // `context.db` read below now scopes every relation filter in `where`
-    // itself (`buildAccessScopedWhere`, #916), so this `where` needs no
-    // separate label-filter pass.
     const where = whereWithCountFilters
 
     // Build the include: to-one relationships fetch the related row (for its
@@ -274,8 +256,6 @@ export async function ListView({
       include._count = { select: countSelect }
     }
 
-    // A to-many relationship column sorts by its related `_count`; every other
-    // sortable column orders by its own value.
     const orderBy = activeSort
       ? isToManyRelationshipField(listConfig.fields[activeSort.field])
         ? { [activeSort.field]: { _count: activeSort.direction } }
@@ -299,7 +279,6 @@ export async function ListView({
     console.error(`Failed to fetch ${listKey}:`, error)
   }
 
-  // Extract only the relationship refs needed by client (don't send entire config)
   const relationshipRefs: Record<string, string> = {}
   Object.entries(listConfig.fields).forEach(([fieldName, field]) => {
     if (
@@ -313,10 +292,8 @@ export async function ListView({
   })
 
   // Resolve each relationship value before crossing the server/client boundary
-  // (ListConfig objects carry functions and can't be passed as props):
-  //  • to-one → the related row's `{ id, label }` via the shared label seam.
-  //  • to-many → the access-visible related COUNT (a number) read off `_count`.
-  // The raw `_count` payload is dropped from the serialized item (issue #732).
+  // — ListConfig objects carry functions and can't be passed as props. The raw
+  // `_count` payload is dropped from the serialized item (issue #732).
   const itemsWithResolvedLabels = items.map((item) => {
     const resolved: Record<string, unknown> = { ...item }
     delete resolved._count
@@ -338,13 +315,11 @@ export async function ListView({
     return resolved
   })
 
-  // Serialize items for client component (convert Dates, etc to JSON-safe format)
   const serializedItems = jsonSafeClone(itemsWithResolvedLabels)
 
   // Collect each filterable field's serializable Filter spec metadata (fields,
   // operators, enumerated values / relationship label search) to drive the
-  // Filter builder's pickers. This carries no functions, so it crosses the
-  // server/client boundary; it mirrors the same specs the server-side
+  // Filter builder's pickers. It mirrors the same specs the server-side
   // `buildListFilterWhere` above uses, so the builder can only produce queries
   // the engine understands.
   const filterSuggestions = await collectFilterSuggestions(listConfig, listKey, config, {
@@ -355,14 +330,9 @@ export async function ListView({
   // When the list opts into avatars (issue #735), the label column renders with
   // an initials bubble ahead of the emphasized Item label. The label column is
   // resolved through the shared label seam (`getLabelFieldName`), so it can
-  // never drift from the field the Item label is read off. A per-field cell
-  // override on that field still wins — the client routes to the override first.
+  // never drift from the field the Item label is read off.
   const avatarColumn = listConfig.ui?.avatar ? getLabelFieldName(listConfig) : undefined
 
-  // Resolve the custom Bulk actions (issue #736) this session may see. The
-  // per-action `hasAccess` gate runs server-side against the live context here,
-  // so the client only ever receives serialisable metadata for actions it is
-  // allowed to invoke.
   const bulkActions = await resolveVisibleBulkActions(
     listConfig.ui?.listView?.bulkActions,
     context,
@@ -384,7 +354,6 @@ export async function ListView({
         }
       />
 
-      {/* Client Table */}
       <ListViewClient
         items={serializedItems || []}
         fieldTypes={Object.fromEntries(

--- a/packages/ui/src/components/ListViewClient.tsx
+++ b/packages/ui/src/components/ListViewClient.tsx
@@ -92,8 +92,7 @@ export interface ListViewClientProps {
   /**
    * Serializable per-field filter metadata (from the core engine's
    * `collectFilterSuggestions`) that drives the Filter builder's field /
-   * operator / value pickers. Carries no functions, so it is safe to pass to
-   * this client component. When empty, the builder shows only free-text search.
+   * operator / value pickers. When empty, the builder shows only free-text search.
    */
   filterSuggestions?: FilterFieldSuggestion[]
   /**
@@ -127,10 +126,6 @@ export interface ListViewClientProps {
   bulkActions?: SerializedBulkAction[]
 }
 
-/**
- * Client component for interactive list table
- * Handles sorting, pagination, and row interactions
- */
 export function ListViewClient({
   items,
   fieldTypes,
@@ -155,25 +150,19 @@ export function ListViewClient({
   const sortBy = initialSort?.field ?? null
   const sortOrder = initialSort?.direction ?? 'asc'
 
-  // Row selection (issue #733). The selection is keyed on the ACTIVE FILTER
-  // STATE: the `search` param is the filter engine's URL filter query (#730 —
-  // field-scoped tokens, comparisons, quoted values, bare-word free text), so
-  // changing ANY filter token changes `filterKey` and clears the accumulated id
-  // set, while page and sort changes keep it stable (selection persists while
-  // paging). Reads back empty under a different filter.
+  // Row selection (issue #733) is keyed on the active `search` filter query
+  // (the ADR-0017 filter engine's URL param, parsed server-side in `ListView`)
+  // — changing any filter token changes `filterKey` and clears the accumulated
+  // id set, while page/sort changes keep it stable so selection persists while
+  // paging. Reads back empty under a different filter.
   const filterKey = initialSearch ?? ''
   const selection = useRowSelection(listKey, filterKey)
 
-  // Selection is offered when ANY Bulk action exists: the built-in Delete
-  // (gated by static delete access) OR one or more custom Bulk actions declared
-  // for this list (issue #736). Widening the gate to `canDelete ||
-  // hasCustomBulkActions` means a list with only custom actions still turns
-  // selection on even when delete is denied.
   const hasCustomBulkActions = bulkActions.length > 0
   const selectionEnabled = canDelete || hasCustomBulkActions
   const canBulkDelete = canDelete && !!serverAction
-  // Custom actions dispatch through the same generic server action; without it
-  // they cannot run, so they are only rendered when it is wired.
+  // Custom actions dispatch through the generic `serverAction`; without it
+  // they are not rendered.
   const canRunBulkActions = hasCustomBulkActions && !!serverAction
 
   // The "N of M deleted" report must outlive the table refresh: `router.refresh()`
@@ -194,7 +183,6 @@ export function ListViewClient({
     selection.togglePage(pageIds)
   }
 
-  // Determine which columns to show
   const displayColumns =
     columns ||
     Object.keys(fieldTypes).filter((key) => !['password', 'createdAt', 'updatedAt'].includes(key))
@@ -224,9 +212,8 @@ export function ListViewClient({
     router.push(`${basePath}/${urlKey}?${withPageSize(params).toString()}`)
   }
 
-  // Apply a Filter builder query: write it into the `?search=` URL param the
-  // filter engine consumes, preserving the active sort/pageSize and resetting to
-  // page 1. An empty query drops the param entirely (clears the filter).
+  // Writes a Filter builder query into the `?search=` URL param, resetting to
+  // page 1. An empty query drops the param (clears the filter).
   const applyQuery = (query: string) => {
     const params = new URLSearchParams()
     const trimmed = query.trim()
@@ -236,7 +223,7 @@ export function ListViewClient({
     if (sortBy) {
       params.set('sort', `${sortBy}:${sortOrder}`)
     }
-    params.set('page', '1') // Reset to page 1 on a new filter.
+    params.set('page', '1')
     const qs = withPageSize(params).toString()
     router.push(`${basePath}/${urlKey}${qs ? `?${qs}` : ''}`)
   }
@@ -265,8 +252,7 @@ export function ListViewClient({
     const result = await serverAction({ listKey, action: 'bulkDelete', ids })
     const { deleted, total } = parseBulkDeleteResult(result, ids.length)
 
-    // Persist the report before mutating the view, so it survives the remount the
-    // navigation below triggers and renders against the fresh list.
+    // Set before navigating so it isn't lost on the remount navigation triggers.
     setBulkStatus(`${deleted} of ${total} deleted`)
     selection.clear()
 
@@ -279,11 +265,8 @@ export function ListViewClient({
     router.push(buildPaginationUrl(1))
   }
 
-  // Run a custom Bulk action (issue #736). Mirrors the bulk-delete flow: one
-  // secured server round-trip dispatched by `key` over the selected ids, an
-  // outcome status line persisted so it survives the table refresh, selection
-  // cleared, then a reset to page 1 of the current filter. The handler runs
-  // server-side through the secured context — per-id denials are absorbed there,
+  // Runs a custom Bulk action (issue #736); mirrors `handleBulkDelete`'s
+  // round-trip/page-reset flow. Per-id denials are absorbed server-side and
   // never leaked here.
   const handleBulkAction = async (key: string) => {
     if (!serverAction) return
@@ -298,11 +281,7 @@ export function ListViewClient({
     router.push(buildPaginationUrl(1))
   }
 
-  /**
-   * The serialised field config for a column. Prefer the explicit `fields`
-   * prop; otherwise synthesise a minimal config from `fieldTypes` (and the
-   * relationship ref) so Cells still resolve via the field-type registry.
-   */
+  /** Resolves a column's field config: the explicit `fields` entry, or a synthesised fallback (see `fields` prop) plus the relationship ref. */
   const columnField = (column: string): SerializableFieldConfig => {
     if (fields?.[column]) return fields[column]
     const ref = relationshipRefs[column]
@@ -341,9 +320,8 @@ export function ListViewClient({
 
   return (
     <div className="space-y-4">
-      {/* Filter builder (issue #731) — constructs the `?search=` filter query the
-          engine consumes. Keyed on the active query so it remounts (and re-reads
-          the URL) whenever the applied filter changes. */}
+      {/* Keyed on the active query so it remounts (and re-reads the URL) whenever
+          the applied filter changes (issue #731). */}
       <FilterBuilder
         key={initialSearch ?? ''}
         suggestions={filterSuggestions}
@@ -351,8 +329,8 @@ export function ListViewClient({
         onApply={applyQuery}
       />
 
-      {/* Bulk-action result ("N of M deleted"). Lives here (always mounted) so
-          it survives the selection clearing after a delete. */}
+      {/* Always mounted (outside the selection bar) so the report survives the
+          selection clearing after a bulk action. */}
       {bulkStatus && (
         <div
           data-slot="selection-status"
@@ -363,7 +341,6 @@ export function ListViewClient({
         </div>
       )}
 
-      {/* Selection bar — visible only while rows are selected. */}
       {selectionEnabled && (
         <RowSelectionBar
           count={selection.selectedCount}
@@ -383,7 +360,6 @@ export function ListViewClient({
         />
       )}
 
-      {/* Table */}
       <div className="rounded-lg border">
         <Table>
           <TableHeader>
@@ -401,8 +377,6 @@ export function ListViewClient({
               {displayColumns.map((column) => {
                 const field = columnField(column)
                 const numeric = isCountAlignedColumn(field)
-                // Virtual and to-one relationship columns have no orderable
-                // column, so they expose no sort affordance (issue #732).
                 const sortable = isSortableColumn(field)
                 return (
                   <TableHead
@@ -516,7 +490,6 @@ export function ListViewClient({
         </Table>
       </div>
 
-      {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between">
           <p className="text-sm tabular-nums text-muted-foreground">

--- a/packages/ui/src/components/LoadingSpinner.tsx
+++ b/packages/ui/src/components/LoadingSpinner.tsx
@@ -5,10 +5,6 @@ export interface LoadingSpinnerProps {
   className?: string
 }
 
-/**
- * Loading spinner component
- * Used to indicate loading states
- */
 export function LoadingSpinner({ size = 'md', className }: LoadingSpinnerProps) {
   const sizeClasses = {
     sm: 'h-4 w-4 border-2',

--- a/packages/ui/src/components/Navigation.tsx
+++ b/packages/ui/src/components/Navigation.tsx
@@ -98,10 +98,6 @@ export function NavLink({ href, active = false, icon, count, children }: NavLink
   )
 }
 
-/**
- * Navigation sidebar showing all lists
- * Server Component
- */
 export function Navigation({
   context,
   config,
@@ -120,8 +116,7 @@ export function Navigation({
 
   return (
     <nav className="sticky top-0 flex h-screen w-64 flex-col border-r border-border bg-card">
-      {/* Header — a restrained solid wordmark. The gradient pair is reserved for
-          the dashboard signature moment, so the brand text stays a solid token. */}
+      {/* Solid wordmark — same gradient-reservation rule as NavLink's active state. */}
       <div className="border-b border-border p-6">
         <Link href={basePath} className="block">
           <h1 className="font-heading text-xl font-bold tracking-tight text-foreground">
@@ -130,7 +125,6 @@ export function Navigation({
         </Link>
       </div>
 
-      {/* Navigation Links */}
       <div className="flex-1 overflow-y-auto p-4">
         <div className="space-y-1">
           <NavLink

--- a/packages/ui/src/components/RelationshipTable.tsx
+++ b/packages/ui/src/components/RelationshipTable.tsx
@@ -23,13 +23,11 @@ type AnyListConfig = ListConfig<any>
 
 export interface RelationshipTableProps {
   config: OpenSaasConfig
-  /** The derived section describing this to-many relationship. */
   section: RelationshipTableSection
   /**
    * The parent record's related rows for this relationship, already fetched and
    * access-filtered through the secured context (`context.db` include) and
-   * BOUNDED by the section's `take` (issue #752). Only access-visible rows/fields
-   * are present here, and at most `section.take` of them.
+   * BOUNDED by the section's `take` (issue #752).
    */
   rows: Array<Record<string, unknown>>
   /**
@@ -41,8 +39,8 @@ export interface RelationshipTableProps {
   total: number
   basePath: string
   /**
-   * The access-scoped context, used to evaluate the related list's operation
-   * access so a removal control is only offered when the session may perform it.
+   * The access-scoped context, used to evaluate the related list's own access
+   * (removal, create, and inline-edit gating) — never the parent's.
    */
   context: AccessContext<unknown>
   /** The list being edited (the parent record's list). */
@@ -55,11 +53,8 @@ export interface RelationshipTableProps {
 
 /**
  * Decide which removal control (if any) a row should show (ADR-0018, #739).
- *
- * The configured `removeAction` is the ceiling; operation-level access on the
- * RELATED list is the gate. A hard deny (no update/delete access at all) hides
- * the control — no affordance for what will always fail. A filter result is
- * treated as "potentially allowed", so the control shows and a row-level denial
+ * The configured `removeAction` is the ceiling; {@link isOperationPotentiallyAllowed}
+ * against the RELATED list's operation access is the gate — a denial there
  * surfaces at commit time as a Silent failure (row stays, reason shown).
  */
 async function resolveRemoveMode(
@@ -88,10 +83,10 @@ const NON_EDITABLE_COLUMNS = new Set(['id', 'createdAt', 'updatedAt'])
 /**
  * The subset of columns whose cells may be inline-edited (issue #737, ADR-0018).
  *
- * Gating mirrors #738/#739: the RELATED list's own operation-level update access
- * is the table gate — a hard deny yields no editable cells, so a fully
- * update-denied table stays read-only. Each column is then editable only when it
- * is a writable scalar field of the related list, EXCLUDING:
+ * The RELATED list's own operation-level update access
+ * ({@link isOperationPotentiallyAllowed}) is the table gate — a hard deny yields
+ * no editable cells. Each column is then editable only when it is a writable
+ * scalar field of the related list, EXCLUDING:
  * - relationship columns (relationship editing is out of scope here — they render
  *   as `{ id, label }` and stay read-only),
  * - virtual/computed fields (not stored; nothing to write),
@@ -99,12 +94,10 @@ const NON_EDITABLE_COLUMNS = new Set(['id', 'createdAt', 'updatedAt'])
  *   `draft === displayValue` guard never holds and an unchanged cell would waste
  *   a round-trip; they also need a proper structured editor — out of scope here),
  * - password fields and system columns (`id`/`createdAt`/`updatedAt`),
- * - any field whose UPDATE field-access is statically denied.
+ * - any field whose UPDATE field-access is statically denied
+ *   ({@link isFieldPotentiallyWritable}).
  *
- * A field-access rule that returns a filter or depends on the row is treated as
- * "potentially writable": the affordance shows and a row-level denial surfaces at
- * commit as a revert (never a denied-vs-absent leak). All evaluation is on the
- * related list's own access — never the parent's.
+ * All evaluation is on the related list's own access — never the parent's.
  */
 export async function resolveEditableColumns(
   section: RelationshipTableSection,
@@ -149,11 +142,8 @@ interface CreateFormData {
  * Gating (ADR-0018): the "+ Add" is shown only when
  * - a back-reference field exists to preset the link (list-only refs have none,
  *   so cannot be pre-linked and are excluded — mirroring #739's disconnect), and
- * - the RELATED list's own `create` access is not statically denied. A hard deny
- *   (no create rule, or `create` returns `false`) hides the control — no
- *   affordance for what will always fail. A filter/function result is
- *   "potentially allowed", so the control shows and a row-level denial surfaces
- *   at commit time as a Silent failure (generic reason, no denied-vs-absent leak).
+ * - the RELATED list's own `create` access is not statically denied
+ *   ({@link isOperationPotentiallyAllowed}).
  *
  * The create form is the related list's fields with the back-reference removed —
  * it is preset + hidden, set on the server from the parent id — so the drawer
@@ -263,16 +253,8 @@ export async function RelationshipTable({
   const relatedListConfig = config.lists[section.relatedListKey]
   const relatedUrlKey = getUrlKey(section.relatedListKey)
 
-  // Which removal control (if any) this table's rows may show, gated on the
-  // related list's own operation access (never the parent's).
   const removeMode = await resolveRemoveMode(section, relatedListConfig, context)
-
-  // The pre-linked create drawer (#738), gated on the related list's own create
-  // access (never the parent's) and the presence of a back-reference to preset.
   const createForm = await resolveCreateForm(section, relatedListConfig, config, context)
-
-  // Which columns may be inline-edited (#737), gated on the related list's own
-  // operation- and field-level update access (never the parent's).
   const editableColumns = await resolveEditableColumns(section, relatedListConfig, context)
 
   // The related list config for each relationship column, keyed by column, so

--- a/packages/ui/src/components/RelationshipTableCell.tsx
+++ b/packages/ui/src/components/RelationshipTableCell.tsx
@@ -10,9 +10,7 @@ import type { SerializableFieldConfig } from '../lib/serializeFieldConfig.js'
 import type { ServerActionInput } from '../server/types.js'
 
 export interface RelationshipTableCellProps {
-  /** The related row's id — the update target through the secured context. */
   rowId: string
-  /** The column (field) name being rendered/edited. */
   column: string
   /** The access-filtered, JSON-serialisable current value for this cell. */
   value: unknown
@@ -227,7 +225,6 @@ export function RelationshipTableCell({
       <div
         ref={editorRef}
         data-slot="relationship-table-cell-editor"
-        // Keep edit interactions inside the cell — never navigate the row.
         onClick={(event) => event.stopPropagation()}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
@@ -242,8 +239,8 @@ export function RelationshipTableCell({
         }}
         onBlur={(event) => {
           const next = event.relatedTarget
-          // Focus staying inside the editor (or moving into an overlay the
-          // editor opened, e.g. a select dropdown) is not a commit.
+          // Neither counts as a commit: focus is still inside the editor, or
+          // moved into an overlay it opened (see isInOverlay above).
           if (editorRef.current && next instanceof Node && editorRef.current.contains(next)) return
           if (isInOverlay(next)) return
           void commit()
@@ -277,7 +274,6 @@ export function RelationshipTableCell({
           numeric ? 'text-right' : 'text-left',
         )}
         onClick={(event) => {
-          // Edit in place instead of navigating the row.
           event.stopPropagation()
           startEdit()
         }}

--- a/packages/ui/src/components/RelationshipTableClient.tsx
+++ b/packages/ui/src/components/RelationshipTableClient.tsx
@@ -102,10 +102,8 @@ export interface RelationshipTableClientProps {
 }
 
 /**
- * The footer's "showing N of M" label (issue #752): N is the rendered
- * (bounded) row count, M the full access-scoped total. When no total is
- * supplied M falls back to N, so the row count is ALWAYS shown — a bounded
- * table reads "Showing 10 of 42 rows", an unbounded one "Showing 3 of 3 rows".
+ * The footer's "showing N of M" label (issue #752). When `total` is omitted it
+ * falls back to `count`, so the row count is always shown (e.g. "Showing 3 of 3 rows").
  */
 export function formatCountLabel(count: number, total: number | undefined): string {
   const m = total ?? count
@@ -256,7 +254,6 @@ export function RelationshipTableClient({
     <Card data-slot="relationship-table" className="overflow-hidden">
       <div className="flex items-center justify-between gap-2 border-b border-border p-4">
         <h2 className="font-heading text-lg font-semibold">{title}</h2>
-        {/* Seam: the pre-linked create drawer's "+ Add" control (#738) mounts here. */}
         <div data-slot="relationship-table-toolbar" className="flex items-center gap-2">
           {canCreate && createFields && (
             <RelationshipCreateDrawer
@@ -322,9 +319,6 @@ export function RelationshipTableClient({
                         data-slot="relationship-table-cell"
                         className={cn(numeric && 'text-right')}
                       >
-                        {/* Inline cell edit (#737): editable columns commit a
-                            single-field update through the secured context; the
-                            rest render a read-only Cell (and the row navigates). */}
                         <RelationshipTableCell
                           rowId={rowId}
                           column={column}
@@ -414,7 +408,6 @@ export function RelationshipTableClient({
         </TableFooter>
       </Table>
 
-      {/* Delete opt-in requires a confirmation before the destructive action. */}
       <ConfirmDialog
         isOpen={confirmId !== null}
         title={`Delete ${title} row`}

--- a/packages/ui/src/components/RowSelectionBar.tsx
+++ b/packages/ui/src/components/RowSelectionBar.tsx
@@ -107,7 +107,6 @@ export function RowSelectionBar({
       </span>
 
       <div className="flex items-center gap-2">
-        {/* Seam for #736: list-specific Bulk actions render here. */}
         <div
           data-slot="selection-actions"
           className={cn('flex items-center gap-2', classNames?.actions)}

--- a/packages/ui/src/components/SingletonView.tsx
+++ b/packages/ui/src/components/SingletonView.tsx
@@ -12,7 +12,7 @@ export interface SingletonViewProps {
   config: OpenSaasConfig
   listKey: string
   basePath?: string
-  // Server action can return any shape depending on the list item type
+  // See AdminUIProps.serverAction for why this is Promise<unknown>.
   serverAction: (input: ServerActionInput) => Promise<unknown>
 }
 
@@ -39,8 +39,6 @@ export interface SingletonViewProps {
  * An update-denied singleton still renders the edit form (the happy path), but
  * the save fails gracefully: the server action's `update` access check returns
  * a denied envelope, which `ItemFormClient` surfaces as an error.
- *
- * Server Component that fetches data and sets up actions.
  */
 export async function SingletonView({
   context,
@@ -63,10 +61,8 @@ export async function SingletonView({
     )
   }
 
-  // Resolve the singleton record. `get()` auto-creates with field defaults when
-  // absent (the default), so a record is the common case. It returns null when
-  // either `autoCreate: false` with no row yet, OR `query` access is denied —
-  // these are indistinguishable here, so we disambiguate via access below.
+  // Resolve the singleton record; see the docblock above for what a null
+  // `get()` means and how the branches below disambiguate it.
   let record: Record<string, unknown> | null = null
   try {
     const delegate = context.db[getDbKey(listKey)]
@@ -78,8 +74,7 @@ export async function SingletonView({
   }
 
   if (!record) {
-    // A null `get()` is ambiguous (autoCreate:false-empty vs query-denied).
-    // Evaluate operation access to choose the safe affordance.
+    // Disambiguate via operation-level access (see docblock).
     const accessArgs = { session: context.session, context }
     const canQuery = await isOperationPotentiallyAllowed(
       listConfig.access?.operation,
@@ -87,8 +82,6 @@ export async function SingletonView({
       accessArgs,
     )
 
-    // Query denied → the session cannot read this singleton at all. Show a
-    // friendly message; never an editable/create form.
     if (!canQuery) {
       return (
         <div className="p-8 max-w-4xl">
@@ -102,8 +95,6 @@ export async function SingletonView({
       )
     }
 
-    // Query allowed but no row → an `autoCreate: false` singleton. Offer a
-    // create-on-first-save form only when `create` is actually permitted.
     const canCreate = await isOperationPotentiallyAllowed(
       listConfig.access?.operation,
       'create',
@@ -123,10 +114,9 @@ export async function SingletonView({
       )
     }
 
-    // Create-on-first-save: render the form in create mode with an empty record.
-    // The save goes through the existing `serverAction` create path; core
-    // assigns the singleton `id` (always `1`) and enforces the single-record
-    // constraint, so the form sends only the user-entered field data.
+    // Core assigns the singleton `id` (always `1`) and enforces the
+    // single-record constraint on create, so the form sends only the
+    // user-entered field data.
     const {
       serializableFields: createFields,
       initialData: createInitialData,
@@ -142,7 +132,6 @@ export async function SingletonView({
           title={`Create ${formatListName(listKey)}`}
         />
 
-        {/* Create-on-first-save form */}
         <div className="bg-card border border-border rounded-lg p-6">
           <ItemFormClient
             listKey={listKey}
@@ -173,14 +162,12 @@ export async function SingletonView({
 
   return (
     <div className="p-8 max-w-4xl">
-      {/* A singleton has no list view, so link back to the dashboard. */}
       <PageHeader
         backHref={basePath}
         backLabel="Back to dashboard"
         title={`Edit ${formatListName(listKey)}`}
       />
 
-      {/* Form */}
       <div className="bg-card border border-border rounded-lg p-6">
         <ItemFormClient
           listKey={listKey}

--- a/packages/ui/src/components/SkeletonLoader.tsx
+++ b/packages/ui/src/components/SkeletonLoader.tsx
@@ -5,9 +5,6 @@ export interface SkeletonLoaderProps {
   variant?: 'text' | 'circular' | 'rectangular'
 }
 
-/**
- * Skeleton loader component for content placeholders
- */
 export function SkeletonLoader({ className, variant = 'rectangular' }: SkeletonLoaderProps) {
   const variantClasses = {
     text: 'h-4 rounded',
@@ -67,9 +64,6 @@ export function TableSkeleton({ rows = 5, columns = 4 }: { rows?: number; column
   )
 }
 
-/**
- * Form skeleton loader
- */
 export function FormSkeleton({ fields = 4 }: { fields?: number }) {
   return (
     <div className="bg-card border border-border rounded-lg p-6">

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -16,7 +16,6 @@ export interface ThemeToggleProps {
   className?: string
 }
 
-// Cycle order for the single-button control: light → dark → system → light.
 const NEXT_CHOICE: Record<ThemeChoice, ThemeChoice> = {
   light: 'dark',
   dark: 'system',

--- a/packages/ui/src/components/UserMenu.tsx
+++ b/packages/ui/src/components/UserMenu.tsx
@@ -10,10 +10,6 @@ export interface UserMenuProps {
   onSignOut?: () => Promise<void>
 }
 
-/**
- * User menu component with sign-out button
- * Client Component
- */
 export function UserMenu({ userName, userEmail, onSignOut }: UserMenuProps) {
   const router = useRouter()
 

--- a/packages/ui/src/components/cells/AvatarLabelCell.tsx
+++ b/packages/ui/src/components/cells/AvatarLabelCell.tsx
@@ -5,6 +5,10 @@ import { Avatar } from '../../primitives/avatar.js'
 import type { CellComponentProps } from './registry.js'
 
 /**
+ * Renders an avatar bubble beside the label, opted into via `ui.avatar` on the
+ * label column (a per-field `ui.cell` override still takes priority). Slot:
+ * `cell-avatar-label`.
+ *
  * The bubble is rendered `decorative` (hidden from the accessibility tree): the
  * emphasized label text beside it already conveys the row's identity, so the
  * cell's accessible name stays exactly the label — not "AL Ada Lovelace" — which

--- a/packages/ui/src/components/cells/AvatarLabelCell.tsx
+++ b/packages/ui/src/components/cells/AvatarLabelCell.tsx
@@ -5,17 +5,6 @@ import { Avatar } from '../../primitives/avatar.js'
 import type { CellComponentProps } from './registry.js'
 
 /**
- * Avatar label Cell (issue #735) — the opt-in rendering of a list's label
- * column: an initials {@link Avatar} bubble ahead of the emphasized Item label.
- * Both the initials and the bubble colour derive deterministically from the
- * label value, so a row looks the same everywhere it appears.
- *
- * This Cell is applied to the label column only when the list opts in via
- * `ui.avatar`; a per-field cell override still wins (the caller routes to the
- * override first). An empty label degrades to a neutral bubble plus a muted
- * dash, matching the plain text Cell's empty rendering. Slot:
- * `cell-avatar-label`.
- *
  * The bubble is rendered `decorative` (hidden from the accessibility tree): the
  * emphasized label text beside it already conveys the row's identity, so the
  * cell's accessible name stays exactly the label — not "AL Ada Lovelace" — which

--- a/packages/ui/src/components/cells/CellRenderer.tsx
+++ b/packages/ui/src/components/cells/CellRenderer.tsx
@@ -4,11 +4,6 @@ import * as React from 'react'
 import { getCellComponent, type CellComponent, type CellComponentProps } from './registry.js'
 import { TextCell } from './TextCell.js'
 
-/**
- * Internal component that renders the already-resolved Cell. Resolving in the
- * outer factory and rendering here (Cell arrives as a prop) mirrors
- * `FieldRenderer`, keeping the resolved component out of this scope's render.
- */
 function CellRendererInner({
   Component,
   ...props
@@ -18,15 +13,8 @@ function CellRendererInner({
 
 /**
  * Resolves and renders the Cell for one field value, mirroring `FieldRenderer`'s
- * form-component resolution priority exactly:
- *
- * 1. `field.ui.cell` — per-field override (highest priority)
- * 2. `field.ui.fieldType` — custom type lookup in the cell registry
- * 3. `field.type` — default field-type lookup in the cell registry
- * 4. {@link TextCell} — plain-text fallback (unknown/third-party types)
- *
- * The resolution delegates to each field type's registered Cell — there is no
- * switch on field type here, matching the field-builder self-containment rule.
+ * form-component resolution priority. No switch on field type here, matching
+ * the field-builder self-containment rule.
  */
 export function CellRenderer(props: CellComponentProps) {
   const { field } = props

--- a/packages/ui/src/components/cells/CheckboxCell.tsx
+++ b/packages/ui/src/components/cells/CheckboxCell.tsx
@@ -4,12 +4,6 @@ import * as React from 'react'
 import { Check, Minus } from 'lucide-react'
 import type { CellComponentProps } from './registry.js'
 
-/**
- * Checkbox Cell — renders a mark rather than raw text: a check for `true`, a
- * muted dash for `false`. The boolean is preserved as an accessible name
- * (`Yes`/`No`) so screen readers and tests can read the state. Slot:
- * `cell-checkbox`.
- */
 export function CheckboxCell({ value }: CellComponentProps) {
   if (value) {
     return (

--- a/packages/ui/src/components/cells/IntegerCell.tsx
+++ b/packages/ui/src/components/cells/IntegerCell.tsx
@@ -4,11 +4,7 @@ import * as React from 'react'
 import { cn } from '../../lib/utils.js'
 import type { CellComponentProps } from './registry.js'
 
-/**
- * Numeric Cell — renders in tabular figures so digits line up down the column.
- * Right alignment is applied by the table cell (the numeric column). Slot:
- * `cell-integer`.
- */
+// Right alignment is applied by the table cell (the numeric column), not here.
 export function IntegerCell({ value }: CellComponentProps) {
   if (value === null || value === undefined) {
     return (

--- a/packages/ui/src/components/cells/RelationshipCell.tsx
+++ b/packages/ui/src/components/cells/RelationshipCell.tsx
@@ -7,8 +7,8 @@ import type { CellComponentProps } from './registry.js'
 
 /**
  * One related row's `{ id, label }`. The label is normally resolved server-side
- * via the shared label seam (`getItemLabel`); the raw-record fallback
- * (`name` → `title` → `label` → `id`) covers callers that pass unresolved rows.
+ * via the shared label seam (`getItemLabel`); the fallback here covers callers
+ * that pass unresolved rows.
  */
 interface RelatedRef {
   id: string | null
@@ -33,18 +33,11 @@ function EmptyDash() {
 }
 
 /**
- * Relationship Cell (issue #732):
- *
- * - **To-many** (`field.many`) renders the access-visible related COUNT — a
- *   right-aligned tabular number the list view resolves via the secured query's
- *   filtered `_count`, so it only ever counts rows the session may see. Slot:
- *   `cell-relationship-count`.
- * - **To-one** renders the related row's Item label, linked to its edit page
- *   when the field's `ref` (and `basePath`) resolve a URL. Slot:
- *   `cell-relationship`.
- *
- * A to-many value is normally the resolved count (a number); an array of
- * resolved refs is tolerated as a fallback (its length is the count).
+ * Relationship Cell (issue #732). To-many renders the related COUNT — resolved
+ * server-side via the secured query's filtered `_count`, so it only ever counts
+ * rows the session may see; an array of refs is tolerated as a fallback (its
+ * length is the count). To-one renders the related row's Item label, linked to
+ * its edit page when the field's `ref` resolves a URL.
  */
 export function RelationshipCell({ value, field, basePath = '/admin' }: CellComponentProps) {
   if (field.many === true) {

--- a/packages/ui/src/components/cells/SelectCell.tsx
+++ b/packages/ui/src/components/cells/SelectCell.tsx
@@ -5,19 +5,8 @@ import type { SelectOptionVariant } from '@opensaas/stack-core/fields'
 import { Badge } from '../../primitives/badge.js'
 import type { CellComponentProps } from './registry.js'
 
-/**
- * Neutral badge variant used when an option carries no `ui.variant` metadata.
- * State stays scannable even before a project colours its options.
- */
 const NEUTRAL_VARIANT: SelectOptionVariant = 'secondary'
 
-/**
- * Select Cell — renders a value as a coloured status Badge. The colour comes
- * from the matched option's additive `ui.variant` metadata (issue #729);
- * unmapped options (and unknown values) fall back to the neutral badge. The
- * option's `label` is shown, matching the field's read-mode rendering. Slot:
- * `cell-select`.
- */
 export function SelectCell({ value, field }: CellComponentProps) {
   if (value === null || value === undefined || value === '') {
     return (

--- a/packages/ui/src/components/cells/TextCell.tsx
+++ b/packages/ui/src/components/cells/TextCell.tsx
@@ -3,11 +3,6 @@
 import * as React from 'react'
 import type { CellComponentProps } from './registry.js'
 
-/**
- * Plain-text Cell — the default rendering for text fields and the fallback for
- * any field type without a registered Cell. Renders a muted dash for
- * empty values. Slot: `cell-text`.
- */
 export function TextCell({ value }: CellComponentProps) {
   if (value === null || value === undefined || value === '') {
     return (

--- a/packages/ui/src/components/cells/TimestampCell.tsx
+++ b/packages/ui/src/components/cells/TimestampCell.tsx
@@ -17,10 +17,6 @@ function toDate(value: unknown): Date | null {
   return null
 }
 
-/**
- * Timestamp Cell — renders a humanly-formatted local date/time. Slot:
- * `cell-timestamp`.
- */
 export function TimestampCell({ value }: CellComponentProps) {
   const date = toDate(value)
   if (date === null) {

--- a/packages/ui/src/components/cells/registry.ts
+++ b/packages/ui/src/components/cells/registry.ts
@@ -8,11 +8,9 @@ import { TimestampCell } from './TimestampCell.js'
 import { RelationshipCell } from './RelationshipCell.js'
 
 /**
- * Props every Cell component receives. A Cell is the list-table rendering of
- * one field's value (see `CONTEXT.md` — "Cell"). Props are deliberately
- * serialisable — `value` is the JSON-safe, access-filtered field value and
- * `field` is the serialised field config — so Cells stay drop-in for the
- * server-driven list view.
+ * Props every Cell component receives — the list-table rendering of one
+ * field's value (see `CONTEXT.md` — "Cell"). Kept serialisable so Cells stay
+ * drop-in for the server-driven list view.
  */
 export type CellComponentProps = {
   /** The access-filtered, JSON-serialisable field value for this row. */
@@ -33,10 +31,10 @@ export type CellComponentProps = {
 export type CellComponent = ComponentType<CellComponentProps>
 
 /**
- * Registry mapping field types to their default Cell components — the
- * field-type layer of the resolution chain. Mirrors `fieldComponentRegistry`
- * for form fields; extend it with {@link registerCellComponent} exactly the
- * same way a third-party field registers its form component.
+ * Registry mapping field types to their default Cell components. Mirrors
+ * `fieldComponentRegistry` for form fields; extend it with
+ * {@link registerCellComponent} exactly the same way a third-party field
+ * registers its form component.
  */
 const cellComponentRegistry: Record<string, CellComponent> = {
   text: TextCell,
@@ -55,18 +53,12 @@ const cellComponentRegistry: Record<string, CellComponent> = {
  * Register a default Cell component for a field type. A third-party field
  * package calls this to make its values render correctly in tables, exactly as
  * it calls `registerFieldComponent` for its form component.
- *
- * @param fieldType - The field type identifier
- * @param component - A Cell component accepting {@link CellComponentProps}
  */
 export function registerCellComponent(fieldType: string, component: CellComponent): void {
   cellComponentRegistry[fieldType] = component
 }
 
-/**
- * Get the Cell component registered for a field type, or `undefined` when none
- * is registered (the caller falls back to plain text).
- */
+/** Cell component registered for `fieldType`, or `undefined` (the caller falls back to plain text). */
 export function getCellComponent(fieldType: string): CellComponent | undefined {
   return cellComponentRegistry[fieldType]
 }

--- a/packages/ui/src/components/fields/ComboboxField.tsx
+++ b/packages/ui/src/components/fields/ComboboxField.tsx
@@ -68,7 +68,6 @@ export function ComboboxField({
     ? (resolveLabel(value) ?? items.find((item) => item.id === value)?.label)
     : undefined
 
-  // Read mode
   if (mode === 'read') {
     return (
       <FieldRoot mode="read">

--- a/packages/ui/src/components/fields/FieldRenderer.tsx
+++ b/packages/ui/src/components/fields/FieldRenderer.tsx
@@ -24,9 +24,6 @@ export interface FieldRendererProps {
   serverAction?: (input: ServerActionInput) => Promise<unknown>
 }
 
-/**
- * Internal component that receives the resolved Component
- */
 function FieldRendererInner({
   Component,
   fieldName,
@@ -52,7 +49,6 @@ function FieldRendererInner({
       ? ((fieldConfig as Record<string, unknown>).validation as Record<string, unknown>).isRequired
       : false
 
-  // Build props based on field type
   const baseProps = {
     name: fieldName,
     value,
@@ -64,7 +60,6 @@ function FieldRendererInner({
     mode,
   }
 
-  // Derive field-type-specific props from data-presence checks — no branching on fieldConfig.type.
   const specificProps: Record<string, unknown> = buildFallbackUIProps(
     fieldConfig,
     relationshipItems,
@@ -74,7 +69,6 @@ function FieldRendererInner({
     serverAction,
   )
 
-  // Pass through any UI options from fieldConfig.ui (excluding component and fieldType)
   if (fieldConfig.ui) {
     const {
       component: _component,
@@ -83,9 +77,8 @@ function FieldRendererInner({
       ...uiOptions
     } = fieldConfig.ui
     Object.assign(specificProps, uiOptions)
-    // Surface the field's help/description text to the component as `helpText`
-    // (rendered through the shared field-shell `FieldHelp`). Config exposes this
-    // as `ui.description` (Keystone-aligned); the component prop is `helpText`.
+    // Config exposes help/description text as `ui.description` (Keystone-aligned);
+    // the component prop is `helpText`.
     if (description !== undefined && specificProps.helpText === undefined) {
       specificProps.helpText = description
     }
@@ -109,12 +102,10 @@ function buildFallbackUIProps(
 ): Record<string, unknown> {
   const props: Record<string, unknown> = {}
 
-  // Select options — only present on select fields
   if (fieldConfig.options) {
     props.options = fieldConfig.options
   }
 
-  // Relationship props — only present on relationship fields
   if (fieldConfig.ref) {
     const [relatedListName] = fieldConfig.ref.split('.')
     props.relatedListKey = getUrlKey(relatedListName ?? '')
@@ -132,24 +123,15 @@ function buildFallbackUIProps(
   return props
 }
 
-/**
- * Factory component that renders the appropriate field type
- * based on the field configuration and component registry
- */
 export function FieldRenderer(props: FieldRendererProps) {
   const { fieldName, fieldConfig, mode = 'edit' } = props
 
   const label = (fieldConfig as Record<string, unknown>).label || formatFieldName(fieldName)
 
-  // Skip rendering ID and timestamp fields in forms
   if (mode === 'edit' && ['id', 'createdAt', 'updatedAt'].includes(fieldName)) {
     return null
   }
 
-  // Get component from:
-  // 1. Per-field component override (ui.component)
-  // 2. Custom field type override (ui.fieldType) - uses global registry
-  // 3. Default field type (fieldConfig.type) - uses global registry
   const Component =
     fieldConfig.ui?.component ||
     (fieldConfig.ui?.fieldType
@@ -166,10 +148,8 @@ export function FieldRenderer(props: FieldRendererProps) {
     )
   }
 
-  // A virtual field is computed and never writable — force read-only
-  // presentation regardless of the requested mode (issue #821). This is a
-  // display-only guard: it never skips rendering (unlike id/createdAt/
-  // updatedAt above), it just never offers an editable input.
+  // Virtual fields are computed and unwritable — force read-only regardless of
+  // requested mode (issue #821; see `VirtualField`'s defence-in-depth doc).
   const effectiveMode = fieldConfig.virtual ? 'read' : mode
 
   return <FieldRendererInner {...props} mode={effectiveMode} Component={Component} />

--- a/packages/ui/src/components/fields/FileField.tsx
+++ b/packages/ui/src/components/fields/FileField.tsx
@@ -21,9 +21,7 @@ export interface FileFieldProps {
 }
 
 /**
- * File upload field with drag-and-drop support
- *
- * Stores File objects in form state. The actual upload happens server-side
+ * Stores File objects in form state — the actual upload happens server-side
  * during form submission via field hooks.
  */
 export function FileField({
@@ -42,8 +40,6 @@ export function FileField({
 
   const handleFileSelect = useCallback(
     (file: File) => {
-      // Store File object in form state
-      // Upload will happen server-side during form submission
       onChange(file)
     },
     [onChange],
@@ -88,7 +84,6 @@ export function FileField({
     onChange(null)
   }, [onChange])
 
-  // Determine if value is File or FileMetadata
   // Use duck typing instead of instanceof to support SSR
   const isFile =
     value &&
@@ -97,7 +92,6 @@ export function FileField({
     typeof (value as { arrayBuffer?: unknown }).arrayBuffer === 'function'
   const isFileMetadata = value && !isFile && typeof value === 'object' && 'url' in value
 
-  // Read-only mode
   if (mode === 'read') {
     return (
       <FieldRoot mode="read">
@@ -133,7 +127,6 @@ export function FileField({
     )
   }
 
-  // Edit mode
   return (
     <FieldRoot>
       {label && (
@@ -143,7 +136,6 @@ export function FileField({
       )}
 
       {isFile || isFileMetadata ? (
-        // File selected/uploaded - show file info
         <div className="flex items-center gap-2 p-3 border rounded-md">
           <Check className="h-4 w-4 text-success" />
           <div className="flex-1 min-w-0">
@@ -177,7 +169,6 @@ export function FileField({
           </Button>
         </div>
       ) : (
-        // No file - show upload area
         <>
           <div
             className={`

--- a/packages/ui/src/components/fields/ImageField.tsx
+++ b/packages/ui/src/components/fields/ImageField.tsx
@@ -111,7 +111,6 @@ export function ImageField({
     typeof (value as { arrayBuffer?: unknown }).arrayBuffer === 'function'
   const isImageMetadata = value && !isFile && typeof value === 'object' && 'url' in value
 
-  // Read-only mode
   if (mode === 'read') {
     return (
       <FieldRoot mode="read">
@@ -176,7 +175,6 @@ export function ImageField({
     )
   }
 
-  // Edit mode
   return (
     <FieldRoot>
       {label && (
@@ -186,7 +184,6 @@ export function ImageField({
       )}
 
       {previewUrl || isImageMetadata ? (
-        // Image selected/uploaded or preview available - show preview
         <div className="space-y-2">
           <div className="relative inline-block group">
             <Image
@@ -270,7 +267,6 @@ export function ImageField({
           )}
         </div>
       ) : (
-        // No image - show upload area
         <>
           <div
             className={`

--- a/packages/ui/src/components/fields/ImageField.tsx
+++ b/packages/ui/src/components/fields/ImageField.tsx
@@ -24,10 +24,8 @@ export interface ImageFieldProps {
 }
 
 /**
- * Image upload field with preview, drag-and-drop, and transformation support
- *
- * Stores File objects in form state with client-side preview. The actual upload
- * happens server-side during form submission via field hooks.
+ * Stores File objects in form state with a client-side preview — the actual
+ * upload happens server-side during form submission via field hooks.
  */
 export function ImageField({
   name,
@@ -48,12 +46,10 @@ export function ImageField({
 
   const handleFileSelect = useCallback(
     (file: File) => {
-      // Validate file is an image
       if (!file.type.startsWith('image/')) {
         return
       }
 
-      // Generate client-side preview
       if (showPreview) {
         const reader = new FileReader()
         reader.onload = (e) => {
@@ -62,8 +58,6 @@ export function ImageField({
         reader.readAsDataURL(file)
       }
 
-      // Store File object in form state
-      // Upload will happen server-side during form submission
       onChange(file)
     },
     [onChange, showPreview],
@@ -109,7 +103,6 @@ export function ImageField({
     setPreviewUrl(null)
   }, [onChange])
 
-  // Determine if value is File or ImageMetadata
   // Use duck typing instead of instanceof to support SSR
   const isFile =
     value &&

--- a/packages/ui/src/components/fields/JsonField.tsx
+++ b/packages/ui/src/components/fields/JsonField.tsx
@@ -34,11 +34,9 @@ export function JsonField({
   formatted = true,
   helpText,
 }: JsonFieldProps) {
-  // Track the string being edited separately from the prop value
   const [editingValue, setEditingValue] = useState<string | null>(null)
   const [parseError, setParseError] = useState<string | undefined>()
 
-  // Compute the display value - either what's being edited or the prop value
   const displayValue = useMemo(() => {
     if (editingValue !== null) {
       return editingValue
@@ -55,9 +53,7 @@ export function JsonField({
   const handleChange = (text: string) => {
     setEditingValue(text)
 
-    // Try to parse and update value
     if (text.trim() === '') {
-      // Empty string - treat as null/undefined
       onChange(undefined)
       setParseError(undefined)
       return
@@ -68,7 +64,7 @@ export function JsonField({
       onChange(parsed)
       setParseError(undefined)
     } catch (e) {
-      // Invalid JSON - set error but don't update value
+      // Invalid JSON: leave the last valid value uncommitted instead of clobbering it.
       if (e instanceof Error) {
         setParseError(`Invalid JSON: ${e.message}`)
       } else {
@@ -78,7 +74,6 @@ export function JsonField({
   }
 
   const handleBlur = () => {
-    // Clear editing state on blur
     setEditingValue(null)
   }
 

--- a/packages/ui/src/components/fields/PasswordField.tsx
+++ b/packages/ui/src/components/fields/PasswordField.tsx
@@ -33,7 +33,6 @@ export function PasswordField({
   showConfirm = true,
   helpText,
 }: PasswordFieldProps) {
-  // Check if value is the isSet object
   const isSetObject = typeof value === 'object' && value !== null && 'isSet' in value
   const isPasswordSet = isSetObject ? value.isSet : false
 
@@ -51,7 +50,6 @@ export function PasswordField({
     )
   }
 
-  // If not changing password and it's set, show the button
   if (!isChangingPassword && isSetObject) {
     return (
       <FieldRoot>
@@ -81,7 +79,6 @@ export function PasswordField({
     setPasswordValue('')
     setConfirmValue('')
     setShowPassword(false)
-    // Reset to the isSet object
     if (isSetObject) {
       onChange(value)
     }
@@ -89,7 +86,6 @@ export function PasswordField({
 
   const handlePasswordChange = (newValue: string) => {
     setPasswordValue(newValue)
-    // Update the parent with the actual password string
     onChange(newValue || undefined)
   }
 

--- a/packages/ui/src/components/fields/RelationshipField.tsx
+++ b/packages/ui/src/components/fields/RelationshipField.tsx
@@ -41,7 +41,6 @@ export function RelationshipField({
   listKey,
   serverAction,
 }: RelationshipFieldProps) {
-  // Delegate to specialized components based on cardinality
   if (many) {
     return (
       <RelationshipManager

--- a/packages/ui/src/components/fields/RelationshipManager.tsx
+++ b/packages/ui/src/components/fields/RelationshipManager.tsx
@@ -112,7 +112,6 @@ export function RelationshipManager({
   }))
   const availableItems = searchResults.filter((item) => !selectedIds.includes(item.id))
 
-  // Read mode
   if (mode === 'read') {
     return (
       <FieldRoot mode="read" data-slot="relationship-manager" className={classNames?.root}>
@@ -142,7 +141,6 @@ export function RelationshipManager({
         {label}
       </FieldLabel>
 
-      {/* Selected Items Table */}
       {selectedItems.length > 0 ? (
         <div
           data-slot="relationship-manager-frame"
@@ -200,7 +198,6 @@ export function RelationshipManager({
         </div>
       )}
 
-      {/* Action Buttons */}
       <div
         data-slot="relationship-manager-actions"
         className={cn('flex gap-2', classNames?.actions)}
@@ -238,9 +235,6 @@ export function RelationshipManager({
             </ComboboxList>
           </ComboboxContent>
         </Combobox>
-
-        {/* Note: "Create New" functionality would require additional props for the related list's fields
-            and form rendering logic. For now, we'll leave it as a placeholder or implement in a future iteration */}
       </div>
 
       {error && <FieldError className={cn('mt-2', classNames?.error)}>{error}</FieldError>}

--- a/packages/ui/src/components/fields/VirtualField.tsx
+++ b/packages/ui/src/components/fields/VirtualField.tsx
@@ -11,8 +11,6 @@ export interface VirtualFieldProps {
 }
 
 /**
- * Format a resolved virtual value for read-only display.
- *
  * A virtual field may declare any `outputType` (e.g. `Decimal`, a plain
  * object) and crosses the server/client boundary through a JSON round-trip,
  * so a non-primitive value must be stringified rather than rendered via

--- a/packages/ui/src/components/fields/field-shell.tsx
+++ b/packages/ui/src/components/fields/field-shell.tsx
@@ -5,19 +5,13 @@ import { Label } from '../../primitives/label.js'
 import { cn } from '../../lib/utils.js'
 
 /**
- * Shared field-shell primitives (issue #709).
+ * Shared field-shell primitives (issue #709). Every field component composes
+ * its label / help / error rhythm from these pieces, and all visual values
+ * resolve through theme tokens — no hardcoded status colours live here or in
+ * any field that uses this shell.
  *
- * Every field component composes its label / help / error rhythm from these
- * pieces so that spacing, typography, and status colours are identical across
- * text, integer, checkbox, select, timestamp, password, relationship, json,
- * image/file, and combobox fields. All visual values resolve through theme
- * tokens — `text-muted-foreground`, `text-destructive`, `text-warning`, and the
- * radius/typography tokens the underlying primitives consume. No hardcoded
- * status colours live here or in any field that uses this shell.
- *
- * These parts carry stable `data-slot` names (`field`, `field-label`,
- * `field-help`, `field-error`, `field-warning`, `field-value`) so a plain-CSS
- * restyle can target them, and every part merges a caller `className` via `cn`.
+ * These parts carry stable `data-slot` names so a plain-CSS restyle can target
+ * them, and every part merges a caller `className` via `cn`.
  */
 
 export interface FieldRootProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/ui/src/components/fields/registry.ts
+++ b/packages/ui/src/components/fields/registry.ts
@@ -56,6 +56,7 @@ export function registerFieldComponent(
   fieldComponentRegistry[fieldType] = component
 }
 
+/** Field component registered for `fieldType`, or `undefined` if none is registered. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getFieldComponent(fieldType: string): ComponentType<any> | undefined {
   return fieldComponentRegistry[fieldType]

--- a/packages/ui/src/components/fields/registry.ts
+++ b/packages/ui/src/components/fields/registry.ts
@@ -12,10 +12,6 @@ import { FileField } from './FileField.js'
 import { ImageField } from './ImageField.js'
 import { VirtualField } from './VirtualField.js'
 
-/**
- * Base props that all field components must accept
- * Field components can extend this with additional field-specific props
- */
 export type FieldComponentProps = {
   name: string
   value: unknown
@@ -28,19 +24,13 @@ export type FieldComponentProps = {
 }
 
 /**
- * Type for field component
- * Field components must accept props that extend FieldComponentProps.
- * The registry uses ComponentType<any> because components have different
- * specific prop types (e.g., value: string vs value: number), but all
- * must include the base FieldComponentProps structure.
+ * Field components have per-type prop shapes (e.g. `value: string` vs
+ * `value: number`), so this widens to accept anything satisfying the base
+ * `FieldComponentProps` shape plus arbitrary extra props — unlike
+ * `CellComponent`, which shares one prop contract and stays strongly typed.
  */
 export type FieldComponent = ComponentType<FieldComponentProps & Record<string, unknown>>
 
-/**
- * Registry mapping field types to their default UI components
- * This can be extended for custom field types
- * Uses ComponentType<any> to allow components with more specific prop types
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fieldComponentRegistry: Record<string, ComponentType<any>> = {
   text: TextField,
@@ -57,13 +47,7 @@ export const fieldComponentRegistry: Record<string, ComponentType<any>> = {
   virtual: VirtualField,
 }
 
-/**
- * Register a custom field component for a field type
- * Useful for adding support for custom field types
- *
- * @param fieldType - The field type identifier
- * @param component - A React component that accepts FieldComponentProps (and optionally additional props)
- */
+/** Register a custom field component for a field type. */
 export function registerFieldComponent(
   fieldType: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,10 +56,6 @@ export function registerFieldComponent(
   fieldComponentRegistry[fieldType] = component
 }
 
-/**
- * Get the component for a field type
- * Returns undefined if no component is registered
- */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getFieldComponent(fieldType: string): ComponentType<any> | undefined {
   return fieldComponentRegistry[fieldType]

--- a/packages/ui/src/components/standalone/DeleteButton.tsx
+++ b/packages/ui/src/components/standalone/DeleteButton.tsx
@@ -35,9 +35,6 @@ export interface DeleteButtonProps {
 }
 
 /**
- * Standalone delete button with confirmation dialog
- * Can be embedded in any custom page
- *
  * @example
  * ```tsx
  * <DeleteButton

--- a/packages/ui/src/components/standalone/ItemCreateForm.tsx
+++ b/packages/ui/src/components/standalone/ItemCreateForm.tsx
@@ -24,9 +24,6 @@ export interface ItemCreateFormProps<TData = Record<string, unknown>> {
 }
 
 /**
- * Standalone form component for creating items
- * Can be embedded in any custom page
- *
  * @example
  * ```tsx
  * <ItemCreateForm
@@ -49,7 +46,6 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
   className,
   classNames,
 }: ItemCreateFormProps<TData>) {
-  // Serialize field configs to remove non-serializable properties
   const serializedFields = useMemo(() => serializeFieldConfigs(fields), [fields])
 
   const {
@@ -78,7 +74,6 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
       onSubmit={handleSubmit}
       className={cn(className, classNames?.root)}
     >
-      {/* General Error */}
       {generalError && (
         <div
           data-slot="form-error"
@@ -91,7 +86,6 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
         </div>
       )}
 
-      {/* Form Fields */}
       <div data-slot="form-fields" className={cn('space-y-6', classNames?.fields)}>
         {editableFields.map(([fieldName, fieldConfig]) => (
           <FieldRenderer
@@ -109,7 +103,6 @@ export function ItemCreateForm<TData = Record<string, unknown>>({
         ))}
       </div>
 
-      {/* Form Actions */}
       <div
         data-slot="form-actions"
         className={cn('flex gap-3 pt-6 mt-6 border-t border-border', classNames?.actions)}

--- a/packages/ui/src/components/standalone/ItemEditForm.tsx
+++ b/packages/ui/src/components/standalone/ItemEditForm.tsx
@@ -116,7 +116,6 @@ export function ItemEditForm<TData = Record<string, unknown>>({
         ))}
       </div>
 
-      {/* Form Actions */}
       <div
         data-slot="form-actions"
         className={cn('flex gap-3 pt-6 mt-6 border-t border-border', classNames?.actions)}

--- a/packages/ui/src/components/standalone/ItemEditForm.tsx
+++ b/packages/ui/src/components/standalone/ItemEditForm.tsx
@@ -26,9 +26,6 @@ export interface ItemEditFormProps<TData = Record<string, unknown>> {
 }
 
 /**
- * Standalone form component for editing items
- * Can be embedded in any custom page
- *
  * @example
  * ```tsx
  * <ItemEditForm
@@ -54,7 +51,6 @@ export function ItemEditForm<TData = Record<string, unknown>>({
   classNames,
   basePath = '/admin',
 }: ItemEditFormProps<TData>) {
-  // Serialize field configs to remove non-serializable properties
   const serializedFields = useMemo(() => serializeFieldConfigs(fields), [fields])
 
   // Apply valueForClientSerialization transformations to initial data
@@ -90,7 +86,6 @@ export function ItemEditForm<TData = Record<string, unknown>>({
       onSubmit={handleSubmit}
       className={cn(className, classNames?.root)}
     >
-      {/* General Error */}
       {generalError && (
         <div
           data-slot="form-error"
@@ -103,7 +98,6 @@ export function ItemEditForm<TData = Record<string, unknown>>({
         </div>
       )}
 
-      {/* Form Fields */}
       <div data-slot="form-fields" className={cn('space-y-6', classNames?.fields)}>
         {editableFields.map(([fieldName, fieldConfig]) => (
           <FieldRenderer

--- a/packages/ui/src/components/standalone/ListTable.tsx
+++ b/packages/ui/src/components/standalone/ListTable.tsx
@@ -71,9 +71,6 @@ export interface ListTableProps {
 }
 
 /**
- * Standalone table component for displaying list data
- * Can be embedded in any custom page
- *
  * @example
  * ```tsx
  * <ListTable
@@ -120,12 +117,10 @@ export function ListTable({
     options: fieldOptions?.[fieldName],
   })
 
-  // Determine which columns to show
   const displayColumns =
     columns ||
     Object.keys(fieldTypes).filter((key) => !['password', 'createdAt', 'updatedAt'].includes(key))
 
-  // Sort items if needed
   const sortedItems = [...items]
   if (sortBy && sortable) {
     sortedItems.sort((a, b) => {

--- a/packages/ui/src/components/standalone/SearchBar.tsx
+++ b/packages/ui/src/components/standalone/SearchBar.tsx
@@ -39,9 +39,6 @@ export interface SearchBarProps {
 }
 
 /**
- * Standalone search bar component
- * Can be embedded in any custom page
- *
  * @example
  * ```tsx
  * <SearchBar

--- a/packages/ui/src/lib/avatar.ts
+++ b/packages/ui/src/lib/avatar.ts
@@ -23,8 +23,8 @@ export const AVATAR_TONES: readonly string[] = [
 export function getInitials(label: string): string {
   const words = label.trim().split(/\s+/).filter(Boolean)
   if (words.length === 0) return '?'
+  // Spread (not indexing) throughout so a multi-byte character (e.g. an emoji) isn't split mid-codepoint.
   if (words.length === 1) {
-    // Spread (not indexing) so a multi-byte character (e.g. an emoji) isn't split mid-codepoint.
     return [...words[0]].slice(0, 2).join('').toUpperCase()
   }
   const first = [...words[0]][0] ?? ''

--- a/packages/ui/src/lib/avatar.ts
+++ b/packages/ui/src/lib/avatar.ts
@@ -20,21 +20,11 @@ export const AVATAR_TONES: readonly string[] = [
   'bg-secondary text-secondary-foreground',
 ]
 
-/**
- * Derive up to two uppercase initials from a label.
- *
- * - Two or more words → first letter of the first and last word (e.g.
- *   "Ada Lovelace" → "AL").
- * - One word → its first two letters (e.g. "opensaas" → "OP").
- * - Empty / whitespace-only → "?" so the bubble never renders blank.
- *
- * Non-letter leading characters (an emoji, a digit) are kept as-is after
- * upper-casing, matching how a person scanning the column would read them.
- */
 export function getInitials(label: string): string {
   const words = label.trim().split(/\s+/).filter(Boolean)
   if (words.length === 0) return '?'
   if (words.length === 1) {
+    // Spread (not indexing) so a multi-byte character (e.g. an emoji) isn't split mid-codepoint.
     return [...words[0]].slice(0, 2).join('').toUpperCase()
   }
   const first = [...words[0]][0] ?? ''

--- a/packages/ui/src/lib/deriveItemView.ts
+++ b/packages/ui/src/lib/deriveItemView.ts
@@ -86,30 +86,20 @@ export interface ItemViewLayout {
  */
 const DEFAULT_EXCLUDED_COLUMNS = new Set(['password', 'createdAt', 'updatedAt'])
 
-/** Read an array of strings from an unknown config value, else `undefined`. */
 function readStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
     ? (value as string[])
     : undefined
 }
 
-/**
- * Read a positive-integer row bound (`ui.itemView.take`) from an unknown config
- * value, falling back to {@link DEFAULT_ITEM_VIEW_TAKE} for anything that is not
- * a positive integer (missing, zero, negative, fractional, or non-numeric) so a
- * malformed override can never disable the bound.
- */
+/** Falls back to {@link DEFAULT_ITEM_VIEW_TAKE} for anything not a positive integer, so a malformed override can't disable the bound. */
 function readPositiveInteger(value: unknown): number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0
     ? value
     : DEFAULT_ITEM_VIEW_TAKE
 }
 
-/**
- * Read a to-many relationship's item-view overrides off its serialisable `ui`
- * config without casting: `ui.itemView` is `unknown` (index-signature) so each
- * property is narrowed at runtime.
- */
+/** `ui.itemView` is `unknown` (index-signature), so each property is narrowed at runtime instead of cast. */
 function readRelationshipItemView(field: FieldConfig): {
   displayMode: 'table' | 'picker'
   columns?: string[]
@@ -151,16 +141,11 @@ function isDisconnectable(
   return backRefField.db?.isNullable !== false
 }
 
-/** Whether a field config is a to-many relationship. */
 function isToManyRelationship(field: FieldConfig): boolean {
   return field.type === 'relationship' && 'many' in field && field.many === true
 }
 
-/**
- * The default columns for a related list's Relationship table: the list's own
- * column curation (`ui.listView.initialColumns`, else all non-system fields),
- * with the back-reference to the parent removed.
- */
+/** The related list's own column curation (`ui.listView.initialColumns`, else all non-system fields), minus the back-reference to the parent. */
 function defaultColumnsFor(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
   relatedListConfig: ListConfig<any> | undefined,
@@ -173,11 +158,7 @@ function defaultColumnsFor(
   return curated.filter((column) => column !== backReferenceField)
 }
 
-/**
- * Reorder sections by the list's `ui.itemView.order` (by relationship field
- * name). Listed fields come first in that order; unlisted sections keep their
- * relative (declaration) order after them.
- */
+/** Reorder sections by `ui.itemView.order`; unlisted sections keep their declaration order after the listed ones. */
 function applyOrder(
   sections: RelationshipTableSection[],
   order: string[] | undefined,

--- a/packages/ui/src/lib/filterBuilderState.ts
+++ b/packages/ui/src/lib/filterBuilderState.ts
@@ -64,9 +64,6 @@ export function queryToState(
         continue
       }
     }
-    // Bare word, unknown field, unsupported operator, or empty value: keep it as
-    // free text so it survives the round-trip (the engine would treat it as free
-    // text anyway).
     freeTokens.push(token)
   }
 

--- a/packages/ui/src/lib/operationAccess.ts
+++ b/packages/ui/src/lib/operationAccess.ts
@@ -1,9 +1,6 @@
 import type { AccessContext, FieldAccess, OperationAccess, Session } from '@opensaas/stack-core'
 import { checkFieldAccess } from '@opensaas/stack-core/internal'
 
-/**
- * The names of the operation-level access checks we evaluate in the UI.
- */
 export type OperationAccessName = 'query' | 'create' | 'update' | 'delete'
 
 /**
@@ -21,14 +18,9 @@ export type OperationAccessName = 'query' | 'create' | 'update' | 'delete'
  * permitted" — the actual operation still runs through the access engine, which
  * re-applies the filter. This helper only decides which affordance to render.
  *
- * Access functions are user-defined and may throw (e.g. they assume a session
- * shape that anonymous requests don't have). A throw is treated as **denied** —
- * the safest outcome, so a misbehaving access function never exposes an
- * editable/create form to a session that might not be allowed.
- *
- * No access function configured for the operation is also treated as denied,
- * matching the core engine's deny-by-default (`checkAccess` returns `false`
- * when `accessControl` is undefined).
+ * Access functions are user-defined and may throw. A throw is treated as
+ * **denied** — the safest outcome, so a misbehaving access function never
+ * exposes an editable/create form to a session that might not be allowed.
  */
 export async function isOperationPotentiallyAllowed(
   access: OperationAccess | undefined,
@@ -42,7 +34,6 @@ export async function isOperationPotentiallyAllowed(
   try {
     const result = await accessControl({
       session: args.session,
-      // The access engine passes the same context through to the function.
       context: args.context,
     })
     // `false` denies; `true` or a filter object both mean "potentially allowed".

--- a/packages/ui/src/lib/prepareItemForm.ts
+++ b/packages/ui/src/lib/prepareItemForm.ts
@@ -34,10 +34,6 @@ export interface PreparedItemForm {
   relationshipData: Record<string, Array<{ id: string; label: string }>>
 }
 
-/**
- * Build the `include` object needed to hydrate relationship fields when
- * fetching an item for editing.
- */
 export function buildRelationshipInclude(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig is generic over TypeInfo
   listConfig: ListConfig<any>,
@@ -66,11 +62,7 @@ export async function prepareItemForm(
   listConfig: ListConfig<any>,
   itemData: Record<string, unknown>,
 ): Promise<PreparedItemForm> {
-  // Fetch a bounded window of relationship options for all relationship
-  // fields via the relationship-options read primitive — this replaces an
-  // unbounded `findMany({})` per field with a scalar-only, take-limited
-  // fetch that always unions the item's currently-selected id(s) so their
-  // label renders even outside the window.
+  // Bounded/projected fetch — see getRelationshipOptions.
   const relationshipData: Record<string, Array<{ id: string; label: string }>> = {}
   const relationshipFields = Object.entries(listConfig.fields).filter(
     ([, fieldConfig]) => (fieldConfig as { type: string }).type === 'relationship',
@@ -100,11 +92,8 @@ export async function prepareItemForm(
     if (result) relationshipData[result[0]] = [...result[1]]
   }
 
-  // Serialize field configs to remove non-serializable properties
   const serializableFields = serializeFieldConfigs(listConfig.fields)
 
-  // Transform relationship data in itemData from objects to IDs for form
-  // Also apply valueForClientSerialization transformation
   const formData = { ...itemData }
   for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
     const fieldConfigAny = fieldConfig as {
@@ -115,15 +104,12 @@ export async function prepareItemForm(
     if (fieldConfigAny.type === 'relationship' && formData[fieldName]) {
       const value = formData[fieldName]
       if (fieldConfigAny.many && Array.isArray(value)) {
-        // Many relationship: extract IDs from array of objects
         formData[fieldName] = value.map((item: Record<string, unknown>) => item.id as string)
       } else if (value && typeof value === 'object' && 'id' in value) {
-        // Single relationship: extract ID from object
         formData[fieldName] = (value as Record<string, unknown>).id as string
       }
     }
 
-    // Apply valueForClientSerialization if defined
     if (
       fieldConfigAny.ui?.valueForClientSerialization &&
       typeof fieldConfigAny.ui.valueForClientSerialization === 'function'
@@ -135,7 +121,6 @@ export async function prepareItemForm(
     }
   }
 
-  // JSON round-trip ensures only serializable data crosses the client boundary
   const initialData = jsonSafeClone(formData)
 
   return { serializableFields, initialData, relationshipData }

--- a/packages/ui/src/lib/serializeFieldConfig.ts
+++ b/packages/ui/src/lib/serializeFieldConfig.ts
@@ -3,10 +3,7 @@ import type { SelectOption } from '@opensaas/stack-core/fields'
 import type { ComponentType } from 'react'
 import type { CellComponent } from '../components/cells/registry.js'
 
-/**
- * Serializable field config for client components
- * Strips out functions and non-serializable properties
- */
+/** The client-safe projection of a `FieldConfig` — see {@link serializeFieldConfig}. */
 export type SerializableFieldConfig = {
   type: string
   label?: string
@@ -45,49 +42,40 @@ export type SerializableFieldConfig = {
 }
 
 /**
- * Extract only serializable properties from a single field config
- * Removes functions (getZodSchema, getPrismaType, getTypeScriptType)
- * and non-serializable properties (access, hooks, typePatch, valueForClientSerialization)
+ * Omits functions (getZodSchema, getPrismaType, getTypeScriptType) and
+ * non-serializable properties (access, hooks, typePatch, valueForClientSerialization).
  */
 export function serializeFieldConfig(fieldConfig: FieldConfig): SerializableFieldConfig {
   const config: SerializableFieldConfig = {
     type: fieldConfig.type,
   }
 
-  // Process ui options, excluding the valueForClientSerialization function
   if (fieldConfig.ui) {
     const { valueForClientSerialization: _valueForClientSerialization, ...serializableUi } =
       fieldConfig.ui
     config.ui = serializableUi
   }
 
-  // Extract label if present
   if ('label' in fieldConfig && fieldConfig.label !== undefined) {
     config.label = fieldConfig.label as string
   }
 
-  // Extract validation if present
   if ('validation' in fieldConfig && fieldConfig.validation !== undefined) {
     config.validation = fieldConfig.validation as SerializableFieldConfig['validation']
   }
 
-  // Extract options for select fields (including additive per-option ui.variant)
   if ('options' in fieldConfig && fieldConfig.options !== undefined) {
     config.options = fieldConfig.options as Array<SelectOption>
   }
 
-  // Extract many for relationship fields
   if ('many' in fieldConfig && fieldConfig.many !== undefined) {
     config.many = fieldConfig.many as boolean
   }
 
-  // Extract ref for relationship fields
   if ('ref' in fieldConfig && fieldConfig.ref !== undefined) {
     config.ref = fieldConfig.ref as string
   }
 
-  // Extract the virtual flag so the client can suppress sort affordances for
-  // computed fields (issue #732).
   if ('virtual' in fieldConfig && fieldConfig.virtual === true) {
     config.virtual = true
   }
@@ -95,11 +83,7 @@ export function serializeFieldConfig(fieldConfig: FieldConfig): SerializableFiel
   return config
 }
 
-/**
- * Extract only serializable properties from field configs
- * Removes functions (getZodSchema, getPrismaType, getTypeScriptType)
- * and non-serializable properties (access, hooks, typePatch)
- */
+/** Same as {@link serializeFieldConfig}, applied to every field in a list's fields map. */
 export function serializeFieldConfigs(
   fields: Record<string, FieldConfig>,
 ): Record<string, SerializableFieldConfig> {

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -24,21 +24,13 @@ export type PresetDefinition = {
 }
 
 /**
- * Preset theme catalog (re-curated for the token vocabulary — issue #707).
+ * Preset theme catalog (issue #707).
  *
- * - `modern` (default) — the restrained, Linear-class direction: low-chroma
- *   neutral surfaces, one saturated brand color used sparingly, the gradient
- *   pair as garnish, quiet muted text, softer radius. It is the SINGLE SOURCE
- *   for the raw `--color-*-light` / `--color-*-dark` defaults in
- *   `styles/globals.css`: the `generate:css` codegen emits that `:root` block
- *   from these values (a test enforces the two are in sync), so they can never
- *   drift. It deliberately omits `radius`/`shadows` and inherits the stylesheet
- *   defaults rather than duplicating them.
- * - `classic` — flat and enterprise-safe: blue primary, no gradient (the pair
- *   collapses to a single color), squared-off radius, and elevation removed
- *   (shadows `none`) so hierarchy comes from crisp borders alone.
- * - `neon` — the high-chroma cyan / purple / pink personality preserved: pink
- *   primary, purple accent, a cyan→pink signature gradient, rounder radius.
+ * `modern` (default) is the SINGLE SOURCE for the raw `--color-*-light` /
+ * `--color-*-dark` defaults in `styles/globals.css`: the `generate:css`
+ * codegen emits that `:root` block from these values (a test enforces the two
+ * stay in sync), so it deliberately omits `radius`/`shadows` and inherits the
+ * stylesheet defaults rather than duplicating them.
  *
  * Values are any valid CSS color string (ADR-0015) — the compiler never parses
  * them, it emits them verbatim.
@@ -99,8 +91,6 @@ export const presetThemes: Record<ThemePreset, PresetDefinition> = {
       gradientFrom: 'oklch(0.62 0.19 264)',
       gradientTo: 'oklch(0.68 0.18 320)',
     },
-    // radius + shadows inherited from styles/globals.css. The colors above are
-    // the source the stylesheet's `--color-*` defaults are generated from.
   },
   classic: {
     // Squared-off corners and no elevation — hierarchy from borders alone.
@@ -235,11 +225,7 @@ function isProduction(): boolean {
   return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
 }
 
-/**
- * Dev-mode guard for the clean break on the color value format. Fires a
- * `console.warn` when a color override is a bare HSL triplet, telling the
- * developer to wrap it in `hsl(...)`. Silent in production.
- */
+/** Dev-only warning when a color override is a bare HSL triplet (the old shadcn format) — silent in production. */
 function warnOnBareTriplet(tokenKey: string, value: string): void {
   if (isProduction()) return
   if (BARE_HSL_TRIPLET.test(value.trim())) {

--- a/packages/ui/src/lib/useItemForm.ts
+++ b/packages/ui/src/lib/useItemForm.ts
@@ -3,9 +3,6 @@
 import { useState, useTransition } from 'react'
 import type { SerializableFieldConfig } from './serializeFieldConfig.js'
 
-/**
- * The action an item form submission represents.
- */
 export type ItemFormAction = 'create' | 'update'
 
 const SYSTEM_FIELDS = ['id', 'createdAt', 'updatedAt']

--- a/packages/ui/src/lib/useRowSelection.ts
+++ b/packages/ui/src/lib/useRowSelection.ts
@@ -141,10 +141,8 @@ function writeIds(storageKey: string, filterKey: string, ids: readonly string[])
 /**
  * Manage row selection for one list view, persisted per `filterKey`.
  *
- * @param listKey - The list being viewed (namespaces the persisted set).
- * @param filterKey - A stable string identifying the active filter. Changing it
- *   reads the selection back as empty; page and sort changes must NOT change it,
- *   so the selection persists while paging.
+ * `filterKey` must NOT change on page/sort changes — only when the filter
+ * itself changes — since changing it reads the selection back as empty.
  */
 export function useRowSelection(listKey: string, filterKey: string): RowSelection {
   const storageKey = storageKeyFor(listKey)

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -2,16 +2,10 @@ import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import type { SerializableFieldConfig } from './serializeFieldConfig.js'
 
-/**
- * Merge Tailwind CSS classes with clsx
- */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-/**
- * Format a list name for display (PascalCase → Title Case)
- */
 export function formatListName(name: string): string {
   return name
     .replace(/([A-Z])/g, ' $1')
@@ -19,9 +13,6 @@ export function formatListName(name: string): string {
     .replace(/^./, (str) => str.toUpperCase())
 }
 
-/**
- * Format a field name for display (camelCase → Title Case)
- */
 export function formatFieldName(name: string): string {
   return name
     .replace(/([A-Z])/g, ' $1')
@@ -35,10 +26,6 @@ export function formatFieldName(name: string): string {
  */
 const NUMERIC_FIELD_TYPES = new Set(['integer', 'float', 'decimal', 'bigint', 'bigInt'])
 
-/**
- * Whether a column of the given field type should be treated as numeric for
- * table alignment (right-aligned cells and headers).
- */
 export function isNumericField(fieldType: string | undefined): boolean {
   return fieldType !== undefined && NUMERIC_FIELD_TYPES.has(fieldType)
 }

--- a/packages/ui/src/primitives/avatar.tsx
+++ b/packages/ui/src/primitives/avatar.tsx
@@ -40,8 +40,6 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
     const initials = getInitials(name ?? '')
     const tone = getAvatarTone(trimmed)
 
-    // Decorative avatars are removed from the a11y tree; labelled avatars expose
-    // the full name as an image role.
     const a11yProps = decorative
       ? ({ 'aria-hidden': true } as const)
       : ({ role: 'img', 'aria-label': trimmed || 'Unknown' } as const)

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -3,12 +3,6 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '../lib/utils.js'
 
-/**
- * Status badge primitive (issue #709). Every intent variant resolves through a
- * theme token — `success`, `warning`, and `destructive` render published /
- * draft / error states with NO hardcoded status colours. Radius comes from the
- * `--radius` token (`rounded-md`) and typography from `font-sans`.
- */
 const badgeVariants = cva(
   'inline-flex items-center gap-1 rounded-md border px-2 py-0.5 font-sans text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -4,10 +4,6 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '../lib/utils.js'
 
-// Restrained default direction (specs/THEMING.md). Every visual value resolves
-// through a theme token: colors (`bg-primary`, `text-*-foreground`, `ring`),
-// radius (`rounded-md`), elevation (`shadow-sm`/`shadow-md` shadow tokens), and
-// typography (`font-sans`). No hardcoded colors, radii, or shadows.
 const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-sans text-sm font-medium transition-[color,background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {

--- a/packages/ui/src/primitives/datetime-picker.tsx
+++ b/packages/ui/src/primitives/datetime-picker.tsx
@@ -27,7 +27,6 @@ export function DateTimePicker({
   const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(value || undefined)
 
   const handleDateSelect = (date: Date) => {
-    // Preserve time if we already have a selected date
     if (selectedDate) {
       date.setHours(selectedDate.getHours())
       date.setMinutes(selectedDate.getMinutes())

--- a/packages/ui/src/server/types.ts
+++ b/packages/ui/src/server/types.ts
@@ -1,12 +1,5 @@
-/**
- * Input for the generic server action
- * Re-exported from @opensaas/stack-core for convenience
- */
 export type { ServerActionProps as ServerActionInput } from '@opensaas/stack-core/internal'
 
-/**
- * Result of a server action
- */
 export interface ActionResult<T = Record<string, unknown>> {
   success: boolean
   data?: T


### PR DESCRIPTION
## Summary

- Applies the `## Comments` rule from `CLAUDE.md` (calibrated by the worked examples in `docs/agents/comments.md`, produced by #936) to `packages/ui/src` — ~58 non-test source files across `components/`, `components/cells/`, `components/fields/`, `components/standalone/`, `lib/`, `primitives/`, and `server/`.
- Removes comments that restate the line/block beneath them, docblocks on self-describing constants, notes narrating removed code, and generic boilerplate repeated verbatim across sibling files/components.
- Consolidates rationale that was repeated across multiple call sites (e.g. the ADR-0017 filter-engine and #732/#915 sortable-field explanations in `ListView.tsx`/`ListViewClient.tsx`, the #588 owning-field gate in `RelationshipTable.tsx`, the `#736` bulk-action security boundary) onto a single canonical statement, with siblings trimmed to a pointer/`{@link}`.
- Preserves: `eslint-disable ... --` justifications verbatim, outside-constraint notes (Prisma/Next.js/browser/library behavior, e.g. the Router Cache and hydration-mismatch notes in `ListViewClient.tsx`/`ThemeToggle.tsx`), warnings against a plausible-but-wrong edit (e.g. the bulk-action error-leak warning, the `RelationshipTable` `id`-preservation note), "Known limits"-style blocks, and public-API TSDoc on exported component props / standalone components (`AdminUI`, `components/standalone/*`) that are this package's advertised consumer contract.

## Scope

- Comment-only changes. No behavior changes, no renames, no adjacent refactors.
- Test files (`*.test.ts` / `*.test.tsx`) were left untouched.

## Test plan

- [x] `pnpm lint` — clean (2 pre-existing warnings unrelated to this change)
- [x] `pnpm format` — no changes
- [x] `pnpm --filter @opensaas/stack-ui build` — succeeds
- [x] `pnpm --filter @opensaas/stack-ui test run` — 579 tests passed, 51 files
- [x] Patch changeset added (`.changeset/gentle-otters-clean.md`)

Closes #941


---
_Generated by [Claude Code](https://claude.ai/code/session_01XckHayV7XXCZTNCqu6Ksqc)_