### PR TITLE
Comment cleanup: packages/auth

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+Clean up comments in `packages/auth/src` per the CLAUDE.md Comments rule — removed restating/duplicated comments, kept public-API TSDoc and footgun/external-constraint warnings. No behavior changes.

--- a/packages/auth/src/client/index.ts
+++ b/packages/auth/src/client/index.ts
@@ -24,21 +24,4 @@ export function createClient(options: { baseURL: string }): ReturnType<typeof cr
   })
 }
 
-/**
- * Re-export useful types from better-auth
- */
 export type { Session }
-
-/**
- * Note: React hooks (useSession, etc.) are accessed from the client instance
- *
- * @example
- * ```typescript
- * import { authClient } from '@/lib/auth-client'
- *
- * function MyComponent() {
- *   const { data: session } = authClient.useSession()
- *   // ...
- * }
- * ```
- */

--- a/packages/auth/src/config/adopt-better-auth-tables.ts
+++ b/packages/auth/src/config/adopt-better-auth-tables.ts
@@ -1,49 +1,8 @@
 /**
- * "Adopt existing better-auth tables" recipe.
- *
- * A migrating project usually already has a working, hand-wired better-auth
- * installation: its tables are `AuthUser`/`AuthSession`/`AuthAccount`/
- * `AuthVerification`, mapped into a separate `auth` Postgres schema, and its
- * application `User` (`public.User`) is a *different* model. Reconstructing the
- * matching {@link AuthConfig} by hand — four `modelName`s plus a `schema` on each
- * model — is repetitive and easy to get wrong.
- *
- * {@link adoptBetterAuthTables} produces that {@link AuthConfig} fragment from a
- * couple of options so the migrator doesn't rebuild it from scratch. It only
- * sets the *adoption* knobs (per-model `modelName` + the plugin-level `schema`);
- * the developer composes it with the rest of their auth config (providers,
- * session fields, `extendUserList`, etc.):
- *
- * ```typescript
- * authPlugin({
- *   ...adoptBetterAuthTables(),
- *   emailAndPassword: { enabled: true },
- *   sessionFields: ['userId', 'email', 'name'],
- * })
- * ```
- *
- * Combined with the keys/field derivation (`deriveAuthLists`) and schema
- * placement, the generated Auth lists reach **Schema parity** with the live
- * tables — they are modelled for runtime/types without producing a destructive
- * auth migration. The recipe never touches the application's own domain `User`:
- * its model names are `Auth`-prefixed by default and the plugin only ever
- * adds/extends its *derived* keys.
- *
- * The single most common adoption shape is a project that ran better-auth
- * *before* adding Stack: its live tables are still better-auth's own default
- * lowercase names (`user`/`session`/`account`/`verification`), even though the
- * derived list keys need the `Auth` prefix to avoid colliding with the app's
- * own domain `User`. Pass `useBetterAuthTableNames: true` to point every
- * model's physical table at that default while keeping the prefixed list keys
- * (or `tableNames` for an explicit per-model override):
- *
- * ```typescript
- * authPlugin({
- *   ...adoptBetterAuthTables({ useBetterAuthTableNames: true }),
- *   // AuthUser/AuthSession/AuthAccount/AuthVerification list keys,
- *   // @@map("user")/@@map("session")/@@map("account")/@@map("verification")
- * })
- * ```
+ * "Adopt existing better-auth tables" recipe: produces the {@link AuthConfig}
+ * adoption fragment for a pre-existing better-auth install. See
+ * `packages/auth/CLAUDE.md` ("Adopting an existing better-auth install") for
+ * the full rationale and examples.
  */
 
 import type { AuthConfig, AuthModelConfig } from './types.js'
@@ -157,7 +116,6 @@ export type AdoptBetterAuthTablesOptions = {
   rateLimit?: boolean
 }
 
-/** The better-auth models and their default (unprefixed) model names. */
 const MODEL_DEFAULT_NAMES = {
   user: 'User',
   session: 'Session',
@@ -166,7 +124,6 @@ const MODEL_DEFAULT_NAMES = {
   rateLimit: 'RateLimit',
 } as const
 
-/** better-auth's own default lowercase table names, per model. */
 const BETTER_AUTH_DEFAULT_TABLE_NAMES = {
   user: 'user',
   session: 'session',
@@ -195,10 +152,6 @@ export type AdoptBetterAuthTablesConfig = Pick<
  *
  * Returns only the model/schema knobs needed to adopt the live tables; spread it
  * into {@link authPlugin} alongside your own auth config.
- *
- * @param options - Adoption conventions (schema, model-name prefix, column maps)
- * @returns An {@link AuthConfig} fragment with `schema` + per-model `modelName`
- *   (and any field column maps) set to match the live tables
  */
 export function adoptBetterAuthTables(
   options: AdoptBetterAuthTablesOptions = {},

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -1,29 +1,7 @@
 /**
- * Pure `better-auth config → Auth lists` derivation.
- *
- * This module is intentionally free of side effects and plugin/runtime
- * concerns: given the resolved better-auth model config (per-model `modelName`,
- * `tableName`, and `fields` column maps) plus any custom User fields, it
- * produces the four OpenSaaS Auth lists (user/session/account/verification)
- * with:
- *
- *  - list keys taken from each model's `modelName`
- *  - a table `@@map` (list-level `db.map`) taken from each model's resolved
- *    `tableName` — independent of `modelName`, so a renamed list key can still
- *    adopt a differently-named live table
- *  - field-level `@map` (`db.map`) for any better-auth field → column override
- *  - relationship refs between the auth lists wired to the *derived* keys
- *    (e.g. `Session.user → AuthUser.sessions`)
- *
- * When the developer supplies no `modelName`/`fields` overrides, the output
- * keeps the historical default keys (`User`/`Session`/`Account`/
- * `Verification`) and field shapes — see the unit tests. Per ADR-0013, each
- * list ships with **no** operation-level access unless the caller supplies it
- * (`accessConfig`, or `userConfig.access` for the user list) — deny-by-default,
- * not the plugin's former permissive defaults.
- *
- * `getAuthLists`/`convertBetterAuthSchema` (and the runtime user-key
- * resolution) consume this module so derivation lives in exactly one place.
+ * Pure `better-auth config → Auth lists` derivation, free of side effects and
+ * plugin/runtime concerns. See `packages/auth/CLAUDE.md` ("Deriving Auth lists
+ * from better-auth config") for the full behavior and examples.
  */
 
 import { list } from '@opensaas/stack-core'
@@ -64,22 +42,11 @@ export type DerivedAuthLists = {
  * Build the list-level `db` config (`timestamps` + `@@map` + `@@schema`) for a
  * derived list.
  *
- * `timestamps` is a per-model input rather than hardcoded: better-auth's
- * adapter writes `createdAt`/`updatedAt` on every user/session/account/
- * verification row (and the schema converter returns `null` for those columns,
- * assuming the generator injects them), so those four opt back into
- * auto-timestamps now that they're OFF by default (ADR-0004). The `RateLimit`
- * model has neither column in better-auth's own schema, so it passes `false`.
- *
- * The physical table name (`@@map`) comes from the model's resolved
- * `tableName` — independent of the list key/`modelName` — so a renamed list
- * key can still adopt a differently-named live table (e.g. better-auth's own
- * default lowercase table names). When a `schema` is configured (plugin-level
- * or per-model), the list is placed in that Postgres schema via `@@schema(...)`.
- *
- * With no `tableName`/`schema` overrides and `timestamps: true` we emit only
- * `{ timestamps: true }`, leaving the default `User`/`Session`/... output
- * unchanged.
+ * `timestamps` is a per-model input, not hardcoded: better-auth's adapter
+ * writes `createdAt`/`updatedAt` on every user/session/account/verification
+ * row, so those four opt back into auto-timestamps now that they're OFF by
+ * default (ADR-0004). The `RateLimit` model has neither column upstream, so
+ * it passes `false`.
  */
 function listDb(
   model: NormalizedAuthModelConfig,
@@ -132,12 +99,8 @@ function userRelationshipDb(fields: Record<string, string>): NonNullable<Relatio
 
 /**
  * Create the Auth user list, applying derived field column maps + table map and
- * wiring the session/account relationships to the derived keys.
- *
- * Per ADR-0013, the plugin ships no permissive access default: the list is
- * closed unless the application supplies access via `extendUserList.access`
- * (takes precedence — it predates the keyed `access` passthrough and is
- * User-specific) or the `access.user` passthrough.
+ * wiring the session/account relationships to the derived keys. Ships closed
+ * per ADR-0013 unless `userConfig.access` or `access.user` is supplied.
  */
 function createUserList(
   model: NormalizedAuthModelConfig,
@@ -158,11 +121,9 @@ function createUserList(
       emailVerified: checkbox({ defaultValue: false, db: fieldDb('emailVerified', f) }),
       image: text({ db: fieldDb('image', f) }),
 
-      // Relationships to the other auth lists — refs follow the derived keys.
       sessions: relationship({ ref: `${keys.session}.user`, many: true }),
       accounts: relationship({ ref: `${keys.account}.user`, many: true }),
 
-      // Custom fields from user config
       ...(userConfig.fields || {}),
     },
     db: listDb(model, true),
@@ -171,12 +132,7 @@ function createUserList(
   })
 }
 
-/**
- * Create the Auth session list.
- *
- * Per ADR-0013, the plugin ships no permissive access default — closed unless
- * the application supplies `access.session`.
- */
+/** Create the Auth session list. Ships closed per ADR-0013 unless `access.session` is supplied. */
 function createSessionList(
   model: NormalizedAuthModelConfig,
   keys: DerivedAuthLists['keys'],
@@ -207,12 +163,7 @@ function createSessionList(
   })
 }
 
-/**
- * Create the Auth account list.
- *
- * Per ADR-0013, the plugin ships no permissive access default — closed unless
- * the application supplies `access.account`.
- */
+/** Create the Auth account list. Ships closed per ADR-0013 unless `access.account` is supplied. */
 function createAccountList(
   model: NormalizedAuthModelConfig,
   keys: DerivedAuthLists['keys'],
@@ -242,12 +193,7 @@ function createAccountList(
   })
 }
 
-/**
- * Create the Auth verification list.
- *
- * Per ADR-0013, the plugin ships no permissive access default — closed unless
- * the application supplies `access.verification`.
- */
+/** Create the Auth verification list. Ships closed per ADR-0013 unless `access.verification` is supplied. */
 function createVerificationList(
   model: NormalizedAuthModelConfig,
   access: AuthAccessConfig['verification'],
@@ -281,8 +227,7 @@ function createVerificationList(
  * `createdAt`/`updatedAt` either (see `listDb`'s `timestamps` argument):
  * better-auth's own rate-limit table has neither column.
  *
- * Per ADR-0013, the plugin ships no permissive access default — closed unless
- * the application supplies `access.rateLimit`.
+ * Ships closed per ADR-0013 unless `access.rateLimit` is supplied.
  */
 function createRateLimitList(
   model: NormalizedAuthModelConfig,

--- a/packages/auth/src/config/index.ts
+++ b/packages/auth/src/config/index.ts
@@ -10,12 +10,6 @@ import type {
   SendAuthEmail,
 } from './types.js'
 
-/**
- * Default better-auth model names. Used when the developer does not override
- * `modelName`, preserving the historical `User`/`Session`/`Account`/`Verification`
- * keys exactly. `rateLimit` only applies when `rateLimit.storage: 'database'`
- * derives the fifth Auth list.
- */
 const DEFAULT_MODEL_NAMES = {
   user: 'User',
   session: 'Session',
@@ -25,11 +19,6 @@ const DEFAULT_MODEL_NAMES = {
 } as const
 
 /**
- * Resolve a single better-auth model config block into its normalized form,
- * falling back to the better-auth default model name and an empty column map.
- * The model's Postgres schema is the per-model `schema` override when present,
- * otherwise the plugin-level `schema` default (or `undefined` for `public`).
- *
  * `tableName` defaults to today's behaviour when not explicitly set: it
  * follows `modelName` when that differs from the better-auth default (so a
  * renamed list still pins its table via `@@map`), otherwise it stays unset.
@@ -52,12 +41,6 @@ function normalizeModelConfig(
   }
 }
 
-/**
- * Resolve the better-auth model config for all four auth models, plus a fifth
- * `rateLimit` model when `rateLimit.storage: 'database'` requires deriving
- * the `RateLimit` list. `defaultSchema` is the plugin-level `schema` applied
- * to every model unless a per-model `schema` override is given.
- */
 function normalizeAuthModels(config: AuthConfig): NormalizedAuthModels {
   const defaultSchema = config.schema
   const models: NormalizedAuthModels = {
@@ -82,11 +65,6 @@ function normalizeAuthModels(config: AuthConfig): NormalizedAuthModels {
   return models
 }
 
-/**
- * Default `sendResetPassword`/`sendVerificationEmail` — logs to console
- * instead of sending, matching the pre-existing "no sendEmail configured"
- * behavior for apps that haven't wired a real email provider yet.
- */
 function defaultSendAuthEmail(kind: 'password reset' | 'verification'): SendAuthEmail {
   return async ({ user, url }) => {
     console.log(
@@ -97,11 +75,7 @@ function defaultSendAuthEmail(kind: 'password reset' | 'verification'): SendAuth
   }
 }
 
-/**
- * Normalize auth configuration with defaults
- */
 export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
-  // Email and password defaults
   const emailAndPassword = config.emailAndPassword?.enabled
     ? {
         enabled: true as const,
@@ -119,7 +93,6 @@ export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
         sendResetPassword: defaultSendAuthEmail('password reset'),
       }
 
-  // Email verification defaults
   const emailVerification = config.emailVerification?.enabled
     ? {
         enabled: true as const,
@@ -137,7 +110,6 @@ export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
         sendVerificationEmail: defaultSendAuthEmail('verification'),
       }
 
-  // Password reset defaults
   const passwordReset = config.passwordReset?.enabled
     ? {
         enabled: true as const,
@@ -145,17 +117,13 @@ export function normalizeAuthConfig(config: AuthConfig): NormalizedAuthConfig {
       }
     : { enabled: false as const, tokenExpiration: 3600 }
 
-  // Session defaults
   const session = {
-    expiresIn: config.session?.expiresIn || 604800, // 7 days
-    updateAge: config.session?.updateAge ?? 86400, // 1 day, matching better-auth's own default
+    expiresIn: config.session?.expiresIn || 604800,
+    updateAge: config.session?.updateAge ?? 86400, // matches better-auth's own default
   }
 
-  // Session fields defaults
   const sessionFields = config.sessionFields || ['userId', 'email', 'name']
 
-  // Resolve better-auth per-model config (modelName + field column maps).
-  // Defaults preserve the historical User/Session/Account/Verification keys.
   const models = normalizeAuthModels(config)
 
   return {

--- a/packages/auth/src/config/plugin.ts
+++ b/packages/auth/src/config/plugin.ts
@@ -39,11 +39,6 @@ export function authPlugin(config: AuthConfig): Plugin {
     },
 
     init: async (context) => {
-      // Derive the auth lists from the better-auth model config (modelName +
-      // field column maps). With no overrides this yields the historical
-      // User/Session/Account/Verification keys; with overrides (e.g.
-      // user.modelName: 'AuthUser') the lists are keyed and column-mapped to
-      // match the developer's live better-auth tables.
       const authLists = getAuthLists(
         normalized.extendUserList,
         normalized.models,
@@ -74,14 +69,6 @@ export function authPlugin(config: AuthConfig): Plugin {
       // registered under its key and takes the merge (`extendList`) path
       // against it — instead of pre-empting that key with a bare
       // `list({ fields })` that carries no `db`/`access` (see #861).
-      //
-      // The plugin only ever touches its OWN derived keys. When a developer
-      // renames the auth user model (e.g. user.modelName: 'AuthUser'), the
-      // derived key is 'AuthUser' and an app's separate 'User' list is left
-      // untouched — the plugin never extends/overwrites a list it didn't
-      // derive. Extending only kicks in when an existing list shares the
-      // derived key (e.g. the default 'User'), which is the intended
-      // "merge auth fields into my User" behaviour.
       for (const [listName, listConfig] of Object.entries(authLists)) {
         if (context.config.lists[listName]) {
           // A list already exists under this derived key — merge auth fields
@@ -94,55 +81,40 @@ export function authPlugin(config: AuthConfig): Plugin {
             mcp: listConfig.mcp,
           })
         } else {
-          // Otherwise, add the auth list
           context.addList(listName, listConfig)
         }
       }
 
-      // Extract additional lists from Better Auth plugins. Because the auth
-      // lists above are already registered, a schema extension of a base
-      // model (user/session/account/verification) always finds its resolved
-      // key occupied by the real derived list and merges via `extendList` —
-      // its `db`/`access` are preserved. Non-base plugin tables (e.g.
-      // `oauth_application`, `passkey`) still register as new lists via
-      // `addList`, same as before.
+      // Non-base plugin tables (e.g. `oauth_application`, `passkey`) register
+      // as new lists via `addList`; a base-model schema extension merges via
+      // `extendList` against the already-registered derived list (see the
+      // ordering note above).
       for (const plugin of normalized.betterAuthPlugins) {
         if (plugin && typeof plugin === 'object' && plugin.schema) {
-          // Plugin has schema property - convert to OpenSaaS lists
           const pluginSchema = plugin.schema
           const pluginLists = convertBetterAuthSchema(pluginSchema, baseModelKeys)
 
-          // Add or extend lists from plugin
           for (const [listName, listConfig] of Object.entries(pluginLists)) {
             if (context.config.lists[listName]) {
-              // List already exists — merge fields/hooks/mcp in only. Access
-              // control belongs to whoever owns the list; per ADR-0013 an
-              // extension must never carry operation-level access for a
-              // pre-existing list (the plugin engine throws if it does).
+              // Merge fields/hooks/mcp only — per ADR-0013 an extension must
+              // never carry operation-level access for a pre-existing list
+              // (the plugin engine throws if it does).
               context.extendList(listName, {
                 fields: listConfig.fields,
                 hooks: listConfig.hooks,
                 mcp: listConfig.mcp,
               })
             } else {
-              // List doesn't exist, add it
               context.addList(listName, listConfig)
             }
           }
         }
       }
 
-      // Store auth config for runtime access
-      // Access at runtime via: config._pluginData.auth
       context.setPluginData<NormalizedAuthConfig>('auth', normalized)
     },
 
     beforeGenerate: (generationConfig) => {
-      // Collect every schema the Auth lists are placed in (per-model schema,
-      // else the plugin-level schema). When none is configured the Auth lists
-      // stay in the default `public` schema and we leave the config untouched —
-      // the greenfield default Prisma schema is unchanged (no `schemas`, no
-      // `previewFeatures`, no `@@schema`).
       const authSchemas = Array.from(
         new Set(
           Object.values(normalized.models)
@@ -181,18 +153,13 @@ export function authPlugin(config: AuthConfig): Plugin {
     },
 
     runtime: (context, sudo) => {
-      // Resolve the user list's context.db key from the configured user model.
-      // context.db is keyed camelCase, so 'User' -> 'user', 'AuthUser' -> 'authUser'.
       const userDbKey = getDbKey(normalized.models.user.modelName)
 
-      // Provide auth-related utilities at runtime
       return {
         /**
-         * Get user by ID.
-         *
-         * Resolves through `sudo()` (per ADR-0013): the User list ships closed
-         * by default, and "who is this session" must not depend on the
-         * application's User access policy.
+         * Resolves through `sudo()` (per ADR-0013): the User list ships
+         * closed by default, and "who is this session" must not depend on
+         * the application's User access policy.
          */
         getUser: async (userId: string) => {
           return await sudo().db[userDbKey].findUnique({
@@ -200,10 +167,7 @@ export function authPlugin(config: AuthConfig): Plugin {
           })
         },
 
-        /**
-         * Get current user from session. Extracts userId from session and
-         * fetches user data via `sudo()` — see {@link getUser}.
-         */
+        /** See {@link getUser} — same `sudo()` rationale (ADR-0013), keyed off `context.session.userId`. */
         getCurrentUser: async () => {
           if (!context.session?.userId) {
             return null

--- a/packages/auth/src/config/types.ts
+++ b/packages/auth/src/config/types.ts
@@ -13,18 +13,12 @@ export type SendAuthEmail = (
   request?: Request,
 ) => Promise<void>
 
-/**
- * OAuth provider configuration
- */
 export type OAuthProvider = {
   clientId: string
   clientSecret: string
   enabled?: boolean
 }
 
-/**
- * Social provider configurations
- */
 export type SocialProvidersConfig = {
   github?: OAuthProvider
   google?: OAuthProvider
@@ -33,9 +27,6 @@ export type SocialProvidersConfig = {
   [key: string]: OAuthProvider | undefined
 }
 
-/**
- * Email and password configuration
- */
 export type EmailPasswordConfig = {
   enabled: boolean
   /**
@@ -76,9 +67,6 @@ export type EmailPasswordConfig = {
   sendResetPassword?: SendAuthEmail
 }
 
-/**
- * Email verification configuration
- */
 export type EmailVerificationConfig = {
   enabled: boolean
   /**
@@ -111,9 +99,6 @@ export type EmailVerificationConfig = {
   sendVerificationEmail?: SendAuthEmail
 }
 
-/**
- * Password reset configuration
- */
 export type PasswordResetConfig = {
   enabled: boolean
   /**
@@ -123,9 +108,6 @@ export type PasswordResetConfig = {
   tokenExpiration?: number
 }
 
-/**
- * Session configuration
- */
 export type SessionConfig = {
   /**
    * Session expiration in seconds
@@ -141,24 +123,6 @@ export type SessionConfig = {
   updateAge?: number | false
 }
 
-/**
- * Per-model better-auth configuration block.
- *
- * Mirrors better-auth's own `BetterAuthDBOptions` (the `user`/`session`/
- * `account`/`verification` config a developer already writes): `modelName`
- * renames the table/list and `fields` maps individual better-auth field names
- * to database column names. The auth plugin derives its Auth lists from this
- * config so the generated lists carry the same keys and column maps as the
- * developer's live better-auth tables.
- *
- * @example
- * ```typescript
- * authPlugin({
- *   user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
- *   session: { modelName: 'AuthSession' },
- * })
- * ```
- */
 /**
  * App-authored operation + field-level access control for the Auth lists,
  * keyed by better-auth model name (not by the derived list key, so it stays
@@ -213,6 +177,24 @@ export type AuthAccessConfig = {
   rateLimit?: ListConfig<any>['access']
 }
 
+/**
+ * Per-model better-auth configuration block.
+ *
+ * Mirrors better-auth's own `BetterAuthDBOptions` (the `user`/`session`/
+ * `account`/`verification` config a developer already writes): `modelName`
+ * renames the table/list and `fields` maps individual better-auth field names
+ * to database column names. The auth plugin derives its Auth lists from this
+ * config so the generated lists carry the same keys and column maps as the
+ * developer's live better-auth tables.
+ *
+ * @example
+ * ```typescript
+ * authPlugin({
+ *   user: { modelName: 'AuthUser', fields: { name: 'full_name' } },
+ *   session: { modelName: 'AuthSession' },
+ * })
+ * ```
+ */
 export type AuthModelConfig = {
   /**
    * The table/list name for this model.
@@ -264,33 +246,16 @@ export type AuthModelConfig = {
   schema?: string
 }
 
-/**
- * Auth configuration options
- */
 export type AuthConfig = {
-  /**
-   * Email and password authentication
-   */
   emailAndPassword?: EmailPasswordConfig | { enabled: true }
 
-  /**
-   * Email verification
-   */
   emailVerification?: EmailVerificationConfig | { enabled: true }
 
-  /**
-   * Password reset
-   */
   passwordReset?: PasswordResetConfig | { enabled: true }
 
-  /**
-   * OAuth/social providers
-   */
   socialProviders?: SocialProvidersConfig
 
   /**
-   * Session configuration.
-   *
    * Carries session expiry settings as well as the better-auth `session` model
    * config (`modelName` + field column `fields` maps) used to derive the Auth
    * session list.
@@ -305,14 +270,8 @@ export type AuthConfig = {
    */
   user?: AuthModelConfig
 
-  /**
-   * better-auth `account` model configuration (modelName + field column maps).
-   */
   account?: AuthModelConfig
 
-  /**
-   * better-auth `verification` model configuration (modelName + field column maps).
-   */
   verification?: AuthModelConfig
 
   /**
@@ -550,10 +509,6 @@ export type NormalizedAuthModels = {
   rateLimit?: NormalizedAuthModelConfig
 }
 
-/**
- * Internal normalized auth configuration
- * Used after parsing user config
- */
 export type NormalizedAuthConfig = Required<
   Omit<
     AuthConfig,
@@ -574,7 +529,6 @@ export type NormalizedAuthConfig = Required<
   passwordReset: Required<PasswordResetConfig>
   /** Resolved session expiry settings (model config lives under `models.session`). */
   session: Required<SessionConfig>
-  /** Resolved better-auth model config (modelName + field column maps + schema) for all auth models. */
   models: NormalizedAuthModels
   /**
    * Plugin-level Postgres schema for the Auth lists, if any. Resolved per-model

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,13 +1,5 @@
 /**
- * @opensaas/stack-auth
- *
- * Better-auth integration for OpenSaas Stack
- *
- * This package provides:
- * - Auto-generated User, Session, Account, Verification lists
- * - Session integration with OpenSaas access control
- * - Pre-built auth UI components (SignIn, SignUp, ForgotPassword)
- * - Easy configuration with authPlugin()
+ * @opensaas/stack-auth — Better-auth integration for OpenSaas Stack.
  *
  * @example
  * ```typescript
@@ -28,7 +20,6 @@
  * ```
  */
 
-// Config exports
 export { normalizeAuthConfig } from './config/index.js'
 export { authPlugin } from './config/plugin.js'
 export type { AuthConfig, NormalizedAuthConfig } from './config/index.js'
@@ -38,16 +29,14 @@ export type * from './config/types.js'
 export { deriveAuthLists } from './config/derive-auth-lists.js'
 export type { DerivedAuthLists } from './config/derive-auth-lists.js'
 
-// "Adopt existing better-auth tables" recipe — sets the model/schema knobs that
-// match a pre-existing separate-schema better-auth install so a migrating
-// project reaches Schema parity without rebuilding the config by hand.
+// "Adopt existing better-auth tables" recipe — presets the model/schema knobs
+// for a pre-existing separate-schema better-auth install (advanced use case).
 export { adoptBetterAuthTables } from './config/adopt-better-auth-tables.js'
 export type {
   AdoptBetterAuthTablesOptions,
   AdoptBetterAuthTablesConfig,
 } from './config/adopt-better-auth-tables.js'
 
-// Runtime type exports
 export type { AuthRuntimeServices } from './runtime/types.js'
 
 // List generators (for advanced use cases)

--- a/packages/auth/src/lists/index.ts
+++ b/packages/auth/src/lists/index.ts
@@ -42,8 +42,6 @@ const DEFAULT_MODELS: NormalizedAuthModels = {
 }
 
 /**
- * Create the base User list with better-auth required fields.
- *
  * Backwards-compatible helper: derives the default `User` list (keyed `User`,
  * default field shapes) via {@link deriveAuthLists}.
  */

--- a/packages/auth/src/mcp/better-auth.ts
+++ b/packages/auth/src/mcp/better-auth.ts
@@ -1,14 +1,5 @@
-/**
- * Better Auth integration for MCP OAuth authentication
- * Provides session handling and authentication utilities
- */
-
 import type { McpSession, McpSessionProvider } from '@opensaas/stack-core/mcp'
 
-/**
- * Better Auth instance type (flexible)
- * Uses minimal typing to avoid tight coupling with better-auth package
- */
 export type BetterAuthInstance = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth API types vary by plugins, must use any
   api: any
@@ -118,25 +109,20 @@ export function hasScopes(session: McpSession, requiredScopes: string[]): boolea
   return requiredScopes.every((scope) => session.scopes!.includes(scope))
 }
 
-/**
- * Check if MCP session is expired
- */
 export function isSessionExpired(session: McpSession): boolean {
   if (!session.expiresAt) return false
   return new Date() > session.expiresAt
 }
 
 /**
- * Create OAuth discovery metadata handler
- * Exposes OAuth authorization server metadata for MCP clients
+ * Exposes OAuth authorization server metadata for MCP clients.
  *
- * This should be placed at `/.well-known/oauth-authorization-server/route.ts`
- * Better Auth already handles `/api/auth/.well-known/oauth-authorization-server`
- * but some clients may fail to parse WWW-Authenticate headers
+ * Place at `/.well-known/oauth-authorization-server/route.ts`. Better Auth
+ * already handles `/api/auth/.well-known/oauth-authorization-server`, but
+ * some clients may fail to parse the `WWW-Authenticate` header.
  */
 export function createOAuthDiscoveryHandler(_auth: BetterAuthInstance) {
   return async (req: Request) => {
-    // Delegate to Better Auth's built-in handler
     const authPath = '/api/auth/.well-known/oauth-authorization-server'
     const authUrl = new URL(authPath, req.url)
 

--- a/packages/auth/src/mcp/better-auth.ts
+++ b/packages/auth/src/mcp/better-auth.ts
@@ -56,13 +56,11 @@ export function withMcpAuth(
   handler: (req: Request, session: McpSession) => Promise<Response> | Response,
 ): (req: Request) => Promise<Response> {
   return async (req: Request) => {
-    // Extract MCP session from Better Auth
     const session = await auth.api.getMcpSession({
       headers: req.headers,
     })
 
     if (!session) {
-      // Return 401 with WWW-Authenticate header for OAuth clients
       return new Response(null, {
         status: 401,
         headers: {
@@ -71,7 +69,6 @@ export function withMcpAuth(
       })
     }
 
-    // Call handler with authenticated session
     return handler(req, session)
   }
 }
@@ -133,14 +130,12 @@ export function createOAuthDiscoveryHandler(_auth: BetterAuthInstance) {
 }
 
 /**
- * Create OAuth protected resource metadata handler
- * Exposes OAuth protected resource metadata for MCP clients
+ * Exposes OAuth protected resource metadata for MCP clients.
  *
- * This should be placed at `/.well-known/oauth-protected-resource/route.ts`
+ * Place at `/.well-known/oauth-protected-resource/route.ts`.
  */
 export function createOAuthProtectedResourceHandler(_auth: BetterAuthInstance) {
   return async (req: Request) => {
-    // Delegate to Better Auth's built-in handler
     const authPath = '/api/auth/.well-known/oauth-protected-resource'
     const authUrl = new URL(authPath, req.url)
 

--- a/packages/auth/src/plugins/index.ts
+++ b/packages/auth/src/plugins/index.ts
@@ -1,7 +1,1 @@
-/**
- * Re-export Better Auth plugins for convenience
- * This allows users to import plugins from @opensaas/stack-auth/plugins
- * instead of better-auth/plugins
- */
-
 export { mcp } from 'better-auth/plugins'

--- a/packages/auth/src/runtime/types.ts
+++ b/packages/auth/src/runtime/types.ts
@@ -1,25 +1,17 @@
 /**
- * Type definitions for auth plugin runtime services
- * These types are used for type-safe access to context.plugins.auth
- */
-
-/**
- * Runtime services provided by the auth plugin
- * Available via context.plugins.auth
+ * Runtime services provided by the auth plugin, available via
+ * `context.plugins.auth`.
  */
 export interface AuthRuntimeServices {
   /**
-   * Get user by ID.
    * Resolves through the plugin runtime's `sudo` helper, so the result does
    * not depend on the application's User list access policy (ADR-0013).
    *
-   * @param userId - The ID of the user to fetch
    * @returns User object or null if not found
    */
   getUser: (userId: string) => Promise<unknown>
 
   /**
-   * Get current user from session.
    * Extracts userId from session and fetches user data through the plugin
    * runtime's `sudo` helper — see {@link getUser}.
    *

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -7,13 +7,9 @@ import type { DatabaseConfig } from '@opensaas/stack-core/internal'
 import type { NormalizedAuthConfig, NormalizedAuthModelConfig } from '../config/types.js'
 
 /**
- * The `BetterAuthOptions` shape produced when an app's own plugin tuple is
- * passed to `buildBetterAuthOptions()`/`createAuth()` — the tuple plus the
- * `nextCookies()` plugin the stack always appends last. Carrying the literal
- * tuple type (rather than the widened `BetterAuthPlugin[]`) is what lets
- * `betterAuth()` re-infer plugin endpoints (e.g. `emailOTP()`'s
- * `api.signInEmailOTP`) and a `customSession()` plugin's replaced session
- * shape from the resulting options object.
+ * `BetterAuthOptions['plugins']` narrowed to the app's literal tuple plus the
+ * appended `nextCookies()` — see {@link buildBetterAuthOptions}'s tuple-typing
+ * doc for why this matters.
  */
 type ResolvedBetterAuthOptions<TPlugins extends readonly BetterAuthPlugin[]> = Omit<
   BetterAuthOptions,
@@ -53,9 +49,6 @@ function assertPluginTupleMatchesResolved(
   }
 }
 
-/**
- * Get better-auth database configuration from OpenSaas config
- */
 function getDatabaseConfig(
   dbConfig: DatabaseConfig,
   context: AccessContext,
@@ -66,10 +59,8 @@ function getDatabaseConfig(
 }
 
 /**
- * Translate a normalized OpenSaaS auth model config into the better-auth
- * per-model options (`modelName` + `fields` column map). Returns `undefined`
- * when there is nothing to override so the running auth instance keeps
- * better-auth's own defaults untouched.
+ * Returns `undefined` when there is nothing to override, so the running auth
+ * instance keeps better-auth's own defaults untouched.
  */
 function toBetterAuthModelOptions(
   model: NormalizedAuthModelConfig,
@@ -156,13 +147,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   )
 }
 
-/**
- * Deep-merge `overrides` onto `base`, recursing into plain-object values so a
- * nested addition (one database hook, one session sub-option) merges
- * alongside sibling keys the stack already set there rather than replacing
- * the whole branch. Arrays and any other value type replace outright.
- * `overrides` wins on every key collision.
- */
 function mergeBetterAuthOptions(
   base: Record<string, unknown>,
   overrides: Record<string, unknown>,
@@ -239,7 +223,6 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
   const resolvedConfig = await Promise.resolve(opensaasConfig)
   const resolvedContext = await Promise.resolve(context)
 
-  // Extract auth config from plugin data
   const authConfig = resolvedConfig._pluginData?.auth as NormalizedAuthConfig | undefined
 
   if (!authConfig) {
@@ -280,13 +263,9 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
     assertPluginTupleMatchesResolved(plugins, resolvedPlugins)
   }
 
-  // Build better-auth configuration
   const betterAuthConfig: BetterAuthOptions = {
     database: getDatabaseConfig(resolvedConfig.db, resolvedContext),
 
-    // Mirror the per-model config (modelName + field column maps) back to
-    // better-auth so the running auth instance reads/writes the same
-    // tables/columns the OpenSaaS Auth lists were derived from.
     user: toBetterAuthModelOptions(authConfig.models.user),
     session: {
       ...toBetterAuthModelOptions(authConfig.models.session),
@@ -301,7 +280,6 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
     account: toBetterAuthModelOptions(authConfig.models.account),
     verification: toBetterAuthModelOptions(authConfig.models.verification),
 
-    // Enable email and password if configured
     emailAndPassword: authConfig.emailAndPassword.enabled
       ? {
           enabled: true,
@@ -316,8 +294,8 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
         }
       : undefined,
 
-    // Email verification (independent of emailAndPassword — also covers
-    // e.g. a social-provider account whose email isn't yet verified)
+    // Independent of `emailAndPassword` — also covers e.g. a social-provider
+    // account whose email isn't yet verified.
     emailVerification: authConfig.emailVerification.enabled
       ? {
           sendVerificationEmail: authConfig.emailVerification.sendVerificationEmail,
@@ -326,10 +304,8 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
         }
       : undefined,
 
-    // Trust host (required for production)
     trustedOrigins: process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',') || [],
 
-    // Social providers
     socialProviders: Object.entries(authConfig.socialProviders)
       .filter(([_, config]) => config?.enabled !== false)
       .reduce(
@@ -345,10 +321,10 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
         {} as Record<string, { clientId: string; clientSecret: string }>,
       ),
 
-    // Rate limiting configuration. `modelName`/`fields` are only forwarded
-    // when `models.rateLimit` was derived (rateLimit.storage === 'database')
-    // — mirroring the running instance's model options back to the table the
-    // `RateLimit` Auth list was derived from.
+    // `modelName`/`fields` are only forwarded when `models.rateLimit` was
+    // derived (rateLimit.storage === 'database') — mirroring the running
+    // instance's model options back to the table the `RateLimit` Auth list
+    // was derived from.
     rateLimit: authConfig.rateLimit
       ? {
           enabled: authConfig.rateLimit.enabled,
@@ -361,12 +337,10 @@ export async function buildBetterAuthOptions<const TPlugins extends readonly Bet
         }
       : undefined,
 
-    // Pass through any additional Better Auth plugins, then append
-    // nextCookies LAST so it can write the Set-Cookie headers produced by
-    // any auth.api.* call made inside a Next.js server action into Next's
-    // cookie store. This is what makes the server-action auth forms (which
-    // call auth.api.signInEmail/signUpEmail/etc. server-side) actually
-    // persist a session. It must be the final plugin in the array.
+    // nextCookies must be LAST so it can write the Set-Cookie headers
+    // produced by any auth.api.* call inside a Next.js server action into
+    // Next's cookie store — this is what makes the server-action auth forms
+    // actually persist a session.
     plugins: [...resolvedPlugins, nextCookies()],
   }
 
@@ -425,11 +399,9 @@ export function createAuth<const TPlugins extends readonly BetterAuthPlugin[]>(
   context: AccessContext | Promise<AccessContext>,
   plugins?: TPlugins,
 ): Auth<BetterAuthOptions> | Auth<ResolvedBetterAuthOptions<TPlugins>> {
-  // Resolve config and context asynchronously
   const configPromise = Promise.resolve(opensaasConfig)
   const contextPromise = Promise.resolve(context)
 
-  // Create auth instance lazily when needed
   type AuthInstance = Auth<BetterAuthOptions> | Auth<ResolvedBetterAuthOptions<TPlugins>>
   let authInstance: AuthInstance | null = null
   let authPromise: Promise<AuthInstance> | null = null
@@ -450,7 +422,6 @@ export function createAuth<const TPlugins extends readonly BetterAuthPlugin[]>(
     return authPromise
   }
 
-  // Return a proxy that lazily initializes the auth instance
   return new Proxy({} as AuthInstance, {
     get(_, prop) {
       if (prop === 'then') {
@@ -458,7 +429,6 @@ export function createAuth<const TPlugins extends readonly BetterAuthPlugin[]>(
         return undefined
       }
 
-      // Create a lazy wrapper function
       const lazyWrapper = async (...args: unknown[]) => {
         const instance = await getAuthInstance()
         const value = instance[prop as keyof typeof instance]
@@ -468,14 +438,12 @@ export function createAuth<const TPlugins extends readonly BetterAuthPlugin[]>(
         return value
       }
 
-      // Return a proxy that supports both direct calls and nested property access
       return new Proxy(lazyWrapper, {
         get(target, subProp) {
           if (subProp === 'then') {
             // Support await on nested properties
             return undefined
           }
-          // Handle nested property access (e.g., auth.api.getSession)
           return async (...args: unknown[]) => {
             const instance = await getAuthInstance()
             const parentValue = instance[prop as keyof typeof instance]
@@ -502,13 +470,6 @@ export function createAuth<const TPlugins extends readonly BetterAuthPlugin[]>(
  */
 const unresolvedSessionFieldWarnings = new Set<string>()
 
-/**
- * Warn (once per field, per process) that a `sessionFields` entry could not
- * be resolved from the session shape `auth.api.getSession()` actually
- * returned — naming the field and what keys were available to check, so the
- * gap is visible here instead of surfacing later as an access-control
- * function silently reading `undefined`.
- */
 function warnUnresolvedSessionField(field: string, resolvedSession: Record<string, unknown>): void {
   if (unresolvedSessionFieldWarnings.has(field)) return
   unresolvedSessionFieldWarnings.add(field)
@@ -527,17 +488,6 @@ function warnUnresolvedSessionField(field: string, resolvedSession: Record<strin
   )
 }
 
-/**
- * Resolve a single `sessionFields` entry off the resolved better-auth
- * session (whatever `auth.api.getSession()` returned — the default `{
- * session, user }` shape, or a `customSession` plugin's replaced shape).
- *
- * `userId` is special-cased to the authenticated user's `id` — the
- * documented default apps depend on. Every other name resolves against a
- * fixed precedence so a collision between sources is predictable rather
- * than incidental: a top-level key on the resolved session object, then the
- * `user` object, then the `session` sub-object.
- */
 function resolveSessionField(
   field: string,
   resolvedSession: Record<string, unknown>,
@@ -582,11 +532,8 @@ function resolveSessionField(
  * outage) into "anonymous" is indistinguishable from a mass sign-out under
  * fail-closed access control, so the caller must see it.
  *
- * Not called by any generated code before this helper existed — apps used to
- * hand-roll this same transform against `auth.api.getSession({ headers:
- * await headers() })`. Exported as the single reusable implementation; pass
- * the caller's request headers (e.g. Next.js `await headers()` in a Server
- * Component/action) so a session cookie can actually be resolved.
+ * Pass the caller's request headers (e.g. Next.js `await headers()` in a
+ * Server Component/action) so a session cookie can actually be resolved.
  *
  * `auth` is typed structurally over just the one member this function reads
  * — `api.getSession` — rather than a single concrete `Auth<Options>`

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -33,17 +33,11 @@ type BetterAuthFieldAttribute = {
   bigint?: boolean
 }
 
-/**
- * Better Auth table schema structure
- */
 type BetterAuthTableSchema = {
   modelName?: string
   fields: Record<string, BetterAuthFieldAttribute>
 }
 
-/**
- * Convert Better Auth field type to OpenSaaS field config
- */
 function convertField(
   fieldName: string,
   betterAuthField: BetterAuthFieldAttribute,
@@ -55,14 +49,10 @@ function convertField(
     return null
   }
 
-  // Handle references (relationships)
   if (references) {
-    // Relationships are handled separately
-    // Return null here and handle in relationship pass
     return null
   }
 
-  // Map Better Auth types to OpenSaaS field types
   switch (type) {
     case 'string':
       return text({
@@ -98,7 +88,6 @@ function convertField(
       })
 
     default:
-      // Unknown type - default to text
       console.warn(
         `[stack-auth] Unknown Better Auth field type "${type}" for field "${fieldName}", defaulting to text field`,
       )
@@ -109,16 +98,9 @@ function convertField(
 }
 
 /**
- * Convert Better Auth table schema to OpenSaaS ListConfig.
- *
- * Per ADR-0013, plugin-injected lists ship **closed** — no access is set here,
- * so the list denies every operation until the application grants it. For a
- * table that resolves onto one of the four base auth models (user/session/
- * account/verification), that means `authPlugin({ access: { ... } })`; for any
- * other better-auth-plugin-declared table (e.g. OAuth client tables from the
- * `mcp` plugin), the application must declare the list itself under the same
- * derived key so the plugin's field-only extend path can merge in (its access
- * then stands untouched).
+ * Per ADR-0013, ships closed — no access is set here. See
+ * `packages/auth/CLAUDE.md` ("Access control on Auth lists") for how an app
+ * grants access to a table this produces.
  */
 export function convertTableToList(
   tableName: string,
@@ -127,7 +109,6 @@ export function convertTableToList(
 ): ListConfig<any> {
   const fields: Record<string, FieldConfig> = {}
 
-  // First pass: convert regular fields
   for (const [fieldName, fieldAttr] of Object.entries(tableSchema.fields)) {
     const fieldConfig = convertField(fieldName, fieldAttr)
     if (fieldConfig) {
@@ -135,14 +116,12 @@ export function convertTableToList(
     }
   }
 
-  // Second pass: add relationships
-  // NOTE: Better Auth uses one-way references, but OpenSaaS requires bidirectional relationships
-  // We skip relationship conversion for now and rely on the foreign key fields
-  // Users can manually add bidirectional relationships if needed by extending the User list
+  // Better Auth uses one-way references; OpenSaaS requires bidirectional
+  // relationships, so reference fields are kept as plain text (foreign-key)
+  // columns here. An app can add a bidirectional relationship manually by
+  // extending the corresponding list.
   for (const [fieldName, fieldAttr] of Object.entries(tableSchema.fields)) {
     if (fieldAttr.references) {
-      // For now, treat reference fields as regular text fields (foreign keys)
-      // This preserves the userId, clientId, etc. fields that Better Auth expects
       if (!fields[fieldName]) {
         fields[fieldName] = text({
           validation: { isRequired: fieldAttr.required },
@@ -198,17 +177,13 @@ function resolveBaseModelKey(
 }
 
 /**
- * Convert all Better Auth tables to OpenSaaS list configs
- * This is called by authPlugin() to generate lists from Better Auth + plugins
+ * Convert all Better Auth tables to OpenSaaS list configs, called by
+ * `authPlugin()` to generate lists from Better Auth + plugins.
  *
  * @param tables - The better-auth plugin's declared schema extension
- * @param baseModelKeys - The resolved list keys for the four base auth models
- *   (`user`/`session`/`account`/`verification`), from the same model-key remap
- *   the Auth lists themselves use. When a table name matches one of these keys
- *   (case-insensitively), its list key is taken from here instead of being
- *   re-derived from the table name — so a schema extension targeting `user`
- *   lands on the adopted Auth list (e.g. `AuthUser`) rather than a re-derived
- *   `User`, even when that key collides with an unrelated host list.
+ * @param baseModelKeys - Resolved list keys for the four base auth models,
+ *   from the same model-key remap the Auth lists themselves use — see the
+ *   base-model-remap precedence below.
  */
 export function convertBetterAuthSchema(
   tables: Record<string, BetterAuthTableSchema>,

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -1,16 +1,8 @@
-/**
- * Convert Better Auth database schema to OpenSaaS list configs
- * Allows dynamic list generation from Better Auth plugins
- */
-
 import { list } from '@opensaas/stack-core'
 import { text, timestamp, checkbox, integer, bigInt } from '@opensaas/stack-core/fields'
 import type { ListConfig, FieldConfig } from '@opensaas/stack-core'
 
-/**
- * Better Auth field attribute structure
- * Inferred from better-auth internal types
- */
+/** Inferred from better-auth internal types (not directly importable). */
 type BetterAuthFieldAttribute = {
   type: string | string[] // 'string' | 'number' | 'boolean' | 'date' | etc., or an enum array
   required?: boolean
@@ -206,10 +198,6 @@ export function convertBetterAuthSchema(
   return lists
 }
 
-/**
- * Convert table name to PascalCase
- * e.g., "oauth_application" -> "OauthApplication"
- */
 function toPascalCase(str: string): string {
   return str
     .split(/[_-]/)

--- a/packages/auth/src/ui/components/ForgotPasswordForm.tsx
+++ b/packages/auth/src/ui/components/ForgotPasswordForm.tsx
@@ -25,9 +25,6 @@ export type ForgotPasswordFormProps = {
 }
 
 /**
- * Forgot password form component
- * Allows users to request a password reset email
- *
  * Submits through an app-owned server action rather than calling the auth API
  * from the browser. See the "Auth action" contract in `@opensaas/stack-auth/ui`.
  *

--- a/packages/auth/src/ui/components/ResetPasswordForm.tsx
+++ b/packages/auth/src/ui/components/ResetPasswordForm.tsx
@@ -42,9 +42,6 @@ export type ResetPasswordFormProps = {
 }
 
 /**
- * Reset password form component
- * Completes a password reset using the token from the reset email.
- *
  * Submits through an app-owned server action rather than calling the auth API
  * from the browser. See the "Auth action" contract in `@opensaas/stack-auth/ui`.
  *
@@ -78,8 +75,6 @@ export function ResetPasswordForm({
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
-  // Guard: no token means the user hit this page directly or followed a
-  // malformed/expired link. Don't render a form that can't succeed.
   if (!token) {
     return (
       <div className={`w-full max-w-md mx-auto p-6 ${className}`}>

--- a/packages/auth/src/ui/components/SignInForm.tsx
+++ b/packages/auth/src/ui/components/SignInForm.tsx
@@ -46,9 +46,6 @@ export type SignInFormProps = {
 }
 
 /**
- * Sign in form component
- * Provides email/password sign in and OAuth provider buttons
- *
  * Submits through app-owned server actions rather than calling the auth API
  * from the browser. See the "Auth action" contract in `@opensaas/stack-auth/ui`.
  *
@@ -96,7 +93,6 @@ export function SignInForm({
         throw new Error(cleanAuthErrorMessage(result.error, 'Sign in failed'))
       }
 
-      // If onSuccess is provided, call it. Otherwise, automatically redirect
       if (onSuccess) {
         onSuccess()
       } else {

--- a/packages/auth/src/ui/components/SignUpForm.tsx
+++ b/packages/auth/src/ui/components/SignUpForm.tsx
@@ -51,9 +51,6 @@ export type SignUpFormProps = {
 }
 
 /**
- * Sign up form component
- * Provides email/password registration and OAuth provider buttons
- *
  * Submits through app-owned server actions rather than calling the auth API
  * from the browser. See the "Auth action" contract in `@opensaas/stack-auth/ui`.
  *
@@ -90,7 +87,6 @@ export function SignUpForm({
     e.preventDefault()
     setError('')
 
-    // Validate password confirmation
     if (requirePasswordConfirmation && password !== confirmPassword) {
       setError('Passwords do not match')
       return
@@ -105,7 +101,6 @@ export function SignUpForm({
         throw new Error(cleanAuthErrorMessage(result.error, 'Sign up failed'))
       }
 
-      // If onSuccess is provided, call it. Otherwise, automatically redirect
       if (onSuccess) {
         onSuccess()
       } else {

--- a/packages/auth/src/ui/lib/clean-error-message.ts
+++ b/packages/auth/src/ui/lib/clean-error-message.ts
@@ -1,10 +1,7 @@
 /**
- * Strip better-call's `[body.field]` validation prefixes from an auth error
- * message so forms can display something user-friendly.
- *
- * Better-auth surfaces validation errors like `[body.password] Password is too
- * short`. This removes those bracketed prefixes and normalises whitespace,
- * falling back to a default when the message is empty or missing.
+ * Strip better-call's `[body.field]` validation prefixes (e.g. `[body.password]
+ * Password is too short`) from an auth error message so forms can display
+ * something user-friendly.
  *
  * Internal to the auth forms — not part of the package's public contract.
  */

--- a/packages/auth/src/ui/types.ts
+++ b/packages/auth/src/ui/types.ts
@@ -1,12 +1,7 @@
 /**
  * Contract types shared between the pre-built auth forms and the app-owned
- * server actions they invoke.
- *
- * The forms live in this package but never own an `auth` instance. Instead each
- * form receives **Auth actions** as props — `'use server'` functions the app
- * defines against its own better-auth instance. These types are the agreement
- * between the two: the app implements actions matching them, the forms call
- * actions matching them.
+ * `'use server'` actions they invoke instead of owning an `authClient`. See
+ * ADR-0020.
  */
 
 /**
@@ -15,30 +10,22 @@
  */
 export type AuthActionResult = { success: true } | { success: false; error: string }
 
-/** Input to the sign-in action. */
 export type SignInInput = { email: string; password: string }
 
-/** Input to the sign-up action. */
 export type SignUpInput = { name: string; email: string; password: string }
 
-/** Input to the request-password-reset action. */
 export type RequestPasswordResetInput = { email: string }
 
-/** Input to the reset-password action. */
 export type ResetPasswordInput = { token: string; password: string }
 
-/** Signs a user in with email + password. */
 export type SignInAction = (input: SignInInput) => Promise<AuthActionResult>
 
-/** Creates an account with email + password. */
 export type SignUpAction = (input: SignUpInput) => Promise<AuthActionResult>
 
-/** Requests a password-reset email. */
 export type RequestPasswordResetAction = (
   input: RequestPasswordResetInput,
 ) => Promise<AuthActionResult>
 
-/** Completes a password reset using a token from the reset email. */
 export type ResetPasswordAction = (input: ResetPasswordInput) => Promise<AuthActionResult>
 
 /**


### PR DESCRIPTION
## Summary

- Applied the `## Comments` rule from root `CLAUDE.md` (calibrated by `docs/agents/comments.md`, produced by #936) to all 21 non-test source files in `packages/auth/src`.
- Removed comments that restated the code beneath them, docblocks on self-describing declarations, and rationale duplicated elsewhere in `packages/auth/CLAUDE.md` / linked ADRs / issues.
- Kept TSDoc on exported config options, field builders, and plugin surfaces (the consumer-facing public API), all `eslint-disable ... --` justifications verbatim, external-constraint notes (Prisma behavior, Better-auth contracts, Next.js server/client boundaries), and footgun warnings — most notably the `createAuth()` lazy `Proxy` caveat (ADR-0014), preserved in full.
- Comment-only diff: no code line was added, removed, or modified — verified by diffing against the pre-cleanup tree and confirming every changed line is a comment/docblock line (two inline trailing-comment trims on otherwise-unchanged lines in `config/index.ts` are the only edits that touch a code line, and only the comment portion of it).

## Test plan

- [x] `pnpm build` (core, cli, auth) passes
- [x] `pnpm lint` (eslint) passes on `packages/auth/src` with no errors
- [x] `pnpm format` (prettier --check) passes on `packages/auth/src`
- [x] `packages/auth` test suite: 14 test files, 261 tests passed, 2 skipped — unchanged from baseline
- [x] No `*.test.ts` / `*.test.tsx` files touched
- [x] Patch changeset added (`@opensaas/stack-auth`)

Closes #943


---
_Generated by [Claude Code](https://claude.ai/code/session_01ND5wziJTbHwhmtE5awE6hG)_