### PR TITLE
Comment cleanup: storage packages, tiptap and create-opensaas-app

### DIFF
--- a/.changeset/tiny-clouds-listen.md
+++ b/.changeset/tiny-clouds-listen.md
@@ -1,0 +1,9 @@
+---
+'@opensaas/stack-storage': patch
+'@opensaas/stack-storage-s3': patch
+'@opensaas/stack-storage-vercel': patch
+'@opensaas/stack-tiptap': patch
+'create-opensaas-app': patch
+---
+
+Comment cleanup only, no behavior change: removed restating/narration comments, kept TSDoc on public config options and field builders, and kept external API/behavior constraint notes (Prisma, S3, Vercel Blob, Keystone parity, Next.js SSR, Zod).

--- a/packages/create-opensaas-app/src/copy-templates.ts
+++ b/packages/create-opensaas-app/src/copy-templates.ts
@@ -10,7 +10,6 @@ const templatesDir = path.join(packageDir, 'templates')
 const examplesDir = path.join(packageDir, '../../examples')
 const corePackageJsonPath = path.join(packageDir, '../core/package.json')
 
-// Files/directories to exclude when copying
 const excludePatterns = [
   'node_modules',
   '.next',
@@ -56,7 +55,6 @@ async function copyTemplate(
     },
   })
 
-  // Update package.json to replace workspace versions
   const packageJsonPath = path.join(target, 'package.json')
   if (await fs.pathExists(packageJsonPath)) {
     await updatePackageJsonVersions(packageJsonPath, stackVersion)
@@ -69,7 +67,6 @@ async function copyTemplate(
 async function main(): Promise<void> {
   console.log('📦 Copying templates from examples...\n')
 
-  // Get the current version from the core package
   const corePackageJson = await fs.readJSON(corePackageJsonPath)
   const stackVersion = corePackageJson.version
 
@@ -80,10 +77,8 @@ async function main(): Promise<void> {
 
   console.log(`Using stack version: ${stackVersion}\n`)
 
-  // Clean templates directory
   await fs.emptyDir(templatesDir)
 
-  // Copy starter examples to templates
   await copyTemplate('starter', 'basic', stackVersion)
   await copyTemplate('starter-auth', 'with-auth', stackVersion)
 

--- a/packages/create-opensaas-app/src/index.ts
+++ b/packages/create-opensaas-app/src/index.ts
@@ -53,7 +53,6 @@ function parseDbFlag(args: string[]): DbProvider | undefined {
 async function main() {
   console.log(chalk.bold.cyan('\n✨ Create OpenSaas Stack Application\n'))
 
-  // Parse command line arguments
   const args = process.argv.slice(2)
   // The project name is the first positional arg. Skip the value consumed by a
   // space-separated `--db <provider>` so e.g. `--db postgres my-app` still picks
@@ -73,7 +72,6 @@ async function main() {
   // prompt; absent, we prompt (defaulting to SQLite, the zero-setup local DB).
   const dbFlag = parseDbFlag(args)
 
-  // Prompt for project name if not provided
   if (!projectName) {
     const response = await prompts({
       type: 'text',
@@ -94,7 +92,6 @@ async function main() {
     projectName = response.projectName
   }
 
-  // Validate project name
   const validation = validateProjectName(projectName)
   if (!validation.ok) {
     console.error(chalk.red(`\n❌ ${validation.message}`))
@@ -105,7 +102,6 @@ async function main() {
     process.exit(1)
   }
 
-  // Prompt for auth unless a flag fixed the choice.
   let withAuth = hasAuthFlag
   if (!hasAuthFlag && !hasNoAuthFlag) {
     const response = await prompts({
@@ -123,9 +119,9 @@ async function main() {
     withAuth = response.withAuth
   }
 
-  // Prompt for the database unless `--db` fixed the choice. SQLite is the
-  // default (zero-setup local dev); PostgreSQL emits the production-ready pg
-  // driver adapter, a Postgres `.env`, and migrate scripts from day one.
+  // SQLite is the default (zero-setup local dev); PostgreSQL emits the
+  // production-ready pg driver adapter, a Postgres `.env`, and migrate scripts
+  // from day one.
   let dbProvider: DbProvider = dbFlag ?? 'sqlite'
   if (!dbFlag) {
     const dbResponse = await prompts({
@@ -147,7 +143,6 @@ async function main() {
     dbProvider = dbResponse.dbProvider
   }
 
-  // Prompt for MCP/AI development tools unless a flag fixed the choice.
   let enableMCP = hasAiFlag
   if (!hasAiFlag && !hasNoAiFlag) {
     const mcpResponse = await prompts({
@@ -165,7 +160,6 @@ async function main() {
     enableMCP = mcpResponse.enableMCP
   }
 
-  // Create project
   await createProject({ projectName, withAuth, enableMCP, dbProvider, skipInstall })
 }
 
@@ -175,18 +169,15 @@ async function createProject(options: TemplateOptions) {
   const spinner = ora('Creating project...').start()
 
   try {
-    // Determine template
     const template = withAuth ? 'with-auth' : 'basic'
     const templateDir = path.join(__dirname, '../templates', template)
     const targetDir = path.join(process.cwd(), projectName)
 
-    // Check if directory already exists
     if (await fs.pathExists(targetDir)) {
       spinner.fail(chalk.red(`Directory ${projectName} already exists`))
       process.exit(1)
     }
 
-    // Check if template exists
     if (!(await fs.pathExists(templateDir))) {
       spinner.fail(chalk.red(`Template ${template} not found`))
       console.error(chalk.dim(`\nExpected template at: ${templateDir}`))
@@ -196,26 +187,22 @@ async function createProject(options: TemplateOptions) {
       process.exit(1)
     }
 
-    // Copy template files
     await fs.copy(templateDir, targetDir)
 
-    // Customize package.json. Templates are SQLite-based, so a `--db postgres`
-    // project swaps the SQLite adapter/driver for the Postgres ones (the
-    // transform preserves scripts — including migrate/migrate:deploy — and the
-    // @opensaas deps).
+    // Templates are SQLite-based, so a `--db postgres` project swaps the
+    // SQLite adapter/driver for the Postgres ones (the transform preserves
+    // scripts — including migrate/migrate:deploy — and the @opensaas deps).
     const pkgPath = path.join(targetDir, 'package.json')
     const pkg = await fs.readJSON(pkgPath)
     const namedPkg = applyProjectName(pkg, projectName)
     const finalPkg = dbProvider === 'postgresql' ? toPostgresPackageJson(namedPkg) : namedPkg
     await fs.writeJSON(pkgPath, finalPkg, { spaces: 2 })
 
-    // Rewrite opensaas.config.ts to the Postgres `PrismaPg` driver adapter when
-    // the user chose PostgreSQL. SQLite keeps the template's config untouched.
+    // SQLite keeps the template's config untouched.
     if (dbProvider === 'postgresql') {
       await rewriteConfigForPostgres(targetDir)
     }
 
-    // Customize README
     const readmePath = path.join(targetDir, 'README.md')
     if (await fs.pathExists(readmePath)) {
       const readme = await fs.readFile(readmePath, 'utf-8')
@@ -233,7 +220,6 @@ async function createProject(options: TemplateOptions) {
 
     spinner.succeed(chalk.green('Project created!'))
 
-    // Install MCP server if requested
     if (enableMCP) {
       await installMCPServer()
     }
@@ -243,7 +229,6 @@ async function createProject(options: TemplateOptions) {
     // database the user configures first. Opt out entirely with --no-install.
     const autoRan = skipInstall ? false : await runSetup(targetDir, projectName, dbProvider)
 
-    // Show next steps
     console.log(chalk.green('\n✅ Your project is ready!\n'))
     console.log(chalk.bold('Next steps:\n'))
     for (const command of nextStepCommands({ projectName, autoRan, provider: dbProvider })) {
@@ -312,10 +297,7 @@ async function writeEnvFile(
   const envExamplePath = path.join(targetDir, '.env.example')
 
   if (withAuth && (await fs.pathExists(envExamplePath))) {
-    // The auth template's `.env.example` carries SQLite database vars plus the
-    // Better-auth variables. For SQLite, copy it through unchanged. For
-    // PostgreSQL, swap the database block for the pooled/direct placeholders
-    // while preserving the auth variables, then write both files.
+    // Overwrites `.env.example` too, not just `.env`, so both reflect the chosen provider.
     const example = await fs.readFile(envExamplePath, 'utf-8')
     const withDb =
       provider === 'postgresql' ? replaceAuthEnvDatabase(example, projectName) : example

--- a/packages/create-opensaas-app/src/lib/postgres.ts
+++ b/packages/create-opensaas-app/src/lib/postgres.ts
@@ -49,7 +49,6 @@ export function toPostgresConfig(source: string): string {
     )
   }
 
-  // Swap the driver-adapter import.
   let result = source.replace(SQLITE_ADAPTER_IMPORT, PG_ADAPTER_IMPORTS)
 
   // Swap the `db` block. The SQLite block is:

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -8,9 +8,6 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { randomBytes } from 'node:crypto'
 import type { StorageProvider, UploadOptions, UploadResult } from '@opensaas/stack-storage'
 
-/**
- * Configuration for S3 storage
- */
 export interface S3StorageConfig {
   type: 's3'
   /** S3 bucket name */
@@ -46,7 +43,6 @@ export class S3StorageProvider implements StorageProvider {
   constructor(config: S3StorageConfig) {
     this.config = config
 
-    // Create S3 client
     this.client = new S3Client({
       region: config.region,
       credentials:
@@ -61,9 +57,6 @@ export class S3StorageProvider implements StorageProvider {
     })
   }
 
-  /**
-   * Generates a unique filename if configured
-   */
   private generateFilename(originalFilename: string): string {
     if (this.config.generateUniqueFilenames === false) {
       return originalFilename
@@ -75,9 +68,6 @@ export class S3StorageProvider implements StorageProvider {
     return `${timestamp}-${uniqueId}${ext}`
   }
 
-  /**
-   * Gets the full key for an object including path prefix
-   */
   private getFullKey(filename: string): string {
     if (this.config.pathPrefix) {
       return `${this.config.pathPrefix}/${filename}`
@@ -93,7 +83,6 @@ export class S3StorageProvider implements StorageProvider {
     const generatedFilename = this.generateFilename(filename)
     const key = this.getFullKey(generatedFilename)
 
-    // Upload to S3
     const command = new PutObjectCommand({
       Bucket: this.config.bucket,
       Key: key,
@@ -106,7 +95,6 @@ export class S3StorageProvider implements StorageProvider {
 
     await this.client.send(command)
 
-    // Generate URL
     const url = this.getUrl(generatedFilename)
 
     return {
@@ -157,18 +145,14 @@ export class S3StorageProvider implements StorageProvider {
   getUrl(filename: string): string {
     const key = this.getFullKey(filename)
 
-    // Use custom domain if configured
     if (this.config.customDomain) {
       return `${this.config.customDomain}/${key}`
     }
 
-    // Use standard S3 URL
     if (this.config.endpoint) {
-      // Custom endpoint (S3-compatible services)
       return `${this.config.endpoint}/${this.config.bucket}/${key}`
     }
 
-    // Standard AWS S3 URL
     return `https://${this.config.bucket}.s3.${this.config.region}.amazonaws.com/${key}`
   }
 

--- a/packages/storage-vercel/src/index.ts
+++ b/packages/storage-vercel/src/index.ts
@@ -22,9 +22,6 @@ function normalizeStoreId(storeId: string): string {
   return storeId.startsWith('store_') ? storeId.slice('store_'.length) : storeId
 }
 
-/**
- * Configuration for Vercel Blob storage
- */
 export interface VercelBlobStorageConfig {
   type: 'vercel-blob'
   /**
@@ -62,9 +59,6 @@ export interface VercelBlobStorageConfig {
   [key: string]: unknown
 }
 
-/**
- * Vercel Blob storage provider
- */
 export class VercelBlobStorageProvider implements StorageProvider {
   private config: VercelBlobStorageConfig
 
@@ -89,9 +83,6 @@ export class VercelBlobStorageProvider implements StorageProvider {
     return auth
   }
 
-  /**
-   * Generates a unique filename if configured
-   */
   private generateFilename(originalFilename: string): string {
     if (this.config.generateUniqueFilenames === false) {
       return originalFilename
@@ -103,9 +94,6 @@ export class VercelBlobStorageProvider implements StorageProvider {
     return `${timestamp}-${uniqueId}${ext}`
   }
 
-  /**
-   * Gets the full pathname for a file including path prefix
-   */
   private getFullPath(filename: string): string {
     if (this.config.pathPrefix) {
       return `${this.config.pathPrefix}/${filename}`
@@ -187,10 +175,8 @@ export class VercelBlobStorageProvider implements StorageProvider {
     const generatedFilename = this.generateFilename(filename)
     const pathname = this.getFullPath(generatedFilename)
 
-    // Convert Uint8Array to Buffer if needed
     const buffer = Buffer.isBuffer(file) ? file : Buffer.from(file)
 
-    // Upload to Vercel Blob
     const uploadOptions: PutCommandOptions = {
       access: this.getAccess(),
       contentType: options?.contentType,

--- a/packages/storage/src/config/types.ts
+++ b/packages/storage/src/config/types.ts
@@ -3,24 +3,13 @@
  * This allows pluggable storage solutions (local, S3, Vercel Blob, etc.)
  */
 export interface StorageProvider {
-  /**
-   * Uploads a file to the storage provider
-   * @param file - File data as Buffer or Uint8Array
-   * @param filename - Desired filename (may be transformed by provider)
-   * @param options - Additional upload options (contentType, metadata, etc.)
-   * @returns Upload result with URL and metadata
-   */
+  /** Uploads a file. `filename` may be transformed by the provider (e.g. to guarantee uniqueness). */
   upload(
     file: Buffer | Uint8Array,
     filename: string,
     options?: UploadOptions,
   ): Promise<UploadResult>
 
-  /**
-   * Downloads a file from the storage provider
-   * @param filename - Filename to download
-   * @returns File data as Buffer
-   */
   download(filename: string): Promise<Buffer>
 
   /**
@@ -29,29 +18,15 @@ export interface StorageProvider {
    * Idempotent: deleting a filename that doesn't exist in the backing store
    * resolves without error. Only non-not-found errors (permissions, network,
    * etc.) should reject.
-   * @param filename - Filename to delete
    */
   delete(filename: string): Promise<void>
 
-  /**
-   * Gets the public URL for a file
-   * @param filename - Filename to get URL for
-   * @returns Public URL string
-   */
   getUrl(filename: string): string
 
-  /**
-   * Optional: Gets a signed URL for private files
-   * @param filename - Filename to get signed URL for
-   * @param expiresIn - Expiration time in seconds
-   * @returns Signed URL string
-   */
+  /** Gets a signed URL for private files. */
   getSignedUrl?(filename: string, expiresIn?: number): Promise<string>
 }
 
-/**
- * Options for uploading a file
- */
 export interface UploadOptions {
   /** MIME type of the file */
   contentType?: string
@@ -63,9 +38,6 @@ export interface UploadOptions {
   cacheControl?: string
 }
 
-/**
- * Result from uploading a file
- */
 export interface UploadResult {
   /** Generated filename (may differ from input) */
   filename: string
@@ -79,9 +51,6 @@ export interface UploadResult {
   metadata?: Record<string, unknown>
 }
 
-/**
- * Configuration for local filesystem storage
- */
 export interface LocalStorageConfig {
   type: 'local'
   /** Directory to store uploaded files */
@@ -94,33 +63,21 @@ export interface LocalStorageConfig {
   [key: string]: unknown
 }
 
-/**
- * Base configuration shared by all storage providers
- */
 export interface BaseStorageConfig {
   type: string
   [key: string]: unknown
 }
 
-/**
- * Storage configuration - maps names to storage provider configs
- * Example: { avatars: s3Config, documents: localConfig }
- */
+/** Maps names to storage provider configs, e.g. `{ avatars: s3Config, documents: localConfig }`. */
 export type StorageConfig = Record<string, BaseStorageConfig | LocalStorageConfig>
 
-/**
- * Re-export metadata types from core package
- * These types are now defined in @opensaas/stack-core to avoid circular dependencies
- */
+// Defined in @opensaas/stack-core, not here, to avoid circular dependencies.
 export type {
   FileMetadata,
   ImageMetadata,
   ImageTransformationResult,
 } from '@opensaas/stack-core/internal'
 
-/**
- * Configuration for image transformations
- */
 export interface ImageTransformationConfig {
   /** Target width in pixels */
   width?: number

--- a/packages/storage/src/fields/index.ts
+++ b/packages/storage/src/fields/index.ts
@@ -74,12 +74,10 @@ export interface FileDbConfig {
     | { mode: 'keystone'; map?: Partial<FileColumnMap>; parts?: readonly FileColumnPart[] }
 }
 
-/** Whether a field-level `db.columns` option requests multi-column mode. */
 function isMultiColumn(columns: ImageDbConfig['columns'] | FileDbConfig['columns']): boolean {
   return columns === 'keystone' || (typeof columns === 'object' && columns?.mode === 'keystone')
 }
 
-/** Extract any per-part `@map` overrides from a `db.columns` option. */
 function imageColumnOverrides(
   columns: ImageDbConfig['columns'],
 ): Partial<ImageColumnMap> | undefined {
@@ -90,15 +88,14 @@ function fileColumnOverrides(columns: FileDbConfig['columns']): Partial<FileColu
   return typeof columns === 'object' ? columns.map : undefined
 }
 
-/** The file parts a field-level `db.columns` option opts into (defaults to the base three). */
 function fileColumnPartsFor(columns: FileDbConfig['columns']): readonly FileColumnPart[] {
   return typeof columns === 'object' && columns.parts ? columns.parts : DEFAULT_FILE_COLUMN_PARTS
 }
 
 /**
- * Detect a File-like input (something we should upload). An already-shaped
- * metadata value or populated multi-column row is authoritative and must never
- * trigger an upload (the no-re-upload guarantee — see ADR-0006).
+ * An already-shaped metadata value or populated multi-column row is
+ * authoritative and must never trigger a re-upload (the no-re-upload
+ * guarantee — see ADR-0006).
  */
 function isFileLike(value: unknown): value is File {
   return (
@@ -109,9 +106,6 @@ function isFileLike(value: unknown): value is File {
   )
 }
 
-/**
- * File field configuration
- */
 export interface FileFieldConfig<
   TTypeInfo extends TypeInfo = TypeInfo,
 > extends BaseFieldConfig<TTypeInfo> {
@@ -124,11 +118,7 @@ export interface FileFieldConfig<
   cleanupOnDelete?: boolean
   /** Automatically delete old file from storage when replaced with new file */
   cleanupOnReplace?: boolean
-  /**
-   * Database configuration. By default a file is backed by a single `Json?`
-   * column; set `db.columns: 'keystone'` to map onto existing Keystone per-part
-   * columns in place (non-destructive migration). See ADR-0006.
-   */
+  /** Database configuration; see {@link FileDbConfig} for multi-column mode. */
   db?: FileDbConfig
   /** UI options */
   ui?: {
@@ -147,9 +137,6 @@ export interface FileFieldConfig<
   }
 }
 
-/**
- * Image field configuration
- */
 export interface ImageFieldConfig<
   TTypeInfo extends TypeInfo = TypeInfo,
 > extends BaseFieldConfig<TTypeInfo> {
@@ -164,11 +151,7 @@ export interface ImageFieldConfig<
   cleanupOnDelete?: boolean
   /** Automatically delete old file from storage when replaced with new file */
   cleanupOnReplace?: boolean
-  /**
-   * Database configuration. By default an image is backed by a single `Json?`
-   * column; set `db.columns: 'keystone'` to map onto existing Keystone per-part
-   * columns in place (non-destructive migration). See ADR-0006.
-   */
+  /** Database configuration; see {@link ImageDbConfig} for multi-column mode. */
   db?: ImageDbConfig
   /** UI options */
   ui?: {
@@ -214,9 +197,8 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
 ): FileFieldConfig<TTypeInfo> {
   const { hooks: userHooks, ...restOptions } = options
 
-  // Multi-column (Keystone-parity) mode maps onto existing per-part columns
-  // instead of a single Json? column. The column map is resolved lazily per
-  // field name so default `<field>_<part>` names line up with the live columns.
+  // Column map resolves lazily per field name so default `<field>_<part>`
+  // names line up with the live columns.
   const multiColumn = isMultiColumn(options.db?.columns)
   const columnMapFor = (fieldName: string): FileColumnMap =>
     resolveFileColumnMap(fieldName, fileColumnOverrides(options.db?.columns))
@@ -240,38 +222,31 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
       resolveInput: async ({ resolvedData, fieldKey, context, item }: any) => {
         const inputValue = resolvedData?.[fieldKey]
 
-        // If null/undefined, return as-is (deletion or no change)
         if (inputValue === null || inputValue === undefined) {
           return inputValue
         }
 
-        // If already FileMetadata, keep existing (edit mode - no new file
-        // uploaded). An existing metadata value is AUTHORITATIVE and must never
+        // An existing metadata value is AUTHORITATIVE and must never
         // re-upload. See ADR-0006.
         if (typeof inputValue === 'object' && 'filename' in inputValue && 'url' in inputValue) {
           return inputValue as FileMetadata
         }
 
-        // Only a File-like input triggers an upload.
         if (isFileLike(inputValue)) {
-          // Convert File to buffer
           const fileObj = inputValue
           const arrayBuffer = await fileObj.arrayBuffer()
           const buffer = Buffer.from(arrayBuffer)
 
-          // Upload file using context.storage utilities
           const metadata = (await context.storage.uploadFile(fieldConfig.storage, fileObj, buffer, {
             validation: fieldConfig.validation,
           })) as FileMetadata
 
-          // If cleanupOnReplace is enabled and there was an old file, delete it
           if (fieldConfig.cleanupOnReplace && item && fieldKey) {
             const oldMetadata = item[fieldKey] as FileMetadata | null
             if (oldMetadata && oldMetadata.filename) {
               try {
                 await context.storage.deleteFile(oldMetadata.storageProvider, oldMetadata.filename)
               } catch (error) {
-                // Log error but don't fail the operation
                 console.error(`Failed to cleanup old file: ${oldMetadata.filename}`, error)
               }
             }
@@ -286,7 +261,7 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
       afterOperation: async ({ operation, originalItem, fieldKey, context }: any) => {
-        // Only cleanup on delete if enabled. The deleted row is `originalItem`.
+        // The deleted row is `originalItem`.
         if (operation === 'delete' && fieldConfig.cleanupOnDelete) {
           const fileMetadata = originalItem?.[fieldKey] as FileMetadata | null
 
@@ -294,18 +269,15 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
             try {
               await context.storage.deleteFile(fileMetadata.storageProvider, fileMetadata.filename)
             } catch (error) {
-              // Log error but don't fail the operation
               console.error(`Failed to cleanup file on delete: ${fileMetadata.filename}`, error)
             }
           }
         }
       },
-      // Merge with user-provided hooks if any
       ...userHooks,
     },
 
     getZodSchema: (_fieldName: string, _operation: 'create' | 'update') => {
-      // File metadata follows the FileMetadata schema
       const fileMetadataSchema = z.object({
         filename: z.string(),
         originalFilename: z.string(),
@@ -325,12 +297,10 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
     },
 
     getPrismaType: (_fieldName: string) => {
-      // Store as JSON in database (single-column default mode).
       return { type: 'Json', modifiers: '?' }
     },
 
     getTypeScriptType: () => {
-      // TypeScript type is FileMetadata | null
       return {
         type: 'FileMetadata | null',
         optional: true,
@@ -348,8 +318,7 @@ export function file<TTypeInfo extends TypeInfo = TypeInfo>(
     },
   }
 
-  // Multi-column emission + assemble/split. Only attached in multi-column mode
-  // so the single-Json? default is completely unaffected.
+  // Only attached in multi-column mode; the single-Json? default is unaffected.
   if (multiColumn) {
     fieldConfig.getPrismaColumns = (fieldName: string): MultiColumnPrismaResult[] => {
       const map = columnMapFor(fieldName)
@@ -398,8 +367,7 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
 ): ImageFieldConfig<TTypeInfo> {
   const { hooks: userHooks, ...restOptions } = options
 
-  // Multi-column (Keystone-parity) mode maps onto existing per-part columns
-  // instead of a single Json? column. See ADR-0006.
+  // See ADR-0006.
   const multiColumn = isMultiColumn(options.db?.columns)
   const columnMapFor = (fieldName: string): ImageColumnMap =>
     resolveImageColumnMap(fieldName, imageColumnOverrides(options.db?.columns))
@@ -422,13 +390,11 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
       resolveInput: async ({ resolvedData, fieldKey, context, item }: any) => {
         const inputValue = resolvedData?.[fieldKey]
 
-        // If null/undefined, return as-is (deletion or no change)
         if (inputValue === null || inputValue === undefined) {
           return inputValue
         }
 
-        // If already ImageMetadata, keep existing (edit mode - no new file
-        // uploaded). An existing metadata value is AUTHORITATIVE and must never
+        // An existing metadata value is AUTHORITATIVE and must never
         // re-upload. See ADR-0006.
         if (
           typeof inputValue === 'object' &&
@@ -440,14 +406,11 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
           return inputValue as ImageMetadata
         }
 
-        // Only a File-like input triggers an upload.
         if (isFileLike(inputValue)) {
-          // Convert File to buffer
           const fileObj = inputValue
           const arrayBuffer = await fileObj.arrayBuffer()
           const buffer = Buffer.from(arrayBuffer)
 
-          // Upload image using context.storage utilities
           const metadata = (await context.storage.uploadImage(
             fieldConfig.storage,
             fileObj,
@@ -458,14 +421,12 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
             },
           )) as ImageMetadata
 
-          // If cleanupOnReplace is enabled and there was an old file, delete it
           if (fieldConfig.cleanupOnReplace && item && fieldKey) {
             const oldMetadata = item[fieldKey] as ImageMetadata | null
             if (oldMetadata && oldMetadata.filename) {
               try {
                 await context.storage.deleteImage(oldMetadata)
               } catch (error) {
-                // Log error but don't fail the operation
                 console.error(`Failed to cleanup old image: ${oldMetadata.filename}`, error)
               }
             }
@@ -480,7 +441,7 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field builder hooks are generic and resolved at runtime
       afterOperation: async ({ operation, originalItem, fieldKey, context }: any) => {
-        // Only cleanup on delete if enabled. The deleted row is `originalItem`.
+        // The deleted row is `originalItem`.
         if (operation === 'delete' && fieldConfig.cleanupOnDelete) {
           const imageMetadata = originalItem?.[fieldKey] as ImageMetadata | null
 
@@ -488,18 +449,15 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
             try {
               await context.storage.deleteImage(imageMetadata)
             } catch (error) {
-              // Log error but don't fail the operation
               console.error(`Failed to cleanup image on delete: ${imageMetadata.filename}`, error)
             }
           }
         }
       },
-      // Merge with user-provided hooks if any
       ...userHooks,
     },
 
     getZodSchema: (_fieldName: string, _operation: 'create' | 'update') => {
-      // Image metadata follows the ImageMetadata schema (extends FileMetadata)
       const imageMetadataSchema = z.object({
         filename: z.string(),
         originalFilename: z.string(),
@@ -524,20 +482,15 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
           .optional(),
       })
 
-      // Allow null or undefined values. `.nullish()` (= `.nullable().optional()`)
-      // makes the object KEY optional in Zod 4 — a bare union that merely accepts
-      // an `undefined` value does NOT (see issue #618, and the #570 precedent in
-      // core's validation tests).
+      // Same `.nullish()` KEY-optionality rationale as file()'s getZodSchema above.
       return imageMetadataSchema.nullish()
     },
 
     getPrismaType: (_fieldName: string) => {
-      // Store as JSON in database
       return { type: 'Json', modifiers: '?' }
     },
 
     getTypeScriptType: () => {
-      // TypeScript type is ImageMetadata | null
       return {
         type: 'ImageMetadata | null',
         optional: true,
@@ -555,8 +508,7 @@ export function image<TTypeInfo extends TypeInfo = TypeInfo>(
     },
   }
 
-  // Multi-column emission + assemble/split. Only attached in multi-column mode
-  // so the single-Json? default is completely unaffected.
+  // Only attached in multi-column mode; the single-Json? default is unaffected.
   if (multiColumn) {
     fieldConfig.getPrismaColumns = (fieldName: string): MultiColumnPrismaResult[] => {
       const map = columnMapFor(fieldName)

--- a/packages/storage/src/providers/local.ts
+++ b/packages/storage/src/providers/local.ts
@@ -8,10 +8,6 @@ import type {
   LocalStorageConfig,
 } from '../config/types.js'
 
-/**
- * Local filesystem storage provider
- * Stores files on the local filesystem
- */
 export class LocalStorageProvider implements StorageProvider {
   private config: LocalStorageConfig
 
@@ -19,9 +15,6 @@ export class LocalStorageProvider implements StorageProvider {
     this.config = config
   }
 
-  /**
-   * Ensures the upload directory exists
-   */
   private async ensureUploadDir(): Promise<void> {
     try {
       await fs.access(this.config.uploadDir)
@@ -30,9 +23,6 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
-  /**
-   * Generates a unique filename if configured
-   */
   private generateFilename(originalFilename: string): string {
     if (this.config.generateUniqueFilenames === false) {
       return originalFilename
@@ -54,10 +44,8 @@ export class LocalStorageProvider implements StorageProvider {
     const generatedFilename = this.generateFilename(filename)
     const filePath = path.join(this.config.uploadDir, generatedFilename)
 
-    // Write file to disk
     await fs.writeFile(filePath, file)
 
-    // Get file stats for size
     const stats = await fs.stat(filePath)
 
     return {

--- a/packages/storage/src/runtime/index.ts
+++ b/packages/storage/src/runtime/index.ts
@@ -181,8 +181,7 @@ export async function uploadImage(
   })
 
   let transformations:
-    | Record<string, { url: string; width: number; height: number; size: number }>
-    | undefined
+    Record<string, { url: string; width: number; height: number; size: number }> | undefined
   if (options?.transformations) {
     transformations = await processImageTransformations(
       buffer,

--- a/packages/storage/src/runtime/index.ts
+++ b/packages/storage/src/runtime/index.ts
@@ -88,7 +88,6 @@ export async function uploadFile(
 ): Promise<FileMetadata> {
   const { file, buffer } = data
 
-  // Validate file
   if (options?.validation) {
     const validation = validateFile(
       {
@@ -104,19 +103,15 @@ export async function uploadFile(
     }
   }
 
-  // Get storage provider
   const provider = createStorageProvider(config, storageProviderName)
 
-  // Determine content type
   const contentType = file.type || getMimeType(file.name)
 
-  // Upload file
   const result = await provider.upload(buffer, file.name, {
     contentType,
     metadata: options?.metadata,
   })
 
-  // Return metadata
   return {
     filename: result.filename,
     originalFilename: file.name,
@@ -159,7 +154,6 @@ export async function uploadImage(
 ): Promise<ImageMetadata> {
   const { file, buffer } = data
 
-  // Validate file
   if (options?.validation) {
     const validation = validateFile(
       {
@@ -175,24 +169,20 @@ export async function uploadImage(
     }
   }
 
-  // Get storage provider
   const provider = createStorageProvider(config, storageProviderName)
 
-  // Determine content type
   const contentType = file.type || getMimeType(file.name)
 
-  // Get original image dimensions
   const { width, height } = await getImageDimensions(buffer)
 
-  // Upload original image
   const result = await provider.upload(buffer, file.name, {
     contentType,
     metadata: options?.metadata,
   })
 
-  // Process transformations if provided
   let transformations:
-    Record<string, { url: string; width: number; height: number; size: number }> | undefined
+    | Record<string, { url: string; width: number; height: number; size: number }>
+    | undefined
   if (options?.transformations) {
     transformations = await processImageTransformations(
       buffer,
@@ -203,7 +193,6 @@ export async function uploadImage(
     )
   }
 
-  // Return metadata
   return {
     filename: result.filename,
     originalFilename: file.name,
@@ -219,9 +208,6 @@ export async function uploadImage(
   }
 }
 
-/**
- * Deletes a file from storage
- */
 export async function deleteFile(
   config: OpenSaasConfig,
   storageProviderName: string,
@@ -231,19 +217,13 @@ export async function deleteFile(
   await provider.delete(filename)
 }
 
-/**
- * Deletes an image and all its transformations from storage
- */
 export async function deleteImage(config: OpenSaasConfig, metadata: ImageMetadata): Promise<void> {
   const provider = createStorageProvider(config, metadata.storageProvider)
 
-  // Delete original image
   await provider.delete(metadata.filename)
 
-  // Delete all transformations
   if (metadata.transformations) {
     for (const transformationResult of Object.values(metadata.transformations)) {
-      // Extract filename from URL
       const filename = transformationResult.url.split('/').pop()
       if (filename) {
         await provider.delete(filename)

--- a/packages/storage/src/utils/image.ts
+++ b/packages/storage/src/utils/image.ts
@@ -5,9 +5,6 @@ import type {
   StorageProvider,
 } from '../config/types.js'
 
-/**
- * Gets image dimensions from a buffer
- */
 export async function getImageDimensions(
   buffer: Buffer | Uint8Array,
 ): Promise<{ width: number; height: number }> {
@@ -18,16 +15,12 @@ export async function getImageDimensions(
   }
 }
 
-/**
- * Applies a single transformation to an image
- */
 export async function transformImage(
   buffer: Buffer | Uint8Array,
   transformation: ImageTransformationConfig,
 ): Promise<Buffer> {
   let image = sharp(buffer)
 
-  // Apply resizing
   if (transformation.width || transformation.height) {
     image = image.resize({
       width: transformation.width,
@@ -36,7 +29,6 @@ export async function transformImage(
     })
   }
 
-  // Apply format conversion
   if (transformation.format) {
     const options = {
       quality: transformation.quality || 80,
@@ -61,10 +53,6 @@ export async function transformImage(
   return await image.toBuffer()
 }
 
-/**
- * Processes all transformations for an image
- * Uploads the original and all transformed versions
- */
 export async function processImageTransformations(
   buffer: Buffer | Uint8Array,
   originalFilename: string,
@@ -75,17 +63,13 @@ export async function processImageTransformations(
   const results: Record<string, ImageTransformationResult> = {}
 
   for (const [name, config] of Object.entries(transformations)) {
-    // Transform the image
     const transformedBuffer = await transformImage(buffer, config)
 
-    // Get dimensions of transformed image
     const { width, height } = await getImageDimensions(transformedBuffer)
 
-    // Generate filename for transformation
     const ext = config.format ? `.${config.format}` : ''
     const transformedFilename = `${originalFilename}-${name}${ext}`
 
-    // Upload transformed image
     const uploadResult = await storageProvider.upload(transformedBuffer, transformedFilename, {
       contentType:
         config.format === 'jpeg'

--- a/packages/storage/src/utils/multi-column.ts
+++ b/packages/storage/src/utils/multi-column.ts
@@ -19,7 +19,13 @@ import type { FileMetadata, ImageMetadata } from '../config/types.js'
  * column (whose physical name is configurable via `@map`).
  */
 export type ImageColumnPart =
-  'url' | 'width' | 'height' | 'filesize' | 'contentType' | 'contentDisposition' | 'pathname'
+  | 'url'
+  | 'width'
+  | 'height'
+  | 'filesize'
+  | 'contentType'
+  | 'contentDisposition'
+  | 'pathname'
 
 /**
  * The logical "parts" of a Keystone file field. `pathname` and `contentType`
@@ -90,7 +96,6 @@ const FILE_PART_PRISMA_TYPE: Record<FileColumnPart, 'String' | 'Int'> = {
  */
 export type ImageColumnMap = Record<ImageColumnPart, string>
 
-/** Map of file part → physical column name. */
 export type FileColumnMap = Record<FileColumnPart, string>
 
 /** A single physical column to emit for a multi-column field. */
@@ -149,9 +154,7 @@ export function resolveImageColumnMap(
   return { ...keystoneImageColumnMap(fieldName), ...overrides }
 }
 
-/**
- * Resolve the effective file column map.
- */
+/** Resolve the effective file column map; see {@link resolveImageColumnMap}. */
 export function resolveFileColumnMap(
   fieldName: string,
   overrides?: Partial<FileColumnMap>,

--- a/packages/storage/src/utils/multi-column.ts
+++ b/packages/storage/src/utils/multi-column.ts
@@ -19,13 +19,7 @@ import type { FileMetadata, ImageMetadata } from '../config/types.js'
  * column (whose physical name is configurable via `@map`).
  */
 export type ImageColumnPart =
-  | 'url'
-  | 'width'
-  | 'height'
-  | 'filesize'
-  | 'contentType'
-  | 'contentDisposition'
-  | 'pathname'
+  'url' | 'width' | 'height' | 'filesize' | 'contentType' | 'contentDisposition' | 'pathname'
 
 /**
  * The logical "parts" of a Keystone file field. `pathname` and `contentType`

--- a/packages/storage/src/utils/upload.ts
+++ b/packages/storage/src/utils/upload.ts
@@ -1,8 +1,5 @@
 import mime from 'mime-types'
 
-/**
- * File validation options
- */
 export interface FileValidationOptions {
   /** Maximum file size in bytes */
   maxFileSize?: number
@@ -12,17 +9,11 @@ export interface FileValidationOptions {
   acceptedExtensions?: string[]
 }
 
-/**
- * File validation result
- */
 export interface FileValidationResult {
   valid: boolean
   error?: string
 }
 
-/**
- * Validates a file against the provided options
- */
 export function validateFile(
   file: { size: number; name: string; type: string },
   options?: FileValidationOptions,
@@ -31,7 +22,6 @@ export function validateFile(
     return { valid: true }
   }
 
-  // Check file size
   if (options.maxFileSize && file.size > options.maxFileSize) {
     return {
       valid: false,
@@ -39,7 +29,6 @@ export function validateFile(
     }
   }
 
-  // Check MIME type
   if (options.acceptedMimeTypes && options.acceptedMimeTypes.length > 0) {
     const fileMimeType = file.type || mime.lookup(file.name) || ''
     if (!options.acceptedMimeTypes.includes(fileMimeType)) {
@@ -50,7 +39,6 @@ export function validateFile(
     }
   }
 
-  // Check file extension
   if (options.acceptedExtensions && options.acceptedExtensions.length > 0) {
     const ext = file.name.substring(file.name.lastIndexOf('.')).toLowerCase()
     if (!options.acceptedExtensions.includes(ext)) {
@@ -64,9 +52,6 @@ export function validateFile(
   return { valid: true }
 }
 
-/**
- * Formats file size in human-readable format
- */
 export function formatFileSize(bytes: number): string {
   if (bytes === 0) return '0 Bytes'
 
@@ -77,16 +62,10 @@ export function formatFileSize(bytes: number): string {
   return `${Math.round((bytes / Math.pow(k, i)) * 100) / 100} ${sizes[i]}`
 }
 
-/**
- * Gets MIME type from filename
- */
 export function getMimeType(filename: string): string {
   return mime.lookup(filename) || 'application/octet-stream'
 }
 
-/**
- * Extracts file metadata from a File or Blob
- */
 export interface FileInfo {
   name: string
   size: number
@@ -94,18 +73,12 @@ export interface FileInfo {
   lastModified?: number
 }
 
-/**
- * Converts a File/Blob to Buffer for Node.js processing
- */
 export async function fileToBuffer(file: Blob | File): Promise<Buffer> {
   const arrayBuffer = await file.arrayBuffer()
   return Buffer.from(arrayBuffer)
 }
 
-/**
- * Parses FormData and extracts file information
- * This is a utility for developers to use in their upload routes
- */
+/** Utility for developers to use in their own upload routes. */
 export async function parseFileFromFormData(
   formData: FormData,
   fieldName: string = 'file',

--- a/packages/tiptap/src/components/TiptapField.tsx
+++ b/packages/tiptap/src/components/TiptapField.tsx
@@ -66,14 +66,12 @@ export function TiptapField({
     },
   })
 
-  // Update content when value changes externally
   useEffect(() => {
     if (editor && value !== editor.getJSON()) {
       editor.commands.setContent(value || '')
     }
   }, [editor, value])
 
-  // Update editable state when mode or disabled changes
   useEffect(() => {
     if (editor) {
       editor.setEditable(isEditable)
@@ -98,9 +96,7 @@ export function TiptapField({
         {required && <span className="text-destructive">*</span>}
       </label>
 
-      {/* Editor with toolbar */}
       <div className={`tiptap-editor ${error ? 'border-destructive' : ''}`}>
-        {/* Toolbar */}
         {isEditable && editor && (
           <div className="tiptap-toolbar">
             <button
@@ -174,7 +170,6 @@ export function TiptapField({
           </div>
         )}
 
-        {/* Editor content */}
         <div
           className={disabled ? 'opacity-50 cursor-not-allowed' : ''}
           style={{

--- a/packages/tiptap/src/config/types.ts
+++ b/packages/tiptap/src/config/types.ts
@@ -10,26 +10,16 @@ export type RichTextField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConf
     isRequired?: boolean
   }
   ui?: {
-    /**
-     * Placeholder text for empty editor
-     */
+    /** Placeholder text for empty editor */
     placeholder?: string
-    /**
-     * Minimum height for editor in pixels
-     */
+    /** Minimum height for editor in pixels */
     minHeight?: number
-    /**
-     * Maximum height for editor in pixels
-     */
+    /** Maximum height for editor in pixels */
     maxHeight?: number
-    /**
-     * Custom React component to render this field
-     */
+    /** Custom React component to render this field */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     component?: any
-    /**
-     * Custom field type name to use from the global registry
-     */
+    /** Custom field type name to use from the global registry */
     fieldType?: string
   }
 }

--- a/packages/tiptap/src/fields/richText.ts
+++ b/packages/tiptap/src/fields/richText.ts
@@ -28,18 +28,16 @@ export function richText(options?: Omit<RichTextField, 'type'>): RichTextField {
       const validation = options?.validation
       const isRequired = validation?.isRequired
 
-      // Accept any valid JSON structure from Tiptap
-      // Tiptap outputs JSONContent which is a complex nested structure
+      // Tiptap emits a complex nested JSONContent structure; accept any valid JSON.
       const baseSchema = z.any()
 
       if (isRequired && operation === 'create') {
-        // For create, reject undefined
+        // Reject undefined on create.
         return baseSchema
       } else if (isRequired && operation === 'update') {
-        // For update, allow undefined (partial updates)
+        // Allow undefined on update (partial updates).
         return z.union([baseSchema, z.undefined()])
       } else {
-        // Not required
         return baseSchema.optional()
       }
     },


### PR DESCRIPTION
## Summary

Applies the Comments rule from `CLAUDE.md`'s `## Comments` section to `packages/storage`, `packages/storage-s3`, `packages/storage-vercel`, `packages/tiptap` and `packages/create-opensaas-app`, following the worked before/after examples in `docs/agents/comments.md` (produced by #936).

- Deleted comments that restate the line beneath them, docblocks that are pure restatements of the exported name (`FileFieldConfig`, `getMimeType`, etc.), section-label comments over self-explanatory code (`// Validate file`, `// Copy template files`, ...), and JSX comments restating the element below them.
- Trimmed duplicated rationale — e.g. the `.nullish()`/Zod-4 key-optionality note in `packages/storage/src/fields/index.ts` is stated in full once (on `file()`) and pointed to from `image()`; `resolveFileColumnMap` now points at `resolveImageColumnMap` instead of re-deriving the same explanation.
- Kept TSDoc on exported config options, field builders, and plugin surfaces (e.g. `StorageProvider`, `ImageDbConfig`/`FileDbConfig`, `richText()`'s `@example`), `eslint-disable ... --` justifications, and external-constraint / footgun notes worth preserving — the S3 and Vercel Blob API behavior notes (credential precedence, store-ID parsing, stream-to-buffer conversion, overwrite semantics), the ADR-0006 no-re-upload guarantee, and the Next.js SSR (`immediatelyRender: false`) note in the Tiptap component.
- `packages/create-opensaas-app` was mostly scaffolding narration (`// Parse command line arguments`, `// Create project`, ...) — deleted the narration, kept the CLI-flag-parsing edge-case rationale (e.g. why `--db postgres my-app` still resolves `my-app` as the project name) and the Postgres-transform/env-file rationale.

Comment-only change: no behavior changes, no renames, no adjacent refactors.

## Test plan

- [x] `pnpm exec eslint` on all five packages' `src/` — clean
- [x] `pnpm build` for `@opensaas/stack-core`, `@opensaas/stack-storage`, `@opensaas/stack-storage-s3`, `@opensaas/stack-storage-vercel`, `@opensaas/stack-tiptap`, `create-opensaas-app` — all typecheck clean
- [x] `pnpm test` for `@opensaas/stack-storage` (167 passed), `@opensaas/stack-storage-s3` (43 passed), `@opensaas/stack-storage-vercel` (56 passed), `create-opensaas-app` (41 passed, 2 skipped) — no test file touched, no test diffs
- [x] Patch changeset added for all five affected packages

Closes #944


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJa9nv8EkKyes9D7pTZN2r)_