### PR TITLE
core: redact HashedPassword.toJSON() so JSON.stringify never leaks the hash

### DIFF
--- a/.changeset/silent-otters-redact.md
+++ b/.changeset/silent-otters-redact.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix `HashedPassword.toJSON()` returning the raw bcrypt hash, so `JSON.stringify` of a row (e.g. a server→client prop, `Response.json()`, an MCP tool response) no longer leaks the stored hash for a `password()` field.
+
+`toJSON()` now returns `{ isSet: boolean }`, matching the redaction the admin UI already applies via `valueForClientSerialization`. `toString()`, `valueOf()`, `[Symbol.toPrimitive]`, and `==` comparison against the hash are unchanged. If you parse `JSON.stringify`'d rows and read the password field as a string, update that code to read `.isSet` instead — this is a visible output/type change on `HashedPassword.toJSON()`, though the field's read access remains the application's to configure (unchanged).

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -930,7 +930,10 @@ function formatCalendarDay(value: unknown): string | null | undefined {
  * ```
  *
  * **Important Notes:**
- * - Password fields are excluded from read operations by default in access control
+ * - Password field values are redacted to `{ isSet: boolean }` on serialization
+ *   (`JSON.stringify`, the admin UI). Field-level `read` access is not denied by
+ *   default — configure `access.field.read` if the raw value should never reach
+ *   `context.db` callers at all.
  * - Always use the `compare()` method to verify passwords - never compare strings directly
  * - The password field value has type `HashedPassword` which extends string with compare()
  * - Empty strings and undefined values are skipped (not hashed) to allow partial updates

--- a/packages/core/src/utils/password.ts
+++ b/packages/core/src/utils/password.ts
@@ -67,9 +67,11 @@ export class HashedPassword {
     return this.hash
   }
 
-  // JSON.stringify calls this when present, so the hash serializes as a plain string.
-  toJSON(): string {
-    return this.hash
+  // JSON.stringify calls this when present, so this is the serialize-for-output
+  // redaction point — never return the hash here. toString()/valueOf()/
+  // Symbol.toPrimitive stay unredacted for internal string/compare use.
+  toJSON(): { isSet: boolean } {
+    return { isSet: !!this.hash }
   }
 
   valueOf(): string {

--- a/packages/core/tests/mcp-handler.test.ts
+++ b/packages/core/tests/mcp-handler.test.ts
@@ -3,6 +3,7 @@ import { createMcpHandlers } from '../src/mcp/handler.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 import type { AccessContext } from '../src/access/types.js'
 import type { McpSession, McpSessionProvider } from '../src/mcp/types.js'
+import { HashedPassword } from '../src/utils/password.js'
 
 describe('MCP Handler', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -358,6 +359,41 @@ describe('MCP Handler', () => {
 
       const result = JSON.parse(data.result.content[0].text)
       expect(result.items[0].occurredAtMs).toBe('9007199254740993')
+    })
+
+    // Regression test (issue #965): the response's JSON.stringify replacer runs
+    // AFTER toJSON, so it can't intercept a HashedPassword that leaks its hash
+    // from toJSON — the redaction has to live in HashedPassword itself.
+    it('should not leak a bcrypt hash for a password field in the query response', async () => {
+      const hash = '$2b$04$q5yvruv7NaUYCQvV.UGzf.92.dpteicGq5MoSHYNWqzIm.bsIIJrW'
+      const mockResults = [{ id: '1', title: 'Post 1', password: new HashedPassword(hash) }]
+      mockPrisma.post.findMany.mockResolvedValue(mockResults)
+
+      const handlers = createMcpHandlers({ config, getSession: mockGetSession, getContext })
+
+      const request = new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'list_post_query',
+            arguments: { where: {}, take: 10 },
+          },
+        }),
+      })
+
+      const response = await handlers.POST(request)
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      const responseBody = data.result.content[0].text
+      expect(responseBody).not.toContain(hash)
+
+      const result = JSON.parse(responseBody)
+      expect(result.items[0].password).toEqual({ isSet: true })
     })
 
     it('should execute create operation', async () => {

--- a/packages/core/tests/password-types.test.ts
+++ b/packages/core/tests/password-types.test.ts
@@ -143,4 +143,32 @@ describe('Password Field Type Safety', () => {
       expect(await passwordField.compare('test')).toBe(false)
     }
   })
+
+  it('should redact the password field when a read row is JSON.stringify-ed', async () => {
+    const readableConfig = config({
+      db: { provider: 'sqlite' },
+      lists: {
+        User: list({
+          fields: {
+            email: text({ validation: { isRequired: true } }),
+            password: password({ validation: { isRequired: true } }),
+          },
+          access: { operation: { query: () => true } },
+        }),
+      },
+    })
+    const readablePrismaClient = {
+      user: {
+        ...mockPrismaClient.user,
+        findFirst: mockPrismaClient.user.findUnique,
+      },
+    } as unknown as PrismaClient
+    const context = getContext(await readableConfig, readablePrismaClient, null)
+
+    const user = await context.db.user.findUnique({ where: { id: '1' } })
+
+    const serialized = JSON.stringify(user)
+    expect(serialized).not.toContain('$2a$10$hashedpassword')
+    expect(JSON.parse(serialized).password).toEqual({ isSet: true })
+  })
 })

--- a/packages/core/tests/password.test.ts
+++ b/packages/core/tests/password.test.ts
@@ -161,12 +161,26 @@ describe('Password Utilities', () => {
       expect(`Password: ${wrapped}`).toBe(`Password: ${hash}`)
     })
 
-    it('should serialize to JSON correctly', async () => {
+    it('should redact the hash when serialized to JSON', async () => {
       const hash = await hashPassword('test')
       const wrapped = new HashedPassword(hash)
 
+      expect(JSON.stringify(wrapped)).toBe(JSON.stringify({ isSet: true }))
+
       const json = JSON.stringify({ password: wrapped })
-      expect(json).toBe(JSON.stringify({ password: hash }))
+      expect(json).toBe(JSON.stringify({ password: { isSet: true } }))
+      expect(json).not.toContain(hash)
+    })
+
+    it('should keep returning the raw hash from string-coercion surfaces', async () => {
+      const hash = await hashPassword('test')
+      const wrapped = new HashedPassword(hash)
+
+      expect(wrapped.toString()).toBe(hash)
+      expect(wrapped.valueOf()).toBe(hash)
+      expect(String(wrapped)).toBe(hash)
+      expect(`${wrapped}`).toBe(hash)
+      expect(wrapped == hash).toBe(true)
     })
 
     it('should work with valueOf', async () => {


### PR DESCRIPTION
## Summary

- `HashedPassword.toJSON()` now returns `{ isSet: boolean }` instead of the raw bcrypt hash, so `JSON.stringify` of any row carrying a `password()` field (server→client props, `Response.json()`, the MCP `query` tool's response, structured logging) no longer leaks the stored hash.
- This matches the redaction the `password()` field's admin-UI path already applies via `valueForClientSerialization`, closing the gap where that was the *only* safe serialization path.
- String-coercion surfaces (`toString()`, `valueOf()`, `[Symbol.toPrimitive]`, template-literal interpolation, `==` comparison) are unchanged and still return the raw hash, for internal string/compare use. `compare()` is unaffected.
- Corrected the `password()` field builder's docblock, which incorrectly claimed password fields are excluded from reads by default in access control — there is no such special-casing, and field-level read access defaults to allow. The docblock now describes the actual redaction-on-serialization behavior.
- Rewrote the pre-existing test that explicitly pinned the leaky behavior (`should serialize to JSON correctly`) to assert the redacted shape instead.

Out of scope (per issue discussion): changing the `password()` field's default `read` access, and the derived auth lists' plain-text credential fields (`Account.password`/`accessToken`/etc.) — tracked separately.

## Test plan

- [x] `JSON.stringify(new HashedPassword(hash))` yields `{ isSet: true }` and contains no substring of the hash
- [x] `JSON.stringify(row)` for a row read through `context.db` with a `password()` field emits the redacted marker, no bcrypt hash anywhere in the output
- [x] The MCP `query` tool's serialized response for a list carrying a `password()` field contains no bcrypt hash, asserted against the handler's actual response body
- [x] `toString()`, `valueOf()`, `String(wrapped)`, `` `${wrapped}` ``, and `wrapped == hash` all still yield the raw hash
- [x] `compare()` unaffected
- [x] `pnpm build`, `pnpm lint`, `pnpm format`, `pnpm manypkg fix`, and the core package's full test suite (1057 tests) pass
- [x] Changeset added (`@opensaas/stack-core`, patch)

Closes #965


---
_Generated by [Claude Code](https://claude.ai/code/session_012jDvGRH1p9YEscgU9h33nS)_