### PR TITLE
Extend isIndexed to integer, timestamp, and select fields

### DIFF
--- a/.changeset/silly-plums-arrive.md
+++ b/.changeset/silly-plums-arrive.md
@@ -1,0 +1,18 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Extend `isIndexed` to `integer`, `timestamp`, and `select`, matching `text`, `decimal`, `bigInt`, `calendarDay`, and `relationship`.
+
+```typescript
+fields: {
+  rank: integer({ isIndexed: true }),
+  publishedAt: timestamp({ isIndexed: true }),
+  status: select({
+    options: [{ label: 'Draft', value: 'draft' }],
+    isIndexed: 'unique',
+  }),
+}
+```
+
+`isIndexed: true` generates a block-level `@@index([field])`; `isIndexed: 'unique'` generates an inline `@unique`. `select` supports both under the default string column and a native-enum column (`db: { type: 'enum' }`). No field type's default indexing behavior changes — an existing config generates the same schema as before.

--- a/docs/content/concepts/field-types.md
+++ b/docs/content/concepts/field-types.md
@@ -58,6 +58,9 @@ fields: {
     },
     defaultValue: 0,
   }),
+  rank: integer({
+    isIndexed: true,
+  }),
 }
 ```
 
@@ -67,6 +70,7 @@ fields: {
 - `validation.min`: Minimum value
 - `validation.max`: Maximum value
 - `defaultValue`: Default integer value
+- `isIndexed`: Boolean or `'unique'` for indexing
 
 ### BigInt Field
 
@@ -221,6 +225,9 @@ fields: {
   updatedAt: timestamp({
     db: { updatedAt: true }, // Auto-update on changes
   }),
+  scheduledAt: timestamp({
+    isIndexed: true,
+  }),
 }
 ```
 
@@ -228,6 +235,7 @@ fields: {
 
 - `defaultValue.kind`: `'now'` for current timestamp
 - `db.updatedAt`: Boolean - auto-update on record changes
+- `isIndexed`: Boolean or `'unique'` for indexing (not indexed by default)
 
 ### Calendar Day Field
 
@@ -377,6 +385,10 @@ fields: {
       displayMode: 'select', // or 'radio', 'segmented-control'
     },
   }),
+  category: select({
+    options: [{ label: 'News', value: 'news' }],
+    isIndexed: true,
+  }),
 }
 ```
 
@@ -386,6 +398,7 @@ fields: {
 - `defaultValue`: Default selected value
 - `validation.isRequired`: Boolean
 - `ui.displayMode`: `'select'` | `'radio'` | `'segmented-control'`
+- `isIndexed`: Boolean or `'unique'` for indexing — well-defined under both the default string column and a native-enum column (`db: { type: 'enum' }`)
 
 ### Relationship Field
 

--- a/docs/content/reference/fields-api.md
+++ b/docs/content/reference/fields-api.md
@@ -153,6 +153,7 @@ integer(options?: {
     min?: number
     max?: number
   }
+  isIndexed?: boolean | 'unique'
   ui?: {
     [key: string]: unknown
   }
@@ -198,6 +199,28 @@ Default value when creating new items.
 
 ```typescript
 score: integer({ defaultValue: 0 })
+```
+
+##### `isIndexed`
+
+Database index configuration.
+
+**Type:** `boolean | 'unique'`
+
+**Values:**
+
+- `true` - Create non-unique index for faster queries
+- `'unique'` - Create unique index (enforces uniqueness)
+- `false` or omitted - No index
+
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
+
+**Example:**
+
+```typescript
+rank: integer({
+  isIndexed: true,
+})
 ```
 
 #### Database Type
@@ -629,6 +652,7 @@ import { timestamp } from '@opensaas/stack-core/fields'
 
 timestamp(options?: {
   defaultValue?: { kind: 'now' } | Date
+  isIndexed?: boolean | 'unique'
   ui?: {
     [key: string]: unknown
   }
@@ -658,6 +682,30 @@ createdAt: timestamp({
 })
 
 publishedAt: timestamp()
+```
+
+##### `isIndexed`
+
+Database index configuration.
+
+**Type:** `boolean | 'unique'`
+
+**Values:**
+
+- `true` - Create non-unique index for faster queries
+- `'unique'` - Create unique index (enforces uniqueness)
+- `false` or omitted - No index
+
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column.
+
+`timestamp` does not default to indexed — an explicit `isIndexed: true` is required, even for a field commonly used as a sort key, so an existing config's generated schema never changes without an intentional edit.
+
+**Example:**
+
+```typescript
+publishedAt: timestamp({
+  isIndexed: true,
+})
 ```
 
 #### Database Type
@@ -951,6 +999,7 @@ select(options: {
     isRequired?: boolean
   }
   defaultValue?: string
+  isIndexed?: boolean | 'unique'
   ui?: {
     displayMode?: 'select' | 'segmented-control' | 'radio'
     [key: string]: unknown
@@ -1018,6 +1067,29 @@ UI component to use for selection.
 - `'select'` - Dropdown select menu
 - `'segmented-control'` - Button group (good for 2-4 options)
 - `'radio'` - Radio button group
+
+##### `isIndexed`
+
+Database index configuration.
+
+**Type:** `boolean | 'unique'`
+
+**Values:**
+
+- `true` - Create non-unique index for faster queries
+- `'unique'` - Create unique index (enforces uniqueness)
+- `false` or omitted - No index
+
+`isIndexed` is sugar for an unnamed single-column `@@index`/`@@unique`. For a named constraint (e.g. adopting a live table's existing constraint name), a `sort` direction, or a constraint spanning more than one field, use the list's [`db.indexes`](/docs/reference/config-api#dbindexes) instead — the two must not both target the same column. Well-defined under both the default string column and a native-enum column (`db: { type: 'enum' }`).
+
+**Example:**
+
+```typescript
+status: select({
+  options: [/* ... */],
+  isIndexed: true,
+})
+```
 
 #### Database Type
 

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -1176,6 +1176,9 @@ describe('Prisma Schema Generator', () => {
               label: text({ isIndexed: true }),
               amount: decimal({ isIndexed: true }),
               takenOn: calendarDay({ isIndexed: true }),
+              count: integer({ isIndexed: true }),
+              recordedAt: timestamp({ isIndexed: true }),
+              status: select({ options: [{ label: 'Open', value: 'open' }], isIndexed: true }),
             },
           },
         },
@@ -1186,6 +1189,33 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toContain('@@index([label])')
       expect(schema).toContain('@@index([amount])')
       expect(schema).toContain('@@index([takenOn])')
+      expect(schema).toContain('@@index([count])')
+      expect(schema).toContain('@@index([recordedAt])')
+      expect(schema).toContain('@@index([status])')
+      expect(schema).not.toMatch(/\s@index\b/)
+    })
+
+    it('should generate @@index for a select with a native-enum column', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'postgresql',
+        },
+        lists: {
+          Post: {
+            fields: {
+              status: select({
+                options: [{ label: 'Open', value: 'open' }],
+                db: { type: 'enum' },
+                isIndexed: true,
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('@@index([status])')
       expect(schema).not.toMatch(/\s@index\b/)
     })
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -844,6 +844,7 @@ export type IntegerField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfi
     min?: number
     max?: number
   }
+  isIndexed?: boolean | 'unique'
 }
 
 export type DecimalField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<TTypeInfo> & {
@@ -885,6 +886,7 @@ export type CheckboxField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConf
 export type TimestampField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<TTypeInfo> & {
   type: 'timestamp'
   defaultValue?: { kind: 'now' } | Date
+  isIndexed?: boolean | 'unique'
 }
 
 export type CalendarDayField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig<TTypeInfo> & {
@@ -989,6 +991,7 @@ export type SelectField<TTypeInfo extends TypeInfo = TypeInfo> = BaseFieldConfig
   validation?: {
     isRequired?: boolean
   }
+  isIndexed?: boolean | 'unique'
   ui?: {
     displayMode?: 'select' | 'segmented-control' | 'radio'
   }

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -229,9 +229,16 @@ export function integer<
         modifiers += ` @map("${db.map}")`
       }
 
+      // Unique modifier — non-unique index routes through `index` below,
+      // same as `text()`'s getPrismaType.
+      if (options?.isIndexed === 'unique') {
+        modifiers += ' @unique'
+      }
+
       return {
         type: 'Int',
         modifiers: modifiers.trimStart() || undefined,
+        index: options?.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {
@@ -657,9 +664,16 @@ export function timestamp<
         modifiers += ` @map("${db.map}")`
       }
 
+      // Unique modifier — non-unique index routes through `index` below,
+      // same as `text()`'s getPrismaType.
+      if (options?.isIndexed === 'unique') {
+        modifiers += ' @unique'
+      }
+
       return {
         type: 'DateTime',
         modifiers: modifiers.trimStart() || undefined,
+        index: options?.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {
@@ -1129,10 +1143,17 @@ export function select<
           modifiers += ` @map("${options.db.map}")`
         }
 
+        // Unique modifier — non-unique index routes through `index` below,
+        // same as `text()`'s getPrismaType.
+        if (options.isIndexed === 'unique') {
+          modifiers += ' @unique'
+        }
+
         return {
           type: enumName,
           modifiers: modifiers || undefined,
           enumValues: options.options.map((opt) => opt.value),
+          index: options.isIndexed === true ? true : undefined,
         }
       }
 
@@ -1146,9 +1167,14 @@ export function select<
         modifiers += ` @map("${options.db.map}")`
       }
 
+      if (options.isIndexed === 'unique') {
+        modifiers += ' @unique'
+      }
+
       return {
         type: 'String',
         modifiers: modifiers || undefined,
+        index: options.isIndexed === true ? true : undefined,
       }
     },
     getTypeScriptType: () => {

--- a/packages/core/tests/field-types.test.ts
+++ b/packages/core/tests/field-types.test.ts
@@ -307,6 +307,29 @@ describe('Field Types', () => {
         expect(prismaType.type).toBe('Int')
         expect(prismaType.modifiers).toBe('@db.BigInt')
       })
+
+      test('isIndexed: true requests a block-level index', () => {
+        const field = integer({ isIndexed: true })
+        const prismaType = field.getPrismaType('rank')
+
+        expect(prismaType.index).toBe(true)
+      })
+
+      test("isIndexed: 'unique' generates @unique modifier", () => {
+        const field = integer({ isIndexed: 'unique' })
+        const prismaType = field.getPrismaType('rank')
+
+        expect(prismaType.modifiers).toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
+      })
+
+      test('no isIndexed generates neither modifier nor index', () => {
+        const field = integer()
+        const prismaType = field.getPrismaType('rank')
+
+        expect(prismaType.modifiers).not.toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
+      })
     })
 
     describe('getTypeScriptType', () => {
@@ -679,6 +702,29 @@ describe('Field Types', () => {
         expect(prismaType.type).toBe('DateTime')
         expect(prismaType.modifiers).toContain('@db.Timestamptz')
       })
+
+      test('isIndexed: true requests a block-level index', () => {
+        const field = timestamp({ isIndexed: true })
+        const prismaType = field.getPrismaType('publishedAt')
+
+        expect(prismaType.index).toBe(true)
+      })
+
+      test("isIndexed: 'unique' generates @unique modifier", () => {
+        const field = timestamp({ isIndexed: 'unique' })
+        const prismaType = field.getPrismaType('publishedAt')
+
+        expect(prismaType.modifiers).toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
+      })
+
+      test('no isIndexed generates neither modifier nor index', () => {
+        const field = timestamp()
+        const prismaType = field.getPrismaType('publishedAt')
+
+        expect(prismaType.modifiers).not.toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
+      })
     })
 
     describe('getTypeScriptType', () => {
@@ -904,6 +950,52 @@ describe('Field Types', () => {
 
         expect(prismaType.type).toBe('String')
         expect(prismaType.modifiers).toBe(' @default("draft")')
+      })
+
+      test('isIndexed: true requests a block-level index on the default string column', () => {
+        const field = select({
+          options: [{ label: 'Draft', value: 'draft' }],
+          isIndexed: true,
+        })
+        const prismaType = field.getPrismaType('status')
+
+        expect(prismaType.type).toBe('String')
+        expect(prismaType.index).toBe(true)
+      })
+
+      test("isIndexed: 'unique' generates @unique on the default string column", () => {
+        const field = select({
+          options: [{ label: 'Draft', value: 'draft' }],
+          isIndexed: 'unique',
+        })
+        const prismaType = field.getPrismaType('status')
+
+        expect(prismaType.modifiers).toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
+      })
+
+      test('isIndexed: true requests a block-level index on a native-enum column', () => {
+        const field = select({
+          options: [{ label: 'Draft', value: 'draft' }],
+          db: { type: 'enum' },
+          isIndexed: true,
+        })
+        const prismaType = field.getPrismaType('status', undefined, 'Post')
+
+        expect(prismaType.type).toBe('PostStatus')
+        expect(prismaType.index).toBe(true)
+      })
+
+      test("isIndexed: 'unique' generates @unique on a native-enum column", () => {
+        const field = select({
+          options: [{ label: 'Draft', value: 'draft' }],
+          db: { type: 'enum' },
+          isIndexed: 'unique',
+        })
+        const prismaType = field.getPrismaType('status', undefined, 'Post')
+
+        expect(prismaType.modifiers).toContain('@unique')
+        expect(prismaType.index).toBeUndefined()
       })
     })
 


### PR DESCRIPTION
## Summary

- `integer`, `timestamp`, and `select` field types now accept `isIndexed?: boolean | 'unique'`, matching `text`, `decimal`, `bigInt`, `calendarDay`, and `relationship`.
- `isIndexed: true` requests a block-level `@@index([field])`; `isIndexed: 'unique'` requests an inline `@unique` on the column; `false`/omitted generates neither.
- `select` supports both under its default plain-string column and under an opt-in native-enum column (`db: { type: 'enum' }`).
- No default indexing behavior changes for any field type — `timestamp` in particular does **not** become indexed by default, so an existing config generates a byte-for-byte identical schema unless it opts in.
- No generator changes were needed: the out-of-line `@@index`/`@@unique` mechanism from #859 already reads `getPrismaType().index` generically for every field type, and the context layer's unique-field detection (`context/index.ts`) already tests `'isIndexed' in fieldConfig` generically.
- `json`, `password`, `checkbox`, and `virtual` remain excluded (per the issue's decisions: provider-specific indexability, no sensible use case, and no column at all, respectively).

## Test plan

- [x] `packages/core/tests/field-types.test.ts` — added `isIndexed: true` / `'unique'` / omitted cases for `integer`, `timestamp`, and `select` (both plain-string and native-enum `select` columns)
- [x] `packages/cli/src/generator/prisma.test.ts` — extended the existing "should generate @@index for every scalar type that accepts isIndexed" test (rather than adding a parallel test) to cover `integer`, `timestamp`, and `select`; added a dedicated test for the native-enum `select` column
- [x] `pnpm test` passes in `packages/core` (1064 tests) and `packages/cli` (377 tests)
- [x] `pnpm build` passes in both packages
- [x] `pnpm lint` — no new warnings/errors
- [x] `pnpm format` — no changes needed
- [x] Minor changeset added (`@opensaas/stack-core`)
- [x] Field reference docs (`docs/content/reference/fields-api.md`, `docs/content/concepts/field-types.md`) updated to list the new types

Closes #860


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkgv5rBZSxTuCjiWdsqXof)_