### PR TITLE
fix(auth): Session.user/Account.user FK column now maps to userId

### DIFF
--- a/.changeset/tidy-otters-clap.md
+++ b/.changeset/tidy-otters-clap.md
@@ -1,0 +1,7 @@
+---
+'@opensaas/stack-auth': patch
+---
+
+Fix `Session.user`/`Account.user` foreign key generating a `user` physical column instead of `userId`, mismatching better-auth's own schema and breaking clean-diff adoption (ADR-0007). An explicit `fields: { userId: ... }` override is unaffected.
+
+**Migration note:** existing greenfield projects need to rename the column on `Session` and `Account` (e.g. `ALTER TABLE "Session" RENAME COLUMN "user" TO "userId";` and the same for `Account`) to match the new generated schema.

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -77,7 +77,10 @@ and the plugin's add-vs-extend logic consume:
   (defaults to `modelName` when it differs from the better-auth default,
   otherwise unset — i.e. unchanged output when `tableName` isn't set)
 - per-model `fields` (better-auth field → column) → field-level `@map`
-- the `userId` column override → the `user` relationship foreign-key `@map`
+- the `user` relationship foreign key always maps to a `userId` column
+  (mirroring better-auth's own column, not the generator's Keystone-parity
+  default of the relationship field name) — a `userId` column override
+  in `fields` replaces that default, exactly like any other field `@map`
 - relationship refs between the Auth lists follow the derived keys
   (e.g. `Session.user → AuthUser.sessions`)
 

--- a/packages/auth/src/config/derive-auth-lists.ts
+++ b/packages/auth/src/config/derive-auth-lists.ts
@@ -78,18 +78,23 @@ function fieldDb(fieldName: string, fields: Record<string, string>): { map: stri
  * `Account.user`), honouring a `userId` column override from the better-auth
  * `fields` map and mirroring better-auth's own FK shape: no separate FK index
  * — the index is applied at the field level via `isIndexed: false` —
- * `onDelete: Cascade`, and a required (non-nullable) foreign key, since
- * better-auth's adapter always writes a `userId` on every session/account row
- * it creates. This means a generated Auth schema diffs clean against a live
- * better-auth database on all three dimensions instead of showing a spurious
- * index drop, a referential-action change, and a `DROP NOT NULL` (issues #679,
- * #863).
+ * `onDelete: Cascade`, a required (non-nullable) foreign key, and a `userId`
+ * column, since better-auth's adapter always writes a `userId` column on
+ * every session/account row it creates. The column map is set unconditionally
+ * (defaulting to `userId`) rather than only when `fields.userId` is
+ * configured, since the generator's own Keystone-parity default would
+ * otherwise map the column to the relationship field name (`user`) — the
+ * wrong column for a database better-auth itself wrote to. This means a
+ * generated Auth schema diffs clean against a live better-auth database on
+ * all four dimensions instead of showing a spurious index drop, a
+ * referential-action change, a `DROP NOT NULL`, and a column rename (issues
+ * #679, #863, #935).
  */
 function userRelationshipDb(fields: Record<string, string>): NonNullable<RelationshipField['db']> {
-  const column = fields.userId
+  const column = fields.userId ?? 'userId'
   return {
     isNullable: false,
-    ...(column ? { foreignKey: { map: column } } : {}),
+    foreignKey: { map: column },
     extendPrismaSchema: ({ fkLine, relationLine }) => ({
       fkLine,
       relationLine: relationLine.replace('@relation(', '@relation(onDelete: Cascade, '),

--- a/packages/auth/tests/derive-auth-lists.test.ts
+++ b/packages/auth/tests/derive-auth-lists.test.ts
@@ -61,8 +61,11 @@ describe('deriveAuthLists - default behaviour (no overrides)', () => {
 
     expect(lists.User.fields.name.db?.map).toBeUndefined()
     expect(lists.Session.fields.token.db?.map).toBeUndefined()
-    // FK column not overridden -> no foreignKey map on the relationship
-    expect(lists.Session.fields.user.db?.foreignKey).toBeUndefined()
+    // FK column not overridden -> the helper still pins it to userId, since
+    // the generator's own Keystone-parity default would otherwise map the
+    // column to the relationship field name ("user") — issue #935.
+    expect(lists.Session.fields.user.db?.foreignKey).toEqual({ map: 'userId' })
+    expect(lists.Account.fields.user.db?.foreignKey).toEqual({ map: 'userId' })
   })
 
   it('opts every auth list into auto-timestamps', () => {

--- a/packages/auth/tests/generated-fk-shape.test.ts
+++ b/packages/auth/tests/generated-fk-shape.test.ts
@@ -95,6 +95,10 @@ describe('generated auth schema — required columns mirror better-auth (issue #
       expect(block).not.toMatch(/userId\s+String\?/)
       expect(block).toMatch(/user\s+User\s+@relation/)
       expect(block).not.toMatch(/user\s+User\?/)
+
+      // The physical column must be userId, not the Keystone-parity default
+      // of the relationship field name ("user") — issue #935.
+      expect(block).not.toContain('@map("user")')
     }
   })
 


### PR DESCRIPTION
## Summary

- `userRelationshipDb()` (`packages/auth/src/config/derive-auth-lists.ts`) only set the FK column `@map` when a `userId` field override was explicitly configured in `authPlugin`. With no override, the generator's own Keystone-parity default stood: the FK column mapped to the **relationship field name** (`user`) rather than the Prisma field name (`userId`).
- better-auth's own column is `userId` on both `Session` and `Account`, so a bare `authPlugin()` config (and `adoptBetterAuthTables()`, which doesn't set the override either) generated a schema that diffs as a drop-and-add on the FK of the two busiest auth tables — breaking the ADR-0007 clean-diff promise.
- The helper now always sets `foreignKey: { map: ... }`, defaulting to `'userId'` when `fields.userId` isn't configured. An explicit override still wins, unchanged.
- Tightened `generated-fk-shape.test.ts` and `derive-auth-lists.test.ts`, both of which previously asserted patterns that matched the wrong (`user`) column and would not have caught this regression.
- Updated `packages/auth/CLAUDE.md`'s derivation summary to describe the new default.

## Migration note

This changes generated schema output for existing greenfield projects that ran with the `user` column. They'll need to rename the column on `Session` and `Account` to match (e.g. `ALTER TABLE "Session" RENAME COLUMN "user" TO "userId";` and the same for `Account`), called out in the changeset.

## Test plan

- [x] `pnpm --filter @opensaas/stack-auth test` — 261 passed, 2 skipped
- [x] `pnpm --filter @opensaas/stack-core test` — 1067 passed
- [x] `pnpm --filter @opensaas/stack-cli test` — 377 passed
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm manypkg fix` / `pnpm format` — no changes needed
- [x] Changeset added (`@opensaas/stack-auth`: patch)

Closes #935


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gnnd1nT6Y9Yq2HXeizBYZ8)_