### PR TITLE
MCP tool failures return isError results, not JSON-RPC protocol errors

### DIFF
--- a/.changeset/tame-hounds-nap.md
+++ b/.changeset/tame-hounds-nap.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+MCP derived CRUD tool and custom tool failures (access denial, thrown engine/database errors, input schema validation) now return a successful JSON-RPC response with `result.isError: true` instead of a JSON-RPC `error` object, so the calling model can see and recover from them. Genuine protocol failures (unknown method, malformed request, unknown tool name) are unchanged. Note: the wire shape of tool failures changes — a consumer asserting on the old `error` shape will need to update.

--- a/docs/content/how-to/mcp.md
+++ b/docs/content/how-to/mcp.md
@@ -417,7 +417,7 @@ fields: {
 
 ### Silent Failures
 
-When access is denied, query tools return empty results rather than errors — this prevents information leakage about whether records exist. Create, update, and delete tools return a JSON-RPC error ("Access denied or record not found") that deliberately does not distinguish between a missing record and denied access.
+When access is denied, query tools return empty results rather than errors — this prevents information leakage about whether records exist. Create, update, and delete tools return a successful tool result marked `isError: true` ("Access denied or record not found") that deliberately does not distinguish between a missing record and denied access — this is a recoverable tool failure, not a JSON-RPC protocol error, so the calling model can see it and adjust its request.
 
 ### Session Fields over MCP
 

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod'
 import type { OpenSaasConfig, FieldConfig, McpCustomTool } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
+import { AccessScopeDepthExceededError, RelationFilterAccessDeniedError } from '../access/errors.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { McpSession, McpSessionProvider } from './types.js'
 
@@ -482,7 +483,7 @@ async function handleCrudTool(
           data: args.data,
         })
         if (!result) {
-          return createErrorResponse(
+          return createErrorResultResponse(
             'Failed to create record. Access denied or validation failed.',
             id,
           )
@@ -495,7 +496,7 @@ async function handleCrudTool(
           data: args.data,
         })
         if (!result) {
-          return createErrorResponse(
+          return createErrorResultResponse(
             'Failed to update record. Access denied or record not found.',
             id,
           )
@@ -507,7 +508,7 @@ async function handleCrudTool(
           where: args.where,
         })
         if (!result) {
-          return createErrorResponse(
+          return createErrorResultResponse(
             'Failed to delete record. Access denied or record not found.',
             id,
           )
@@ -518,7 +519,13 @@ async function handleCrudTool(
         return createErrorResponse(`Unknown operation: ${operation}`, id)
     }
   } catch (error) {
-    return createErrorResponse(
+    if (
+      error instanceof AccessScopeDepthExceededError ||
+      error instanceof RelationFilterAccessDeniedError
+    ) {
+      return createErrorResultResponse(error.message, id)
+    }
+    return createErrorResultResponse(
       'Operation failed: ' + (error instanceof Error ? error.message : 'Unknown error'),
       id,
     )
@@ -550,20 +557,7 @@ async function handleCustomTool(
   if (isZodSchema(customTool.inputSchema)) {
     const parsed = customTool.inputSchema.safeParse(args)
     if (!parsed.success) {
-      return new Response(
-        JSON.stringify({
-          jsonrpc: '2.0',
-          id: id ?? null,
-          error: {
-            code: -32602,
-            message: `Invalid params: ${parsed.error.message}`,
-          },
-        }),
-        {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        },
-      )
+      return createErrorResultResponse(`Invalid params: ${parsed.error.message}`, id)
     }
     input = parsed.data
   }
@@ -578,7 +572,7 @@ async function handleCustomTool(
 
     return createSuccessResponse(result, id)
   } catch (error) {
-    return createErrorResponse(
+    return createErrorResultResponse(
       'Custom tool execution failed: ' + (error instanceof Error ? error.message : 'Unknown error'),
       id,
     )
@@ -597,15 +591,18 @@ function mcpJsonReplacer(_key: string, value: unknown): unknown {
   return typeof value === 'bigint' ? value.toString() : value
 }
 
+function toToolContent(data: unknown): { type: 'text'; text: string }[] {
+  const text = typeof data === 'string' ? data : JSON.stringify(data, mcpJsonReplacer, 2)
+  return [{ type: 'text', text }]
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Response data structure is flexible per MCP protocol
 function createSuccessResponse(data: any, id?: number | string): Response {
   return new Response(
     JSON.stringify({
       jsonrpc: '2.0',
       id: id ?? null,
-      result: {
-        content: [{ type: 'text', text: JSON.stringify(data, mcpJsonReplacer, 2) }],
-      },
+      result: { content: toToolContent(data) },
     }),
     {
       headers: { 'Content-Type': 'application/json' },
@@ -613,6 +610,28 @@ function createSuccessResponse(data: any, id?: number | string): Response {
   )
 }
 
+/**
+ * A dispatched tool that failed — access denial, a thrown engine/database
+ * error, or custom-tool input validation. This is a successful JSON-RPC
+ * response (HTTP 200, no `error` member): the model that called the tool
+ * needs to see the failure in `result` to have any chance of correcting its
+ * request, whereas a JSON-RPC `error` object is a protocol-level failure a
+ * host may never surface back to it.
+ */
+function createErrorResultResponse(message: string, id?: number | string): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: id ?? null,
+      result: { content: toToolContent(message), isError: true },
+    }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
+}
+
+/** Genuine JSON-RPC protocol failures — unknown method, malformed request, unknown tool name. */
 function createErrorResponse(message: string, id?: number | string): Response {
   return new Response(
     JSON.stringify({

--- a/packages/core/tests/mcp-handler.test.ts
+++ b/packages/core/tests/mcp-handler.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as z from 'zod'
 import { createMcpHandlers } from '../src/mcp/handler.js'
 import type { OpenSaasConfig } from '../src/config/types.js'
 import type { AccessContext } from '../src/access/types.js'
 import type { McpSession, McpSessionProvider } from '../src/mcp/types.js'
 import { HashedPassword } from '../src/utils/password.js'
+import {
+  AccessScopeDepthExceededError,
+  RelationFilterAccessDeniedError,
+} from '../src/access/errors.js'
 
 describe('MCP Handler', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -546,10 +551,12 @@ describe('MCP Handler', () => {
       })
 
       const response = await handlers.POST(request)
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(200)
 
       const data = await response.json()
-      expect(data.error.message).toContain('Access denied')
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('Access denied')
     })
   })
 
@@ -637,6 +644,109 @@ describe('MCP Handler', () => {
       const data = await response.json()
       expect(data.error.message).toContain('Unknown tool')
     })
+
+    it('should return a custom tool input schema validation failure as a tool result', async () => {
+      const configWithCustomTools = {
+        ...config,
+        lists: {
+          Post: {
+            ...config.lists.Post,
+            mcp: {
+              customTools: [
+                {
+                  name: 'publishPost',
+                  description: 'Publish a post',
+                  inputSchema: z.object({ postId: z.string() }),
+                  handler: vi.fn(),
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const handlers = createMcpHandlers({
+        config: configWithCustomTools,
+        getSession: mockGetSession,
+        getContext,
+      })
+
+      const request = new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'publishPost',
+            arguments: {},
+          },
+        }),
+      })
+
+      const response = await handlers.POST(request)
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('Invalid params')
+    })
+
+    it('should return a thrown custom tool error as a tool result', async () => {
+      const configWithCustomTools = {
+        ...config,
+        lists: {
+          Post: {
+            ...config.lists.Post,
+            mcp: {
+              customTools: [
+                {
+                  name: 'publishPost',
+                  description: 'Publish a post',
+                  inputSchema: {
+                    type: 'object' as const,
+                    properties: { postId: { type: 'string' } },
+                  },
+                  handler: vi.fn(async () => {
+                    throw new Error('cannot publish an already-published post')
+                  }),
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const handlers = createMcpHandlers({
+        config: configWithCustomTools,
+        getSession: mockGetSession,
+        getContext,
+      })
+
+      const request = new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'publishPost',
+            arguments: { postId: 'post-123' },
+          },
+        }),
+      })
+
+      const response = await handlers.POST(request)
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('cannot publish an already-published post')
+    })
   })
 
   describe('error handling', () => {
@@ -704,10 +814,74 @@ describe('MCP Handler', () => {
       })
 
       const response = await handlers.POST(request)
-      expect(response.status).toBe(400)
+      expect(response.status).toBe(200)
 
       const data = await response.json()
-      expect(data.error.message).toContain('Database error')
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('Database error')
+    })
+
+    it('should return a relation-filter access-denial error as a tool result naming the relation and related list', async () => {
+      mockPrisma.post.findMany.mockRejectedValue(
+        new RelationFilterAccessDeniedError('Post', 'author', 'User'),
+      )
+
+      const handlers = createMcpHandlers({ config, getSession: mockGetSession, getContext })
+
+      const request = new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'list_post_query',
+            arguments: { where: { author: { is: {} } } },
+          },
+        }),
+      })
+
+      const response = await handlers.POST(request)
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('Post.author')
+      expect(data.result.content[0].text).toContain('User')
+    })
+
+    it('should return a depth-exceeded error as a tool result worded as a cost refusal', async () => {
+      mockPrisma.post.findMany.mockRejectedValue(
+        new AccessScopeDepthExceededError('Post', 'author', 3),
+      )
+
+      const handlers = createMcpHandlers({ config, getSession: mockGetSession, getContext })
+
+      const request = new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'list_post_query',
+            arguments: {},
+          },
+        }),
+      })
+
+      const response = await handlers.POST(request)
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('Post.author')
+      expect(data.result.content[0].text).toContain('cost limit')
     })
   })
 


### PR DESCRIPTION
## Summary

- Derived CRUD tool failures (access denial on create/update/delete, `context.db` throwing — including the engine's `AccessScopeDepthExceededError` and `RelationFilterAccessDeniedError`) now return HTTP 200 with `result.isError: true` instead of a JSON-RPC `error` object, so the calling model actually sees the failure and can retry.
- Custom tool failures (input schema validation failure, a throw from the tool body) get the same treatment.
- The two engine errors are special-cased in the CRUD catch block so their existing, already-precise messages (naming the relation/list and, for the depth cap, wording it as a cost limit) reach the model verbatim rather than being flattened by the generic `"Operation failed: " + message` fallback.
- Genuine protocol failures are unchanged: unknown method (`-32601`), missing/unknown tool name, and malformed request body still return JSON-RPC `error` objects with their existing codes/status.
- Success and error tool results now share one `toToolContent` helper so error content is serialised through the same bigint-safe JSON replacer as success content.
- Existing handler tests that asserted the old HTTP 400 / `error.message` shape for access-denial and database-error cases are updated to assert the new result shape; added tests cover the two typed engine errors and both custom-tool failure paths.

## Test plan

- [x] `pnpm test` in `packages/core` — 1071 tests pass (50 files), including the updated/added MCP handler tests
- [x] `pnpm build` in `packages/core` — typechecks clean
- [x] `pnpm lint` at repo root — no new warnings/errors
- [x] `pnpm format` — no unrelated diffs
- [x] Changeset added (`@opensaas/stack-core` patch) noting the wire-shape change

Closes #995


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbQoPkM68jvrgXkVtRYyB5)_