### PR TITLE
fix(core): recover P2002 constraint info under Prisma 7 driver adapters

### DIFF
--- a/.changeset/tiny-cobras-jump.md
+++ b/.changeset/tiny-cobras-jump.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix `P2002` unique-constraint errors losing per-field detail under Prisma 7 driver adapters (`@prisma/adapter-pg`, PGlite), where `meta.target` is left empty. The error handler now recovers the violated columns and constraint name from the adapter's error shape, and a new `uniqueConstraintOf(error)` helper exposes this to callers of `context.db.*` directly. Unique-violation messages under driver adapters change from the generic fallback back to field-specific text.

--- a/e2e/starter-auth/02-posts-access-control.spec.ts
+++ b/e2e/starter-auth/02-posts-access-control.spec.ts
@@ -150,8 +150,12 @@ test.describe('Posts CRUD and Access Control', () => {
       await page.fill('textarea[name="content"]', 'Content')
       await page.click('button[type="submit"]')
 
-      // Should show error about duplicate slug
-      await expect(page.locator('text="A record with this value already exists"')).toBeVisible({
+      // Should show a field-specific error naming the violated column, not the
+      // generic fallback (Prisma 7 driver adapters don't populate meta.target
+      // directly — see issue #979).
+      await expect(
+        page.locator('text="Slug must be unique. The value you entered is already in use."'),
+      ).toBeVisible({
         timeout: 5000,
       })
     })

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -203,6 +203,14 @@ function getDefaultData(listConfig: ListConfig<any>): Record<string, unknown> {
   return data
 }
 
+// A camelCase field name (e.g. a relationship's `tenantId` foreign key) needs
+// its word boundary split before title-casing, or it reads as one run-together
+// word ("Tenantid") in a user-facing unique-constraint message.
+function humanizeFieldName(fieldName: string): string {
+  const spaced = fieldName.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
   if (
@@ -216,38 +224,30 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
 
     // P2002 is Prisma's unique constraint violation code.
     if (prismaError.code === 'P2002') {
-      const constraintInfo = uniqueConstraintOf(prismaError)
-      const target = constraintInfo?.fields
-      const constraintName = constraintInfo?.constraintName
+      const target = uniqueConstraintOf(prismaError)?.fields
       const fieldErrors: Record<string, string> = {}
 
       if (target && target.length > 0) {
         for (const fieldName of target) {
           const fieldConfig = listConfig.fields[fieldName]
-          const label = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
 
           if (fieldConfig) {
-            fieldErrors[fieldName] = `This ${label.toLowerCase()} is already in use`
+            fieldErrors[fieldName] =
+              `This ${humanizeFieldName(fieldName).toLowerCase()} is already in use`
           } else {
             fieldErrors[fieldName] = `This value is already in use`
           }
         }
 
-        const fieldLabels = target.map((f) => f.charAt(0).toUpperCase() + f.slice(1)).join(', ')
+        const fieldLabels = target.map(humanizeFieldName).join(', ')
         return new DatabaseError(
           `${fieldLabels} must be unique. The value you entered is already in use.`,
           fieldErrors,
           prismaError.code,
-          constraintName,
         )
       }
 
-      return new DatabaseError(
-        'A record with this value already exists',
-        {},
-        prismaError.code,
-        constraintName,
-      )
+      return new DatabaseError('A record with this value already exists', {}, prismaError.code)
     }
 
     return new DatabaseError(

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -14,6 +14,7 @@ import {
 import type { DeclaredOnlyTree } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
+import { uniqueConstraintOf } from '../lib/prisma-errors.js'
 import type { PrismaClientLike } from '../access/types.js'
 import { buildInclude, pickFields, isFragment, buildFieldSelectionScope } from '../query/index.js'
 import type { FieldSelection, FieldSelectionScope } from '../query/index.js'
@@ -215,10 +216,12 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
 
     // P2002 is Prisma's unique constraint violation code.
     if (prismaError.code === 'P2002') {
-      const target = prismaError.meta?.target
+      const constraintInfo = uniqueConstraintOf(prismaError)
+      const target = constraintInfo?.fields
+      const constraintName = constraintInfo?.constraintName
       const fieldErrors: Record<string, string> = {}
 
-      if (target && Array.isArray(target)) {
+      if (target && target.length > 0) {
         for (const fieldName of target) {
           const fieldConfig = listConfig.fields[fieldName]
           const label = fieldName.charAt(0).toUpperCase() + fieldName.slice(1)
@@ -235,10 +238,16 @@ function parsePrismaError(error: unknown, listConfig: ListConfig<any>): Error {
           `${fieldLabels} must be unique. The value you entered is already in use.`,
           fieldErrors,
           prismaError.code,
+          constraintName,
         )
       }
 
-      return new DatabaseError('A record with this value already exists', {}, prismaError.code)
+      return new DatabaseError(
+        'A record with this value already exists',
+        {},
+        prismaError.code,
+        constraintName,
+      )
     }
 
     return new DatabaseError(

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -20,20 +20,12 @@ export class ValidationError extends Error {
 export class DatabaseError extends Error {
   public fieldErrors: Record<string, string>
   public code?: string
-  /** The name of the violated unique constraint, when recoverable (P2002 only). */
-  public constraintName?: string
 
-  constructor(
-    message: string,
-    fieldErrors: Record<string, string> = {},
-    code?: string,
-    constraintName?: string,
-  ) {
+  constructor(message: string, fieldErrors: Record<string, string> = {}, code?: string) {
     super(message)
     this.name = 'DatabaseError'
     this.fieldErrors = fieldErrors
     this.code = code
-    this.constraintName = constraintName
   }
 }
 

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -20,12 +20,20 @@ export class ValidationError extends Error {
 export class DatabaseError extends Error {
   public fieldErrors: Record<string, string>
   public code?: string
+  /** The name of the violated unique constraint, when recoverable (P2002 only). */
+  public constraintName?: string
 
-  constructor(message: string, fieldErrors: Record<string, string> = {}, code?: string) {
+  constructor(
+    message: string,
+    fieldErrors: Record<string, string> = {},
+    code?: string,
+    constraintName?: string,
+  ) {
     super(message)
     this.name = 'DatabaseError'
     this.fieldErrors = fieldErrors
     this.code = code
+    this.constraintName = constraintName
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,14 @@ export { resolveNavCounts, isListQueryStaticallyDenied } from './config/nav-coun
 // Validation error surfaced by write operations
 export { ValidationError } from './hooks/index.js'
 
+// Resolves which columns (and, where recoverable, which named constraint) a
+// caught P2002 unique-constraint violation hit — normalising Prisma 7 driver
+// adapters' undocumented error shape to the documented `meta.target` one, so
+// a caller of `context.db.*` never needs to reach into adapter internals
+// (see issue #979).
+export { uniqueConstraintOf } from './lib/prisma-errors.js'
+export type { UniqueConstraintInfo } from './lib/prisma-errors.js'
+
 // Thrown by a read when a caller-supplied `include` names a relation nested
 // deeper than the Access Filter can scope (see ADR-0022). Distinct from
 // `ValidationError` — this is the engine refusing to return unscoped data, not

--- a/packages/core/src/lib/prisma-errors.ts
+++ b/packages/core/src/lib/prisma-errors.ts
@@ -1,0 +1,78 @@
+type PrismaP2002Meta = {
+  target?: string[]
+  driverAdapterError?: {
+    cause?: {
+      originalMessage?: string
+      constraint?: { fields?: unknown[] }
+    }
+  }
+}
+
+// Postgres quotes an identifier in `constraint.fields` only when it needed
+// quoting (e.g. camelCase columns), so `"tenantId"` and `slug` are both valid
+// entries for the same array.
+function stripIdentifierQuotes(field: string): string {
+  const match = field.match(/^"(.*)"$/)
+  return match ? match[1] : field
+}
+
+export interface UniqueConstraintInfo {
+  /** Column names covered by the violated constraint, quote-stripped. */
+  fields: string[]
+  /** The violated constraint's name, when recoverable from the error. */
+  constraintName?: string
+}
+
+/**
+ * Resolve which columns — and, where recoverable, which named constraint — a
+ * Prisma `P2002` unique-constraint violation hit.
+ *
+ * Prisma documents `error.meta.target` for this. Under Prisma 7 driver
+ * adapters (verified against `@prisma/adapter-pg` and PGlite; see issue #979)
+ * that field is `undefined` instead — the same information sits at
+ * `error.meta.driverAdapterError.cause`, with the constraint name only
+ * recoverable as free text inside `cause.originalMessage`. This normalises
+ * both shapes to one stable result so callers never need to reach into that
+ * adapter-specific structure themselves.
+ *
+ * A derived constraint name is truncated by Postgres at its 63-character
+ * identifier limit, and one row can violate two unique indexes at once (with
+ * Postgres reporting whichever it checked first) — an index an application
+ * means to branch on should be named explicitly, and a caller may still need
+ * to re-read the colliding row to fully disambiguate.
+ *
+ * Returns `undefined` when `error` isn't a `P2002` with any recoverable
+ * column or constraint information — never throws, since the adapter error
+ * shape is untrusted and every level of it may be absent.
+ */
+export function uniqueConstraintOf(error: unknown): UniqueConstraintInfo | undefined {
+  if (
+    !error ||
+    typeof error !== 'object' ||
+    !('code' in error) ||
+    (error as { code?: unknown }).code !== 'P2002'
+  ) {
+    return undefined
+  }
+
+  const meta = (error as { meta?: PrismaP2002Meta }).meta
+
+  if (meta?.target && Array.isArray(meta.target)) {
+    return { fields: meta.target }
+  }
+
+  const cause = meta?.driverAdapterError?.cause
+  const rawFields = cause?.constraint?.fields
+  const fields = Array.isArray(rawFields)
+    ? rawFields.filter((f): f is string => typeof f === 'string').map(stripIdentifierQuotes)
+    : []
+
+  const constraintName =
+    typeof cause?.originalMessage === 'string'
+      ? cause.originalMessage.match(/unique constraint "([^"]+)"/)?.[1]
+      : undefined
+
+  if (fields.length === 0 && !constraintName) return undefined
+
+  return constraintName ? { fields, constraintName } : { fields }
+}

--- a/packages/core/src/lib/prisma-errors.ts
+++ b/packages/core/src/lib/prisma-errors.ts
@@ -19,7 +19,15 @@ function stripIdentifierQuotes(field: string): string {
 export interface UniqueConstraintInfo {
   /** Column names covered by the violated constraint, quote-stripped. */
   fields: string[]
-  /** The violated constraint's name, when recoverable from the error. */
+  /**
+   * The violated constraint's name, when recoverable from the error.
+   *
+   * Known limit: this is parsed out of Postgres' English-locale error text
+   * (`cause.originalMessage`) — the adapter exposes no structured field for
+   * it. A server running under a non-English `lc_messages` locale will not
+   * match, leaving this `undefined` while `fields` (structured data) still
+   * resolves correctly.
+   */
   constraintName?: string
 }
 

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -996,6 +996,50 @@ describe('getContext', () => {
           expect(created.fieldErrors).toEqual({ authorId: 'This value is already in use' })
         })
 
+        it('humanizes a camelCase field name in the message instead of running words together', async () => {
+          // Before this fix, `target` was always empty under a driver adapter, so
+          // this label-formatting path never ran for a camelCase column. Recovering
+          // real column names makes it reachable — verify it reads as words, not
+          // "tenantid".
+          const camelCaseConfig: OpenSaasConfig = {
+            ...config,
+            lists: {
+              ...config.lists,
+              Post: {
+                ...config.lists.Post,
+                fields: { ...config.lists.Post.fields, tenantSlug: { type: 'text' } },
+              },
+            },
+          }
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2002',
+            meta: {
+              driverAdapterError: {
+                cause: {
+                  originalMessage:
+                    'duplicate key value violates unique constraint "post_tenantSlug_key"',
+                  constraint: { fields: ['"tenantSlug"'] },
+                },
+              },
+            },
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(camelCaseConfig, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          const created = result as { created: boolean; fieldErrors?: Record<string, string> }
+          expect(created.fieldErrors).toEqual({
+            tenantSlug: 'This tenant slug is already in use',
+          })
+        })
+
         it('leaves an already-populated meta.target unaffected (existing path still wins)', async () => {
           mockPrisma.post.create.mockRejectedValue({
             code: 'P2002',

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -895,6 +895,180 @@ describe('getContext', () => {
         const created = result as { created: boolean; fieldErrors?: Record<string, string> }
         expect(created.fieldErrors?.title).toBeDefined()
       })
+
+      // Prisma 7 driver adapters (verified against @prisma/adapter-pg and PGlite,
+      // issue #979) leave `meta.target` undefined and put the equivalent data at
+      // `meta.driverAdapterError.cause` instead, as free-text-adjacent structured
+      // data rather than the documented shape.
+      describe('P2002 under Prisma 7 driver adapters (issue #979)', () => {
+        it('produces per-field errors for a composite unique violation', async () => {
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2002',
+            meta: {
+              modelName: 'Post',
+              driverAdapterError: {
+                name: 'DriverAdapterError',
+                cause: {
+                  originalCode: '23505',
+                  originalMessage:
+                    'duplicate key value violates unique constraint "post_title_content_key"',
+                  kind: 'UniqueConstraintViolation',
+                  constraint: { fields: ['title', 'content'] },
+                },
+              },
+            },
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup', content: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          expect(result).toMatchObject({ created: false })
+          const created = result as { created: boolean; fieldErrors?: Record<string, string> }
+          expect(created.fieldErrors?.title).toBeDefined()
+          expect(created.fieldErrors?.content).toBeDefined()
+        })
+
+        it('produces a field error for a single-column unique violation', async () => {
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2002',
+            meta: {
+              modelName: 'Post',
+              driverAdapterError: {
+                cause: {
+                  originalMessage:
+                    'duplicate key value violates unique constraint "post_title_key"',
+                  constraint: { fields: ['title'] },
+                },
+              },
+            },
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          const created = result as { created: boolean; fieldErrors?: Record<string, string> }
+          expect(created.fieldErrors?.title).toBeDefined()
+        })
+
+        it('strips quotes so a camelCase column is keyed correctly (not left quoted)', async () => {
+          // Postgres quotes an identifier in `constraint.fields` only when it
+          // needed quoting — a camelCase column arrives as `"authorId"`. A naive
+          // fix that skips stripping would key fieldErrors by the literal string
+          // `"authorId"` (quotes included), missing the real field name.
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2002',
+            meta: {
+              driverAdapterError: {
+                cause: {
+                  originalMessage:
+                    'duplicate key value violates unique constraint "post_authorId_key"',
+                  constraint: { fields: ['"authorId"'] },
+                },
+              },
+            },
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          const created = result as { created: boolean; fieldErrors?: Record<string, string> }
+          expect(created.fieldErrors).toEqual({ authorId: 'This value is already in use' })
+        })
+
+        it('leaves an already-populated meta.target unaffected (existing path still wins)', async () => {
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2002',
+            meta: {
+              target: ['title'],
+              // Present but must be ignored — meta.target already answers the question.
+              driverAdapterError: {
+                cause: {
+                  originalMessage: 'duplicate key value violates unique constraint "other_key"',
+                  constraint: { fields: ['content'] },
+                },
+              },
+            },
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          const created = result as { created: boolean; fieldErrors?: Record<string, string> }
+          expect(created.fieldErrors).toEqual({ title: 'This title is already in use' })
+        })
+
+        it('falls back to the generic message (not a throw) when nothing is recoverable', async () => {
+          mockPrisma.post.create.mockRejectedValue({ code: 'P2002', meta: {} })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          expect(result).toEqual({
+            created: false,
+            error: 'A record with this value already exists',
+            fieldErrors: {},
+          })
+        })
+
+        it('leaves a non-P2002 Prisma error unaffected', async () => {
+          mockPrisma.post.create.mockRejectedValue({
+            code: 'P2025',
+            meta: { driverAdapterError: { cause: { constraint: { fields: ['title'] } } } },
+            message: 'Record to update not found',
+          })
+          mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1' })
+
+          const context = await getContext(config, mockPrisma, { userId: 'u1' })
+          const result = await context.serverAction({
+            listKey: 'Post',
+            action: 'createRelated',
+            data: { title: 'Dup' },
+            field: 'author',
+            parentId: 'u1',
+          })
+
+          expect(result).toEqual({
+            created: false,
+            error: 'Record to update not found',
+            fieldErrors: {},
+          })
+        })
+      })
     })
 
     describe('relationshipOptions', () => {

--- a/packages/core/tests/prisma-errors.test.ts
+++ b/packages/core/tests/prisma-errors.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { uniqueConstraintOf } from '../src/lib/prisma-errors.js'
+
+// Fixtures below are the verified output captured during triage of issue #979
+// (PGlite behind a Postgres wire-protocol socket, @prisma/adapter-pg@7.8.0,
+// @prisma/client@7.8.0) — not a hand-invented shape.
+const compositeDriverAdapterError = {
+  code: 'P2002',
+  meta: {
+    modelName: 'Thing',
+    driverAdapterError: {
+      name: 'DriverAdapterError',
+      cause: {
+        originalCode: '23505',
+        originalMessage: 'duplicate key value violates unique constraint "thing_tenant_slug_key"',
+        kind: 'UniqueConstraintViolation',
+        constraint: { fields: ['"tenantId"', 'slug'] },
+      },
+    },
+  },
+}
+
+const singleColumnDriverAdapterError = {
+  code: 'P2002',
+  meta: {
+    modelName: 'Thing',
+    driverAdapterError: {
+      name: 'DriverAdapterError',
+      cause: {
+        originalCode: '23505',
+        originalMessage: 'duplicate key value violates unique constraint "thing_extRef_key"',
+        kind: 'UniqueConstraintViolation',
+        constraint: { fields: ['"extRef"'] },
+      },
+    },
+  },
+}
+
+describe('uniqueConstraintOf', () => {
+  it('resolves fields and constraint name from a composite driver-adapter P2002', () => {
+    expect(uniqueConstraintOf(compositeDriverAdapterError)).toEqual({
+      fields: ['tenantId', 'slug'],
+      constraintName: 'thing_tenant_slug_key',
+    })
+  })
+
+  it('resolves a single-column driver-adapter P2002', () => {
+    expect(uniqueConstraintOf(singleColumnDriverAdapterError)).toEqual({
+      fields: ['extRef'],
+      constraintName: 'thing_extRef_key',
+    })
+  })
+
+  it('strips quotes only from identifiers Postgres quoted (camelCase), leaving plain names as-is', () => {
+    const info = uniqueConstraintOf(compositeDriverAdapterError)
+    // `tenantId` is camelCase and arrives quoted; `slug` is lowercase and does not.
+    expect(info?.fields).toEqual(['tenantId', 'slug'])
+  })
+
+  it('prefers an already-populated meta.target and does not consult driverAdapterError', () => {
+    const error = {
+      code: 'P2002',
+      meta: {
+        target: ['email'],
+        // Present but must be ignored — meta.target already wins.
+        driverAdapterError: {
+          cause: {
+            originalMessage: 'duplicate key value violates unique constraint "other_key"',
+            constraint: { fields: ['other'] },
+          },
+        },
+      },
+    }
+
+    expect(uniqueConstraintOf(error)).toEqual({ fields: ['email'] })
+  })
+
+  it('returns undefined for a P2002 with no recoverable constraint information', () => {
+    expect(uniqueConstraintOf({ code: 'P2002', meta: {} })).toBeUndefined()
+    expect(uniqueConstraintOf({ code: 'P2002' })).toBeUndefined()
+  })
+
+  it('returns undefined for a non-P2002 error', () => {
+    expect(uniqueConstraintOf({ code: 'P2025', meta: { target: ['email'] } })).toBeUndefined()
+  })
+
+  it('returns undefined for non-error values without throwing', () => {
+    expect(uniqueConstraintOf(null)).toBeUndefined()
+    expect(uniqueConstraintOf(undefined)).toBeUndefined()
+    expect(uniqueConstraintOf('boom')).toBeUndefined()
+    expect(uniqueConstraintOf({})).toBeUndefined()
+  })
+
+  it('never throws when the adapter error shape is malformed at any level', () => {
+    expect(() =>
+      uniqueConstraintOf({ code: 'P2002', meta: { driverAdapterError: null } }),
+    ).not.toThrow()
+    expect(() =>
+      uniqueConstraintOf({ code: 'P2002', meta: { driverAdapterError: { cause: null } } }),
+    ).not.toThrow()
+    expect(() =>
+      uniqueConstraintOf({
+        code: 'P2002',
+        meta: { driverAdapterError: { cause: { constraint: { fields: [1, null, 'ok'] } } } },
+      }),
+    ).not.toThrow()
+    expect(
+      uniqueConstraintOf({
+        code: 'P2002',
+        meta: { driverAdapterError: { cause: { constraint: { fields: [1, null, 'ok'] } } } },
+      }),
+    ).toEqual({ fields: ['ok'] })
+  })
+})

--- a/packages/core/tests/prisma-errors.test.ts
+++ b/packages/core/tests/prisma-errors.test.ts
@@ -36,12 +36,39 @@ const singleColumnDriverAdapterError = {
   },
 }
 
+// This shape is read directly out of @prisma/adapter-better-sqlite3's own
+// error-mapping source (its SQLITE_CONSTRAINT_UNIQUE branch), not hand-invented:
+// `constraint.fields` comes unquoted (SQLite has no Postgres-style identifier
+// quoting), and `originalMessage` ("UNIQUE constraint failed: Post.slug") has no
+// quoted constraint name for the regex to recover.
+const sqliteDriverAdapterError = {
+  code: 'P2002',
+  meta: {
+    modelName: 'Post',
+    driverAdapterError: {
+      name: 'DriverAdapterError',
+      cause: {
+        originalCode: 'SQLITE_CONSTRAINT_UNIQUE',
+        originalMessage: 'UNIQUE constraint failed: Post.slug',
+        kind: 'UniqueConstraintViolation',
+        constraint: { fields: ['slug'] },
+      },
+    },
+  },
+}
+
 describe('uniqueConstraintOf', () => {
   it('resolves fields and constraint name from a composite driver-adapter P2002', () => {
     expect(uniqueConstraintOf(compositeDriverAdapterError)).toEqual({
       fields: ['tenantId', 'slug'],
       constraintName: 'thing_tenant_slug_key',
     })
+  })
+
+  it('resolves fields (no constraint name) from a SQLite driver-adapter P2002', () => {
+    // SQLite's error text carries no quoted constraint name, so this must
+    // degrade to fields-only rather than leaving an empty/garbage name.
+    expect(uniqueConstraintOf(sqliteDriverAdapterError)).toEqual({ fields: ['slug'] })
   })
 
   it('resolves a single-column driver-adapter P2002', () => {


### PR DESCRIPTION
## Summary

- Under Prisma 7 driver adapters (`@prisma/adapter-pg`, PGlite), a `P2002` unique-constraint error leaves `error.meta.target` `undefined` instead of populating it — the equivalent data instead sits at `error.meta.driverAdapterError.cause`. Core's `parsePrismaError` read only `meta.target`, so every unique violation under a driver adapter fell through to the generic `"A record with this value already exists"` message instead of the intended per-field errors.
- `parsePrismaError` now falls back to `meta.driverAdapterError.cause` when `meta.target` is absent, resolving both the violated column names (stripping Postgres' quoting of camelCase identifiers, e.g. `"tenantId"` → `tenantId`) and the constraint name (parsed from `cause.originalMessage`). An already-populated `meta.target` is left untouched — the documented path still wins.
- `DatabaseError` gains a `constraintName` field so the recovered constraint identity is reachable on the error the stack already raises.
- Added and exported `uniqueConstraintOf(error)` from `@opensaas/stack-core`, so any caller of `context.db.*` can resolve `{ fields, constraintName }` from a caught `P2002` without reaching into adapter internals themselves. `parsePrismaError` is implemented on top of the same helper.
- Never throws: every level of the adapter's error shape (`driverAdapterError`, `cause`, `constraint`, `fields`) is treated as optional and untrusted; missing or malformed data degrades to the pre-existing generic message.

Fixtures for the driver-adapter shape are taken from a verified repro captured during triage (PGlite behind a Postgres wire-protocol socket + `@prisma/adapter-pg@7.8.0`), not hand-invented.

## Test plan

- [x] `pnpm test` in `packages/core` (new tests: `tests/prisma-errors.test.ts` for the `uniqueConstraintOf` helper directly, and a new `describe` block in `tests/context.test.ts` exercising `parsePrismaError` via `serverAction`'s `createRelated` path for composite/single-column driver-adapter violations, camelCase quote-stripping, `meta.target`-already-populated precedence, no-recoverable-info fallback, and non-`P2002` errors)
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm manypkg fix`
- [x] Changeset added (`@opensaas/stack-core`, patch)

Closes #979


---
_Generated by [Claude Code](https://claude.ai/code/session_01QZe1w8KNxYEjCGUYCdicbZ)_