### PR TITLE
Fix include on a to-one relationship throwing PrismaClientValidationError (#974)

### DIFF
--- a/.changeset/wobbly-otters-scope.md
+++ b/.changeset/wobbly-otters-scope.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+Fix `include` on a to-one relationship throwing `PrismaClientValidationError` when the related list's `query` access resolves to a filter (Prisma only accepts a nested `where` on a to-many include). The relation is now fetched and access-scoped via a batched existence check instead, returning `null` for an excluded related row rather than throwing — a caller relying on the previous exception, or whose types assumed a non-null relation, should re-check nullability.

--- a/packages/core/src/access/access-filter.test.ts
+++ b/packages/core/src/access/access-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildAccessScopedInclude } from './access-filter.js'
+import { buildAccessScopedInclude, resolveToOneAccessVisibility } from './access-filter.js'
 import { AccessScopeDepthExceededError } from './errors.js'
 import { READ_INCLUDE_MAX_DEPTH } from './depth-limits.js'
 import type { OpenSaasConfig, FieldConfig } from '../config/types.js'
@@ -22,6 +22,14 @@ import type { AccessContext } from './types.js'
  * relation the request doesn't name never has its list's `query` access
  * invoked, and naming a relation fetches its own columns and stops (the "One
  * hop" rule) at every level, not just the root.
+ *
+ * The scenarios in this file build every chain relation as to-MANY
+ * (`rel(ref, true)`), so `where`-in-`include` keeps meaning what it always
+ * has here — the walk-depth/caller-directed logic under test is arity-
+ * agnostic. The to-one-specific behavior this function grew for issue #974
+ * (a `where` on a to-one include is not something Prisma accepts, so it's
+ * recorded in `toOneAccessFilters` instead and resolved post-query by
+ * `resolveToOneAccessVisibility`) has its own dedicated describe blocks below.
  */
 
 // A relationship field pointing at another list.
@@ -71,10 +79,10 @@ function chainConfig(count: number): {
     const listName = `L${i}`
     const fields: Record<string, FieldConfig> = { name: { type: 'text' } as FieldConfig }
     if (i < count - 1) {
-      fields.next = rel(`L${i + 1}.prev`)
+      fields.next = rel(`L${i + 1}.prev`, true)
     }
     if (i > 0) {
-      fields.prev = rel(`L${i - 1}.next`)
+      fields.prev = rel(`L${i - 1}.next`, true)
     }
     const filter = { ownerId: { equals: listName } }
     const queryFn = vi.fn(i === 0 ? () => true : () => filter)
@@ -139,7 +147,7 @@ describe('buildAccessScopedInclude — caller-directed walk (ADR-0026)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
     } as any as OpenSaasConfig
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { b: true },
       config.lists.A.fields,
       { session: null, context: makeContext() },
@@ -155,7 +163,7 @@ describe('buildAccessScopedInclude — caller-directed walk (ADR-0026)', () => {
   it("fetches a named relation's own columns and stops — does not auto-expand its subtree (One hop)", async () => {
     const { config, queryFns } = chainConfig(4) // L0 → L1 → L2 → L3
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { next: true },
       config.lists.L0.fields,
       { session: null, context: makeContext() },
@@ -175,7 +183,7 @@ describe('buildAccessScopedInclude — caller-directed walk (ADR-0026)', () => {
   it('scopes a nested path at every level the request names it', async () => {
     const { config, queryFns } = chainConfig(4) // L0 → L1 → L2 → L3
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { next: { include: { next: { include: { next: true } } } } },
       config.lists.L0.fields,
       { session: null, context: makeContext() },
@@ -215,7 +223,7 @@ describe('buildAccessScopedInclude — caller-directed walk (ADR-0026)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
     } as any as OpenSaasConfig
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { b: { include: { c: { include: { a: true } } } } },
       config.lists.A.fields,
       { session: null, context: makeContext() },
@@ -253,7 +261,7 @@ describe('buildAccessScopedInclude — caller take on a to-many relation (issue 
   it('preserves the take and AND-combines it with the access where', async () => {
     const config = scopedConfig()
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { posts: { take: 10 } },
       config.lists.User.fields,
       { session: null, context: makeContext() },
@@ -276,7 +284,7 @@ describe('buildAccessScopedInclude — caller take on a to-many relation (issue 
     const config = scopedConfig()
     config.lists.Post.access = { operation: { query: () => false } }
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { posts: { take: 10 } },
       config.lists.User.fields,
       { session: null, context: makeContext() },
@@ -342,7 +350,7 @@ describe('buildAccessScopedInclude — fail-closed at the read-include depth cap
     // Outer `next` (hop 1) + nestedInclude(HOPS_AT_CAP - 1) = HOPS_AT_CAP hops total — right at the boundary.
     const requested = { next: nestedInclude(HOPS_AT_CAP - 1) }
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       requested,
       config.lists.L0.fields,
       { session: null, context: makeContext() },
@@ -373,7 +381,7 @@ describe('buildAccessScopedInclude — fail-closed at the read-include depth cap
     const chainLength = HOPS_AT_CAP + 3
     const { config } = chainConfig(chainLength)
 
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       {},
       config.lists.L0.fields,
       { session: null, context: makeContext() },
@@ -397,7 +405,7 @@ describe('buildAccessScopedInclude — fail-closed at the read-include depth cap
 
     // An arbitrary (non-declared-relationship) key passed through unchanged —
     // access control does not govern keys it doesn't recognize as relationships.
-    const include = await buildAccessScopedInclude(
+    const { include } = await buildAccessScopedInclude(
       { someUnrelatedKey: true },
       config.lists.Leaf.fields,
       { session: null, context: makeContext() },
@@ -405,5 +413,263 @@ describe('buildAccessScopedInclude — fail-closed at the read-include depth cap
       'Leaf',
     )
     expect(include).toEqual({ someUnrelatedKey: true })
+  })
+})
+
+/**
+ * Regression coverage for issue #974: Prisma accepts a nested `where` on an
+ * `include` entry only for a to-many relation — the same shape on a to-one
+ * relation raises `PrismaClientValidationError`. `buildAccessScopedInclude`
+ * must never attach one for a to-one relation, whatever its related list's
+ * `query` access resolves to; the scoping information goes into
+ * `toOneAccessFilters` instead.
+ */
+describe('buildAccessScopedInclude — to-one relations record a post-query filter, not `where` (issue #974)', () => {
+  function ownerConfig(queryAccess: unknown): OpenSaasConfig {
+    return {
+      db: { provider: 'sqlite' },
+      lists: {
+        Child: {
+          fields: { name: { type: 'text' } as FieldConfig, owner: rel('Owner') },
+          access: { operation: { query: () => true } },
+        },
+        Owner: {
+          fields: { name: { type: 'text' } as FieldConfig },
+          access: { operation: { query: queryAccess } },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any
+  }
+
+  it('records the access filter instead of attaching `where` when the related list scopes by a filter', async () => {
+    const config = ownerConfig(() => ({ id: { equals: 'u1' } }))
+
+    const { include, toOneAccessFilters } = await buildAccessScopedInclude(
+      { owner: true },
+      config.lists.Child.fields,
+      { session: null, context: makeContext() },
+      config,
+      'Child',
+    )
+
+    // The Prisma-bound include never carries a `where` on this to-one key —
+    // Prisma would reject it.
+    expect(include).toEqual({ owner: true })
+    expect(toOneAccessFilters).toEqual({
+      filters: {
+        owner: { kind: 'scoped', relatedListName: 'Owner', accessWhere: { id: { equals: 'u1' } } },
+      },
+      nested: {},
+    })
+  })
+
+  it('leaves a to-one relation whose related list is fully open untouched — no filter recorded, no extra query later', async () => {
+    const config = ownerConfig(() => true)
+
+    const { include, toOneAccessFilters } = await buildAccessScopedInclude(
+      { owner: true },
+      config.lists.Child.fields,
+      { session: null, context: makeContext() },
+      config,
+      'Child',
+    )
+
+    expect(include).toEqual({ owner: true })
+    expect(toOneAccessFilters).toEqual({ filters: {}, nested: {} })
+  })
+
+  it('drops a to-one relation whose related list denies query access outright, and records the denial', async () => {
+    const config = ownerConfig(() => false)
+
+    const { include, toOneAccessFilters } = await buildAccessScopedInclude(
+      { owner: true },
+      config.lists.Child.fields,
+      { session: null, context: makeContext() },
+      config,
+      'Child',
+    )
+
+    // Never asked of Prisma at all — same as before this fix.
+    expect(include).toEqual({})
+    expect(toOneAccessFilters).toEqual({ filters: { owner: { kind: 'denied' } }, nested: {} })
+  })
+
+  it('records a to-one filter nested inside another relation the caller explicitly included', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite' },
+      lists: {
+        GrandChild: {
+          fields: { name: { type: 'text' } as FieldConfig, child: rel('Child') },
+          access: { operation: { query: () => true } },
+        },
+        Child: {
+          fields: { name: { type: 'text' } as FieldConfig, owner: rel('Owner') },
+          access: { operation: { query: () => true } },
+        },
+        Owner: {
+          fields: { name: { type: 'text' } as FieldConfig },
+          access: { operation: { query: () => ({ id: { equals: 'u1' } }) } },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal config for unit test
+    } as any
+
+    const { include, toOneAccessFilters } = await buildAccessScopedInclude(
+      { child: { include: { owner: true } } },
+      config.lists.GrandChild.fields,
+      { session: null, context: makeContext() },
+      config,
+      'GrandChild',
+    )
+
+    expect(include).toEqual({ child: { include: { owner: true } } })
+    expect(toOneAccessFilters).toEqual({
+      filters: {},
+      nested: {
+        child: {
+          filters: {
+            owner: {
+              kind: 'scoped',
+              relatedListName: 'Owner',
+              accessWhere: { id: { equals: 'u1' } },
+            },
+          },
+          nested: {},
+        },
+      },
+    })
+  })
+})
+
+describe('resolveToOneAccessVisibility (issue #974)', () => {
+  function makeVisibilityContext(findMany: ReturnType<typeof vi.fn>): AccessContext {
+    return {
+      session: null,
+      _isSudo: false,
+      _resolveOutputChain: [],
+      prisma: { owner: { findMany } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
+    } as any
+  }
+
+  it('passes a denied filter straight through with no query', async () => {
+    const findMany = vi.fn()
+    const context = makeVisibilityContext(findMany)
+
+    const resolved = await resolveToOneAccessVisibility(
+      [{ id: 'c1' }],
+      { filters: { owner: { kind: 'denied' } }, nested: {} },
+      { session: null, context },
+    )
+
+    expect(resolved).toEqual({ filters: { owner: { kind: 'denied' } }, nested: {} })
+    expect(findMany).not.toHaveBeenCalled()
+  })
+
+  it('skips the query when no row carries a value at the scoped key', async () => {
+    const findMany = vi.fn()
+    const context = makeVisibilityContext(findMany)
+    const tree = {
+      filters: {
+        owner: {
+          kind: 'scoped' as const,
+          relatedListName: 'Owner',
+          accessWhere: { id: { equals: 'u1' } },
+        },
+      },
+      nested: {},
+    }
+
+    const resolved = await resolveToOneAccessVisibility([{ id: 'c1', owner: null }], tree, {
+      session: null,
+      context,
+    })
+
+    expect(resolved).toEqual({
+      filters: { owner: { kind: 'visible', ids: new Set() } },
+      nested: {},
+    })
+    expect(findMany).not.toHaveBeenCalled()
+  })
+
+  it('batches every row into ONE existence check, through the raw Prisma client, using the exact access filter', async () => {
+    const findMany = vi.fn().mockResolvedValue([{ id: 'u1' }, { id: 'u2' }])
+    const context = makeVisibilityContext(findMany)
+    const tree = {
+      filters: {
+        owner: {
+          kind: 'scoped' as const,
+          relatedListName: 'Owner',
+          accessWhere: { studioId: { equals: 's1' } },
+        },
+      },
+      nested: {},
+    }
+    const items = [
+      { id: 'c1', owner: { id: 'u1' } },
+      { id: 'c2', owner: { id: 'u2' } },
+      { id: 'c3', owner: { id: 'u3' } }, // excluded by the mocked response below
+      { id: 'c4', owner: null }, // contributes no id
+    ]
+
+    const resolved = await resolveToOneAccessVisibility(items, tree, { session: null, context })
+
+    // One call, not one per row.
+    expect(findMany).toHaveBeenCalledTimes(1)
+    expect(findMany).toHaveBeenCalledWith({
+      where: { AND: [{ studioId: { equals: 's1' } }, { id: { in: ['u1', 'u2', 'u3'] } }] },
+      select: { id: true },
+    })
+    expect(resolved.filters.owner).toEqual({ kind: 'visible', ids: new Set(['u1', 'u2']) })
+  })
+
+  it('recurses into nested trees, flattening rows reached through a to-many hop into one batch', async () => {
+    const ownerFindMany = vi.fn().mockResolvedValue([{ id: 'u1' }])
+    const context: AccessContext = {
+      session: null,
+      _isSudo: false,
+      _resolveOutputChain: [],
+      prisma: { owner: { findMany: ownerFindMany } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal context for unit test
+    } as any
+    const tree = {
+      filters: {},
+      nested: {
+        children: {
+          filters: {
+            owner: {
+              kind: 'scoped' as const,
+              relatedListName: 'Owner',
+              accessWhere: { id: { equals: 'u1' } },
+            },
+          },
+          nested: {},
+        },
+      },
+    }
+    const items = [
+      {
+        id: 'p1',
+        children: [
+          { id: 'c1', owner: { id: 'u1' } },
+          { id: 'c2', owner: { id: 'u9' } },
+        ],
+      },
+      { id: 'p2', children: [{ id: 'c3', owner: { id: 'u1' } }] },
+    ]
+
+    const resolved = await resolveToOneAccessVisibility(items, tree, { session: null, context })
+
+    // Every child across BOTH parents resolved in one batched call.
+    expect(ownerFindMany).toHaveBeenCalledTimes(1)
+    expect(ownerFindMany).toHaveBeenCalledWith({
+      where: { AND: [{ id: { equals: 'u1' } }, { id: { in: ['u1', 'u9'] } }] },
+      select: { id: true },
+    })
+    expect(resolved.nested.children.filters.owner).toEqual({
+      kind: 'visible',
+      ids: new Set(['u1']),
+    })
   })
 })

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -9,6 +9,7 @@ import {
   resolveQueryField,
   walkWhereReadAccess,
 } from './query-validation.js'
+import { getDbKey } from '../lib/case-utils.js'
 
 /**
  * Access Filter — phase 1 of the two-phase read (pre-query).
@@ -34,6 +35,26 @@ import {
  * named a nested `include` there too. A relation nobody named never has its
  * list's `query` access evaluated at all — there is no separate "build the
  * whole tree, then reconcile against what was asked for" pass to walk it.
+ *
+ * **To-one relations are scoped after the query, not inside it (issue #974).**
+ * Prisma accepts a nested `where` on an `include` entry only for a to-**many**
+ * relation; the same shape on a to-**one** relation raises
+ * `PrismaClientValidationError`. So for a to-one relation whose related
+ * list's `query` access resolves to a filter, `buildAccessScopedInclude`
+ * does NOT attach that filter as `where` — it fetches the row unscoped and
+ * records the filter in the returned `toOneAccessFilters` tree instead.
+ * `resolveToOneAccessVisibility` (below) turns that tree into the set of
+ * related ids the session may actually see, via ONE batched `id IN (...)`
+ * existence check per (relation, nesting level) across every row in the
+ * read — never a per-row query, and never a hand-rolled evaluation of the
+ * access filter (it is handed to Prisma exactly as `checkAccess` produced
+ * it). `field-visibility.ts`'s `filterReadableFields` is where the result
+ * actually becomes `null` for a row the check excludes — see its module doc.
+ * A to-one relation whose related list's `query` access is `true` (no
+ * filter) or `false` (denied outright) needs no existence check at all: the
+ * former is left as `true` in `include`, unchanged from before; the latter
+ * is recorded as `{ kind: 'denied' }`, and `field-visibility.ts` forces the
+ * key to `null` without ever asking Prisma for it.
  */
 
 /** The structured (object) form of a relation include entry — caller/fold-supplied or produced by this module. */
@@ -81,6 +102,38 @@ function andWhere(
   return accessWhere ?? callerWhere
 }
 
+/** One to-one relation's recorded access filter, or an outright denial — see the module doc's "To-one relations" section. */
+export type ToOneAccessFilterEntry =
+  { kind: 'scoped'; relatedListName: string; accessWhere: PrismaFilter } | { kind: 'denied' }
+
+/**
+ * Which to-one relations, at which nesting level of an `include`, need a
+ * post-query existence check rather than a Prisma-side `where` — because
+ * their related list's `query` access resolved to a filter (`kind: 'scoped'`)
+ * or a denial (`kind: 'denied'`) and Prisma cannot express either as a nested
+ * `where` on a to-one include. `resolveToOneAccessVisibility` consumes this
+ * tree; `filterReadableFields` (`field-visibility.ts`) applies its result.
+ */
+export type ToOneAccessFilterTree = {
+  /** To-one relation keys at THIS level needing a post-query check. */
+  filters: Record<string, ToOneAccessFilterEntry>
+  /** Per-key trees for relations present in the include for other reasons, whose own nested include may contain further to-one filters. */
+  nested: Record<string, ToOneAccessFilterTree>
+}
+
+export function emptyToOneAccessFilterTree(): ToOneAccessFilterTree {
+  return { filters: {}, nested: {} }
+}
+
+function isToOneAccessFilterTreeEmpty(tree: ToOneAccessFilterTree): boolean {
+  return Object.keys(tree.filters).length === 0 && Object.keys(tree.nested).length === 0
+}
+
+/** Whether a relationship field is to-one (at most one related row) rather than to-many. */
+function isToOneRelationship(fieldConfig: FieldConfig): boolean {
+  return !('many' in fieldConfig && fieldConfig.many === true)
+}
+
 /**
  * Build the access-scoped `include` for exactly the relations a read
  * requested, recursing only into branches `requestedInclude` itself names.
@@ -92,14 +145,21 @@ function andWhere(
  * - A declared relationship whose related list's `query` access denies it
  *   (`=== false`) → dropped entirely, no matter what the request asked for
  *   nested beneath it (#566): the caller chooses *which* relations, access
- *   control chooses *whether* and *with what filter*.
- * - Otherwise → the access `where` is AND-combined with any caller-supplied
- *   nested `where` (never replaced — the other half of #566), a
- *   caller-supplied `take` rides through unchanged (#752), and — the "One
- *   hop" rule (ADR-0026) — nested relations are scoped ONLY if
- *   `requestedInclude` itself named a nested `include` here. A bare relation
- *   (or one with no nested `include`) fetches its own columns and stops: no
- *   recursive call, no access evaluation on anything beneath it.
+ *   control chooses *whether* and *with what filter*. For a to-one relation
+ *   this denial is also recorded in `toOneAccessFilters` (`kind: 'denied'`),
+ *   so `filterReadableFields` can still surface an explicit `null` for it
+ *   (issue #974) rather than an absent key.
+ * - Otherwise, for a to-**many** relation → the access `where` is
+ *   AND-combined with any caller-supplied nested `where` (never replaced —
+ *   the other half of #566), and a caller-supplied `take` rides through
+ *   unchanged (#752). For a to-**one** relation → the access filter (if any)
+ *   is recorded in `toOneAccessFilters` instead of attached as `where`,
+ *   because Prisma only accepts a nested `where` on a to-many include
+ *   (issue #974) — the entry itself never carries a `where` for a to-one key.
+ * - Either way — the "One hop" rule (ADR-0026) — nested relations are scoped
+ *   ONLY if `requestedInclude` itself named a nested `include` here. A bare
+ *   relation (or one with no nested `include`) fetches its own columns and
+ *   stops: no recursive call, no access evaluation on anything beneath it.
  *
  * **Depth is a cost limit, not a cycle guard (ADR-0026).** A `requestedInclude`
  * is always a finite literal — the caller's own object, or
@@ -120,13 +180,14 @@ export async function buildAccessScopedInclude(
   config: OpenSaasConfig,
   listKey: string,
   depth: number = 0,
-): Promise<Record<string, unknown>> {
+): Promise<{ include: Record<string, unknown>; toOneAccessFilters: ToOneAccessFilterTree }> {
   const requestedKeys = Object.keys(requestedInclude)
   if (depth >= READ_INCLUDE_MAX_DEPTH && requestedKeys.length > 0) {
     throw new AccessScopeDepthExceededError(listKey, requestedKeys[0], depth)
   }
 
   const result: Record<string, unknown> = {}
+  const toOneAccessFilters = emptyToOneAccessFilterTree()
 
   for (const [relationName, requestedValue] of Object.entries(requestedInclude)) {
     const fieldConfig = fieldConfigs[relationName]
@@ -141,6 +202,8 @@ export async function buildAccessScopedInclude(
     const relatedConfig = getRelatedListConfig(fieldConfig.ref as string, config)
     if (!relatedConfig) continue
 
+    const isToOne = isToOneRelationship(fieldConfig)
+
     const queryAccess = relatedConfig.listConfig.access?.operation?.query
     const accessResult = await checkAccess(queryAccess, {
       session: args.session,
@@ -148,16 +211,19 @@ export async function buildAccessScopedInclude(
     })
 
     if (accessResult === false) {
+      if (isToOne) {
+        toOneAccessFilters.filters[relationName] = { kind: 'denied' }
+      }
       continue
     }
 
     const accessWhere = typeof accessResult === 'object' ? accessResult : undefined
     const requestedEntry = asEntryObject(requestedValue)
-    const mergedWhere = andWhere(accessWhere, requestedEntry?.where)
 
     let nestedInclude: Record<string, unknown> | undefined
+    let nestedToOneFilters: ToOneAccessFilterTree | undefined
     if (requestedEntry?.include) {
-      nestedInclude = await buildAccessScopedInclude(
+      const nested = await buildAccessScopedInclude(
         requestedEntry.include,
         relatedConfig.listConfig.fields,
         args,
@@ -165,17 +231,125 @@ export async function buildAccessScopedInclude(
         relatedConfig.listName,
         depth + 1,
       )
+      nestedInclude = nested.include
+      nestedToOneFilters = nested.toOneAccessFilters
     }
 
     const entry: { where?: PrismaFilter; include?: Record<string, unknown>; take?: number } = {}
-    if (mergedWhere) entry.where = mergedWhere
+    if (isToOne) {
+      if (accessWhere) {
+        toOneAccessFilters.filters[relationName] = {
+          kind: 'scoped',
+          relatedListName: relatedConfig.listName,
+          accessWhere,
+        }
+      }
+    } else {
+      const mergedWhere = andWhere(accessWhere, requestedEntry?.where)
+      if (mergedWhere) entry.where = mergedWhere
+      if (requestedEntry?.take !== undefined) entry.take = requestedEntry.take
+    }
     if (nestedInclude && Object.keys(nestedInclude).length > 0) entry.include = nestedInclude
-    if (requestedEntry?.take !== undefined) entry.take = requestedEntry.take
+    if (nestedToOneFilters && !isToOneAccessFilterTreeEmpty(nestedToOneFilters)) {
+      toOneAccessFilters.nested[relationName] = nestedToOneFilters
+    }
 
     result[relationName] = Object.keys(entry).length > 0 ? entry : true
   }
 
-  return result
+  return { include: result, toOneAccessFilters }
+}
+
+/** One to-one relation's resolved post-query visibility — see `resolveToOneAccessVisibility`. */
+export type ToOneVisibility = { kind: 'denied' } | { kind: 'visible'; ids: ReadonlySet<string> }
+
+/** The resolved counterpart to {@link ToOneAccessFilterTree}, produced by `resolveToOneAccessVisibility`. */
+export type ToOneAccessVisibilityTree = {
+  filters: Record<string, ToOneVisibility>
+  nested: Record<string, ToOneAccessVisibilityTree>
+}
+
+export function emptyToOneAccessVisibilityTree(): ToOneAccessVisibilityTree {
+  return { filters: {}, nested: {} }
+}
+
+/**
+ * Resolve a `ToOneAccessFilterTree` against the RAW rows Prisma already
+ * fetched (unscoped for the flagged to-one relations — see
+ * `buildAccessScopedInclude`) into the set of related ids the session may
+ * actually see, one batched `id IN (...)` existence check per (relation,
+ * nesting level) across every row in `items` — never once per row.
+ *
+ * For each `filters` entry at a level:
+ * - `kind: 'denied'` → carried straight through; no query, nothing to check.
+ * - `kind: 'scoped'` → every id present at this key across ALL of `items` is
+ *   collected first (an empty set skips the query entirely — nothing to
+ *   check), then ONE `findMany` through the RAW `prisma` client (not
+ *   `context.db`, which would re-evaluate the same access-control function a
+ *   second time) asks which of those ids also satisfy `accessWhere` — the
+ *   exact `PrismaFilter` `checkAccess` already produced, handed to Prisma
+ *   unmodified rather than interpreted by hand.
+ *
+ * Recurses into `nested` by flattening the related items reached through
+ * each key across every row in `items` (a to-many hop contributes every one
+ * of its rows; a to-one hop contributes its single row, if any) into the
+ * next level's own `items` array, so a to-one relation nested arbitrarily
+ * deep is still resolved with one batched query per node, not per parent row.
+ */
+export async function resolveToOneAccessVisibility(
+  items: readonly unknown[],
+  tree: ToOneAccessFilterTree,
+  args: {
+    session: Session | null
+    context: AccessContext
+  },
+): Promise<ToOneAccessVisibilityTree> {
+  const resolved = emptyToOneAccessVisibilityTree()
+
+  for (const [key, entry] of Object.entries(tree.filters)) {
+    if (entry.kind === 'denied') {
+      resolved.filters[key] = { kind: 'denied' }
+      continue
+    }
+
+    const ids = new Set<string>()
+    for (const item of items) {
+      if (!item || typeof item !== 'object') continue
+      const value = (item as Record<string, unknown>)[key]
+      if (value && typeof value === 'object' && 'id' in value) {
+        ids.add(String((value as Record<string, unknown>).id))
+      }
+    }
+
+    if (ids.size === 0) {
+      resolved.filters[key] = { kind: 'visible', ids: new Set() }
+      continue
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic model access by list name, mirroring the rest of the read pipeline
+    const model = (args.context.prisma as any)[getDbKey(entry.relatedListName)]
+    const visibleRows = await model.findMany({
+      where: { AND: [entry.accessWhere, { id: { in: [...ids] } }] },
+      select: { id: true },
+    })
+    const visibleIds = new Set<string>(
+      Array.isArray(visibleRows) ? visibleRows.map((row: { id: unknown }) => String(row.id)) : [],
+    )
+    resolved.filters[key] = { kind: 'visible', ids: visibleIds }
+  }
+
+  for (const [key, nestedTree] of Object.entries(tree.nested)) {
+    const nestedItems: unknown[] = []
+    for (const item of items) {
+      if (!item || typeof item !== 'object') continue
+      const value = (item as Record<string, unknown>)[key]
+      if (Array.isArray(value)) nestedItems.push(...value)
+      else if (value && typeof value === 'object') nestedItems.push(value)
+    }
+    resolved.nested[key] = await resolveToOneAccessVisibility(nestedItems, nestedTree, args)
+  }
+
+  return resolved
 }
 
 /**

--- a/packages/core/src/access/field-visibility.ts
+++ b/packages/core/src/access/field-visibility.ts
@@ -7,6 +7,8 @@ import { ResolveOutputCycleError } from './errors.js'
 import type { DeclaredOnlyTree } from './declared-dependencies.js'
 import { emptyDeclaredOnlyTree } from './declared-dependencies.js'
 import type { FieldSelectionScope } from '../query/index.js'
+import type { ToOneAccessVisibilityTree } from './access-filter.js'
+import { emptyToOneAccessVisibilityTree } from './access-filter.js'
 // NOTE: `context/index.ts` imports `filterReadableFields` from this module
 // (via the `access/index.ts` barrel) — this is an intentional cyclic
 // dependency, the same shape and for the same reason as the one documented in
@@ -36,6 +38,22 @@ import { buildDbDelegate } from '../context/index.js'
  * Phase 1 (pre-query row/relation scoping) lives in `access-filter.ts`. See
  * `docs/adr/0001-access-control-is-a-two-phase-read.md` and the access-control
  * glossary in `CONTEXT.md`.
+ *
+ * **To-one relation nulling (issue #974).** A to-one relation whose related
+ * list's `query` access resolves to a filter cannot be scoped by Prisma's own
+ * `where` (it only accepts one on a to-many include — see the "To-one
+ * relations" section of `access-filter.ts`'s module doc), so
+ * `buildAccessScopedInclude` fetches it unscoped and hands this module a
+ * `ToOneAccessVisibilityTree` — already resolved, via one batched existence
+ * check per relation across the whole read, by
+ * `resolveToOneAccessVisibility`. This module is where that resolution
+ * actually becomes the caller-visible `null`: a `kind: 'denied'` key is
+ * forced to `null` even though it was never fetched at all (the key is
+ * absent from `workingItem`), and a `kind: 'visible'` key's fetched row is
+ * nulled out unless its id survived the existence check — in both branches,
+ * before any field-level access check or `resolveOutput` hook runs, so the
+ * rest of the pipeline sees exactly what a denied to-one read has always
+ * meant elsewhere: `null`, never a thrown error.
  */
 
 type ResolveOutputHookRuntime = (args: {
@@ -193,6 +211,11 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
   // The fragment scope this level was reached under (ADR-0027, see module doc
   // above), and the same tree one level down for each nested relation.
   selection?: FieldSelectionScope,
+  // Resolved to-one existence checks at THIS level (issue #974, see module
+  // doc above), and the same tree one level down for each nested relation —
+  // regardless of that relation's own arity, since a filtered to-one can sit
+  // beneath a to-many hop.
+  toOneVisibility: ToOneAccessVisibilityTree = emptyToOneAccessVisibilityTree(),
 ): Promise<Partial<T>> {
   const filtered: Record<string, unknown> = {}
 
@@ -286,6 +309,15 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
       // unrestricted — matching what naming a relation without narrowing it
       // further has always meant.
       const nestedSelection = selection?.nested[fieldName]
+      // This relation's own resolved to-one visibility, if
+      // `buildAccessScopedInclude` flagged anything beneath it (issue #974).
+      // Falls back to empty — the common case for a relation with no
+      // filtered to-one anywhere in its own nested include.
+      const nestedToOneVisibility =
+        toOneVisibility.nested[fieldName] ?? emptyToOneAccessVisibilityTree()
+      // This key's OWN to-one existence check, if `fieldName` itself is a
+      // filtered to-one relation (as opposed to one further down its tree).
+      const toOneEntry = toOneVisibility.filters[fieldName]
 
       if (relatedConfig) {
         if (Array.isArray(value)) {
@@ -300,20 +332,28 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
                 relatedConfig.listName,
                 nestedDeclaredOnly,
                 nestedSelection,
+                nestedToOneVisibility,
               ),
             ),
           )
         } else if (typeof value === 'object') {
-          filtered[fieldName] = await filterReadableFields(
-            value as Record<string, unknown>,
-            relatedConfig.listConfig.fields,
-            args,
-            config,
-            depth + 1,
-            relatedConfig.listName,
-            nestedDeclaredOnly,
-            nestedSelection,
-          )
+          const relatedId = (value as Record<string, unknown>).id
+          const isVisible =
+            !toOneEntry || toOneEntry.kind !== 'visible' || toOneEntry.ids.has(String(relatedId))
+
+          filtered[fieldName] = isVisible
+            ? await filterReadableFields(
+                value as Record<string, unknown>,
+                relatedConfig.listConfig.fields,
+                args,
+                config,
+                depth + 1,
+                relatedConfig.listName,
+                nestedDeclaredOnly,
+                nestedSelection,
+                nestedToOneVisibility,
+              )
+            : null
         }
       } else {
         filtered[fieldName] = value
@@ -339,6 +379,31 @@ export async function filterReadableFields<T extends Record<string, unknown>>(
     } else {
       accessDeniedKeys.add(fieldName)
     }
+  }
+
+  // To-one relations `buildAccessScopedInclude` denied outright (issue #974)
+  // were never asked of Prisma at all, so `fieldName` has no entry in
+  // `workingItem` and the loop above never visits it. Force it present as an
+  // explicit `null` here — matching what a denied single-record read means
+  // everywhere else in the context — rather than leaving the key silently
+  // absent.
+  for (const [fieldName, entry] of Object.entries(toOneVisibility.filters)) {
+    if (entry.kind !== 'denied') continue
+    if (fieldName in filtered || fieldName in workingItem) continue
+    if (selection?.fields && !selection.fields.has(fieldName)) continue
+
+    const fieldConfig = fieldConfigs[fieldName]
+    const canRead = await checkFieldAccess(fieldConfig?.access, 'read', {
+      ...args,
+      item: workingItem,
+    })
+
+    if (!canRead) {
+      accessDeniedKeys.add(fieldName)
+      continue
+    }
+
+    filtered[fieldName] = null
   }
 
   // The item a virtual field's hook sees: stored columns and fetched

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -36,6 +36,15 @@ export {
   buildAccessScopedInclude,
   buildAccessScopedWhere,
   stripVirtualFieldsFromInclude,
+  resolveToOneAccessVisibility,
+  emptyToOneAccessFilterTree,
+  emptyToOneAccessVisibilityTree,
+} from './access-filter.js'
+export type {
+  ToOneAccessFilterTree,
+  ToOneAccessFilterEntry,
+  ToOneAccessVisibilityTree,
+  ToOneVisibility,
 } from './access-filter.js'
 // Phase 2 — Field Visibility (post-query field stripping + resolveOutput).
 export { filterReadableFields } from './field-visibility.js'

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -10,8 +10,10 @@ import {
   foldDeclaredDependencies,
   validateQueryKeys,
   validateQueryFieldReadAccess,
+  resolveToOneAccessVisibility,
+  emptyToOneAccessFilterTree,
 } from '../access/index.js'
-import type { DeclaredOnlyTree } from '../access/index.js'
+import type { DeclaredOnlyTree, ToOneAccessFilterTree } from '../access/index.js'
 import { ValidationError, DatabaseError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { PrismaClientLike } from '../access/types.js'
@@ -924,6 +926,12 @@ export function buildDbDelegate<TPrisma extends PrismaClientLike>(
  * `undefined` for every non-fragment path: a caller `include` (sudo or not)
  * and a bare read both mean "compute every field," matching what they
  * already fetch.
+ *
+ * Also returns `toOneAccessFilters` — the to-one relations `buildAccessScopedInclude`
+ * flagged as needing a post-query existence check rather than a Prisma-side
+ * `where` (issue #974). Only the non-sudo caller-include path can produce a
+ * non-empty tree: it's the only path that evaluates a related list's `query`
+ * access at all. The fragment and sudo paths always return an empty tree.
  */
 async function resolveReadInclude(
   callerInclude: Record<string, unknown> | undefined,
@@ -937,6 +945,7 @@ async function resolveReadInclude(
   include: Record<string, unknown> | undefined
   declaredOnly: DeclaredOnlyTree
   selection: FieldSelectionScope | undefined
+  toOneAccessFilters: ToOneAccessFilterTree
 }> {
   if (fragmentFields !== undefined) {
     const fragmentInclude = buildInclude(fragmentFields) ?? undefined
@@ -949,27 +958,27 @@ async function resolveReadInclude(
       [listName],
       selection,
     )
-    return { ...folded, selection }
+    return { ...folded, selection, toOneAccessFilters: emptyToOneAccessFilterTree() }
   }
 
   if (context._isSudo) {
     const folded = foldDeclaredDependencies(callerInclude, listConfig.fields, config, listName)
-    return { ...folded, selection: undefined }
+    return { ...folded, selection: undefined, toOneAccessFilters: emptyToOneAccessFilterTree() }
   }
 
   const folded = foldDeclaredDependencies(callerInclude, listConfig.fields, config, listName)
   if (!folded.include) {
-    return { ...folded, selection: undefined }
+    return { ...folded, selection: undefined, toOneAccessFilters: emptyToOneAccessFilterTree() }
   }
 
-  const include = await buildAccessScopedInclude(
+  const { include, toOneAccessFilters } = await buildAccessScopedInclude(
     folded.include,
     listConfig.fields,
     { session: context.session, context },
     config,
     listName,
   )
-  return { include, declaredOnly: folded.declaredOnly, selection: undefined }
+  return { include, declaredOnly: folded.declaredOnly, selection: undefined, toOneAccessFilters }
 }
 
 function createFindUnique<TPrisma extends PrismaClientLike>(
@@ -1026,7 +1035,7 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
     // Resolve `include`, folding any declared dependencies (`needs`,
     // ADR-0025) in alongside whatever the fragment/caller/sudo/bare path
     // already produces — see `resolveReadInclude`'s doc comment.
-    let { include, declaredOnly, selection } = await resolveReadInclude(
+    let { include, declaredOnly, selection, toOneAccessFilters } = await resolveReadInclude(
       args.include,
       fragment ? fragment._fields : undefined,
       listName,
@@ -1056,6 +1065,14 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       return null
     }
 
+    // Resolve which of the to-one relations flagged by `toOneAccessFilters`
+    // actually survive their related list's `query` access (issue #974) —
+    // one batched existence check per relation, before field visibility runs.
+    const toOneVisibility = await resolveToOneAccessVisibility([item], toOneAccessFilters, {
+      session: context.session,
+      context,
+    })
+
     // Pass sudo flag through context to skip field-level access checks
     const filtered = await filterReadableFields(
       item,
@@ -1069,6 +1086,7 @@ function createFindUnique<TPrisma extends PrismaClientLike>(
       listName,
       declaredOnly,
       selection,
+      toOneVisibility,
     )
 
     if (fragment) {
@@ -1178,7 +1196,7 @@ function createFindMany<TPrisma extends PrismaClientLike>(
     // Resolve `include`, folding any declared dependencies (`needs`,
     // ADR-0025) in alongside whatever the fragment/caller/sudo/bare path
     // already produces — see `resolveReadInclude`'s doc comment.
-    let { include, declaredOnly, selection } = await resolveReadInclude(
+    let { include, declaredOnly, selection, toOneAccessFilters } = await resolveReadInclude(
       args?.include,
       fragment ? fragment._fields : undefined,
       listName,
@@ -1202,6 +1220,15 @@ function createFindMany<TPrisma extends PrismaClientLike>(
       include,
     })
 
+    // Resolve which of the to-one relations flagged by `toOneAccessFilters`
+    // actually survive their related list's `query` access (issue #974) —
+    // ONE batched existence check per relation across every row in `items`,
+    // before field visibility runs on any of them.
+    const toOneVisibility = await resolveToOneAccessVisibility(items, toOneAccessFilters, {
+      session: context.session,
+      context,
+    })
+
     // Pass sudo flag through context to skip field-level access checks
     const filtered = await Promise.all(
       items.map((item: Record<string, unknown>) =>
@@ -1217,6 +1244,7 @@ function createFindMany<TPrisma extends PrismaClientLike>(
           listName,
           declaredOnly,
           selection,
+          toOneVisibility,
         ),
       ),
     )
@@ -1501,7 +1529,7 @@ function createGet<TPrisma extends PrismaClientLike>(
     // Resolve `include`, folding any declared dependencies (`needs`,
     // ADR-0025) in alongside whatever the fragment/caller/sudo/bare path
     // already produces — see `resolveReadInclude`'s doc comment.
-    let { include, declaredOnly, selection } = await resolveReadInclude(
+    let { include, declaredOnly, selection, toOneAccessFilters } = await resolveReadInclude(
       args?.include,
       fragment ? fragment._fields : undefined,
       listName,
@@ -1519,6 +1547,13 @@ function createGet<TPrisma extends PrismaClientLike>(
     })
 
     if (item) {
+      // Resolve which of the to-one relations flagged by `toOneAccessFilters`
+      // actually survive their related list's `query` access (issue #974).
+      const toOneVisibility = await resolveToOneAccessVisibility([item], toOneAccessFilters, {
+        session: context.session,
+        context,
+      })
+
       const filtered = await filterReadableFields(
         item,
         listConfig.fields,
@@ -1531,6 +1566,7 @@ function createGet<TPrisma extends PrismaClientLike>(
         listName,
         declaredOnly,
         selection,
+        toOneVisibility,
       )
       if (fragment) {
         return pickFields(filtered, fragment._fields)

--- a/packages/core/tests/access-relationships.test.ts
+++ b/packages/core/tests/access-relationships.test.ts
@@ -155,7 +155,7 @@ describe('Relationship Access Control', () => {
         // Test that buildAccessScopedInclude excludes the denied relationship
         const { buildAccessScopedInclude } = await import('../src/access/index.js')
 
-        const include = await buildAccessScopedInclude(
+        const { include } = await buildAccessScopedInclude(
           { author: true },
           config.lists.Post.fields,
           {
@@ -323,7 +323,7 @@ describe('Relationship Access Control', () => {
         // Test that buildAccessScopedInclude creates the right where clause
         const { buildAccessScopedInclude } = await import('../src/access/index.js')
 
-        const include = await buildAccessScopedInclude(
+        const { include } = await buildAccessScopedInclude(
           { posts: true },
           config.lists.User.fields,
           {
@@ -492,7 +492,7 @@ describe('Relationship Access Control', () => {
         // Test that buildAccessScopedInclude creates session-based where clause
         const { buildAccessScopedInclude } = await import('../src/access/index.js')
 
-        const include = await buildAccessScopedInclude(
+        const { include } = await buildAccessScopedInclude(
           { posts: true },
           config.lists.User.fields,
           {

--- a/packages/core/tests/context.test.ts
+++ b/packages/core/tests/context.test.ts
@@ -2194,7 +2194,7 @@ describe('getContext', () => {
           }
         }
 
-        it('findUnique inside a resolveOutput hook row-scopes the relation instead of dropping the where', async () => {
+        it('findUnique inside a resolveOutput hook still fetches the relation, unscoped at the Prisma level (#974)', async () => {
           let innerIncludeSeen: unknown
           const hookConfig = configWithResolveOutputProbe({ post: true }, (include) => {
             innerIncludeSeen = include
@@ -2206,9 +2206,11 @@ describe('getContext', () => {
           const context = await getContext(hookConfig, relPrisma, null)
           await context.db.author.findUnique({ where: { id: 'a1' } })
 
-          // `post` is still fetched (not dropped) but now carries Post's own
-          // query-access `where` — it is no longer a bare, unscoped `true`.
-          expect(innerIncludeSeen).toEqual({ post: { where: { status: { equals: 'published' } } } })
+          // `post` is still fetched (not dropped). It carries no `where` — Post
+          // is a to-one relation here, and Prisma rejects a `where` on a to-one
+          // include (#974); Post's own access filter is enforced afterward via
+          // a batched existence check instead (see access-filter.test.ts).
+          expect(innerIncludeSeen).toEqual({ post: true })
         })
 
         it('findMany inside a resolveOutput hook scopes the relation but does not auto-expand its nested include', async () => {
@@ -2227,10 +2229,10 @@ describe('getContext', () => {
           await context.db.author.findMany()
 
           // The caller's own nested selection (`post.include.author`) is honoured
-          // as-is (access control does not auto-descend further here), while
-          // `post` itself picks up its access `where`.
+          // as-is (access control does not auto-descend further here). `post`
+          // itself carries no `where` — see the findUnique test above (#974).
           expect(innerIncludeSeen).toEqual({
-            post: { where: { status: { equals: 'published' } }, include: { author: true } },
+            post: { include: { author: true } },
           })
         })
       })
@@ -2289,7 +2291,7 @@ describe('getContext', () => {
           expect(chainPrisma.c0.findMany).not.toHaveBeenCalled()
         })
 
-        it('still returns correctly row-scoped data for the same include one hop shallower', async () => {
+        it('still applies row-scoping at the deepest hop for the same include one hop shallower', async () => {
           const chainLength = READ_INCLUDE_MAX_DEPTH + 1
           const chainConfig: OpenSaasConfig = {
             db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
@@ -2300,7 +2302,20 @@ describe('getContext', () => {
           for (let i = 0; i < chainLength; i++) {
             chainPrisma[`c${i}`] = { findMany: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn() }
           }
-          chainPrisma.c0.findMany.mockResolvedValue([])
+
+          // Every hop here is to-one (no `many: true`), so none of them can
+          // carry a `where` on the Prisma include (#974) — the chain comes
+          // back unscoped at the Prisma level, one nested object per hop, and
+          // row-scoping is enforced afterward via a batched existence check
+          // per hop instead.
+          let deepestItem: Record<string, unknown> = { id: `id${chainLength - 1}`, name: 'leaf' }
+          for (let i = chainLength - 2; i >= 0; i--) {
+            deepestItem = { id: `id${i}`, name: 'x', next: deepestItem }
+          }
+          chainPrisma.c0.findMany.mockResolvedValue([deepestItem])
+          for (let i = 1; i < chainLength; i++) {
+            chainPrisma[`c${i}`].findMany.mockResolvedValue([{ id: `id${i}` }])
+          }
 
           const context = await getContext(chainConfig, chainPrisma, null)
 
@@ -2308,13 +2323,27 @@ describe('getContext', () => {
             include: { next: nestedCallerInclude(READ_INCLUDE_MAX_DEPTH - 1) },
           })
 
-          // Walk the built include down to the last list — it must carry that
-          // list's own access `where`, proving row scoping, not just "no throw".
+          // Walk the built include down to the last list — no hop carries a
+          // `where` (they are all to-one).
           let entry = chainPrisma.c0.findMany.mock.calls[0][0].include.next
           for (let i = 1; i < READ_INCLUDE_MAX_DEPTH; i++) {
+            expect(entry.where).toBeUndefined()
             entry = entry.include.next
           }
-          expect(entry.where).toEqual({ ownerId: { equals: `C${READ_INCLUDE_MAX_DEPTH}` } })
+          expect(entry.where).toBeUndefined()
+
+          // The deepest hop's own existence check still carries that list's
+          // access filter — row scoping reaches all the way down, just not
+          // through the Prisma `include` itself.
+          expect(chainPrisma[`c${READ_INCLUDE_MAX_DEPTH}`].findMany).toHaveBeenCalledWith({
+            where: {
+              AND: [
+                { ownerId: { equals: `C${READ_INCLUDE_MAX_DEPTH}` } },
+                { id: { in: [`id${READ_INCLUDE_MAX_DEPTH}`] } },
+              ],
+            },
+            select: { id: true },
+          })
         })
       })
 

--- a/packages/core/tests/singleton.test.ts
+++ b/packages/core/tests/singleton.test.ts
@@ -278,12 +278,20 @@ describe('Singleton Lists', () => {
         featuredAuthorId: 'a1',
         featuredAuthor: { id: 'a1', name: 'Ann' },
       })
+      // `featuredAuthor` is to-one, so Prisma cannot scope it with a nested
+      // `where` (#974) — it's fetched unscoped, then this batched existence
+      // check decides whether it survives.
+      relPrisma.author.findMany.mockResolvedValue([{ id: 'a1' }])
 
       const context = getContext(relConfig, relPrisma, null)
       const result = await context.db.homePage.get({ include: { featuredAuthor: true } })
 
       const call = relPrisma.homePage.findFirst.mock.calls[0][0]
-      expect(call.include.featuredAuthor).toEqual({ where: { published: { equals: true } } })
+      expect(call.include.featuredAuthor).toBe(true)
+      expect(relPrisma.author.findMany).toHaveBeenCalledWith({
+        where: { AND: [{ published: { equals: true } }, { id: { in: ['a1'] } }] },
+        select: { id: true },
+      })
       expect(result?.featuredAuthor).toEqual({ id: 'a1', name: 'Ann' })
     })
   })

--- a/packages/core/tests/to-one-include-access-filter.test.ts
+++ b/packages/core/tests/to-one-include-access-filter.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import type { OpenSaasConfig } from '../src/config/types.js'
+
+/**
+ * End-to-end regression coverage for issue #974: `include`-ing a to-one
+ * relation whose related list's `query` access resolves to a filter used to
+ * throw `PrismaClientValidationError` — the access-scoped include builder
+ * attached that filter as a nested `where`, which Prisma only accepts on a
+ * to-many include. These tests exercise the fix through `context.db`, the
+ * same surface the issue's reproduction used, with a membership-derived
+ * filter (an `OR` reaching through a relation) matching the reporter's real
+ * case — proving the filter is handed to Prisma unmodified rather than
+ * hand-evaluated.
+ */
+describe('include on a to-one relationship with a filtered related list (#974)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockPrisma: any
+  let config: OpenSaasConfig
+  const membershipFilter = {
+    OR: [
+      { id: { equals: 'self-id' } },
+      { memberships: { some: { studio: { admins: { some: { id: { equals: 'self-id' } } } } } } },
+    ],
+  }
+
+  beforeEach(() => {
+    mockPrisma = {
+      child: { findFirst: vi.fn(), findMany: vi.fn() },
+      user: { findFirst: vi.fn(), findMany: vi.fn() },
+    }
+
+    config = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      lists: {
+        Child: {
+          fields: {
+            name: { type: 'text' },
+            owner: { type: 'relationship', ref: 'User' },
+          },
+          access: { operation: { query: () => true } },
+        },
+        User: {
+          fields: { name: { type: 'text' } },
+          access: { operation: { query: () => membershipFilter } },
+        },
+      },
+    }
+  })
+
+  it('findMany succeeds instead of throwing, admits a visible owner, and nulls an excluded one', async () => {
+    mockPrisma.child.findMany.mockResolvedValue([
+      { id: 'c1', name: 'A', owner: { id: 'u1', name: 'Visible' } },
+      { id: 'c2', name: 'B', owner: { id: 'u2', name: 'Hidden' } },
+      { id: 'c3', name: 'C', owner: null },
+    ])
+    // Only u1 satisfies the access filter.
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }])
+
+    const context = getContext(config, mockPrisma, { userId: 'self-id' })
+    const result = await context.db.child.findMany({ include: { owner: true } })
+
+    // The Prisma call itself carries no `where` on `owner` — this is exactly
+    // the shape Prisma rejected before the fix.
+    expect(mockPrisma.child.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ include: { owner: true } }),
+    )
+
+    // One batched existence check, evaluating the EXACT filter `checkAccess`
+    // produced — never a hand-rolled interpretation of it.
+    expect(mockPrisma.user.findMany).toHaveBeenCalledTimes(1)
+    expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+      where: { AND: [membershipFilter, { id: { in: ['u1', 'u2'] } }] },
+      select: { id: true },
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result[0].owner).toEqual({ id: 'u1', name: 'Visible' })
+    expect(result[1].owner).toBeNull()
+    expect(result[2].owner).toBeNull()
+  })
+
+  it('findUnique and findFirst apply the same nulling for a single row', async () => {
+    const deniedRow = { id: 'c2', name: 'B', owner: { id: 'u2', name: 'Hidden' } }
+    // findUnique reads through the model's own `findFirst`; findFirst is
+    // sugar over `findMany` (see `createFindFirst` in context/index.ts) — both
+    // need mocking here.
+    mockPrisma.child.findFirst.mockResolvedValue(deniedRow)
+    mockPrisma.child.findMany.mockResolvedValue([deniedRow])
+    mockPrisma.user.findMany.mockResolvedValue([])
+
+    const context = getContext(config, mockPrisma, { userId: 'self-id' })
+    const viaFindUnique = await context.db.child.findUnique({
+      where: { id: 'c2' },
+      include: { owner: true },
+    })
+    const viaFindFirst = await context.db.child.findFirst({ include: { owner: true } })
+
+    expect(viaFindUnique?.owner).toBeNull()
+    expect(viaFindFirst?.owner).toBeNull()
+  })
+
+  it('nulls every parent row when the related list denies query access outright, without issuing an existence check', async () => {
+    config.lists.User.access = { operation: { query: () => false } }
+    mockPrisma.child.findMany.mockResolvedValue([
+      { id: 'c1', name: 'A' }, // never fetched at all — access-filter drops the key from `include`
+    ])
+
+    const context = getContext(config, mockPrisma, { userId: 'self-id' })
+    const result = await context.db.child.findMany({ include: { owner: true } })
+
+    expect(mockPrisma.child.findMany).toHaveBeenCalledWith(expect.objectContaining({ include: {} }))
+    expect(mockPrisma.user.findMany).not.toHaveBeenCalled()
+    expect(result[0].owner).toBeNull()
+  })
+
+  it('leaves the relation unchanged and issues no extra query when the related list is fully open', async () => {
+    config.lists.User.access = { operation: { query: () => true } }
+    mockPrisma.child.findMany.mockResolvedValue([
+      { id: 'c1', name: 'A', owner: { id: 'u1', name: 'Ann' } },
+    ])
+
+    const context = getContext(config, mockPrisma, { userId: 'self-id' })
+    const result = await context.db.child.findMany({ include: { owner: true } })
+
+    expect(mockPrisma.child.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ include: { owner: true } }),
+    )
+    expect(mockPrisma.user.findMany).not.toHaveBeenCalled()
+    expect(result[0].owner).toEqual({ id: 'u1', name: 'Ann' })
+  })
+
+  it('scopes a filtered to-one relation nested inside a to-many include, at every row', async () => {
+    config.lists.Child.fields.notes = { type: 'relationship', ref: 'Note.child', many: true }
+    config.lists.Note = {
+      fields: {
+        body: { type: 'text' },
+        child: { type: 'relationship', ref: 'Child.notes' },
+        author: { type: 'relationship', ref: 'User' },
+      },
+      access: { operation: { query: () => true } },
+    }
+    mockPrisma.child.findMany.mockResolvedValue([
+      {
+        id: 'c1',
+        name: 'A',
+        notes: [
+          { id: 'n1', body: 'ok', author: { id: 'u1', name: 'Visible' } },
+          { id: 'n2', body: 'no', author: { id: 'u2', name: 'Hidden' } },
+        ],
+      },
+    ])
+    mockPrisma.user.findMany.mockResolvedValue([{ id: 'u1' }])
+
+    const context = getContext(config, mockPrisma, { userId: 'self-id' })
+    const result = await context.db.child.findMany({
+      include: { notes: { include: { author: true } } },
+    })
+
+    // The to-many `notes` relation still carries no `where` here (Note's
+    // query access is fully open); the nested to-one `author` inside it is
+    // resolved via ONE batched existence check across both notes.
+    expect(mockPrisma.user.findMany).toHaveBeenCalledTimes(1)
+    expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+      where: { AND: [membershipFilter, { id: { in: ['u1', 'u2'] } }] },
+      select: { id: true },
+    })
+
+    expect(result[0].notes[0].author).toEqual({ id: 'u1', name: 'Visible' })
+    expect(result[0].notes[1].author).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- `context.db.<list>.findMany({ include: { <toOneRelation>: true } })` threw `PrismaClientValidationError` whenever the related list's `query` access resolved to a filter (rather than a plain boolean) — the access-scoped include builder attached that filter as a nested `where`, which Prisma only accepts on a **to-many** include.
- `buildAccessScopedInclude` (`access-filter.ts`) no longer attaches a `where` to a to-one relation's include entry. Instead it records the access filter (or an outright denial) in a new `toOneAccessFilters` tree.
- `resolveToOneAccessVisibility` (new) resolves that tree **after** the Prisma query runs: one batched `id IN (...)` existence check per relation across every row in the read (never once per row), evaluated by handing the exact `PrismaFilter` `checkAccess` produced straight to Prisma — no hand-rolled filter interpretation, so relation-quantifier filters (e.g. `{ memberships: { some: {...} } }`, the reporter's real case) are evaluated correctly.
- `filterReadableFields` (`field-visibility.ts`) applies the resolved visibility: an excluded related row (or an outright-denied relation) becomes `null`, matching the "denied read is silent" contract everywhere else in the context — the parent row is still returned. This holds at every include depth, including a to-one relation nested inside another include.
- To-many relations are untouched — they still receive their access filter as a nested `where`, exactly as before.

Chosen approach follows the maintainer decision recorded on the issue (option 2: fetch + post-filter to `null`), using existence-check batching (issue's option 1 shape) rather than a per-row query.

## Test plan

- [x] New unit coverage in `access-filter.test.ts` for `buildAccessScopedInclude`'s to-one behavior (scoped/open/denied/nested) and `resolveToOneAccessVisibility` (denial passthrough, empty-id skip, batching across rows, nested-tree flattening through a to-many hop).
- [x] New end-to-end coverage in `tests/to-one-include-access-filter.test.ts` through `context.db` (`findMany`/`findUnique`/`findFirst`), including a membership-derived (`OR`/relation-quantifier) filter matching the issue's real-world case, and a to-one relation nested inside a to-many include.
- [x] Updated existing tests that asserted the old (buggy) `where`-on-to-one shape to reflect the new behavior.
- [x] `pnpm lint`, `pnpm format`, `pnpm manypkg fix`, and the full core test suite (1080 tests) pass.
- [x] `tsc --noEmit` and `pnpm build` pass for `packages/core`.
- [x] Changeset added (patch, notes the behavior change: a query that previously threw now succeeds and may return `null` for a related row).

Closes #974


---
_Generated by [Claude Code](https://claude.ai/code/session_012JTajjY3WdXYv95Y2UXBsS)_