### PR TITLE
fix(core,ui,auth): admin UI URL round-trip for non-PascalCase list keys

### DIFF
--- a/.changeset/wise-hounds-listen.md
+++ b/.changeset/wise-hounds-listen.md
@@ -1,0 +1,22 @@
+---
+'@opensaas/stack-core': minor
+'@opensaas/stack-ui': patch
+'@opensaas/stack-auth': patch
+---
+
+Fix admin UI URL round-trip for a list keyed with anything other than strict PascalCase (issue #991). `getListKeyFromUrl` reconstructs a list key by string transformation, which is lossy for a non-PascalCase key — a real example is a better-auth plugin's derived list (e.g. `oauthApplication`, from the `mcp` plugin's OAuth tables). Such a list appeared in navigation but its own link resolved to a key that did not exist in `config.lists`, rendering "List not found".
+
+`@opensaas/stack-core` adds `resolveListKeyFromUrl(urlSegment, listKeys)` alongside the existing `getListKeyFromUrl`, which is unchanged and still exported. The new resolver matches a URL segment against the config's actual list keys via `getUrlKey` — the same helper that builds the URL — instead of reconstructing one, so route lookup and URL generation cannot drift apart. It returns `undefined` for a segment matching no list (so callers keep rendering their existing "not found" state), and throws if two distinct list keys would produce the same URL segment.
+
+```typescript
+import { resolveListKeyFromUrl } from '@opensaas/stack-core'
+
+resolveListKeyFromUrl('oauth-application', Object.keys(config.lists)) // 'oauthApplication'
+resolveListKeyFromUrl('does-not-exist', Object.keys(config.lists)) // undefined
+```
+
+`@opensaas/stack-ui`'s `AdminUI` now uses `resolveListKeyFromUrl` for its route resolution, fixing the broken link for any such list.
+
+`@opensaas/stack-auth`'s `convertBetterAuthSchema` now PascalCases a better-auth plugin's camelCase `modelName` when deriving a list key (`oauthApplication` → `OauthApplication`, `rateLimit` → `RateLimit`), matching the repo's PascalCase list-key convention and fixing the same round-trip bug at the source for these lists.
+
+**Schema-affecting for `@opensaas/stack-auth` users with a better-auth plugin that declares extra tables** (e.g. `mcp`'s OAuth tables, or `rateLimit.storage: 'database'` with no `modelName` remap configured): the generated Prisma **model name** changes to match the new PascalCase list key. The physical **table name** does not change — the previous camelCase name is preserved via `db.map` (`@@map`) — so `prisma db push` / `prisma migrate dev` sees a model rename, not a table rename, and `context.db.oauthApplication` (the camelCase db accessor) keeps working unchanged. Regenerate (`pnpm generate`) and re-run your migration/push step after upgrading.

--- a/packages/auth/src/server/schema-converter.ts
+++ b/packages/auth/src/server/schema-converter.ts
@@ -93,10 +93,15 @@ function convertField(
  * Per ADR-0013, ships closed — no access is set here. See
  * `packages/auth/CLAUDE.md` ("Access control on Auth lists") for how an app
  * grants access to a table this produces.
+ *
+ * @param tableMap - Physical table name for `db.map` (`@@map`), when the list
+ *   key had to change case to satisfy the PascalCase convention and would
+ *   otherwise rename the live table (issue #991).
  */
 export function convertTableToList(
   tableName: string,
   tableSchema: BetterAuthTableSchema,
+  tableMap?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
 ): ListConfig<any> {
   const fields: Record<string, FieldConfig> = {}
@@ -122,7 +127,7 @@ export function convertTableToList(
     }
   }
 
-  return list({ fields })
+  return list({ fields, ...(tableMap ? { db: { map: tableMap } } : {}) })
 }
 
 /**
@@ -188,14 +193,27 @@ export function convertBetterAuthSchema(
     // A base-model remap always wins: it reflects the actual configured list
     // key for that model, whereas `tableSchema.modelName`/the table name are
     // just how the provider plugin happens to describe its own extension.
-    const listKey =
-      resolveBaseModelKey(tableName, baseModelKeys) ||
-      tableSchema.modelName ||
-      toPascalCase(tableName)
-    lists[listKey] = convertTableToList(tableName, tableSchema)
+    const baseModelKey = resolveBaseModelKey(tableName, baseModelKeys)
+    // Plugin `modelName`s are camelCase; PascalCase for the list key and
+    // preserve the original as `db.map` so the live table is unaffected.
+    const pascalModelName = tableSchema.modelName && capitalizeFirst(tableSchema.modelName)
+    const listKey = baseModelKey || pascalModelName || toPascalCase(tableName)
+    const tableMap =
+      !baseModelKey && pascalModelName !== tableSchema.modelName ? tableSchema.modelName : undefined
+    lists[listKey] = convertTableToList(tableName, tableSchema, tableMap)
   }
 
   return lists
+}
+
+/**
+ * Uppercase the first character only, preserving the rest verbatim — unlike
+ * {@link toPascalCase}, which also lowercases every character after a
+ * separator and would mangle an already-camelCase `modelName`'s internal
+ * word boundaries (`oauthApplication` -> `Oauthapplication`).
+ */
+function capitalizeFirst(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
 function toPascalCase(str: string): string {

--- a/packages/auth/tests/schema-converter.test.ts
+++ b/packages/auth/tests/schema-converter.test.ts
@@ -244,6 +244,32 @@ describe('convertTableToList', () => {
 
     expect(listConfig.access).toBeUndefined()
   })
+
+  it('sets db.map to the given tableMap', () => {
+    const tableSchema = {
+      modelName: 'OauthApplication',
+      fields: {
+        clientId: { type: 'string' },
+      },
+    }
+
+    const listConfig = convertTableToList('oauthApplication', tableSchema, 'oauthApplication')
+
+    expect(listConfig.db?.map).toBe('oauthApplication')
+  })
+
+  it('sets no db.map when tableMap is omitted', () => {
+    const tableSchema = {
+      modelName: 'TestTable',
+      fields: {
+        name: { type: 'string' },
+      },
+    }
+
+    const listConfig = convertTableToList('test_table', tableSchema)
+
+    expect(listConfig.db).toBeUndefined()
+  })
 })
 
 describe('convertBetterAuthSchema', () => {
@@ -369,6 +395,73 @@ describe('convertBetterAuthSchema', () => {
     const lists = convertBetterAuthSchema(schema, { user: 'AuthUser' })
 
     expect(lists).toHaveProperty('OauthApplication')
+  })
+
+  it('PascalCases a camelCase plugin modelName and maps the table back to it (issue #991)', () => {
+    // The real MCP plugin declares its OAuth tables with a camelCase
+    // `modelName` (e.g. `oauthApplication`), unlike the other fixtures in
+    // this file which pass an already-PascalCase `modelName` by convention.
+    const schema = {
+      oauthApplication: {
+        modelName: 'oauthApplication',
+        fields: {
+          clientId: { type: 'string', required: true },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema)
+
+    expect(lists).toHaveProperty('OauthApplication')
+    expect(lists).not.toHaveProperty('oauthApplication')
+    expect(lists.OauthApplication.db?.map).toBe('oauthApplication')
+  })
+
+  it('PascalCases a camelCase rateLimit modelName with no baseModelKeys remap (issue #991)', () => {
+    const schema = {
+      rateLimit: {
+        modelName: 'rateLimit',
+        fields: {
+          key: { type: 'string' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema)
+
+    expect(lists).toHaveProperty('RateLimit')
+    expect(lists.RateLimit.db?.map).toBe('rateLimit')
+  })
+
+  it('sets no db.map when a plugin modelName is already PascalCase', () => {
+    const schema = {
+      passkey: {
+        modelName: 'Passkey',
+        fields: {
+          publicKey: { type: 'string' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema)
+
+    expect(lists).toHaveProperty('Passkey')
+    expect(lists.Passkey.db?.map).toBeUndefined()
+  })
+
+  it('does not map the table when a baseModelKeys remap is used instead', () => {
+    const schema = {
+      user: {
+        modelName: 'user',
+        fields: {
+          isAnonymous: { type: 'boolean' },
+        },
+      },
+    }
+
+    const lists = convertBetterAuthSchema(schema, { user: 'AuthUser' })
+
+    expect(lists.AuthUser.db?.map).toBeUndefined()
   })
 
   it('should convert complex schema with multiple field types', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,7 +50,7 @@ export type {
 } from './context/index.js'
 
 // Naming utilities (documented public helpers; used for URLs and db keys)
-export { getDbKey, getUrlKey, getListKeyFromUrl } from './lib/case-utils.js'
+export { getDbKey, getUrlKey, getListKeyFromUrl, resolveListKeyFromUrl } from './lib/case-utils.js'
 
 // Label seam — resolves the field that represents a row as a single label
 // (projection) and reads it off a row (render). Used by the admin UI for

--- a/packages/core/src/lib/case-utils.test.ts
+++ b/packages/core/src/lib/case-utils.test.ts
@@ -7,6 +7,7 @@ import {
   getDbKey,
   getUrlKey,
   getListKeyFromUrl,
+  resolveListKeyFromUrl,
 } from './case-utils.js'
 
 describe('Case Conversion Utilities', () => {
@@ -94,6 +95,37 @@ describe('Case Conversion Utilities', () => {
       expect(getListKeyFromUrl('user')).toBe('User')
       expect(getListKeyFromUrl('auth-user')).toBe('AuthUser')
       expect(getListKeyFromUrl('blog-post')).toBe('BlogPost')
+    })
+  })
+
+  describe('resolveListKeyFromUrl', () => {
+    it('resolves a PascalCase list key from its URL segment', () => {
+      expect(resolveListKeyFromUrl('blog-post', ['User', 'BlogPost'])).toBe('BlogPost')
+    })
+
+    it('resolves a camelCase list key (e.g. a derived plugin list) from its URL segment', () => {
+      // getListKeyFromUrl('oauth-application') would reconstruct 'OauthApplication',
+      // which isn't a key in this list — that's the bug this resolver fixes.
+      expect(resolveListKeyFromUrl('oauth-application', ['oauthApplication'])).toBe(
+        'oauthApplication',
+      )
+    })
+
+    it('returns undefined for a URL segment matching no list key', () => {
+      expect(resolveListKeyFromUrl('does-not-exist', ['User', 'BlogPost'])).toBeUndefined()
+    })
+
+    it('throws when two distinct list keys produce the same URL segment', () => {
+      expect(() =>
+        resolveListKeyFromUrl('oauth-application', ['oauthApplication', 'OauthApplication']),
+      ).toThrow(/Ambiguous list URL/)
+    })
+
+    it('is derived from getUrlKey, so it cannot drift from how URLs are built', () => {
+      const listKeys = ['User', 'AuthUser', 'BlogPost', 'oauthApplication']
+      for (const listKey of listKeys) {
+        expect(resolveListKeyFromUrl(getUrlKey(listKey), listKeys)).toBe(listKey)
+      }
     })
   })
 

--- a/packages/core/src/lib/case-utils.ts
+++ b/packages/core/src/lib/case-utils.ts
@@ -40,3 +40,29 @@ export function getUrlKey(listKey: string): string {
 export function getListKeyFromUrl(urlSegment: string): string {
   return kebabToPascal(urlSegment)
 }
+
+/**
+ * Resolves a URL segment back to the list key that produced it, by checking
+ * each candidate key against `getUrlKey` — the same helper that builds the
+ * URL — rather than reconstructing a key by string transformation the way
+ * `getListKeyFromUrl` does. That reconstruction is lossy for any list key
+ * that isn't strict PascalCase (e.g. a camelCase key from a derived list),
+ * so this is the config-aware resolver route lookups should use instead.
+ *
+ * Returns `undefined` when no candidate key's URL matches — callers render
+ * their usual "not found" state rather than treating this as an error.
+ * Throws if more than one candidate key produces the same URL segment: that
+ * is a configuration error (two list keys collide once case-folded to a
+ * URL) and must be reported, not resolved by silently picking one.
+ */
+export function resolveListKeyFromUrl(urlSegment: string, listKeys: string[]): string | undefined {
+  const matches = listKeys.filter((listKey) => getUrlKey(listKey) === urlSegment)
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous list URL "${urlSegment}": list keys ${matches.map((key) => `"${key}"`).join(', ')} all resolve to this URL. Rename these lists so their URLs are unique.`,
+    )
+  }
+
+  return matches[0]
+}

--- a/packages/ui/src/components/AdminUI.tsx
+++ b/packages/ui/src/components/AdminUI.tsx
@@ -9,9 +9,9 @@ import { DashboardSkeleton, ItemFormSkeleton, ListViewSkeleton } from './Skeleto
 import type { ServerActionInput } from '../server/types.js'
 import {
   type AccessContext,
-  getListKeyFromUrl,
   getUrlKey,
   OpenSaasConfig,
+  resolveListKeyFromUrl,
   resolveNavCounts,
 } from '@opensaas/stack-core'
 import { compileTheme } from '../lib/theme.js'
@@ -69,7 +69,12 @@ export async function AdminUI({
   }
 
   const [urlSegment, action] = params
-  const listKey = urlSegment ? getListKeyFromUrl(urlSegment) : undefined
+  // Falls back to the raw segment when it resolves to no configured list, so
+  // the existing "not found" branches below (which key off `config.lists`)
+  // still render instead of silently taking the Dashboard/root path.
+  const listKey = urlSegment
+    ? (resolveListKeyFromUrl(urlSegment, Object.keys(config.lists)) ?? urlSegment)
+    : undefined
   const currentPath = deriveCurrentPath(params)
 
   let content: React.ReactNode

--- a/packages/ui/tests/components/AdminUIListKeyResolution.test.tsx
+++ b/packages/ui/tests/components/AdminUIListKeyResolution.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest'
+import * as React from 'react'
+import type { AccessContext, OpenSaasConfig } from '@opensaas/stack-core'
+import { list } from '@opensaas/stack-core'
+import { text } from '@opensaas/stack-core/fields'
+import { AdminUI } from '../../src/components/AdminUI.js'
+import { ListView } from '../../src/components/ListView.js'
+import { ItemForm } from '../../src/components/ItemForm.js'
+import { Dashboard } from '../../src/components/Dashboard.js'
+
+// Mock Next.js navigation — client components call useRouter().
+const mockPush = vi.fn()
+const mockRefresh = vi.fn()
+vi.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}))
+
+vi.mock('next/link.js', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+interface DelegateStub {
+  findMany?: (args: unknown) => Promise<Array<Record<string, unknown>>>
+  count?: (args: unknown) => Promise<number>
+  findUnique?: (args: unknown) => Promise<Record<string, unknown> | null>
+}
+
+function makeContext(delegates: Record<string, DelegateStub>): AccessContext<unknown> {
+  const context = {
+    db: delegates,
+    session: null,
+    storage: {},
+    plugins: {},
+    _isSudo: false,
+    _resolveOutputChain: [],
+  }
+  return context as unknown as AccessContext<unknown>
+}
+
+const noopServerAction = vi.fn(async () => ({ success: true }))
+
+/**
+ * AdminUI returns <> {style?} <div><Navigation/><main>{content}</main></div> </>.
+ * Drill into <main> to recover the routed content element so we can inspect
+ * the props AdminUI passed to it.
+ */
+function routedContent(tree: React.ReactNode): React.ReactElement {
+  const fragment = tree as React.ReactElement<{ children: React.ReactNode }>
+  const children = React.Children.toArray(fragment.props.children)
+  const wrapper = children.find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'div',
+  )
+  if (!wrapper) throw new Error('AdminUI layout wrapper not found')
+  const main = React.Children.toArray(wrapper.props.children).find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'main',
+  )
+  if (!main) throw new Error('AdminUI <main> not found')
+  const boundary = main.props.children as React.ReactElement<{ children: React.ReactNode }>
+  if (React.isValidElement(boundary) && boundary.type === React.Suspense) {
+    return boundary.props.children as React.ReactElement
+  }
+  return boundary
+}
+
+// A camelCase list key, matching what a better-auth plugin (e.g. the MCP
+// plugin's OAuth tables) derives before issue #991's auth-side fix — the
+// admin UI's routing must round-trip it regardless.
+function camelCaseListConfig(): OpenSaasConfig {
+  return {
+    db: { provider: 'sqlite', url: 'file:./test.db' },
+    lists: {
+      oauthApplication: list({ fields: { clientId: text() } }),
+    },
+  }
+}
+
+describe('AdminUI list URL resolution (issue #991)', () => {
+  it('resolves a camelCase list key from its URL segment and opens the list view', async () => {
+    const config = camelCaseListConfig()
+    const context = makeContext({
+      oauthApplication: { findMany: vi.fn(async () => []), count: vi.fn(async () => 0) },
+    })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['oauth-application'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ListView)
+    expect(content.props.listKey).toBe('oauthApplication')
+  })
+
+  it('resolves the create route for a camelCase list key', async () => {
+    const config = camelCaseListConfig()
+    const context = makeContext({ oauthApplication: {} })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['oauth-application', 'create'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ItemForm)
+    expect(content.props.listKey).toBe('oauthApplication')
+    expect(content.props.mode).toBe('create')
+  })
+
+  it('resolves an item edit route for a camelCase list key', async () => {
+    const config = camelCaseListConfig()
+    const context = makeContext({
+      oauthApplication: { findUnique: vi.fn(async () => ({ id: 'abc123' })) },
+    })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['oauth-application', 'abc123'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ItemForm)
+    expect(content.props.listKey).toBe('oauthApplication')
+    expect(content.props.mode).toBe('edit')
+    expect(content.props.itemId).toBe('abc123')
+  })
+
+  it('still resolves a PascalCase list key exactly as before', async () => {
+    const config: OpenSaasConfig = {
+      db: { provider: 'sqlite', url: 'file:./test.db' },
+      lists: { BlogPost: list({ fields: { title: text() } }) },
+    }
+    const context = makeContext({
+      blogPost: { findMany: vi.fn(async () => []), count: vi.fn(async () => 0) },
+    })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['blog-post'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(ListView)
+    expect(content.props.listKey).toBe('BlogPost')
+  })
+
+  it('renders the dashboard at the root, not a list view', async () => {
+    const config = camelCaseListConfig()
+    const context = makeContext({ oauthApplication: {} })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: [],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    const content = routedContent(tree)
+    expect(content.type).toBe(Dashboard)
+  })
+
+  it('falls through to the list-not-found state for a URL matching no list, instead of throwing', async () => {
+    const config = camelCaseListConfig()
+    const context = makeContext({ oauthApplication: {} })
+
+    const tree = await AdminUI({
+      context,
+      config,
+      params: ['does-not-exist'],
+      basePath: '/admin',
+      serverAction: noopServerAction,
+    })
+
+    // Not the dashboard fallback — the route still resolves to a list screen,
+    // which renders its own "List not found" state for the unresolved key.
+    const content = routedContent(tree)
+    expect(content.type).toBe(ListView)
+    expect(content.props.listKey).toBe('does-not-exist')
+  })
+})


### PR DESCRIPTION
## Summary

- `packages/core`: add `resolveListKeyFromUrl(urlSegment, listKeys)` — a config-aware companion to `getListKeyFromUrl` that matches a URL segment against a list of actual list keys via `getUrlKey` (the same helper that builds the URL) instead of reconstructing a key by string rules. Returns `undefined` for an unmatched segment; throws if two list keys would collide on the same URL segment. `getListKeyFromUrl` itself is unchanged, still exported, and untouched by existing tests.
- `packages/ui`: `AdminUI`'s route resolution now uses `resolveListKeyFromUrl(urlSegment, Object.keys(config.lists))` instead of `getListKeyFromUrl(urlSegment)`. A list keyed with anything other than strict PascalCase (e.g. a camelCase key derived from a better-auth plugin) is now reachable from its own navigation link. An unresolved segment falls back to the raw segment string so the existing "List not found" branches (which key off `config.lists`) still render, instead of silently falling through to the dashboard.
- `packages/auth`: `convertBetterAuthSchema` now PascalCases a better-auth plugin's camelCase `modelName` when deriving a list key (`oauthApplication` → `OauthApplication`, `rateLimit` → `RateLimit`), matching the repo's PascalCase list-key convention and fixing the round-trip bug at the source for these lists. The original camelCase name is preserved via `db.map` (`@@map`) so the physical database table is unaffected.

### Why this was broken

`getListKeyFromUrl` reconstructs a list key from a URL segment purely by string transformation (kebab → Pascal). That's lossy for any list key that isn't strict PascalCase. A better-auth plugin's derived list (e.g. the `mcp` plugin's `oauthApplication` OAuth table) is exactly such a key: it appeared correctly in navigation and its link was built correctly (`getUrlKey('oauthApplication')` → `/oauth-application`), but resolving that same URL back (`getListKeyFromUrl('oauth-application')` → `'OauthApplication'`) produced a key that doesn't exist in `config.lists`, so the route rendered "List not found" for a list that does exist. See #991 for the full trace.

## Test plan

- [x] `packages/core`: new tests for `resolveListKeyFromUrl` (`case-utils.test.ts`) — PascalCase and camelCase resolution, unmatched segment, ambiguous-segment throw, and a round-trip check against `getUrlKey` for a set of list keys
- [x] `packages/ui`: new `AdminUIListKeyResolution.test.tsx` — a camelCase list key resolves for its list/create/edit routes, a PascalCase list key still resolves as before, root still renders the dashboard, and an unknown segment still falls through to the list's own "not found" state rather than throwing or redirecting to the dashboard
- [x] `packages/auth`: new tests in `schema-converter.test.ts` — a camelCase plugin `modelName` (including `rateLimit`) is PascalCased and mapped back to the original table name via `db.map`; an already-PascalCase `modelName` gets no `db.map`; a `baseModelKeys` remap is unaffected
- [x] `pnpm lint` passes (only 2 pre-existing, unrelated warnings)
- [x] `pnpm format` and `pnpm manypkg fix` applied, no unexpected diffs
- [x] Full test suites pass: core (1105 tests), auth (278 tests, 2 pre-existing skips), ui (585 tests)
- [x] Changeset added (`@opensaas/stack-core` minor, `@opensaas/stack-ui` patch, `@opensaas/stack-auth` patch) — the auth changeset calls out the schema-affecting model-name change and that the physical table is unaffected

Closes #991


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz9vP6EhcxhasnQRYxFA7r)_