### PR TITLE
feat(core): add context.withSession() alongside sudo()

### DIFF
--- a/.changeset/witty-goats-listen.md
+++ b/.changeset/witty-goats-listen.md
@@ -1,0 +1,19 @@
+---
+'@opensaas/stack-core': minor
+---
+
+Add `context.withSession(session)` — a sibling to `sudo()` for the other axis. It derives a `StackContext` that reuses the receiver's already-resolved config, client (including a transaction client — a call inside `context.transaction()` stays in that transaction), and storage, but carries a substituted session, so access control and hooks run against the new session as normal.
+
+This closes a gap for callers that are legitimately authorised but arrive without the session a list `validate` hook expects — an unattended dispatcher, a service principal, or a job runner:
+
+```typescript
+// Runs with the job owner's session so hooks see the right identity, while
+// still going through the normal access control checks for that session.
+const asOwner = context.withSession(job.ownerSession)
+await asOwner.db.task.update({ where: { id: job.taskId }, data: { status: 'done' } })
+
+// Drop to anonymous
+const anonymous = context.withSession(null)
+```
+
+`withSession` grants no authority of its own — the derived context can do exactly what any context built with that session directly could do. It's orthogonal to `sudo()`: `context.withSession(s).sudo()` and `context.sudo().withSession(s)` are equivalent, since `withSession` preserves the receiver's sudo state instead of resetting it.

--- a/.changeset/witty-goats-listen.md
+++ b/.changeset/witty-goats-listen.md
@@ -1,5 +1,6 @@
 ---
 '@opensaas/stack-core': minor
+'@opensaas/stack-cli': minor
 ---
 
 Add `context.withSession(session)` — a sibling to `sudo()` for the other axis. It derives a `StackContext` that reuses the receiver's already-resolved config, client (including a transaction client — a call inside `context.transaction()` stays in that transaction), and storage, but carries a substituted session, so access control and hooks run against the new session as normal.
@@ -17,3 +18,5 @@ const anonymous = context.withSession(null)
 ```
 
 `withSession` grants no authority of its own — the derived context can do exactly what any context built with that session directly could do. It's orthogonal to `sudo()`: `context.withSession(s).sudo()` and `context.sudo().withSession(s)` are equivalent, since `withSession` preserves the receiver's sudo state instead of resetting it.
+
+The generated `Context<TSession>` type (`.opensaas/types.ts`) now includes `withSession: (session: TSession | null) => Context<TSession>` alongside `sudo`, so the method is typed in application code — run `opensaas generate` (or `pnpm generate`) to pick it up.

--- a/docs/content/reference/context-api.md
+++ b/docs/content/reference/context-api.md
@@ -40,6 +40,7 @@ function getContext<TConfig extends OpenSaasConfig, TPrisma extends PrismaClient
   storage: StorageUtils
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context
+  withSession: (session: Session) => Context
   _isSudo: boolean
 }
 ```
@@ -260,6 +261,26 @@ const adminContext = context.sudo()
 
 // Can access all records regardless of access rules
 const allPosts = await adminContext.db.post.findMany()
+```
+
+##### `withSession()`
+
+Creates a new context carrying a different session, reusing this context's config and client (including a transaction client — a call inside `context.transaction()` stays in that transaction) and storage. Access control and hooks run normally against the new session.
+
+**Type:** `(session: Session) => Context`
+
+**Important:** This is not an authorization — it substitutes who hooks and access control see, it does not change what they decide. The derived context can do exactly what any context built with that session directly could do. It's orthogonal to `sudo()`: `context.withSession(s).sudo()` and `context.sudo().withSession(s)` are equivalent, since `withSession()` preserves the receiver's sudo state.
+
+**Example:**
+
+```typescript
+// An unattended job runner that is legitimately authorised but arrives
+// without the session a list's validate hook expects to see.
+const asOwner = context.withSession(job.ownerSession)
+await asOwner.db.task.update({ where: { id: job.taskId }, data: { status: 'done' } })
+
+// Drop to anonymous
+const anonymous = context.withSession(null)
 ```
 
 ##### `_isSudo`

--- a/docs/content/reference/context-api.md
+++ b/docs/content/reference/context-api.md
@@ -40,7 +40,7 @@ function getContext<TConfig extends OpenSaasConfig, TPrisma extends PrismaClient
   storage: StorageUtils
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context
-  withSession: (session: Session) => Context
+  withSession: (session: Session | null) => Context
   _isSudo: boolean
 }
 ```
@@ -267,7 +267,7 @@ const allPosts = await adminContext.db.post.findMany()
 
 Creates a new context carrying a different session, reusing this context's config and client (including a transaction client — a call inside `context.transaction()` stays in that transaction) and storage. Access control and hooks run normally against the new session.
 
-**Type:** `(session: Session) => Context`
+**Type:** `(session: Session | null) => Context`
 
 **Important:** This is not an authorization — it substitutes who hooks and access control see, it does not change what they decide. The derived context can do exactly what any context built with that session directly could do. It's orthogonal to `sudo()`: `context.withSession(s).sudo()` and `context.sudo().withSession(s)` are equivalent, since `withSession()` preserves the receiver's sudo state.
 

--- a/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/generate.test.ts.snap
@@ -388,12 +388,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -513,12 +514,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 

--- a/packages/cli/src/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cli/src/generator/__snapshots__/types.test.ts.snap
@@ -253,12 +253,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -522,12 +523,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -1151,12 +1153,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -1453,12 +1456,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -1722,12 +1726,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -1984,12 +1989,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -2253,12 +2259,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -2939,12 +2946,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -3479,12 +3487,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -4019,12 +4028,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -4624,12 +4634,13 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;
 
@@ -5253,11 +5264,12 @@ export interface BaseContext<TSession extends OpensaasSession = OpensaasSession>
 
 /**
  * Full context type with server action capabilities and virtual field typing
- * Extends BaseContext and adds serverAction and sudo methods
+ * Extends BaseContext and adds serverAction, sudo, and withSession methods
  * Use this type in server actions and components that need full context capabilities
  */
 export interface Context<TSession extends OpensaasSession = OpensaasSession> extends BaseContext<TSession> {
   serverAction: (props: ServerActionProps) => Promise<unknown>
   sudo: () => Context<TSession>
+  withSession: (session: TSession | null) => Context<TSession>
 }"
 `;

--- a/packages/cli/src/generator/types.ts
+++ b/packages/cli/src/generator/types.ts
@@ -1153,7 +1153,7 @@ function generateContextType(_config: OpenSaasConfig): string {
 
   lines.push('/**')
   lines.push(' * Full context type with server action capabilities and virtual field typing')
-  lines.push(' * Extends BaseContext and adds serverAction and sudo methods')
+  lines.push(' * Extends BaseContext and adds serverAction, sudo, and withSession methods')
   lines.push(
     ' * Use this type in server actions and components that need full context capabilities',
   )
@@ -1163,6 +1163,7 @@ function generateContextType(_config: OpenSaasConfig): string {
   )
   lines.push('  serverAction: (props: ServerActionProps) => Promise<unknown>')
   lines.push('  sudo: () => Context<TSession>')
+  lines.push('  withSession: (session: TSession | null) => Context<TSession>')
   lines.push('}')
 
   return lines.join('\n')

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -192,6 +192,37 @@ Key points:
   optimistically at write time, unchanged. See ADR-0028 and the hooks concept
   doc.
 
+#### Substituting a session (`context.withSession`, #980)
+
+`context.withSession(session)` sits beside `sudo()` on the other axis:
+`sudo()` keeps the session and drops access control; `withSession()` keeps
+access control (and hooks) and swaps the session. It reuses the receiver's
+already-resolved config, client (including a transaction client — a call
+inside `context.transaction()` stays in that transaction), and storage.
+
+```typescript
+// An unattended dispatcher running a committed intent, or any job runner
+// that is legitimately authorised but arrives without the session a list's
+// validate hook wants to see in `args.context.session`.
+async function dispatchJob(context: StackContext, job: { ownerSession: Session }) {
+  const asOwner = context.withSession(job.ownerSession)
+  await asOwner.db.task.update({ where: { id: job.taskId }, data: { status: 'done' } })
+}
+```
+
+**`withSession` grants no authority of its own.** It is not an
+authorisation — the derived context can do exactly what any context built
+with that session directly could do; access rules still evaluate against
+the new session. The application decides who may call it.
+
+**Orthogonal to `sudo()`.** `context.withSession(s).sudo()` and
+`context.sudo().withSession(s)` are equivalent — both elevated and both
+carrying `s`. `withSession` preserves the receiver's sudo state rather than
+resetting it: called on an already-sudo context it stays sudo, called on a
+plain context it does not grant sudo.
+
+`withSession(null)` is a legitimate way to drop to an anonymous context.
+
 ### Generators (`src/generator/`)
 
 - `prisma.ts` - Generates `prisma/schema.prisma` from config

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -200,6 +200,14 @@ access control (and hooks) and swaps the session. It reuses the receiver's
 already-resolved config, client (including a transaction client — a call
 inside `context.transaction()` stays in that transaction), and storage.
 
+Like `sudo()` (and unlike `transaction()`), plugin runtime services are
+**rebuilt, not reused** — `plugin.runtime(context, sudo)` factories are
+re-run so any plugin service that closes over the session (e.g. an auth
+plugin's "who is this session" lookup) binds to the _new_ one rather than
+staying stale. A hot loop calling `withSession()` per iteration re-runs
+every plugin's `runtime()` each time; batch via a shared derived context
+where the loop body doesn't need a different session per iteration.
+
 ```typescript
 // An unattended dispatcher running a committed intent, or any job runner
 // that is legitimately authorised but arrives without the session a list's

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -304,7 +304,8 @@ interface TransactionCapable<TPrisma> {
  *
  * Exposes the secured `db` delegate plus the session, raw `prisma`, storage,
  * plugin services, the generic `serverAction` handler, `sudo()` (bypasses access
- * control but still runs hooks), and `transaction()` (interactive, hook-firing
+ * control but still runs hooks), `withSession()` (substitutes the session but
+ * still runs access control), and `transaction()` (interactive, hook-firing
  * transaction). All access-checked operations run their list/field hooks.
  */
 export interface StackContext<TPrisma extends PrismaClientLike = PrismaClientLike> {
@@ -340,6 +341,23 @@ export interface StackContext<TPrisma extends PrismaClientLike = PrismaClientLik
     options?: TransactionOptions,
   ) => Promise<T>
   sudo: () => StackContext<TPrisma>
+  /**
+   * Derive a context identical to this one except for its session, reusing
+   * the already-resolved config and this context's own client (including a
+   * transaction client — a call inside `context.transaction()` stays in that
+   * transaction) and storage.
+   *
+   * **This is not an authorisation.** It substitutes who hooks and access
+   * control see; it does not change what they decide. The derived context
+   * can do exactly what any context built with `session` directly could
+   * do — access rules still evaluate against the new session. The caller is
+   * responsible for deciding who may invoke this.
+   *
+   * Orthogonal to `sudo()`: `withSession(s)` preserves the receiver's sudo
+   * state (elevated stays elevated), so `context.withSession(s).sudo()` and
+   * `context.sudo().withSession(s)` are equivalent.
+   */
+  withSession: (session: Session | null) => StackContext<TPrisma>
   _isSudo: boolean
 }
 
@@ -776,6 +794,22 @@ export function getContext<
     )
   }
 
+  // Substitutes the session; access control and hooks still run against it
+  // (orthogonal to `sudo`, so the receiver's sudo state is preserved).
+  function withSession(newSession: Session | null): StackContext<TPrisma> {
+    return getContext(
+      config,
+      prisma,
+      newSession,
+      context.storage,
+      _isSudo,
+      undefined,
+      // ADR-0028: a write issued from inside an owned transaction (e.g.
+      // `tx.withSession(s).db.x.create()`) must still defer to that owner.
+      context._transactionOwner,
+    )
+  }
+
   // Interactive, hook-firing transaction (#614). See the `transaction` doc on
   // `StackContext` above for the atomicity/isolation/retry contract.
   //
@@ -842,6 +876,7 @@ export function getContext<
     plugins: context.plugins,
     serverAction,
     sudo,
+    withSession,
     transaction,
     _isSudo,
   }

--- a/packages/core/tests/with-session.test.ts
+++ b/packages/core/tests/with-session.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getContext } from '../src/context/index.js'
+import { config, list } from '../src/config/index.js'
+import { text } from '../src/fields/index.js'
+import type { PrismaClient } from '@prisma/client'
+
+/**
+ * #980: `context.withSession(session)` — the sibling to `sudo()` on the
+ * other axis. It substitutes the session a derived context carries while
+ * reusing the receiver's already-resolved config and client (including a
+ * transaction client) and running access control/hooks exactly as normal.
+ */
+
+describe('withSession', () => {
+  const mockPrisma = {
+    post: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+  } as unknown as PrismaClient
+
+  const seenSessions: (Record<string, unknown> | null | undefined)[] = []
+
+  const testConfig = config({
+    db: { provider: 'sqlite' },
+    lists: {
+      Post: list({
+        fields: {
+          title: text({ validation: { isRequired: true } }),
+        },
+        access: {
+          operation: {
+            query: async () => true,
+            create: async ({ session }) => session?.role === 'admin',
+            update: async ({ session }) => session?.role === 'admin',
+          },
+        },
+        hooks: {
+          validate: async ({ context }) => {
+            seenSessions.push(context.session as Record<string, unknown> | null | undefined)
+          },
+        },
+      }),
+    },
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    seenSessions.length = 0
+  })
+
+  it('returns a context whose session is the substituted one, leaving the original unmutated', () => {
+    const original = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const derived = original.withSession({ userId: '2', role: 'admin' })
+
+    expect(derived.session).toEqual({ userId: '2', role: 'admin' })
+    expect(original.session).toEqual({ userId: '1', role: 'user' })
+  })
+
+  it('a list validate hook sees the substituted session, not the original', async () => {
+    const original = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const derived = original.withSession({ userId: '2', role: 'admin' })
+
+    mockPrisma.post.create.mockResolvedValue({ id: '1', title: 'Hi' })
+
+    await derived.db.post.create({ data: { title: 'Hi' } })
+
+    expect(seenSessions).toEqual([{ userId: '2', role: 'admin' }])
+  })
+
+  it('access rules evaluate against the substituted session — a derived context can do neither more nor less than one built directly with it', async () => {
+    const adminSession = { userId: '2', role: 'admin' }
+    const derived = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' }).withSession(
+      adminSession,
+    )
+    const direct = getContext(testConfig, mockPrisma, adminSession)
+
+    mockPrisma.post.create.mockResolvedValue({ id: '1', title: 'Hi' })
+
+    const derivedResult = await derived.db.post.create({ data: { title: 'Hi' } })
+    const directResult = await direct.db.post.create({ data: { title: 'Hi' } })
+
+    expect(derivedResult).toMatchObject({ title: 'Hi' })
+    expect(directResult).toMatchObject({ title: 'Hi' })
+
+    // Neither more: a non-admin substituted session is denied exactly like a
+    // context built with that session directly.
+    const userSession = { userId: '3', role: 'user' }
+    const derivedDenied = getContext(testConfig, mockPrisma, adminSession).withSession(userSession)
+    const directDenied = getContext(testConfig, mockPrisma, userSession)
+
+    expect(await derivedDenied.db.post.create({ data: { title: 'Nope' } })).toBeNull()
+    expect(await directDenied.db.post.create({ data: { title: 'Nope' } })).toBeNull()
+  })
+
+  it('withSession(null) yields an anonymous context and access rules treat it as such', async () => {
+    const derived = getContext(testConfig, mockPrisma, { userId: '1', role: 'admin' }).withSession(
+      null,
+    )
+
+    expect(derived.session).toBeNull()
+
+    const result = await derived.db.post.create({ data: { title: 'Nope' } })
+    expect(result).toBeNull()
+  })
+
+  it('context.withSession(s).sudo() and context.sudo().withSession(s) are equivalent', () => {
+    const base = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const admin = { userId: '2', role: 'admin' }
+
+    const a = base.withSession(admin).sudo()
+    const b = base.sudo().withSession(admin)
+
+    expect(a._isSudo).toBe(true)
+    expect(b._isSudo).toBe(true)
+    expect(a.session).toEqual(admin)
+    expect(b.session).toEqual(admin)
+  })
+
+  it('preserves sudo state: withSession on a sudo context stays sudo, on a non-sudo context stays non-sudo', () => {
+    const base = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const admin = { userId: '2', role: 'admin' }
+
+    expect(base.sudo().withSession(admin)._isSudo).toBe(true)
+    expect(base.withSession(admin)._isSudo).toBe(false)
+  })
+
+  it('reuses the receiver client — no second connection is opened', () => {
+    const original = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const derived = original.withSession({ userId: '2', role: 'admin' })
+
+    expect(derived.prisma).toBe(original.prisma)
+  })
+
+  it('reuses the receiver storage', () => {
+    const original = getContext(testConfig, mockPrisma, { userId: '1', role: 'user' })
+    const derived = original.withSession({ userId: '2', role: 'admin' })
+
+    expect(derived.storage).toBe(original.storage)
+  })
+
+  it('hooks fire on the derived context exactly as on any other', async () => {
+    const original = getContext(testConfig, mockPrisma, { userId: '1', role: 'admin' })
+    const derived = original.withSession({ userId: '2', role: 'admin' })
+
+    mockPrisma.post.create.mockResolvedValue({ id: '1', title: 'Hi' })
+
+    await derived.db.post.create({ data: { title: 'Hi' } })
+
+    expect(seenSessions).toHaveLength(1)
+  })
+})
+
+describe('withSession inside context.transaction (#614/#980)', () => {
+  function createTxPrisma() {
+    const tables: Record<string, Map<string, Record<string, unknown>>> = { post: new Map() }
+    let idCounter = 0
+    const nextId = () => `id-${++idCounter}`
+
+    function makeModel(table: string) {
+      return {
+        findUnique: vi.fn(
+          async ({ where }: { where: { id: string } }) => tables[table].get(where.id) ?? null,
+        ),
+        findFirst: vi.fn(async () => tables[table].values().next().value ?? null),
+        findMany: vi.fn(async () => Array.from(tables[table].values())),
+        count: vi.fn(async () => tables[table].size),
+        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+          const id = (data.id as string) ?? nextId()
+          const record = { ...data, id }
+          tables[table].set(id, record)
+          return record
+        }),
+      }
+    }
+
+    const client: Record<string, unknown> = { post: makeModel('post') }
+
+    client.$transaction = async (fn: (tx: unknown) => Promise<unknown>) => {
+      const snapshot: Record<string, Map<string, Record<string, unknown>>> = {}
+      for (const [name, map] of Object.entries(tables)) snapshot[name] = new Map(map)
+      const { $transaction: _omit, ...models } = client
+      void _omit
+      try {
+        return await fn(models)
+      } catch (err) {
+        for (const [name, map] of Object.entries(snapshot)) tables[name] = map
+        throw err
+      }
+    }
+
+    return { client, tables }
+  }
+
+  const txConfig = config({
+    db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+    lists: {
+      Post: list({
+        fields: { title: text() },
+        access: { operation: { query: () => true, create: () => true } },
+      }),
+    },
+  })
+
+  it('tx.withSession(s) writes participate in the same transaction and roll back with it', async () => {
+    const mock = createTxPrisma()
+    const context = getContext(txConfig, mock.client, { userId: '1' })
+
+    // Commits: the substituted-session write is inside the callback's transaction.
+    const created = await context.transaction((tx) =>
+      tx.withSession({ userId: '2' }).db.post.create({ data: { title: 'committed' } }),
+    )
+    expect(created).toMatchObject({ title: 'committed' })
+    expect(mock.tables.post.size).toBe(1)
+
+    // Rolls back: a throw after the substituted-session write undoes it too,
+    // proving the write joined the same transaction rather than a separate one.
+    await expect(
+      context.transaction(async (tx) => {
+        await tx.withSession({ userId: '3' }).db.post.create({ data: { title: 'rollback-me' } })
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+    expect(mock.tables.post.size).toBe(1)
+  })
+
+  it('tx.withSession(s) carries the substituted session', async () => {
+    const mock = createTxPrisma()
+    const context = getContext(txConfig, mock.client, { userId: '1' })
+
+    const seen = await context.transaction(async (tx) => {
+      const withOther = tx.withSession({ userId: 'other' })
+      return withOther.session
+    })
+
+    expect(seen).toEqual({ userId: 'other' })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `context.withSession(session)` to `StackContext`, a sibling to `sudo()` on the other axis: `sudo()` keeps the session and bypasses access control; `withSession()` keeps access control (and hooks) running but substitutes the session.
- Reuses the receiver's already-resolved config, client (including a transaction client — a call inside `context.transaction()` stays in that transaction), and storage — no second connection is opened.
- Orthogonal to `sudo()`: `context.withSession(s).sudo()` and `context.sudo().withSession(s)` are equivalent, since `withSession` preserves the receiver's sudo state rather than resetting it.
- Grants no authority of its own — the derived context can do exactly what any context built directly with that session could do; access rules still evaluate against the new session.
- `withSession(null)` is a legitimate way to drop to an anonymous context.
- Documents the new method in `packages/core/CLAUDE.md` and `docs/content/reference/context-api.md`, alongside `sudo()`.

This closes the gap described in #980: an unattended dispatcher, service principal, or job runner that is legitimately authorised but arrives without the session a list `validate` hook expects previously had no supported way to present one — `sudo()` erases the check rather than answering it, and rebuilding a context from scratch requires config/client that aren't reachable from outside.

## Test plan

- [x] New test suite `packages/core/tests/with-session.test.ts` covering: session substitution without mutating the original, hooks/access control seeing the substituted session, parity with a context built directly from that session, `withSession(null)` yielding an anonymous context, `withSession()`/`sudo()` orthogonality (both directions), sudo-state preservation, client/storage reuse, and same-transaction participation (including rollback) inside `context.transaction()`.
- [x] `pnpm build` (core package typechecks)
- [x] `pnpm test` (full core suite, 1111 tests passing)
- [x] `pnpm lint`
- [x] `pnpm manypkg fix`
- [x] `pnpm format`

Closes #980


---
_Generated by [Claude Code](https://claude.ai/code/session_01FuvZVoPwu4apbvhXStZYYM)_