### PR TITLE
core: allow db.foreignKey.map on list-only relationship refs

### DIFF
--- a/.changeset/tame-jokes-relax.md
+++ b/.changeset/tame-jokes-relax.md
@@ -1,0 +1,5 @@
+---
+'@opensaas/stack-core': patch
+---
+
+`relationship({ ref: 'ListName' })` list-only refs now accept `db.foreignKey: { map: '...' }` to rename the foreign key column. The boolean form (`true`/`false`) is still rejected there since ownership is implicit on a list-only ref.

--- a/packages/cli/src/generator/prisma.test.ts
+++ b/packages/cli/src/generator/prisma.test.ts
@@ -773,6 +773,34 @@ describe('Prisma Schema Generator', () => {
       expect(schema).toContain('categoryId   String? @map("category")')
     })
 
+    it('should honour db.foreignKey.map to rename a list-only relationship foreign key column', () => {
+      const config: OpenSaasConfig = {
+        db: {
+          provider: 'sqlite',
+        },
+        lists: {
+          Category: {
+            fields: {
+              name: text(),
+            },
+          },
+          Post: {
+            fields: {
+              title: text(),
+              category: relationship({
+                ref: 'Category',
+                db: { foreignKey: { map: 'category_id' } },
+              }),
+            },
+          },
+        },
+      }
+
+      const schema = generatePrismaSchema(config)
+
+      expect(schema).toContain('categoryId   String? @map("category_id")')
+    })
+
     it('should generate a required FK column and relation field with db.isNullable: false', () => {
       const config: OpenSaasConfig = {
         db: {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1136,13 +1136,20 @@ export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =
        */
       isNullable?: boolean
       /**
-       * Controls foreign key placement and column name for bidirectional relationships
-       * Can be a boolean or an object with a map property
-       * Only valid on single (non-many) relationships
-       * Cannot be true on both sides of a one-to-one relationship
+       * Controls foreign key placement and column name.
+       * Can be a boolean or an object with a map property.
+       * Only valid on single (non-many) relationships.
+       * Cannot be true on both sides of a one-to-one relationship.
        *
-       * When a boolean, defaults the foreign key column name to the field name
-       * When an object with map, uses the provided column name
+       * The boolean form (the "which side owns the foreign key" sense) is only
+       * meaningful on a bidirectional ref (`ref: 'ListName.fieldName'`) — a
+       * list-only ref (`ref: 'ListName'`) always owns the foreign key, so a
+       * boolean here is rejected. The `{ map }` form (the column-name sense)
+       * works on both: it renames the foreign key column without changing
+       * ownership.
+       *
+       * When a boolean, defaults the foreign key column name to the field name.
+       * When an object with map, uses the provided column name.
        *
        * @example
        * ```typescript
@@ -1165,6 +1172,14 @@ export type RelationshipField<TTypeInfo extends TypeInfo = TypeInfo> =
        * Account: list({
        *   fields: {
        *     user: relationship({ ref: 'User.account' }) // No foreign key on this side
+       *   }
+       * })
+       *
+       * // List-only ref: rename the foreign key column (ownership is implicit)
+       * Post: list({
+       *   fields: {
+       *     category: relationship({ ref: 'Category', db: { foreignKey: { map: 'category_id' } } })
+       *     // Generates: categoryId String? @map("category_id")
        *   }
        * })
        * ```

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1535,10 +1535,12 @@ export function relationship<
       )
     }
 
-    if (refParts.length === 1) {
+    if (refParts.length === 1 && typeof options.db.foreignKey === 'boolean') {
       throw new Error(
-        'db.foreignKey can only be used on bidirectional relationships (ref: "ListName.fieldName"). ' +
-          'List-only refs (ref: "ListName") always create foreign keys automatically.',
+        'db.foreignKey cannot be a boolean on list-only refs (ref: "ListName"). ' +
+          'List-only refs always create foreign keys automatically, so the ownership sense of ' +
+          'db.foreignKey is meaningless here. Use db.foreignKey: { map: "columnName" } to rename ' +
+          'the foreign key column instead.',
       )
     }
   }

--- a/packages/core/src/fields/relationship-foreign-key.test.ts
+++ b/packages/core/src/fields/relationship-foreign-key.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { relationship } from './index.js'
+
+describe('relationship field builder: db.foreignKey validation', () => {
+  it('rejects a boolean db.foreignKey on a list-only ref', () => {
+    expect(() => relationship({ ref: 'User', db: { foreignKey: true } })).toThrow(
+      'db.foreignKey cannot be a boolean on list-only refs',
+    )
+    expect(() => relationship({ ref: 'User', db: { foreignKey: false } })).toThrow(
+      'db.foreignKey cannot be a boolean on list-only refs',
+    )
+  })
+
+  it('allows an object db.foreignKey (map) on a list-only ref', () => {
+    expect(() =>
+      relationship({ ref: 'User', db: { foreignKey: { map: 'user_id' } } }),
+    ).not.toThrow()
+  })
+
+  it('still allows a boolean db.foreignKey on a bidirectional ref', () => {
+    expect(() => relationship({ ref: 'User.posts', db: { foreignKey: true } })).not.toThrow()
+  })
+
+  it('still rejects db.foreignKey on a many relationship regardless of ref shape', () => {
+    expect(() =>
+      relationship({ ref: 'User', many: true, db: { foreignKey: { map: 'user_id' } } }),
+    ).toThrow('db.foreignKey can only be used on single relationships')
+  })
+})


### PR DESCRIPTION
## Summary
- `relationship({ ref: 'ListName' })` — a list-only ref — previously threw if given any `db.foreignKey`, even though the FK-emission path already handled the `{ map }` form correctly for that path.
- Narrowed the validation in `relationship()` (`packages/core/src/fields/index.ts`) so a list-only ref only rejects the *boolean* form of `db.foreignKey` (`true`/`false`, the "which side owns the FK" sense, which is meaningless when the ref always owns the FK). The object form (`{ map: '...' }`, the column-naming sense) is now accepted and used to rename the generated foreign key column.
- The `many: true` rejection and the bidirectional-ref behavior are unchanged.
- Updated the `db.foreignKey` TSDoc in `packages/core/src/config/types.ts` to document the list-only case.

## Test plan
- [x] Added `packages/core/src/fields/relationship-foreign-key.test.ts` covering: boolean rejected on list-only refs, object accepted on list-only refs, boolean still accepted on bidirectional refs, and `many: true` still rejected regardless of ref shape.
- [x] Added a CLI generator test in `packages/cli/src/generator/prisma.test.ts` asserting `db.foreignKey: { map: 'category_id' }` on a list-only ref generates `categoryId String? @map("category_id")`.
- [x] `pnpm test` (core: 1136 passed, cli: 378 passed)
- [x] `pnpm lint`, `pnpm manypkg fix`, `pnpm format`

Closes #993


---
_Generated by [Claude Code](https://claude.ai/code/session_01S24jAnCVafU9hk6ZqJvfhp)_