### PR TITLE
MCP query tool accepts a fields projection argument

### DIFF
--- a/.changeset/violet-otters-shine.md
+++ b/.changeset/violet-otters-shine.md
@@ -1,0 +1,27 @@
+---
+'@opensaas/stack-core': minor
+---
+
+The derived MCP `query` tool now accepts an optional `fields` projection — the wire form of the runtime's existing fragment field selection — so an assistant can select scalars and nested relation fields (with `where`/`orderBy`/`take`/`skip`, and a to-many's row count) in a single call instead of following a foreign key with a second one. Omitting `fields` is unchanged, a bare read exactly as before.
+
+```json
+{
+  "name": "list_post_query",
+  "arguments": {
+    "fields": {
+      "title": true,
+      "author": { "fields": { "name": true } },
+      "comments": {
+        "fields": { "text": true },
+        "where": { "approved": { "equals": true } },
+        "take": 5,
+        "count": true
+      }
+    }
+  }
+}
+```
+
+The generated tool schema enumerates two levels of each list's own fields and relations, per session, and refuses (as an `isError` tool result, never a protocol error) anything it doesn't advertise — an unknown field, or a relation named a third level deep. See the ADR (`docs/adr/0033-mcp-tools-advertise-a-bounded-projection.md`) for the full design.
+
+**Behaviour change:** `tools/list` is now evaluated per session. A list whose operation-level `query` access denies the session outright no longer appears in the tool listing at all — none of its four CRUD tools, and no relation entry elsewhere pointing at it. Previously every list's tools were listed regardless of session.

--- a/docs/content/how-to/mcp.md
+++ b/docs/content/how-to/mcp.md
@@ -279,6 +279,7 @@ The MCP handler creates CRUD tools for each list. `{dbKey}` is the camelCase for
   orderBy?: Record<string, 'asc' | 'desc'>,
   take?: number,
   skip?: number,
+  fields?: Record<string, any>, // Projection — see "Selecting Related Data" below
 }
 ```
 
@@ -291,6 +292,39 @@ The MCP handler creates CRUD tools for each list. `{dbKey}` is the camelCase for
   "take": 10
 }
 ```
+
+#### Selecting Related Data with `fields`
+
+By default `query` returns a record's own scalar and virtual fields — never its relations, matching how `context.db` reads behave. Reaching a relation without `fields` means following its foreign key with a second `query` call.
+
+The optional `fields` argument lets the assistant select relation data in the same call, without paying for a full `include` (every column of every touched relation) when it only needed a couple of fields:
+
+```json
+{
+  "fields": {
+    "title": true,
+    "author": {
+      "fields": { "name": true, "email": true }
+    },
+    "comments": {
+      "fields": { "text": true },
+      "where": { "approved": { "equals": true } },
+      "orderBy": { "createdAt": "desc" },
+      "take": 5,
+      "count": true
+    }
+  }
+}
+```
+
+- **Scalars and virtuals** are selected with `true`.
+- **A to-one relation** (`author` above) takes a nested `fields` only.
+- **A to-many relation** (`comments` above) additionally accepts `where`, `orderBy`, `take`, and `skip`, scoped exactly like the equivalent `context.db` read — a nested `take` defaults to 5 when omitted and is clamped to a hard cap of 50, since nested pagination multiplies with the root `take`.
+- **A to-many's row count** can be requested with `count: true`, in place of its rows (omit `fields` on that relation) or alongside them.
+
+The generated tool schema enumerates exactly **two levels** of each list's own vocabulary — the list's own fields, and for each relation, the related list's own scalar/virtual fields. A relation named at that second level is not itself selectable further; reaching past it is a second `query` call, the same round-trip the bare-read default already assumes. This is what keeps the schema finite against a self-referential relationship (e.g. a `Category` with `parent`/`children`) and what makes an unadvertised request rare: naming a field the schema doesn't enumerate, or nesting a relation a third level deep, is refused as an `isError` tool result naming what was asked for — never served on a best-effort basis, and never a JSON-RPC protocol error.
+
+The schema is generated **per session**: a relation whose related list denies this session's operation-level `query` access, or has `mcp.enabled: false`, is omitted from the vocabulary entirely — the same rule that governs whether a list gets tools at all (see "Access Control" below). Field-level `read` access cannot be evaluated at schema-generation time (it needs a fetched row), so it still applies only when the read actually runs, exactly as it does everywhere else.
 
 ### Create Tool
 
@@ -370,6 +404,10 @@ The MCP handler creates CRUD tools for each list. `{dbKey}` is the camelCase for
 ## Access Control
 
 All MCP tools respect your existing access control rules defined in `opensaas.config.ts`.
+
+### Tool Listing Is Per-Session
+
+`tools/list` is evaluated per session. A list whose operation-level `query` access denies the session outright (`=== false`) doesn't appear in the listing at all — none of its four CRUD tools, and no relation entry elsewhere pointing at it (including in another list's `fields` projection schema, above). A list with `mcp.enabled: false` is omitted the same way, as a relation target as well as a tool owner.
 
 ### Operation-Level Access
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -359,6 +359,18 @@ const context = createContext<typeof prisma>(config, prisma, session)
 - Uses context for all operations (access control enforced); writes are validated by the normal `context.db` pipeline (field Zod schemas, hooks, access control)
 - Custom tools may declare a Zod `inputSchema` — validated on `tools/call`, converted to JSON Schema for `tools/list` — or a plain JSON Schema object
 - Auth adapters (like `@opensaas/stack-auth/mcp`) provide session integration; custom session fields pass through to access control
+- The derived `query` tool accepts an optional `fields` projection (`packages/core/src/mcp/projection.ts`) — the wire form of a fragment field selection, translated into a `context.db` `include` so the ordinary read pipeline (access scoping, `needs` folding, the depth cap) applies with no parallel read path. The generated schema enumerates two fixed levels of each list's vocabulary, per session; `tools/list` itself is per-session as a result (ADR-0033)
+
+### The MCP `query` Tool's `fields` Projection (ADR-0033)
+
+An optional `fields` argument on the derived `query` tool narrows (or widens, up to two levels) what a read returns, in the wire form of a fragment field selection: `{ scalarField: true, relation: { fields: {...} } }`. A to-many relation additionally accepts `where`/`orderBy`/`take`/`skip` and a `count`. Omitting `fields` is unchanged — a bare read, per ADR-0024.
+
+`projection.ts` does the work in two passes, both walking the same per-session vocabulary (`relatedListIfVisible`):
+
+- `generateFieldsProjectionSchema` builds the JSON Schema advertised on `tools/list` — a relation whose target list denies this session's operation-level `query` access, or has `mcp.enabled: false`, is omitted from the vocabulary entirely, not merely left unusable.
+- `resolveFieldsProjection` validates a caller's `fields` against that same vocabulary and translates it into a plain `context.db` `include` (deliberately NOT the fragment `query:` argument — going through the ordinary caller-`include` path is what gets `buildAccessScopedInclude`'s nested-`where` AND-fold, the to-one existence check, and the depth cap for free; the trade-off is that every computed field at a traversed level still computes server-side, same as any other `include`-based read, even one the projection didn't select — only the wire response is narrowed). Throws `McpProjectionRefusedError` (caught in the handler and turned into an `isError` tool result, never a JSON-RPC error) naming what was asked for and what's available on any mismatch.
+
+A to-many's `count` is resolved separately via Prisma's `_count.select`, access-scoped by ANDing the related list's `query` access with any caller `where` on that same relation (mirroring, but not reusing, `relationship-count.ts`'s `_count` scoping — that module's own helper isn't exported and was built for a different feature, issue #732's admin list view).
 
 ### With Third-Party Field Packages
 

--- a/packages/core/src/access/access-filter.ts
+++ b/packages/core/src/access/access-filter.ts
@@ -58,7 +58,13 @@ import { getDbKey } from '../lib/case-utils.js'
  */
 
 /** The structured (object) form of a relation include entry — caller/fold-supplied or produced by this module. */
-type IncludeEntryObject = { where?: PrismaFilter; include?: Record<string, unknown>; take?: number }
+type IncludeEntryObject = {
+  where?: PrismaFilter
+  include?: Record<string, unknown>
+  take?: number
+  orderBy?: PrismaFilter | PrismaFilter[]
+  skip?: number
+}
 
 /** A plain object — excludes `null` and arrays, which `typeof x === 'object'` alone would admit. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -72,16 +78,22 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * own type before trusting it, rather than casting the whole value wholesale.
  *
  * A numeric `take` on a to-many relation include (a caller-supplied row bound,
- * issue #752) is carried through: it only ever NARROWS the fetched rows and can
- * never widen past the access `where`, so preserving it is access-neutral.
+ * issue #752), and a caller-supplied `orderBy`/`skip` (#851), are carried
+ * through the same way: none of the three can ever widen the result past the
+ * access `where` — they only narrow or reorder rows the access filter already
+ * admits — so preserving them is access-neutral.
  */
 function asEntryObject(value: unknown): IncludeEntryObject | null {
   if (!isPlainObject(value)) return null
-  const { where, include, take } = value
+  const { where, include, take, orderBy, skip } = value
   const entry: IncludeEntryObject = {}
   if (isPlainObject(where)) entry.where = where
   if (isPlainObject(include)) entry.include = include
   if (typeof take === 'number') entry.take = take
+  if (isPlainObject(orderBy) || Array.isArray(orderBy)) {
+    entry.orderBy = orderBy as PrismaFilter | PrismaFilter[]
+  }
+  if (typeof skip === 'number') entry.skip = skip
   return entry
 }
 
@@ -235,7 +247,7 @@ export async function buildAccessScopedInclude(
       nestedToOneFilters = nested.toOneAccessFilters
     }
 
-    const entry: { where?: PrismaFilter; include?: Record<string, unknown>; take?: number } = {}
+    const entry: IncludeEntryObject = {}
     if (isToOne) {
       if (accessWhere) {
         toOneAccessFilters.filters[relationName] = {
@@ -248,6 +260,8 @@ export async function buildAccessScopedInclude(
       const mergedWhere = andWhere(accessWhere, requestedEntry?.where)
       if (mergedWhere) entry.where = mergedWhere
       if (requestedEntry?.take !== undefined) entry.take = requestedEntry.take
+      if (requestedEntry?.orderBy !== undefined) entry.orderBy = requestedEntry.orderBy
+      if (requestedEntry?.skip !== undefined) entry.skip = requestedEntry.skip
     }
     if (nestedInclude && Object.keys(nestedInclude).length > 0) entry.include = nestedInclude
     if (nestedToOneFilters && !isToOneAccessFilterTreeEmpty(nestedToOneFilters)) {

--- a/packages/core/src/mcp/constants.ts
+++ b/packages/core/src/mcp/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * How many levels deep the `query` tool's `fields` projection schema
+ * enumerates a list's relations: the root list's own fields (level 1), and
+ * for each relation, the related list's own scalar/virtual fields (level 2).
+ * A relation named at level 2 is not itself selectable further — reaching
+ * past it is a second tool call, the same round-trip a bare read already
+ * assumes. Deliberately shallower than `READ_INCLUDE_MAX_DEPTH` (5) so no
+ * schema-conforming request can reach the engine's depth refusal, and fixed
+ * (not configurable) — see ADR-0033 and ADR-0026's position on the depth cap.
+ */
+export const MCP_FIELDS_SCHEMA_DEPTH = 2
+
+/** Row cap applied to a nested to-many relation in a `fields` projection when the caller omits `take`. */
+export const MCP_NESTED_TAKE_DEFAULT = 5
+
+/** Hard ceiling a nested to-many relation's `take` is clamped to, regardless of what the caller requests. */
+export const MCP_NESTED_TAKE_MAX = 50

--- a/packages/core/src/mcp/constants.ts
+++ b/packages/core/src/mcp/constants.ts
@@ -5,8 +5,15 @@
  * A relation named at level 2 is not itself selectable further — reaching
  * past it is a second tool call, the same round-trip a bare read already
  * assumes. Deliberately shallower than `READ_INCLUDE_MAX_DEPTH` (5) so no
- * schema-conforming request can reach the engine's depth refusal, and fixed
- * (not configurable) — see ADR-0033 and ADR-0026's position on the depth cap.
+ * schema-conforming request can reach the engine's depth refusal.
+ *
+ * Fixed (not configurable) by design (ADR-0033, ADR-0026's position on the
+ * depth cap) — `generateFieldsProjectionSchema` and `resolveFieldsProjection`
+ * (`projection.ts`) are hand-written for exactly this depth (one loop over
+ * the root list's fields, one nested loop over a relation's), not driven by
+ * this value at runtime. It exists so the depth has one documented, tested
+ * name rather than an unexplained "2" in two places; changing it is a
+ * deliberate rewrite of both functions, not a config knob.
  */
 export const MCP_FIELDS_SCHEMA_DEPTH = 2
 

--- a/packages/core/src/mcp/field-schema.ts
+++ b/packages/core/src/mcp/field-schema.ts
@@ -1,0 +1,84 @@
+import type { FieldConfig } from '../config/types.js'
+
+/** JSON Schema for one field's own value — shared by the create/update `data` schema and the `query` tool's `fields` projection schema. */
+export function fieldToJsonSchema(
+  fieldName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field configs have varying structures
+  fieldConfig: any,
+): Record<string, unknown> {
+  const baseSchema: Record<string, unknown> = {}
+
+  switch (fieldConfig.type) {
+    case 'text':
+    case 'password':
+      baseSchema.type = 'string'
+      if (fieldConfig.validation?.length) {
+        if (fieldConfig.validation.length.min)
+          baseSchema.minLength = fieldConfig.validation.length.min
+        if (fieldConfig.validation.length.max)
+          baseSchema.maxLength = fieldConfig.validation.length.max
+      }
+      break
+    case 'integer':
+      baseSchema.type = 'number'
+      if (fieldConfig.validation?.min !== undefined) baseSchema.minimum = fieldConfig.validation.min
+      if (fieldConfig.validation?.max !== undefined) baseSchema.maximum = fieldConfig.validation.max
+      break
+    case 'checkbox':
+      baseSchema.type = 'boolean'
+      break
+    case 'timestamp':
+      baseSchema.type = 'string'
+      baseSchema.format = 'date-time'
+      break
+    case 'select':
+      baseSchema.type = 'string'
+      if (fieldConfig.options) {
+        baseSchema.enum = fieldConfig.options.map((opt: { value: string }) => opt.value)
+      }
+      break
+    case 'relationship':
+      baseSchema.type = 'object'
+      baseSchema.properties = {
+        connect: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      }
+      break
+    default:
+      baseSchema.type = 'string'
+  }
+
+  return baseSchema
+}
+
+export function generateFieldSchemas(
+  fields: Record<string, FieldConfig>,
+  operation: 'create' | 'update',
+): {
+  properties: Record<string, unknown>
+  required: string[]
+} {
+  const properties: Record<string, unknown> = {}
+  const required: string[] = []
+
+  for (const [fieldName, fieldConfig] of Object.entries(fields)) {
+    if (['id', 'createdAt', 'updatedAt'].includes(fieldName)) continue
+
+    properties[fieldName] = fieldToJsonSchema(fieldName, fieldConfig)
+
+    if (
+      operation === 'create' &&
+      'validation' in fieldConfig &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Validation property varies by field type
+      (fieldConfig.validation as any)?.isRequired
+    ) {
+      required.push(fieldName)
+    }
+  }
+
+  return { properties, required }
+}

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -3,6 +3,7 @@ import type { OpenSaasConfig, McpCustomTool } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
 import { checkAccess } from '../access/engine.js'
 import { AccessScopeDepthExceededError, RelationFilterAccessDeniedError } from '../access/errors.js'
+import { ValidationError } from '../hooks/index.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { McpSession, McpSessionProvider } from './types.js'
 import { generateFieldSchemas } from './field-schema.js'
@@ -414,6 +415,7 @@ async function handleCrudTool(
     switch (operation) {
       case 'query': {
         let projection: Awaited<ReturnType<typeof resolveFieldsProjection>> | undefined
+        let listConfig: OpenSaasConfig['lists'][string] | undefined
         if (args.fields !== undefined) {
           const listEntry = Object.entries(config.lists).find(
             ([listKey]) => getDbKey(listKey) === dbKey,
@@ -421,7 +423,8 @@ async function handleCrudTool(
           if (!listEntry) {
             return createErrorResponse(`Unknown list for tool: ${dbKey}`, id)
           }
-          const [listKey, listConfig] = listEntry
+          const [listKey, resolvedListConfig] = listEntry
+          listConfig = resolvedListConfig
           try {
             projection = await resolveFieldsProjection(
               args.fields,
@@ -432,7 +435,7 @@ async function handleCrudTool(
               context,
             )
           } catch (error) {
-            if (error instanceof McpProjectionRefusedError) {
+            if (error instanceof McpProjectionRefusedError || error instanceof ValidationError) {
               return createErrorResultResponse(error.message, id)
             }
             throw error
@@ -447,9 +450,18 @@ async function handleCrudTool(
           ...(projection?.include ? { include: projection.include } : {}),
         })
 
-        const items = projection
-          ? result.map((item: Record<string, unknown>) => projectMcpResult(item, projection))
-          : result
+        let items
+        if (projection && listConfig) {
+          const resolvedProjection = projection
+          const resolvedFields = listConfig.fields
+          items = await Promise.all(
+            result.map((item: Record<string, unknown>) =>
+              projectMcpResult(item, resolvedProjection, resolvedFields, context.session, context),
+            ),
+          )
+        } else {
+          items = result
+        }
 
         return createSuccessResponse(
           {

--- a/packages/core/src/mcp/handler.ts
+++ b/packages/core/src/mcp/handler.ts
@@ -1,9 +1,17 @@
 import * as z from 'zod'
-import type { OpenSaasConfig, FieldConfig, McpCustomTool } from '../config/types.js'
+import type { OpenSaasConfig, McpCustomTool } from '../config/types.js'
 import type { AccessContext } from '../access/types.js'
+import { checkAccess } from '../access/engine.js'
 import { AccessScopeDepthExceededError, RelationFilterAccessDeniedError } from '../access/errors.js'
 import { getDbKey } from '../lib/case-utils.js'
 import type { McpSession, McpSessionProvider } from './types.js'
+import { generateFieldSchemas } from './field-schema.js'
+import {
+  McpProjectionRefusedError,
+  generateFieldsProjectionSchema,
+  projectMcpResult,
+  resolveFieldsProjection,
+} from './projection.js'
 
 /**
  * Context session type accepted by the generated getContext factory.
@@ -120,7 +128,8 @@ export function createMcpHandlers(options: {
       }
 
       if (body.method === 'tools/list') {
-        return handleToolsList(config, body.id)
+        const context = await getContext(toContextSession(session))
+        return await handleToolsList(config, context, body.id)
       }
 
       if (body.method === 'tools/call') {
@@ -195,90 +204,23 @@ function handleInitialize(_params?: any, id?: number | string): Response {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Field configs have varying structures
-function fieldToJsonSchema(fieldName: string, fieldConfig: any): Record<string, unknown> {
-  const baseSchema: Record<string, unknown> = {}
-
-  switch (fieldConfig.type) {
-    case 'text':
-    case 'password':
-      baseSchema.type = 'string'
-      if (fieldConfig.validation?.length) {
-        if (fieldConfig.validation.length.min)
-          baseSchema.minLength = fieldConfig.validation.length.min
-        if (fieldConfig.validation.length.max)
-          baseSchema.maxLength = fieldConfig.validation.length.max
-      }
-      break
-    case 'integer':
-      baseSchema.type = 'number'
-      if (fieldConfig.validation?.min !== undefined) baseSchema.minimum = fieldConfig.validation.min
-      if (fieldConfig.validation?.max !== undefined) baseSchema.maximum = fieldConfig.validation.max
-      break
-    case 'checkbox':
-      baseSchema.type = 'boolean'
-      break
-    case 'timestamp':
-      baseSchema.type = 'string'
-      baseSchema.format = 'date-time'
-      break
-    case 'select':
-      baseSchema.type = 'string'
-      if (fieldConfig.options) {
-        baseSchema.enum = fieldConfig.options.map((opt: { value: string }) => opt.value)
-      }
-      break
-    case 'relationship':
-      baseSchema.type = 'object'
-      baseSchema.properties = {
-        connect: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-      }
-      break
-    default:
-      baseSchema.type = 'string'
-  }
-
-  return baseSchema
-}
-
-function generateFieldSchemas(
-  fields: Record<string, FieldConfig>,
-  operation: 'create' | 'update',
-): {
-  properties: Record<string, unknown>
-  required: string[]
-} {
-  const properties: Record<string, unknown> = {}
-  const required: string[] = []
-
-  for (const [fieldName, fieldConfig] of Object.entries(fields)) {
-    if (['id', 'createdAt', 'updatedAt'].includes(fieldName)) continue
-
-    properties[fieldName] = fieldToJsonSchema(fieldName, fieldConfig)
-
-    if (
-      operation === 'create' &&
-      'validation' in fieldConfig &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Validation property varies by field type
-      (fieldConfig.validation as any)?.isRequired
-    ) {
-      required.push(fieldName)
-    }
-  }
-
-  return { properties, required }
-}
-
-function handleToolsList(config: OpenSaasConfig, id?: number | string): Response {
+async function handleToolsList(
+  config: OpenSaasConfig,
+  context: AccessContext,
+  id?: number | string,
+): Promise<Response> {
   const tools: McpTool[] = []
 
   for (const [listKey, listConfig] of Object.entries(config.lists)) {
     if (listConfig.mcp?.enabled === false) continue
+
+    // A session denied operation-level `query` outright sees none of this
+    // list's tools, nor any relation entry elsewhere pointing at it as a
+    // target (`relatedListIfVisible` in projection.ts applies the identical
+    // check there) — ADR-0033.
+    const queryAccess = listConfig.access?.operation?.query
+    const accessResult = await checkAccess(queryAccess, { session: context.session, context })
+    if (accessResult === false) continue
 
     const dbKey = getDbKey(listKey)
     const defaultTools = config.mcp?.defaultTools || {
@@ -296,6 +238,12 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
     }
 
     if (enabledTools.read) {
+      const fieldsSchema = await generateFieldsProjectionSchema(
+        listConfig,
+        config,
+        context.session,
+        context,
+      )
       tools.push({
         name: `list_${dbKey}_query`,
         description: `Query ${listKey} records with optional filters`,
@@ -306,6 +254,7 @@ function handleToolsList(config: OpenSaasConfig, id?: number | string): Response
             take: { type: 'number', description: 'Number of records to return (max 100)' },
             skip: { type: 'number', description: 'Number of records to skip' },
             orderBy: { type: 'object', description: 'Sort order' },
+            fields: fieldsSchema,
           },
         },
       })
@@ -463,20 +412,53 @@ async function handleCrudTool(
     let result: any
 
     switch (operation) {
-      case 'query':
+      case 'query': {
+        let projection: Awaited<ReturnType<typeof resolveFieldsProjection>> | undefined
+        if (args.fields !== undefined) {
+          const listEntry = Object.entries(config.lists).find(
+            ([listKey]) => getDbKey(listKey) === dbKey,
+          )
+          if (!listEntry) {
+            return createErrorResponse(`Unknown list for tool: ${dbKey}`, id)
+          }
+          const [listKey, listConfig] = listEntry
+          try {
+            projection = await resolveFieldsProjection(
+              args.fields,
+              listKey,
+              listConfig,
+              config,
+              context.session,
+              context,
+            )
+          } catch (error) {
+            if (error instanceof McpProjectionRefusedError) {
+              return createErrorResultResponse(error.message, id)
+            }
+            throw error
+          }
+        }
+
         result = await context.db[dbKey].findMany({
           where: args.where,
           take: Math.min(args.take || 10, 100),
           skip: args.skip,
           orderBy: args.orderBy,
+          ...(projection?.include ? { include: projection.include } : {}),
         })
+
+        const items = projection
+          ? result.map((item: Record<string, unknown>) => projectMcpResult(item, projection))
+          : result
+
         return createSuccessResponse(
           {
-            items: result,
-            count: result.length,
+            items,
+            count: items.length,
           },
           id,
         )
+      }
 
       case 'create':
         result = await context.db[dbKey].create({

--- a/packages/core/src/mcp/projection.ts
+++ b/packages/core/src/mcp/projection.ts
@@ -11,6 +11,36 @@ function scalarSelectorSchema(fieldName: string): Record<string, unknown> {
 }
 
 /**
+ * `id`/`createdAt`/`updatedAt` are added to every list automatically and
+ * excluded from `listConfig.fields` (CLAUDE.md's "System Fields"), so they
+ * need their own selector entries at every level a `fields` projection can
+ * name fields — a scalar-only loop over `listConfig.fields` would otherwise
+ * never advertise or accept them. `id` is additionally forced into every
+ * `FieldSelection` this module builds (`withId`, below), never left to the
+ * caller: a record projected down to none of its own identifying columns
+ * cannot be the target of a follow-up `update`/`delete` call.
+ */
+function systemFieldProperties(): Record<string, unknown> {
+  return {
+    id: {
+      type: 'boolean',
+      description: 'Include the "id" field (always returned regardless of selection)',
+    },
+    createdAt: scalarSelectorSchema('createdAt'),
+    updatedAt: scalarSelectorSchema('updatedAt'),
+  }
+}
+
+function isSystemFieldName(name: string): name is 'id' | 'createdAt' | 'updatedAt' {
+  return name === 'id' || name === 'createdAt' || name === 'updatedAt'
+}
+
+/** Force `id` into a field selection being built for one level of a `fields` projection — see `systemFieldProperties`'s doc comment. */
+function withId(selection: Record<string, unknown>): Record<string, unknown> {
+  return { ...selection, id: true }
+}
+
+/**
  * Thrown when a `query` tool's `fields` argument names something the
  * generated projection schema does not advertise — an unknown field, a
  * relation two levels deeper than enumerated, or the wrong shape for what
@@ -85,7 +115,7 @@ export async function generateFieldsProjectionSchema(
   session: Session | null,
   context: AccessContext,
 ): Promise<Record<string, unknown>> {
-  const properties: Record<string, unknown> = {}
+  const properties: Record<string, unknown> = systemFieldProperties()
 
   for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
     if (!isRelationshipField(fieldConfig)) {
@@ -96,7 +126,7 @@ export async function generateFieldsProjectionSchema(
     const related = await relatedListIfVisible(fieldConfig, config, session, context)
     if (!related) continue
 
-    const level2Properties: Record<string, unknown> = {}
+    const level2Properties: Record<string, unknown> = systemFieldProperties()
     for (const [relFieldName, relFieldConfig] of Object.entries(related.listConfig.fields)) {
       if (isRelationshipField(relFieldConfig)) continue
       level2Properties[relFieldName] = scalarSelectorSchema(relFieldName)
@@ -201,11 +231,23 @@ export async function resolveFieldsProjection(
   }
 
   const include: Record<string, unknown> = {}
-  const fieldSelection: Record<string, unknown> = {}
+  // `id` is always projected back, whether or not the caller asked for it —
+  // see `systemFieldProperties`'s doc comment.
+  const fieldSelection: Record<string, unknown> = { id: true }
   const countRequests = new Map<string, 'only' | 'alongside'>()
   let hasIncludeEntries = false
 
   for (const [fieldName, rawValue] of Object.entries(fieldsArg as Record<string, unknown>)) {
+    if (isSystemFieldName(fieldName)) {
+      if (rawValue !== true) {
+        throw new McpProjectionRefusedError(
+          `"${listKey}.${fieldName}" is a scalar — select it with \`true\`, not ${JSON.stringify(rawValue)}.`,
+        )
+      }
+      fieldSelection[fieldName] = true
+      continue
+    }
+
     const fieldConfig = listConfig.fields[fieldName]
     if (!fieldConfig) {
       throw new McpProjectionRefusedError(
@@ -250,6 +292,31 @@ export async function resolveFieldsProjection(
       }
     }
 
+    // Type-check each key before it reaches Prisma — a malformed value here
+    // would otherwise only surface as an opaque Prisma error out of the
+    // `context.db` call below, instead of a clear refusal naming the shape
+    // that was expected (mirrors `access-filter.ts`'s `asEntryObject`).
+    if (entry.where !== undefined && (entry.where === null || typeof entry.where !== 'object')) {
+      throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.where" must be an object.`)
+    }
+    if (
+      entry.orderBy !== undefined &&
+      (entry.orderBy === null || typeof entry.orderBy !== 'object')
+    ) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}.${fieldName}.orderBy" must be an object or an array of objects.`,
+      )
+    }
+    if (entry.take !== undefined && typeof entry.take !== 'number') {
+      throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.take" must be a number.`)
+    }
+    if (entry.skip !== undefined && typeof entry.skip !== 'number') {
+      throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.skip" must be a number.`)
+    }
+    if (entry.count !== undefined && typeof entry.count !== 'boolean') {
+      throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.count" must be a boolean.`)
+    }
+
     const nestedFieldsArg = entry.fields
     const wantsCount = many && entry.count === true
 
@@ -271,12 +338,14 @@ export async function resolveFieldsProjection(
       for (const [relFieldName, relValue] of Object.entries(
         nestedFieldsArg as Record<string, unknown>,
       )) {
-        const relFieldConfig = related.listConfig.fields[relFieldName]
-        if (!relFieldConfig || isRelationshipField(relFieldConfig)) {
-          throw new McpProjectionRefusedError(
-            `"${related.listName}" has no selectable field "${relFieldName}" at this depth — relations ` +
-              `are not selectable two levels deep; issue a second query for that.`,
-          )
+        if (!isSystemFieldName(relFieldName)) {
+          const relFieldConfig = related.listConfig.fields[relFieldName]
+          if (!relFieldConfig || isRelationshipField(relFieldConfig)) {
+            throw new McpProjectionRefusedError(
+              `"${related.listName}" has no selectable field "${relFieldName}" at this depth — relations ` +
+                `are not selectable two levels deep; issue a second query for that.`,
+            )
+          }
         }
         if (relValue !== true) {
           throw new McpProjectionRefusedError(
@@ -297,7 +366,7 @@ export async function resolveFieldsProjection(
       }
       include[fieldName] = Object.keys(includeEntry).length > 0 ? includeEntry : true
       hasIncludeEntries = true
-      fieldSelection[fieldName] = { _type: 'fragment', _fields: nestedSelection }
+      fieldSelection[fieldName] = { _type: 'fragment', _fields: withId(nestedSelection) }
     }
 
     if (wantsCount) {

--- a/packages/core/src/mcp/projection.ts
+++ b/packages/core/src/mcp/projection.ts
@@ -1,0 +1,351 @@
+import type { AccessContext, Session } from '../access/types.js'
+import type { FieldConfig, ListConfig, OpenSaasConfig, RelationshipField } from '../config/types.js'
+import { checkAccess, getRelatedListConfig } from '../access/engine.js'
+import type { FieldSelection } from '../query/index.js'
+import { pickFields } from '../query/index.js'
+import { MCP_NESTED_TAKE_DEFAULT, MCP_NESTED_TAKE_MAX } from './constants.js'
+
+/** A scalar/virtual field in a `fields` projection is selected by naming it `true` — this advertises that, not the field's own value shape (`fieldToJsonSchema`, used for `create`/`update`, is a different schema entirely). */
+function scalarSelectorSchema(fieldName: string): Record<string, unknown> {
+  return { type: 'boolean', description: `Include the "${fieldName}" field` }
+}
+
+/**
+ * Thrown when a `query` tool's `fields` argument names something the
+ * generated projection schema does not advertise — an unknown field, a
+ * relation two levels deeper than enumerated, or the wrong shape for what
+ * it named. Caught in the MCP handler and turned into an `isError` tool
+ * result (never a JSON-RPC protocol error, #995) naming what was asked for
+ * and what is available, so the calling model can retry narrower.
+ */
+export class McpProjectionRefusedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'McpProjectionRefusedError'
+  }
+}
+
+function isRelationshipField(
+  fieldConfig: FieldConfig | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RelationshipField must accept any TypeInfo
+): fieldConfig is RelationshipField<any> {
+  return (
+    !!fieldConfig &&
+    fieldConfig.type === 'relationship' &&
+    'ref' in fieldConfig &&
+    !!fieldConfig.ref
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- RelationshipField must accept any TypeInfo
+function isMany(fieldConfig: RelationshipField<any>): boolean {
+  return fieldConfig.many === true
+}
+
+/**
+ * Resolve a relation field's target list, or `null` if it should not be
+ * advertised/selectable at all: the ref doesn't resolve, its MCP tools are
+ * disabled (ADR-0033 — a list with `mcp.enabled: false` is unreachable
+ * through MCP, including as a relation target), or this session's
+ * operation-level `query` access on it is denied outright.
+ */
+async function relatedListIfVisible(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RelationshipField must accept any TypeInfo
+  fieldConfig: RelationshipField<any>,
+  config: OpenSaasConfig,
+  session: Session | null,
+  context: AccessContext,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+): Promise<{ listName: string; listConfig: ListConfig<any> } | null> {
+  const related = getRelatedListConfig(fieldConfig.ref, config)
+  if (!related) return null
+  if (related.listConfig.mcp?.enabled === false) return null
+
+  const queryAccess = related.listConfig.access?.operation?.query
+  const result = await checkAccess(queryAccess, { session, context })
+  if (result === false) return null
+
+  return related
+}
+
+/**
+ * Generate the JSON Schema for the `query` tool's `fields` projection
+ * argument: two levels of the list's own vocabulary (ADR-0033). Level 1 is
+ * this list's own scalar/virtual fields (booleans) and relations (nested
+ * objects); level 2, inside a relation's own `fields`, is the related
+ * list's scalar/virtual fields only — a relation named there terminates
+ * (not itself selectable further), which is what keeps the schema finite
+ * against a self-referential relationship. Denied/MCP-disabled relation
+ * targets are omitted from the vocabulary entirely, per-session.
+ */
+export async function generateFieldsProjectionSchema(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  config: OpenSaasConfig,
+  session: Session | null,
+  context: AccessContext,
+): Promise<Record<string, unknown>> {
+  const properties: Record<string, unknown> = {}
+
+  for (const [fieldName, fieldConfig] of Object.entries(listConfig.fields)) {
+    if (!isRelationshipField(fieldConfig)) {
+      properties[fieldName] = scalarSelectorSchema(fieldName)
+      continue
+    }
+
+    const related = await relatedListIfVisible(fieldConfig, config, session, context)
+    if (!related) continue
+
+    const level2Properties: Record<string, unknown> = {}
+    for (const [relFieldName, relFieldConfig] of Object.entries(related.listConfig.fields)) {
+      if (isRelationshipField(relFieldConfig)) continue
+      level2Properties[relFieldName] = scalarSelectorSchema(relFieldName)
+    }
+
+    const many = isMany(fieldConfig)
+    properties[fieldName] = {
+      type: 'object',
+      description: many
+        ? `Select fields from the related ${related.listName} records`
+        : `Select fields from the related ${related.listName} record`,
+      properties: {
+        fields: {
+          type: 'object',
+          description: `Fields to return from ${related.listName}`,
+          properties: level2Properties,
+          additionalProperties: false,
+        },
+        ...(many
+          ? {
+              where: { type: 'object', description: `Prisma where clause for ${related.listName}` },
+              orderBy: { type: 'object', description: 'Sort order' },
+              take: {
+                type: 'number',
+                description: `Max rows to return (default ${MCP_NESTED_TAKE_DEFAULT}, hard cap ${MCP_NESTED_TAKE_MAX})`,
+              },
+              skip: { type: 'number', description: 'Rows to skip' },
+              count: {
+                type: 'boolean',
+                description:
+                  'Return the total row count instead of, or alongside, the rows themselves',
+              },
+            }
+          : {}),
+      },
+      ...(many ? {} : { required: ['fields'] }),
+      additionalProperties: false,
+    }
+  }
+
+  return {
+    type: 'object',
+    description:
+      'Select which fields (and, for relations, which nested fields) to return. Omit to get scalars and virtuals only, unchanged from today.',
+    properties,
+    additionalProperties: false,
+  }
+}
+
+/** What `resolveFieldsProjection` produces: a `context.db` `include` to fetch, the field selection to project the result down to, and which relations asked for a count. */
+export type ResolvedFieldsProjection = {
+  include: Record<string, unknown> | undefined
+  fieldSelection: FieldSelection<unknown>
+  countRequests: Map<string, 'only' | 'alongside'>
+}
+
+/** Access-scoped `_count.select` entry for one to-many relation: the related list's `query` access ANDed with any caller `where` on that same relation — mirrors how `buildAccessScopedInclude` scopes the relation's own rows (`andWhere`), since Prisma's `_count` is a sibling key that walk does not itself touch. */
+async function accessScopedCountEntry(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- RelationshipField must accept any TypeInfo
+  fieldConfig: RelationshipField<any>,
+  config: OpenSaasConfig,
+  session: Session | null,
+  context: AccessContext,
+  callerWhere: Record<string, unknown> | undefined,
+): Promise<true | { where: Record<string, unknown> } | null> {
+  const related = getRelatedListConfig(fieldConfig.ref, config)
+  if (!related) return null
+
+  const queryAccess = related.listConfig.access?.operation?.query
+  const result = await checkAccess(queryAccess, { session, context })
+  if (result === false) return null
+
+  const accessWhere = typeof result === 'object' ? result : undefined
+  const merged =
+    accessWhere && callerWhere ? { AND: [accessWhere, callerWhere] } : (accessWhere ?? callerWhere)
+  return merged ? { where: merged } : true
+}
+
+/**
+ * Validate a caller-supplied `fields` argument against the same vocabulary
+ * `generateFieldsProjectionSchema` advertises, and translate it into a
+ * `context.db` `include` (so the normal read pipeline — access scoping,
+ * `needs` folding, the depth cap — applies exactly as it does for any other
+ * caller `include`; no parallel read path) plus a `FieldSelection` for
+ * projecting the result down to what was asked for. Throws
+ * `McpProjectionRefusedError` naming what was asked for and what's
+ * available on any mismatch, never serves on a best-effort basis.
+ */
+export async function resolveFieldsProjection(
+  fieldsArg: unknown,
+  listKey: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ListConfig must accept any TypeInfo
+  listConfig: ListConfig<any>,
+  config: OpenSaasConfig,
+  session: Session | null,
+  context: AccessContext,
+): Promise<ResolvedFieldsProjection> {
+  if (fieldsArg === null || typeof fieldsArg !== 'object' || Array.isArray(fieldsArg)) {
+    throw new McpProjectionRefusedError(
+      `"fields" must be an object mapping field names to \`true\` or a relation selector.`,
+    )
+  }
+
+  const include: Record<string, unknown> = {}
+  const fieldSelection: Record<string, unknown> = {}
+  const countRequests = new Map<string, 'only' | 'alongside'>()
+  let hasIncludeEntries = false
+
+  for (const [fieldName, rawValue] of Object.entries(fieldsArg as Record<string, unknown>)) {
+    const fieldConfig = listConfig.fields[fieldName]
+    if (!fieldConfig) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}" has no field "${fieldName}". Available fields: ${Object.keys(listConfig.fields).join(', ')}.`,
+      )
+    }
+
+    if (!isRelationshipField(fieldConfig)) {
+      if (rawValue !== true) {
+        throw new McpProjectionRefusedError(
+          `"${listKey}.${fieldName}" is a scalar — select it with \`true\`, not ${JSON.stringify(rawValue)}.`,
+        )
+      }
+      fieldSelection[fieldName] = true
+      continue
+    }
+
+    const related = await relatedListIfVisible(fieldConfig, config, session, context)
+    if (!related) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}.${fieldName}" is not available for selection — its related list is not ` +
+          `queryable by this session, or has MCP disabled.`,
+      )
+    }
+
+    if (rawValue === null || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}.${fieldName}" is a relation — select it with an object, e.g. { "fields": { ... } }.`,
+      )
+    }
+
+    const entry = rawValue as Record<string, unknown>
+    const many = isMany(fieldConfig)
+    const allowedKeys = many
+      ? new Set(['fields', 'where', 'orderBy', 'take', 'skip', 'count'])
+      : new Set(['fields'])
+    for (const key of Object.keys(entry)) {
+      if (!allowedKeys.has(key)) {
+        throw new McpProjectionRefusedError(
+          `"${listKey}.${fieldName}" does not accept "${key}" (allowed: ${[...allowedKeys].join(', ')}).`,
+        )
+      }
+    }
+
+    const nestedFieldsArg = entry.fields
+    const wantsCount = many && entry.count === true
+
+    if (nestedFieldsArg === undefined && !wantsCount) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}.${fieldName}" needs "fields"${many ? ' or "count"' : ''}.`,
+      )
+    }
+
+    const nestedSelection: Record<string, true> = {}
+    if (nestedFieldsArg !== undefined) {
+      if (
+        nestedFieldsArg === null ||
+        typeof nestedFieldsArg !== 'object' ||
+        Array.isArray(nestedFieldsArg)
+      ) {
+        throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.fields" must be an object.`)
+      }
+      for (const [relFieldName, relValue] of Object.entries(
+        nestedFieldsArg as Record<string, unknown>,
+      )) {
+        const relFieldConfig = related.listConfig.fields[relFieldName]
+        if (!relFieldConfig || isRelationshipField(relFieldConfig)) {
+          throw new McpProjectionRefusedError(
+            `"${related.listName}" has no selectable field "${relFieldName}" at this depth — relations ` +
+              `are not selectable two levels deep; issue a second query for that.`,
+          )
+        }
+        if (relValue !== true) {
+          throw new McpProjectionRefusedError(
+            `"${related.listName}.${relFieldName}" is a scalar — select it with \`true\`.`,
+          )
+        }
+        nestedSelection[relFieldName] = true
+      }
+
+      const includeEntry: Record<string, unknown> = {}
+      if (many) {
+        if (entry.where !== undefined) includeEntry.where = entry.where
+        if (entry.orderBy !== undefined) includeEntry.orderBy = entry.orderBy
+        const requestedTake =
+          entry.take !== undefined ? Number(entry.take) : MCP_NESTED_TAKE_DEFAULT
+        includeEntry.take = Math.min(requestedTake, MCP_NESTED_TAKE_MAX)
+        if (entry.skip !== undefined) includeEntry.skip = entry.skip
+      }
+      include[fieldName] = Object.keys(includeEntry).length > 0 ? includeEntry : true
+      hasIncludeEntries = true
+      fieldSelection[fieldName] = { _type: 'fragment', _fields: nestedSelection }
+    }
+
+    if (wantsCount) {
+      countRequests.set(fieldName, nestedFieldsArg !== undefined ? 'alongside' : 'only')
+    }
+  }
+
+  if (countRequests.size > 0) {
+    const countSelect: Record<string, unknown> = {}
+    for (const fieldName of countRequests.keys()) {
+      const fieldConfig = listConfig.fields[fieldName] as RelationshipField
+      const rawEntry = (fieldsArg as Record<string, unknown>)[fieldName] as Record<string, unknown>
+      const scoped = await accessScopedCountEntry(
+        fieldConfig,
+        config,
+        session,
+        context,
+        rawEntry.where as Record<string, unknown> | undefined,
+      )
+      if (scoped) countSelect[fieldName] = scoped
+    }
+    if (Object.keys(countSelect).length > 0) {
+      include._count = { select: countSelect }
+      hasIncludeEntries = true
+    }
+  }
+
+  return {
+    include: hasIncludeEntries ? include : undefined,
+    fieldSelection: fieldSelection as FieldSelection<unknown>,
+    countRequests,
+  }
+}
+
+/** Project one raw (already access-checked and field-visibility-filtered) result row down to a resolved `fields` projection, folding in any requested relation counts from Prisma's `_count`. */
+export function projectMcpResult(
+  rawItem: Record<string, unknown>,
+  resolved: ResolvedFieldsProjection,
+): Record<string, unknown> {
+  const picked = pickFields(rawItem, resolved.fieldSelection) as Record<string, unknown>
+  const rawCounts = rawItem._count
+  const counts =
+    rawCounts && typeof rawCounts === 'object' ? (rawCounts as Record<string, unknown>) : {}
+
+  for (const [key, mode] of resolved.countRequests) {
+    const count = typeof counts[key] === 'number' ? (counts[key] as number) : 0
+    picked[key] = mode === 'only' ? count : { items: picked[key], count }
+  }
+
+  return picked
+}

--- a/packages/core/src/mcp/projection.ts
+++ b/packages/core/src/mcp/projection.ts
@@ -1,6 +1,8 @@
 import type { AccessContext, Session } from '../access/types.js'
 import type { FieldConfig, ListConfig, OpenSaasConfig, RelationshipField } from '../config/types.js'
 import { checkAccess, getRelatedListConfig } from '../access/engine.js'
+import { checkFieldAccess } from '../access/field-access.js'
+import { validateQueryFieldReadAccess, validateQueryKeys } from '../access/query-validation.js'
 import type { FieldSelection } from '../query/index.js'
 import { pickFields } from '../query/index.js'
 import { MCP_NESTED_TAKE_DEFAULT, MCP_NESTED_TAKE_MAX } from './constants.js'
@@ -316,6 +318,36 @@ export async function resolveFieldsProjection(
     if (entry.count !== undefined && typeof entry.count !== 'boolean') {
       throw new McpProjectionRefusedError(`"${listKey}.${fieldName}.count" must be a boolean.`)
     }
+    if (entry.take !== undefined && (entry.take as number) < 0) {
+      throw new McpProjectionRefusedError(
+        `"${listKey}.${fieldName}.take" must not be negative (nested reverse pagination isn't supported).`,
+      )
+    }
+
+    // A nested `where`/`orderBy` names fields on the RELATED list — validate
+    // them the same way the root read path validates the root list's own
+    // `where`/`orderBy` (#912/#915), or a session could infer a field-level-
+    // denied related field's value from which rows come back, their order,
+    // or (via `count`, below) how many there are.
+    if (entry.where !== undefined || entry.orderBy !== undefined) {
+      validateQueryKeys({
+        where: entry.where,
+        orderBy: entry.orderBy,
+        listConfig: related.listConfig,
+        listName: related.listName,
+        config,
+        isSudo: false,
+      })
+      await validateQueryFieldReadAccess({
+        where: entry.where,
+        orderBy: entry.orderBy,
+        listConfig: related.listConfig,
+        listName: related.listName,
+        session,
+        context,
+        isSudo: false,
+      })
+    }
 
     const nestedFieldsArg = entry.fields
     const wantsCount = many && entry.count === true
@@ -401,17 +433,38 @@ export async function resolveFieldsProjection(
   }
 }
 
-/** Project one raw (already access-checked and field-visibility-filtered) result row down to a resolved `fields` projection, folding in any requested relation counts from Prisma's `_count`. */
-export function projectMcpResult(
+/**
+ * Project one raw (already access-checked and field-visibility-filtered)
+ * result row down to a resolved `fields` projection, folding in any
+ * requested relation counts from Prisma's `_count`.
+ *
+ * `_count` is not a declared field, so field-visibility (`filterReadableFields`)
+ * never applies the relationship field's own field-level `read` access to it
+ * the way it already does for the relation's rows — this function is where
+ * that check has to happen instead, per row, before a count is ever emitted.
+ * A relation whose rows a denied field never reveals must not reveal its
+ * count either.
+ */
+export async function projectMcpResult(
   rawItem: Record<string, unknown>,
   resolved: ResolvedFieldsProjection,
-): Record<string, unknown> {
+  fieldConfigs: Record<string, FieldConfig>,
+  session: Session | null,
+  context: AccessContext,
+): Promise<Record<string, unknown>> {
   const picked = pickFields(rawItem, resolved.fieldSelection) as Record<string, unknown>
   const rawCounts = rawItem._count
   const counts =
     rawCounts && typeof rawCounts === 'object' ? (rawCounts as Record<string, unknown>) : {}
 
   for (const [key, mode] of resolved.countRequests) {
+    const canReadRelation = await checkFieldAccess(fieldConfigs[key]?.access, 'read', {
+      session,
+      context,
+      item: rawItem,
+    })
+    if (!canReadRelation) continue
+
     const count = typeof counts[key] === 'number' ? (counts[key] as number) : 0
     picked[key] = mode === 'only' ? count : { items: picked[key], count }
   }

--- a/packages/core/tests/mcp-fields-projection-access.test.ts
+++ b/packages/core/tests/mcp-fields-projection-access.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createMcpHandlers } from '../src/mcp/handler.js'
+import { getContext as buildContext } from '../src/context/index.js'
+import { config, list } from '../src/config/index.js'
+import { text, relationship, virtual, checkbox } from '../src/fields/index.js'
+import type { McpSessionProvider } from '../src/mcp/types.js'
+
+/**
+ * Coverage for issue #851 / ADR-0033: the `query` tool's `fields` projection
+ * exercised through the REAL access-control pipeline (`getContext`), not the
+ * lightweight mocked-`context.db` harness `mcp-handler.test.ts` uses. This is
+ * what actually proves a nested to-many `where` gets AND-combined with the
+ * related list's own access filter, a to-one relation failing that filter is
+ * nulled by the real existence check, field-level access still drops values
+ * regardless of the projection, and a selected computed field's declared
+ * `needs` are folded in by the ordinary read pipeline — none of which the
+ * mocked-`context.db` harness can exercise, since it bypasses the engine.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockPrisma(): any {
+  const model = () => ({
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  })
+  return { user: model(), comment: model(), post: model() }
+}
+
+async function buildTestConfig() {
+  return config({
+    db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+    mcp: { enabled: true },
+    lists: {
+      User: list({
+        fields: { name: text() },
+        // Only "u1" is queryable — a FILTER, not a boolean, so a to-one
+        // relation pointing at a different user gets nulled post-query.
+        access: { operation: { query: () => ({ id: { equals: 'u1' } }) } },
+      }),
+      Comment: list({
+        fields: {
+          text: text(),
+          approved: checkbox(),
+          post: relationship({ ref: 'Post.comments' }),
+        },
+        // Only approved comments are queryable.
+        access: { operation: { query: () => ({ approved: { equals: true } }) } },
+      }),
+      Post: list({
+        fields: {
+          title: text(),
+          author: relationship({ ref: 'User' }),
+          comments: relationship({ ref: 'Comment.post', many: true }),
+          secret: text({ access: { read: () => false } }),
+          commentCount: virtual({
+            type: 'number',
+            needs: ['comments'],
+            hooks: {
+              resolveOutput: ({ item }) => {
+                const typed = item as { comments?: unknown[] }
+                return (typed.comments ?? []).length
+              },
+            },
+          }),
+        },
+        access: { operation: { query: () => true } },
+      }),
+    },
+  })
+}
+
+const mockGetSession: McpSessionProvider = vi.fn(async () => ({ userId: 'me' }))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function callPostQuery(testConfig: any, mockPrisma: any, args: Record<string, unknown>) {
+  const handlers = createMcpHandlers({
+    config: testConfig,
+    getSession: mockGetSession,
+    getContext: async (session) => buildContext(testConfig, mockPrisma, session ?? null),
+  })
+
+  const response = await handlers.POST(
+    new Request('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'list_post_query', arguments: args },
+      }),
+    }),
+  )
+  return response.json()
+}
+
+describe('MCP `fields` projection against the real access-control pipeline (#851)', () => {
+  it('nulls a to-one relation whose related row fails the related list access filter', async () => {
+    const testConfig = await buildTestConfig()
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findMany.mockResolvedValue([
+      { id: 'p1', title: 'Hi', author: { id: 'u2', name: 'Bob' } },
+    ])
+    // The batched existence check queries the RAW prisma client for ids
+    // matching the access filter — "u2" doesn't, so it comes back empty.
+    mockPrisma.user.findMany.mockResolvedValue([])
+
+    const data = await callPostQuery(testConfig, mockPrisma, {
+      fields: { title: true, author: { fields: { name: true } } },
+    })
+
+    const result = JSON.parse(data.result.content[0].text)
+    expect(result.items).toEqual([{ title: 'Hi', author: null }])
+  })
+
+  it('AND-combines a nested to-many where with the related list’s own access filter', async () => {
+    const testConfig = await buildTestConfig()
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findMany.mockResolvedValue([
+      { id: 'p1', title: 'Hi', comments: [{ id: 'c1', text: 'nice' }] },
+    ])
+
+    await callPostQuery(testConfig, mockPrisma, {
+      fields: { comments: { fields: { text: true }, where: { text: { contains: 'nice' } } } },
+    })
+
+    expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          comments: {
+            where: { AND: [{ approved: { equals: true } }, { text: { contains: 'nice' } }] },
+            take: 5,
+          },
+        },
+      }),
+    )
+  })
+
+  it('still drops a field-level-denied field even when named in fields', async () => {
+    const testConfig = await buildTestConfig()
+    const mockPrisma = createMockPrisma()
+    mockPrisma.post.findMany.mockResolvedValue([{ id: 'p1', title: 'Hi', secret: 'shh' }])
+
+    const data = await callPostQuery(testConfig, mockPrisma, {
+      fields: { title: true, secret: true },
+    })
+
+    const result = JSON.parse(data.result.content[0].text)
+    expect(result.items).toEqual([{ title: 'Hi' }])
+  })
+
+  it('running a selected computed field folds its declared `needs`, and the count reflects the access-scoped rows', async () => {
+    const testConfig = await buildTestConfig()
+    const mockPrisma = createMockPrisma()
+    // The engine fetches `comments` unscoped by our projection (folded via
+    // `needs`) and access-scopes it exactly like any other named relation —
+    // only the approved one should count.
+    mockPrisma.post.findMany.mockResolvedValue([
+      { id: 'p1', title: 'Hi', comments: [{ id: 'c1', approved: true }] },
+    ])
+
+    const data = await callPostQuery(testConfig, mockPrisma, {
+      fields: { commentCount: true },
+    })
+
+    const result = JSON.parse(data.result.content[0].text)
+    expect(result.items).toEqual([{ commentCount: 1 }])
+
+    // `needs` folded `comments` into the include even though the caller's
+    // own `fields` never named it.
+    const callArgs = mockPrisma.post.findMany.mock.calls[0][0]
+    expect(callArgs.include.comments).toBeDefined()
+  })
+})

--- a/packages/core/tests/mcp-fields-projection-access.test.ts
+++ b/packages/core/tests/mcp-fields-projection-access.test.ts
@@ -113,7 +113,7 @@ describe('MCP `fields` projection against the real access-control pipeline (#851
     })
 
     const result = JSON.parse(data.result.content[0].text)
-    expect(result.items).toEqual([{ title: 'Hi', author: null }])
+    expect(result.items).toEqual([{ id: 'p1', title: 'Hi', author: null }])
   })
 
   it('AND-combines a nested to-many where with the related list’s own access filter', async () => {
@@ -149,7 +149,7 @@ describe('MCP `fields` projection against the real access-control pipeline (#851
     })
 
     const result = JSON.parse(data.result.content[0].text)
-    expect(result.items).toEqual([{ title: 'Hi' }])
+    expect(result.items).toEqual([{ id: 'p1', title: 'Hi' }])
   })
 
   it('running a selected computed field folds its declared `needs`, and the count reflects the access-scoped rows', async () => {
@@ -167,7 +167,7 @@ describe('MCP `fields` projection against the real access-control pipeline (#851
     })
 
     const result = JSON.parse(data.result.content[0].text)
-    expect(result.items).toEqual([{ commentCount: 1 }])
+    expect(result.items).toEqual([{ id: 'p1', commentCount: 1 }])
 
     // `needs` folded `comments` into the include even though the caller's
     // own `fields` never named it.

--- a/packages/core/tests/mcp-handler.test.ts
+++ b/packages/core/tests/mcp-handler.test.ts
@@ -928,3 +928,353 @@ describe('MCP Handler', () => {
     })
   })
 })
+
+// Coverage for issue #851 / ADR-0033: the `query` tool's `fields` projection
+// argument, its generated per-session schema, and `tools/list` becoming
+// per-session. Uses the same lightweight mocked-`context.db` harness as the
+// suite above — these tests exercise the MCP-layer translation (schema
+// shape, `fields` → `include` translation, response projection) rather than
+// the real access-control engine, which is covered separately in
+// `mcp-fields-projection-access.test.ts` against a real `getContext`.
+describe('MCP Handler — fields projection (#851)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockPrisma: any
+  let config: OpenSaasConfig
+  let getContext: (session?: { userId: string }) => AccessContext
+  let mockGetSession: McpSessionProvider
+
+  beforeEach(() => {
+    mockPrisma = {
+      user: { findMany: vi.fn() },
+      comment: { findMany: vi.fn() },
+      post: { findMany: vi.fn() },
+      secret: { findMany: vi.fn() },
+      draft: { findMany: vi.fn() },
+      category: { findMany: vi.fn() },
+    }
+
+    config = {
+      db: { provider: 'postgresql', url: 'postgresql://localhost:5432/test' },
+      mcp: { enabled: true, basePath: '/api/mcp' },
+      lists: {
+        User: {
+          fields: {
+            name: { type: 'text' },
+            email: { type: 'text' },
+          },
+          access: { operation: { query: () => true } },
+        },
+        Comment: {
+          fields: {
+            text: { type: 'text' },
+            approved: { type: 'checkbox' },
+            post: { type: 'relationship', ref: 'Post.comments' },
+          },
+          access: { operation: { query: () => true } },
+        },
+        Post: {
+          fields: {
+            title: { type: 'text' },
+            content: { type: 'text' },
+            author: { type: 'relationship', ref: 'User' },
+            comments: { type: 'relationship', ref: 'Comment.post', many: true },
+            secretInfo: { type: 'relationship', ref: 'Secret' },
+            draftRef: { type: 'relationship', ref: 'Draft' },
+          },
+          access: { operation: { query: () => true } },
+        },
+        // Denies query access outright — must vanish from `tools/list` as a
+        // tool owner AND from `Post`'s `fields` schema as a relation target.
+        Secret: {
+          fields: { value: { type: 'text' } },
+          access: { operation: { query: () => false } },
+        },
+        // MCP-disabled — same double omission as `Secret`, different cause.
+        Draft: {
+          fields: { title: { type: 'text' } },
+          access: { operation: { query: () => true } },
+          mcp: { enabled: false },
+        },
+        // Self-referential — the schema must terminate at depth 2 rather
+        // than recursing forever.
+        Category: {
+          fields: {
+            name: { type: 'text' },
+            parent: { type: 'relationship', ref: 'Category.children' },
+            children: { type: 'relationship', ref: 'Category.parent', many: true },
+          },
+          access: { operation: { query: () => true } },
+        },
+      },
+    }
+
+    getContext = vi.fn((session?: { userId: string }) => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: mockPrisma as any,
+      session: session || null,
+      prisma: mockPrisma,
+    }))
+
+    mockGetSession = vi.fn(async () => ({ userId: 'user-123' }))
+  })
+
+  async function listTools() {
+    const handlers = createMcpHandlers({ config, getSession: mockGetSession, getContext })
+    const request = new Request('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    })
+    const response = await handlers.POST(request)
+    const data = await response.json()
+    return data.result.tools as Array<{ name: string; inputSchema: Record<string, unknown> }>
+  }
+
+  async function callQuery(
+    name: string,
+    args: Record<string, unknown>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    const handlers = createMcpHandlers({ config, getSession: mockGetSession, getContext })
+    const request = new Request('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name, arguments: args },
+      }),
+    })
+    const response = await handlers.POST(request)
+    return response.json()
+  }
+
+  describe('generated `fields` schema on tools/list', () => {
+    it('advertises scalars as booleans and relations as nested selectors', async () => {
+      const tools = await listTools()
+      const postQuery = tools.find((t) => t.name === 'list_post_query')!
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fieldsSchema = (postQuery.inputSchema.properties as any).fields
+
+      expect(fieldsSchema.properties.title).toMatchObject({ type: 'boolean' })
+      expect(fieldsSchema.properties.content).toMatchObject({ type: 'boolean' })
+
+      // To-one: nested `fields` only, required, no where/orderBy/take/skip/count.
+      expect(fieldsSchema.properties.author.required).toEqual(['fields'])
+      const authorFields = fieldsSchema.properties.author.properties.fields.properties
+      expect(authorFields.name).toMatchObject({ type: 'boolean' })
+      expect(authorFields.email).toMatchObject({ type: 'boolean' })
+      expect(fieldsSchema.properties.author.properties.where).toBeUndefined()
+
+      // To-many: fields optional, plus where/orderBy/take/skip/count.
+      expect(fieldsSchema.properties.comments.required).toBeUndefined()
+      const commentFields = fieldsSchema.properties.comments.properties.fields.properties
+      expect(commentFields.text).toMatchObject({ type: 'boolean' })
+      expect(commentFields.approved).toMatchObject({ type: 'boolean' })
+      expect(fieldsSchema.properties.comments.properties.where).toBeDefined()
+      expect(fieldsSchema.properties.comments.properties.orderBy).toBeDefined()
+      expect(fieldsSchema.properties.comments.properties.take).toBeDefined()
+      expect(fieldsSchema.properties.comments.properties.skip).toBeDefined()
+      expect(fieldsSchema.properties.comments.properties.count).toEqual({
+        type: 'boolean',
+        description: expect.any(String),
+      })
+    })
+
+    it('omits a relation whose target list denies query access', async () => {
+      const tools = await listTools()
+      const postQuery = tools.find((t) => t.name === 'list_post_query')!
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fieldsSchema = (postQuery.inputSchema.properties as any).fields
+      expect(fieldsSchema.properties.secretInfo).toBeUndefined()
+    })
+
+    it('omits a relation whose target list has mcp.enabled: false', async () => {
+      const tools = await listTools()
+      const postQuery = tools.find((t) => t.name === 'list_post_query')!
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fieldsSchema = (postQuery.inputSchema.properties as any).fields
+      expect(fieldsSchema.properties.draftRef).toBeUndefined()
+    })
+
+    it('terminates a self-referential relationship at depth 2 (no relation fields at level 2)', async () => {
+      const tools = await listTools()
+      const categoryQuery = tools.find((t) => t.name === 'list_category_query')!
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fieldsSchema = (categoryQuery.inputSchema.properties as any).fields
+
+      const parentFields = fieldsSchema.properties.parent.properties.fields.properties
+      expect(Object.keys(parentFields)).toEqual(['name'])
+      expect(parentFields.name).toMatchObject({ type: 'boolean' })
+
+      const childrenFields = fieldsSchema.properties.children.properties.fields.properties
+      expect(Object.keys(childrenFields)).toEqual(['name'])
+      expect(childrenFields.name).toMatchObject({ type: 'boolean' })
+    })
+  })
+
+  describe('tools/list is per-session', () => {
+    it('omits all four CRUD tools for a list whose query access denies the session', async () => {
+      const tools = await listTools()
+      const toolNames = tools.map((t) => t.name)
+      expect(toolNames).not.toContain('list_secret_query')
+      expect(toolNames).not.toContain('list_secret_create')
+      expect(toolNames).not.toContain('list_secret_update')
+      expect(toolNames).not.toContain('list_secret_delete')
+    })
+
+    it('omits all four CRUD tools for a list with mcp.enabled: false', async () => {
+      const tools = await listTools()
+      const toolNames = tools.map((t) => t.name)
+      expect(toolNames).not.toContain('list_draft_query')
+    })
+  })
+
+  describe('query dispatch with `fields`', () => {
+    it('selects only scalar fields, issuing no `include`', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([{ id: '1', title: 'Hello', content: 'World' }])
+
+      const data = await callQuery('list_post_query', { fields: { title: true } })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.not.objectContaining({ include: expect.anything() }),
+      )
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ title: 'Hello' }])
+    })
+
+    it('selects a to-one relation with nested fields', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: '1', title: 'Hello', author: { id: 'u1', name: 'Ada', email: 'ada@example.com' } },
+      ])
+
+      const data = await callQuery('list_post_query', {
+        fields: { title: true, author: { fields: { name: true } } },
+      })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ include: { author: true } }),
+      )
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ title: 'Hello', author: { name: 'Ada' } }])
+    })
+
+    it('honours nested where/orderBy/take/skip on a to-many relation, applying the default take ceiling when omitted', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([{ id: '1', comments: [] }])
+
+      await callQuery('list_post_query', {
+        fields: {
+          comments: {
+            fields: { text: true },
+            where: { approved: { equals: true } },
+            orderBy: { text: 'asc' },
+            skip: 2,
+          },
+        },
+      })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            comments: {
+              where: { approved: { equals: true } },
+              orderBy: { text: 'asc' },
+              take: 5,
+              skip: 2,
+            },
+          },
+        }),
+      )
+    })
+
+    it('clamps a nested take above the hard cap', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([{ id: '1', comments: [] }])
+
+      await callQuery('list_post_query', {
+        fields: { comments: { fields: { text: true }, take: 9999 } },
+      })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: { comments: { take: 50 } },
+        }),
+      )
+    })
+
+    it('requests a to-many count in place of its rows', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([{ id: '1', _count: { comments: 7 } }])
+
+      const data = await callQuery('list_post_query', {
+        fields: { comments: { count: true } },
+      })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: { _count: { select: { comments: true } } },
+        }),
+      )
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ comments: 7 }])
+    })
+
+    it('requests a to-many count alongside its rows', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: '1', comments: [{ text: 'hi' }], _count: { comments: 7 } },
+      ])
+
+      const data = await callQuery('list_post_query', {
+        fields: { comments: { fields: { text: true }, count: true } },
+      })
+
+      expect(mockPrisma.post.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            comments: { take: 5 },
+            _count: { select: { comments: true } },
+          },
+        }),
+      )
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ comments: { items: [{ text: 'hi' }], count: 7 } }])
+    })
+
+    it('refuses an unadvertised field name as an isError tool result', async () => {
+      const data = await callQuery('list_post_query', { fields: { madeUpField: true } })
+
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('madeUpField')
+    })
+
+    it('refuses a relation named two levels deep as an isError tool result', async () => {
+      const data = await callQuery('list_post_query', {
+        fields: { comments: { fields: { post: true } } },
+      })
+
+      expect(data.error).toBeUndefined()
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('post')
+    })
+
+    it('refuses a relation field selected with `true` instead of a selector object', async () => {
+      const data = await callQuery('list_post_query', { fields: { author: true } })
+
+      expect(data.result.isError).toBe(true)
+    })
+
+    it('refuses a scalar field selected with a non-true value', async () => {
+      const data = await callQuery('list_post_query', { fields: { title: 'yes' } })
+
+      expect(data.result.isError).toBe(true)
+    })
+
+    it('refuses a relation whose target list denies query access', async () => {
+      const data = await callQuery('list_post_query', {
+        fields: { secretInfo: { fields: { value: true } } },
+      })
+
+      expect(data.result.isError).toBe(true)
+    })
+  })
+})

--- a/packages/core/tests/mcp-handler.test.ts
+++ b/packages/core/tests/mcp-handler.test.ts
@@ -968,6 +968,9 @@ describe('MCP Handler — fields projection (#851)', () => {
           fields: {
             text: { type: 'text' },
             approved: { type: 'checkbox' },
+            // Field-level read denied — used to prove a nested `where`/
+            // `orderBy` can't name a field this session cannot read.
+            internalNote: { type: 'text', access: { read: () => false } },
             post: { type: 'relationship', ref: 'Post.comments' },
           },
           access: { operation: { query: () => true } },
@@ -978,6 +981,15 @@ describe('MCP Handler — fields projection (#851)', () => {
             content: { type: 'text' },
             author: { type: 'relationship', ref: 'User' },
             comments: { type: 'relationship', ref: 'Comment.post', many: true },
+            // Field-level read denied on the RELATIONSHIP FIELD ITSELF —
+            // distinct from a related list's operation-level access — used
+            // to prove `count` can't bypass it.
+            restrictedComments: {
+              type: 'relationship',
+              ref: 'Comment',
+              many: true,
+              access: { read: () => false },
+            },
             secretInfo: { type: 'relationship', ref: 'Secret' },
             draftRef: { type: 'relationship', ref: 'Draft' },
           },
@@ -1320,6 +1332,52 @@ describe('MCP Handler — fields projection (#851)', () => {
       })
       expect(badCount.result.isError).toBe(true)
       expect(badCount.result.content[0].text).toContain('count')
+    })
+
+    it('refuses a negative nested take rather than allowing reverse-pagination to bypass the row cap', async () => {
+      const data = await callQuery('list_post_query', {
+        fields: { comments: { fields: { text: true }, take: -100000 } },
+      })
+
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('take')
+      expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+    })
+
+    it('refuses a nested where naming a field-level-denied field on the related list', async () => {
+      const data = await callQuery('list_post_query', {
+        fields: {
+          comments: { fields: { text: true }, where: { internalNote: { equals: 'x' } } },
+        },
+      })
+
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('internalNote')
+      expect(mockPrisma.post.findMany).not.toHaveBeenCalled()
+    })
+
+    it('refuses a nested orderBy naming an undeclared field on the related list', async () => {
+      const data = await callQuery('list_post_query', {
+        fields: {
+          comments: { fields: { text: true }, orderBy: { bogusField: 'asc' } },
+        },
+      })
+
+      expect(data.result.isError).toBe(true)
+      expect(data.result.content[0].text).toContain('bogusField')
+    })
+
+    it('does not expose a relation count when the relationship field itself denies read access', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: '1', restrictedComments: [{ text: 'hi' }], _count: { restrictedComments: 3 } },
+      ])
+
+      const data = await callQuery('list_post_query', {
+        fields: { restrictedComments: { count: true } },
+      })
+
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ id: '1' }])
     })
   })
 })

--- a/packages/core/tests/mcp-handler.test.ts
+++ b/packages/core/tests/mcp-handler.test.ts
@@ -1104,12 +1104,15 @@ describe('MCP Handler — fields projection (#851)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const fieldsSchema = (categoryQuery.inputSchema.properties as any).fields
 
+      // Only scalars (plus the always-present system fields) — no `parent`/
+      // `children` at this depth, which is what actually terminates the
+      // self-reference.
       const parentFields = fieldsSchema.properties.parent.properties.fields.properties
-      expect(Object.keys(parentFields)).toEqual(['name'])
+      expect(Object.keys(parentFields).sort()).toEqual(['createdAt', 'id', 'name', 'updatedAt'])
       expect(parentFields.name).toMatchObject({ type: 'boolean' })
 
       const childrenFields = fieldsSchema.properties.children.properties.fields.properties
-      expect(Object.keys(childrenFields)).toEqual(['name'])
+      expect(Object.keys(childrenFields).sort()).toEqual(['createdAt', 'id', 'name', 'updatedAt'])
       expect(childrenFields.name).toMatchObject({ type: 'boolean' })
     })
   })
@@ -1141,7 +1144,7 @@ describe('MCP Handler — fields projection (#851)', () => {
         expect.not.objectContaining({ include: expect.anything() }),
       )
       const result = JSON.parse(data.result.content[0].text)
-      expect(result.items).toEqual([{ title: 'Hello' }])
+      expect(result.items).toEqual([{ id: '1', title: 'Hello' }])
     })
 
     it('selects a to-one relation with nested fields', async () => {
@@ -1157,7 +1160,7 @@ describe('MCP Handler — fields projection (#851)', () => {
         expect.objectContaining({ include: { author: true } }),
       )
       const result = JSON.parse(data.result.content[0].text)
-      expect(result.items).toEqual([{ title: 'Hello', author: { name: 'Ada' } }])
+      expect(result.items).toEqual([{ id: '1', title: 'Hello', author: { id: 'u1', name: 'Ada' } }])
     })
 
     it('honours nested where/orderBy/take/skip on a to-many relation, applying the default take ceiling when omitted', async () => {
@@ -1215,7 +1218,7 @@ describe('MCP Handler — fields projection (#851)', () => {
         }),
       )
       const result = JSON.parse(data.result.content[0].text)
-      expect(result.items).toEqual([{ comments: 7 }])
+      expect(result.items).toEqual([{ id: '1', comments: 7 }])
     })
 
     it('requests a to-many count alongside its rows', async () => {
@@ -1236,7 +1239,7 @@ describe('MCP Handler — fields projection (#851)', () => {
         }),
       )
       const result = JSON.parse(data.result.content[0].text)
-      expect(result.items).toEqual([{ comments: { items: [{ text: 'hi' }], count: 7 } }])
+      expect(result.items).toEqual([{ id: '1', comments: { items: [{ text: 'hi' }], count: 7 } }])
     })
 
     it('refuses an unadvertised field name as an isError tool result', async () => {
@@ -1275,6 +1278,48 @@ describe('MCP Handler — fields projection (#851)', () => {
       })
 
       expect(data.result.isError).toBe(true)
+    })
+
+    it('always returns id, even when the projection never names it', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([{ id: '1', title: 'Hello' }])
+
+      const data = await callQuery('list_post_query', { fields: { title: true } })
+
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ id: '1', title: 'Hello' }])
+    })
+
+    it('accepts id/createdAt/updatedAt as explicitly selectable system fields', async () => {
+      mockPrisma.post.findMany.mockResolvedValue([
+        { id: '1', title: 'Hello', createdAt: 't1', updatedAt: 't2' },
+      ])
+
+      const data = await callQuery('list_post_query', {
+        fields: { id: true, createdAt: true, updatedAt: true },
+      })
+
+      const result = JSON.parse(data.result.content[0].text)
+      expect(result.items).toEqual([{ id: '1', createdAt: 't1', updatedAt: 't2' }])
+    })
+
+    it('refuses a malformed nested where/take/orderBy/skip/count with a clear message rather than an opaque Prisma error', async () => {
+      const badWhere = await callQuery('list_post_query', {
+        fields: { comments: { fields: { text: true }, where: 'not-an-object' } },
+      })
+      expect(badWhere.result.isError).toBe(true)
+      expect(badWhere.result.content[0].text).toContain('where')
+
+      const badTake = await callQuery('list_post_query', {
+        fields: { comments: { fields: { text: true }, take: 'lots' } },
+      })
+      expect(badTake.result.isError).toBe(true)
+      expect(badTake.result.content[0].text).toContain('take')
+
+      const badCount = await callQuery('list_post_query', {
+        fields: { comments: { count: 'yes' } },
+      })
+      expect(badCount.result.isError).toBe(true)
+      expect(badCount.result.content[0].text).toContain('count')
     })
   })
 })


### PR DESCRIPTION
## Summary

Implements #851 per the design recorded in ADR-0033 (`docs/adr/0033-mcp-tools-advertise-a-bounded-projection.md`), unblocked now that #995 (isError tool results) has landed.

- The derived `list_{dbKey}_query` MCP tool accepts an optional `fields` projection — the wire form of the runtime's existing fragment field selection (`{ scalarField: true, relation: { fields: {...} } }`) — instead of the `include` originally proposed in #851, per the maintainer's triage decision.
- Omitting `fields` is unchanged: a bare read, exactly as before (ADR-0024).
- A to-one relation takes a nested `fields` only; a to-many additionally accepts `where`/`orderBy`/`take`/`skip` and a `count` (in place of, or alongside, its rows). A nested `take` defaults to 5 and is clamped to a hard cap of 50.
- The generated schema enumerates exactly **two levels** of each list's own vocabulary, per session — a relation whose target list denies this session's operation-level `query` access, or has `mcp.enabled: false`, is omitted from the vocabulary entirely (and terminates the schema against a self-referential relationship like `Category.parent`/`children`).
- A `fields` request naming anything the schema doesn't advertise (unknown field, relation nested a third level deep, wrong shape) is refused as an `isError` tool result naming what was asked for and what's available — never served on a best-effort basis, never a JSON-RPC protocol error.
- `fields` is translated into a plain `context.db` `include`, not the fragment `query:` argument, so the *existing* read pipeline does the work — `buildAccessScopedInclude`'s nested-`where` AND-fold, the to-one existence check, `needs` folding, and the depth cap all apply exactly as they do for any other caller `include`. No parallel read path (see `packages/core/CLAUDE.md`'s new "The MCP `query` Tool's `fields` Projection" section for the detail, including the one documented trade-off this choice makes).
- **Behaviour change:** `tools/list` is now evaluated per session. A list whose operation-level `query` access denies the session outright no longer appears in the listing at all — none of its four CRUD tools, and no relation entry elsewhere pointing at it.
- Small additive extension to `buildAccessScopedInclude`/`asEntryObject` (`access-filter.ts`) to carry a caller's nested `orderBy`/`skip` through on a to-many include, mirroring the existing `take` precedent — needed for the to-many pagination criteria above.
- `fieldToJsonSchema`/`generateFieldSchemas` moved from `mcp/handler.ts` to a new `mcp/field-schema.ts` so both the `create`/`update` schema generator and the new `fields` projection schema generator can share it without a circular import.

## Test plan

- [x] `pnpm test` — 1153 tests pass (`packages/core`), including 43 tests in the extended `mcp-handler.test.ts` (schema shape, per-session omission, request→`include` translation, count handling, refusals) and 4 tests in a new `mcp-fields-projection-access.test.ts` that exercise the *real* `getContext` pipeline (nested to-many `where` AND-combined with the related list's access filter, to-one nulling via the real existence check, field-level access still dropping values, a selected computed field folding its declared `needs`).
- [x] `pnpm build` — typechecks clean.
- [x] `pnpm lint` — no new warnings/errors.
- [x] `pnpm manypkg fix` / `pnpm format` — run, no changes beyond formatting.
- [x] Changeset added (minor, `@opensaas/stack-core`) calling out the `tools/list` behaviour change.
- [x] MCP how-to docs (`docs/content/how-to/mcp.md`) updated with a "Selecting Related Data with `fields`" section and a note on per-session tool listing.

Closes #851

---
_Generated by [Claude Code](https://claude.ai/code/session_01CthNCkBfwh5G3HGmG1AVLK)_