### PR TITLE
Throw when create access control returns a non-boolean

### DIFF
--- a/.changeset/loud-otters-jump.md
+++ b/.changeset/loud-otters-jump.md
@@ -1,0 +1,29 @@
+---
+'@opensaas/stack-core': minor
+---
+
+`OperationAccess.create` now throws `InvalidCreateAccessResultError` when the rule returns anything other than `true`/`false` — most notably a Prisma filter, which previously fell through the `create` access check unrecognised and was silently treated as a full allow (both the top-level write pipeline and nested-create paths were affected).
+
+Create has no existing row to scope a filter against, so a filter can no longer be honoured here:
+
+```typescript
+// Before: type-checked, read as row-scoped, actually allowed everyone
+create: ({ session }) => ({ ownerId: { equals: session.userId } })
+
+// Now throws InvalidCreateAccessResultError. Scope ownership in a hook instead:
+hooks: {
+  resolveInput: async ({ resolvedData, context, operation }) => {
+    if (operation === 'create') {
+      return { ...resolvedData, ownerId: context.session?.userId }
+    }
+    return resolvedData
+  },
+},
+access: {
+  operation: {
+    create: ({ session }) => !!session, // boolean only
+  },
+},
+```
+
+`create: () => false` still denies via Silent failure as before; only a non-boolean result now throws.

--- a/docs/content/reference/config-api.md
+++ b/docs/content/reference/config-api.md
@@ -441,11 +441,32 @@ access: {
 
 #### Properties
 
-Each operation accepts an `AccessControl` function that returns:
+`query`, `update`, and `delete` accept an `AccessControl` function that returns:
 
 - `true` - Allow access
 - `false` - Deny access
 - `PrismaFilter` - Prisma where clause to filter accessible records
+
+**`create` accepts a `boolean` result only** — `true` or `false`. It shares
+`AccessControl`'s type (so a filter still type-checks), but there is no
+existing row for `create` to scope with a filter, and — unlike `update`/
+`delete`, which re-check a returned filter against the target row — no
+equivalent re-check is possible for a row that doesn't exist yet. A `create`
+rule that returns a filter (or any other non-boolean) throws
+`InvalidCreateAccessResultError` rather than being silently treated as an
+allow. To scope who may create a row by ownership, evaluate the condition in
+a `resolveInput` or `validate` hook, where the input data is in scope:
+
+```typescript
+hooks: {
+  resolveInput: async ({ resolvedData, context, operation }) => {
+    if (operation === 'create') {
+      return { ...resolvedData, ownerId: context.session?.userId }
+    }
+    return resolvedData
+  },
+},
+```
 
 **Type:** `AccessControl<T>`
 
@@ -472,6 +493,9 @@ update: ({ session, item }) => session?.userId === item.authorId
 query: ({ session }) => ({
   authorId: { equals: session?.userId },
 })
+
+// Boolean only — create cannot be scoped by a filter
+create: ({ session }) => !!session
 ```
 
 ---

--- a/packages/core/src/access/engine.ts
+++ b/packages/core/src/access/engine.ts
@@ -1,6 +1,7 @@
 import type { AccessControl, Session, AccessContext, PrismaFilter } from './types.js'
 import type { OpenSaasConfig, ListConfig, RelationshipField } from '../config/types.js'
 import { getSyntheticFieldName } from '../fields/index.js'
+import { InvalidCreateAccessResultError } from './errors.js'
 
 /**
  * Access engine — operation-level access control and shared helpers.
@@ -109,6 +110,37 @@ export async function checkAccess<T = Record<string, unknown>>(
   const result = await accessControl(args)
 
   return result
+}
+
+/**
+ * Evaluate operation-level `create` access. The single evaluator shared by the
+ * write pipeline's top-level create and the nested-create path — both must
+ * reject the same way, or the two drift again (#1009).
+ *
+ * Unlike `checkAccess` (which `query`/`update`/`delete` call directly and which
+ * legitimately returns a filter for them to re-check against a row), create
+ * has no existing row and no way to test a filter against input data. A rule
+ * that returns anything other than a strict boolean — most notably a filter,
+ * which type-checks against the shared `AccessControl` signature and reads as
+ * though it scopes the create — throws `InvalidCreateAccessResultError`
+ * rather than being silently treated as an allow. See that error's doc,
+ * ADR-0022, and ADR-0030.
+ */
+export async function checkCreateAccess<T = Record<string, unknown>>(
+  listKey: string,
+  accessControl: AccessControl<T> | undefined,
+  args: {
+    session: Session | null
+    context: AccessContext
+  },
+): Promise<boolean> {
+  const result = await checkAccess(accessControl, args)
+
+  if (isBoolean(result)) {
+    return result
+  }
+
+  throw new InvalidCreateAccessResultError(listKey, result)
 }
 
 export function mergeFilters(

--- a/packages/core/src/access/errors.ts
+++ b/packages/core/src/access/errors.ts
@@ -99,7 +99,7 @@ export class RelationFilterAccessDeniedError extends Error {
   }
 }
 
-function describeFieldAccessResult(result: unknown): string {
+function describeAccessResult(result: unknown): string {
   if (result === null) return 'null'
   if (result === undefined) return 'undefined'
   if (typeof result === 'object') return 'an object (e.g. a Prisma filter)'
@@ -135,7 +135,7 @@ export class InvalidFieldAccessResultError extends Error {
   constructor(operation: 'read' | 'create' | 'update', result: unknown) {
     super(
       `Field-level access control for operation "${operation}" returned ` +
-        `${describeFieldAccessResult(result)}, not a boolean. Field access is a per-field ` +
+        `${describeAccessResult(result)}, not a boolean. Field access is a per-field ` +
         `visibility decision — it must return true or false, and (unlike operation-level access) ` +
         `cannot scope which rows are affected. If you meant to restrict access based on the row or ` +
         `the write payload, evaluate the condition yourself and return a boolean, e.g. ` +
@@ -143,5 +143,45 @@ export class InvalidFieldAccessResultError extends Error {
     )
     this.name = 'InvalidFieldAccessResultError'
     this.operation = operation
+  }
+}
+
+/**
+ * Thrown when operation-level `create` access control returns anything other
+ * than a strict `boolean`. `OperationAccess['create']` is typed as
+ * `AccessControl`, which also accepts a `PrismaFilter` — the shape
+ * `query`/`update`/`delete` legitimately use to scope which rows an
+ * operation may touch (see ADR-0001). Create has none of that to scope: there
+ * is no existing row, and — unlike update/delete, which re-check a returned
+ * filter against the target via `findFirst` — no equivalent re-check is
+ * possible against data that doesn't exist in the database yet.
+ *
+ * A filter-returning `create` rule type-checks (the shared `AccessControl`
+ * type admits it) and reads as though it scopes the create. Before this it
+ * fell through a check that only tested `=== false` and was silently treated
+ * as a full allow. This is the same defect shape ADR-0030 closed for
+ * field-level access, resolved the same way per ADR-0022 (an engine that
+ * cannot compute a scope must deny, never pass through) — a loud, distinct
+ * failure rather than a wider `null`/`[]` Silent failure, because this is a
+ * config bug, not an access denial.
+ *
+ * Deliberately does not expose the offending result as a public field, for
+ * the same reason as `InvalidFieldAccessResultError`: there is no
+ * concretely-typed shape to give it, and the root CLAUDE.md forbids exposing
+ * `unknown`/`any` as part of a package's external API.
+ */
+export class InvalidCreateAccessResultError extends Error {
+  public listKey: string
+
+  constructor(listKey: string, result: unknown) {
+    super(
+      `Operation-level "create" access control for "${listKey}" returned ` +
+        `${describeAccessResult(result)}, not a boolean. Create cannot be row-scoped — there is no ` +
+        `existing row, and no input data is available to test a filter against here. Return a ` +
+        `boolean from create access, or move the ownership check into a \`resolveInput\` or ` +
+        `\`validate\` hook, where the input data is in scope.`,
+    )
+    this.name = 'InvalidCreateAccessResultError'
+    this.listKey = listKey
   }
 }

--- a/packages/core/src/access/index.ts
+++ b/packages/core/src/access/index.ts
@@ -14,6 +14,7 @@ export type {
 // Operation-level access primitives and shared ref-parsing helper.
 export {
   checkAccess,
+  checkCreateAccess,
   mergeFilters,
   isBoolean,
   isPrismaFilter,
@@ -64,5 +65,7 @@ export { AccessScopeDepthExceededError } from './errors.js'
 export { ResolveOutputCycleError } from './errors.js'
 // Thrown when a field-level access control function returns a non-boolean result.
 export { InvalidFieldAccessResultError } from './errors.js'
+// Thrown when operation-level `create` access control returns a non-boolean result (#1009).
+export { InvalidCreateAccessResultError } from './errors.js'
 // Thrown when a relation filter's related list denies query access outright (#916).
 export { RelationFilterAccessDeniedError } from './errors.js'

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1506,6 +1506,18 @@ export interface TypeInfo<
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type OperationAccess<T = any> = {
   query?: AccessControl<T>
+  /**
+   * Shares `AccessControl`'s signature (so a filter still type-checks here),
+   * but at runtime `create` accepts a `boolean` result only. There is no
+   * existing row to scope with a filter, and — unlike `update`/`delete`,
+   * which re-check a returned filter against the target row via
+   * `findFirst` — no equivalent re-check exists for a row that doesn't exist
+   * in the database yet. A rule that returns a filter (or any other
+   * non-boolean) throws `InvalidCreateAccessResultError` rather than being
+   * treated as an allow (see #1009, ADR-0022, ADR-0030). To scope create by
+   * ownership, evaluate the condition in a `resolveInput`/`validate` hook,
+   * where the input data is in scope.
+   */
   create?: AccessControl<T>
   update?: AccessControl<T>
   delete?: AccessControl<T>

--- a/packages/core/src/context/nested-operations.ts
+++ b/packages/core/src/context/nested-operations.ts
@@ -2,6 +2,7 @@ import type { OpenSaasConfig, ListConfig, FieldConfig } from '../config/types.js
 import type { AccessContext, FieldAccess } from '../access/types.js'
 import {
   checkAccess,
+  checkCreateAccess,
   filterWritableFields,
   getRelatedListConfig,
   resolveSyntheticReverseRelation,
@@ -210,12 +211,12 @@ async function processNestedCreate(
     itemsArray.map(async (item, index) => {
       if (!context._isSudo) {
         const createAccess = relatedListConfig.access?.operation?.create
-        const accessResult = await checkAccess(createAccess, {
+        const allowed = await checkCreateAccess(relatedListName, createAccess, {
           session: context.session,
           context,
         })
 
-        if (accessResult === false) {
+        if (!allowed) {
           throw new Error('Access denied: Cannot create related item')
         }
       }

--- a/packages/core/src/context/write-pipeline.ts
+++ b/packages/core/src/context/write-pipeline.ts
@@ -2,6 +2,7 @@ import type { OpenSaasConfig, ListConfig } from '../config/types.js'
 import type { AccessContext, PrismaClientLike } from '../access/types.js'
 import {
   checkAccess,
+  checkCreateAccess,
   mergeFilters,
   filterReadableFields,
   filterWritableFields,
@@ -562,8 +563,9 @@ async function runDeletePath(args: {
  * Create strategy for {@link WriteStrategy}.
  *
  * Axis 1: checks `create` access with no existing row; a filter result
- * proceeds with no re-check (unlike update/delete). Enforces the
- * singleton-create constraint even under sudo.
+ * throws `InvalidCreateAccessResultError` rather than proceeding unchecked —
+ * create has no row to re-check a filter against, unlike update/delete
+ * (#1009). Enforces the singleton-create constraint even under sudo.
  * Axis 2: runs all input phases.
  * Axis 3: `model.create({ data })`, prepending `id: 1` for singleton lists.
  */
@@ -590,11 +592,11 @@ export function createWriteStrategy(
       }
 
       if (!context._isSudo) {
-        const accessResult = await checkAccess(listConfig.access?.operation?.create, {
+        const allowed = await checkCreateAccess(listName, listConfig.access?.operation?.create, {
           session: context.session,
           context,
         })
-        if (accessResult === false) {
+        if (!allowed) {
           return { status: 'denied' }
         }
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,14 @@ export { ResolveOutputCycleError } from './access/index.js'
 // validation failure.
 export { InvalidFieldAccessResultError } from './access/index.js'
 
+// Thrown by the write pipeline's create strategy and by the nested-create
+// path when operation-level `create` access returns anything other than a
+// strict boolean (see #1009, ADR-0022, and ADR-0030). A filter — the shape
+// `query`/`update`/`delete` legitimately return — cannot be honoured on
+// create: there is no existing row and no way to test it against input data,
+// so it is refused loudly rather than silently treated as a full allow.
+export { InvalidCreateAccessResultError } from './access/index.js'
+
 // Thrown by a read when a caller-supplied `where` filters on a relation whose
 // related list denies operation-level `query` access outright (see #916 and
 // ADR-0022). Distinct from `ValidationError` for the same reason as

--- a/packages/core/tests/access.test.ts
+++ b/packages/core/tests/access.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   checkAccess,
+  checkCreateAccess,
   mergeFilters,
   checkFieldAccess,
   filterReadableFields,
@@ -8,6 +9,7 @@ import {
   isBoolean,
   isPrismaFilter,
 } from '../src/access/index.js'
+import { InvalidCreateAccessResultError } from '../src/access/errors.js'
 import type { AccessControl, FieldAccess, AccessContext } from '../src/access/types.js'
 import { ValidationError } from '../src/hooks/index.js'
 
@@ -109,6 +111,87 @@ describe('Access Control', () => {
         item,
         context: mockContext,
       })
+    })
+  })
+
+  /**
+   * #1009: `checkAccess`'s `AccessControl` return type also admits a
+   * `PrismaFilter` — the shape `query`/`update`/`delete` legitimately use to
+   * scope which rows an operation may touch. `create` has no row to re-check
+   * a filter against, so `checkCreateAccess` (the evaluator both create paths
+   * share) must reject anything that isn't a strict boolean instead of
+   * silently treating it as an allow.
+   */
+  describe('checkCreateAccess', () => {
+    it('denies (returns false) when no access control is defined', async () => {
+      const result = await checkCreateAccess('Post', undefined, {
+        session: null,
+        context: mockContext,
+      })
+
+      expect(result).toBe(false)
+    })
+
+    it('returns true when access control allows', async () => {
+      const accessControl: AccessControl = vi.fn(async () => true)
+
+      const result = await checkCreateAccess('Post', accessControl, {
+        session: null,
+        context: mockContext,
+      })
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when access control denies', async () => {
+      const accessControl: AccessControl = vi.fn(async () => false)
+
+      const result = await checkCreateAccess('Post', accessControl, {
+        session: null,
+        context: mockContext,
+      })
+
+      expect(result).toBe(false)
+    })
+
+    it('throws InvalidCreateAccessResultError, naming the list, when access control returns a filter', async () => {
+      const accessControl: AccessControl = vi.fn(async () => ({ ownerId: { equals: 'u1' } }))
+
+      await expect(
+        checkCreateAccess('Post', accessControl, {
+          session: { userId: 'u1' },
+          context: mockContext,
+        }),
+      ).rejects.toThrow(InvalidCreateAccessResultError)
+
+      try {
+        await checkCreateAccess('Post', accessControl, {
+          session: { userId: 'u1' },
+          context: mockContext,
+        })
+        expect.unreachable()
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidCreateAccessResultError)
+        expect((err as InvalidCreateAccessResultError).listKey).toBe('Post')
+        expect((err as Error).message).toContain('Post')
+        expect((err as Error).message).toContain('boolean')
+      }
+    })
+
+    it('throws InvalidCreateAccessResultError when access control returns undefined', async () => {
+      const accessControl = vi.fn(async () => undefined) as unknown as AccessControl
+
+      await expect(
+        checkCreateAccess('Post', accessControl, { session: null, context: mockContext }),
+      ).rejects.toThrow(InvalidCreateAccessResultError)
+    })
+
+    it('throws InvalidCreateAccessResultError when access control returns a string', async () => {
+      const accessControl = vi.fn(async () => 'nope') as unknown as AccessControl
+
+      await expect(
+        checkCreateAccess('Post', accessControl, { session: null, context: mockContext }),
+      ).rejects.toThrow(InvalidCreateAccessResultError)
     })
   })
 

--- a/packages/core/tests/nested-access-and-hooks.test.ts
+++ b/packages/core/tests/nested-access-and-hooks.test.ts
@@ -3,6 +3,7 @@ import { getContext } from '../src/context/index.js'
 import { config, list } from '../src/config/index.js'
 import { text, relationship } from '../src/fields/index.js'
 import { checkFieldAccess } from '../src/access/field-access.js'
+import { InvalidCreateAccessResultError } from '../src/access/errors.js'
 
 /**
  * Mock Prisma Client for testing
@@ -213,6 +214,70 @@ describe('Nested Operations - Access Control and Hooks', () => {
           },
         }),
       ).rejects.toThrow('Access denied: Cannot create related item')
+    })
+
+    // #1009: a nested `create` rule returning a filter reads as though it
+    // scopes the create, but the nested-create path (like the top-level one)
+    // has no existing row to re-check that filter against. Before this fix
+    // the check only tested `=== false`, so a filter fell through the nested
+    // path exactly like the top-level one and was silently treated as allow.
+    it('should throw when nested create access control returns a Prisma filter', async () => {
+      const testConfig = config({
+        db: {
+          provider: 'postgresql',
+          url: 'postgresql://localhost:5432/test',
+        },
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+              email: text(),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                // Looks like it scopes the nested create by owner. Cannot be
+                // honoured here — there is no row yet.
+                create: () => ({ ownerId: { equals: 'someone' } }),
+              },
+            },
+          }),
+          Post: list({
+            fields: {
+              title: text(),
+              author: relationship({ ref: 'User.posts' }),
+            },
+            access: {
+              operation: {
+                query: () => true,
+                update: () => true,
+              },
+            },
+          }),
+        },
+      })
+
+      mockPrisma.post.findUnique.mockResolvedValue({
+        id: '1',
+        title: 'Original Title',
+      })
+
+      const context = getContext(await testConfig, mockPrisma, null)
+
+      await expect(
+        context.db.post.update({
+          where: { id: '1' },
+          data: {
+            title: 'Updated Title',
+            author: {
+              create: {
+                name: 'John',
+                email: 'john@example.com',
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow(InvalidCreateAccessResultError)
     })
 
     it('should apply field-level access control to nested create', async () => {

--- a/packages/core/tests/write-pipeline.test.ts
+++ b/packages/core/tests/write-pipeline.test.ts
@@ -6,6 +6,7 @@ import {
   deleteWriteStrategy,
 } from '../src/context/write-pipeline.js'
 import { ValidationError } from '../src/hooks/index.js'
+import { InvalidCreateAccessResultError } from '../src/access/errors.js'
 import { text } from '../src/fields/index.js'
 import type { OpenSaasConfig, ListConfig } from '../src/config/types.js'
 import type { AccessContext, PrismaClientLike } from '../src/access/types.js'
@@ -284,6 +285,34 @@ describe('Write Pipeline — short-circuit to null (silent failure)', () => {
     })
 
     expect(result).toBeNull()
+    expect(post.create).not.toHaveBeenCalled()
+    expect(events).not.toContain('list:beforeOperation')
+    expect(events).not.toContain('list:resolveInput')
+  })
+
+  // #1009: a `create` rule returning a filter reads as though it scopes the
+  // create, but create has no existing row to re-check that filter against
+  // (unlike update/delete, which do). Before this fix the only test was
+  // `=== false`, so a filter fell through and was silently treated as allow.
+  it('create: access control returning a filter throws InvalidCreateAccessResultError, before DB and before beforeOperation', async () => {
+    const { prisma, post } = makeFakePrisma()
+    const listConfig = makeListConfig({
+      operationAccess: { create: () => ({ authorId: 'someone' }) },
+    })
+    const context = makeContext()
+
+    await expect(
+      runWritePipeline({
+        listName: 'Post',
+        listConfig,
+        prisma,
+        context,
+        config: makeConfig(listConfig),
+        inputData: { title: 'hi' },
+        strategy: createWriteStrategy('Post', listConfig, context),
+      }),
+    ).rejects.toThrow(InvalidCreateAccessResultError)
+
     expect(post.create).not.toHaveBeenCalled()
     expect(events).not.toContain('list:beforeOperation')
     expect(events).not.toContain('list:resolveInput')


### PR DESCRIPTION
## Summary

- `OperationAccess.create` is typed as `AccessControl` (`boolean | PrismaFilter`), but both create paths — the write pipeline's top-level create step and the nested-create path (which also backs `connectOrCreate`'s create branch) — only ever tested the result against `=== false`. A `create` rule returning a filter, the natural thing to write for row-scoped create ownership, silently fell through as a full allow.
- Added `checkCreateAccess`, a single shared evaluator in `access/engine.ts` that both create paths now call, so they cannot drift again. It throws a new `InvalidCreateAccessResultError` for any result that isn't a strict boolean — naming the list and explaining that create has no row to scope a filter against, and pointing at the alternative (a `resolveInput`/`validate` hook).
- `create: () => false` still denies via Silent failure exactly as before — only the non-boolean case is a new throw.
- This applies the decision already on record in ADR-0030 (field-level access fails closed on a non-boolean result) and ADR-0022 (an engine that cannot compute a scope must deny, never pass through) to this path. No new ADR needed.
- Updated `OperationAccess.create`'s TSDoc and the `config-api.md` reference doc to state that `create` accepts a boolean only, and why.
- Deliberately out of scope (per the issue): narrowing `OperationAccess['create']`'s type itself, changing `AccessControl`'s shared signature, and giving `create` access the input data (that's #966).

## Test plan

- [x] Unit tests for `checkCreateAccess` (filter/undefined/string throw; `true`/`false`/absent behave as before), naming the list in the error
- [x] Write-pipeline test: top-level `create` access returning a filter throws `InvalidCreateAccessResultError`, before DB and before `beforeOperation`
- [x] Nested-write integration test: nested `create` access returning a filter throws the same error (covers the nested path shared with `connectOrCreate`'s create branch)
- [x] `pnpm build`, `pnpm test` (1172 tests), `pnpm lint`, `pnpm manypkg fix`, `pnpm format` all pass
- [x] Changeset added (minor, `@opensaas/stack-core`)

Closes #1009


---
_Generated by [Claude Code](https://claude.ai/code/session_011Li31AoECc3LcX7CusKTsV)_